### PR TITLE
Transaction

### DIFF
--- a/lib/gcloud/datastore/connection.rb
+++ b/lib/gcloud/datastore/connection.rb
@@ -124,6 +124,53 @@ module Gcloud
                                     encode_cursor(response.batch.end_cursor)
       end
 
+      ##
+      # Runs the given block in a database transaction.
+      # If no block is given the transaction object is returned.
+      #
+      #   user = Gcloud::Datastore::Entity.new
+      #   user.key = Gcloud::Datastore::Key.new "User", "username"
+      #   user["name"] = "Test"
+      #   user["email"] = "test@example.net"
+      #
+      #   Gcloud::Datastore.connection.transaction do |tx|
+      #     if tx.find(user.key).nil?
+      #       tx.save user
+      #     end
+      #   end
+      #
+      # Alternatively, you can manually commit or rollback by
+      # using the returned transaction object.
+      #
+      #   user = Gcloud::Datastore::Entity.new
+      #   user.key = Gcloud::Datastore::Key.new "User", "username"
+      #   user["name"] = "Test"
+      #   user["email"] = "test@example.net"
+      #
+      #   tx = Gcloud::Datastore.connection.transaction
+      #   begin
+      #     if tx.find(user.key).nil?
+      #       tx.save user
+      #     end
+      #     tx.commit
+      #   rescue
+      #     tx.rollback
+      #   end
+      def transaction
+        tx = Transaction.new self
+
+        if block_given?
+          begin
+            yield tx
+            tx.commit
+          rescue
+            tx.rollback
+            fail "Transaction failed to commit."
+          end
+        end
+        tx
+      end
+
       protected
 
       def new_run_query_request query_proto
@@ -250,6 +297,82 @@ module Gcloud
       def initialize arr = [], cursor = nil
         super arr
         @cursor = cursor
+      end
+    end
+
+    ##
+    # Special Connection instance for running transactions.
+    #
+    # See Gcloud::Datastore::Connection.transaction
+    class Transaction < Connection
+      attr_reader :id
+
+      def initialize connection #:nodoc:
+        @dataset_id = connection.dataset_id
+        @conn       = connection.conn
+        @client     = connection.instance_variable_get :@client
+        clear
+        start
+      end
+
+      def save *entities
+        save_entities_to_mutation entities, mutation
+        # Do not save or assign auto_ids yet
+        entities
+      end
+
+      def delete *entities
+        mutation do |m|
+          m.delete = entities.map { |entity| entity.key.to_proto }
+        end
+        # Do not delete yet
+        true
+      end
+
+      def clear
+        @mut = nil
+        @id  = nil
+        @_auto_id_entities = []
+      end
+
+      def start
+        fail "Transaction already opened" unless @id.nil?
+        tx_request = Proto::BeginTransactionRequest.new
+        response_rpc = rpc "beginTransaction", tx_request
+        response = Proto::BeginTransactionResponse.decode response_rpc
+        @id = response.transaction
+      end
+
+      def commit
+        fail "Cannot commit when not in a transaction" if @id.nil?
+        response = commit_rpc mutation
+        auto_id_assign_ids response.mutation_result.insert_auto_id_key
+        true
+      end
+
+      def rollback
+        fail "Cannot rollback when not in a transaction" if @id.nil?
+        rollback = Proto::RollbackRequest.new
+        rollback.transaction = @id
+        Proto::RollbackResponse.decode rpc("rollback", rollback)
+        true
+      end
+
+      protected
+
+      def commit_rpc proto_mutation #:nodoc:
+        commit = Proto::CommitRequest.new
+        commit.transaction = @id
+        commit.mode = Proto::CommitRequest::Mode::TRANSACTIONAL
+        commit.mutation = proto_mutation
+        Proto::CommitResponse.decode rpc("commit", commit)
+      end
+
+      def mutation
+        # Always return the same new mutation object
+        @mut ||= super() # Use parens so the block isn't passed
+        yield @mut if block_given?
+        @mut
       end
     end
   end


### PR DESCRIPTION
Transactions are added and support both the block syntax as well as explicit control. The following example is the block syntax:

``` ruby
connection.transaction do |tx|
  if tx.find(obj.key).nil?
    tx.save obj
  end
end
```

The alternative is to use the object that `Connection#transaction` returns and explicitly call `commit` or `rollback` on the object:

``` ruby
tx = connection.transaction
begin
  if tx.find(obj.key).nil?
    tx.save obj
  end
  tx.commit
rescue
  tx.rollback
end
```
