### PR TITLE
Add Datastore#get alias [Fixes #34]

### DIFF
--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -102,6 +102,7 @@ module Gcloud
         key = Key.new key_or_kind, id_or_name unless key_or_kind.is_a? Key
         find_all(key).first
       end
+      alias_method :get, :find
 
       ##
       # Retrieve the entities for the provided keys.

--- a/test/gcloud/datastore/test_dataset.rb
+++ b/test/gcloud/datastore/test_dataset.rb
@@ -131,6 +131,15 @@ describe Gcloud::Datastore::Dataset do
     entity.must_be_kind_of Gcloud::Datastore::Entity
   end
 
+  it "find is aliased to get" do
+    dataset.connection.expect :lookup,
+                              lookup_response,
+                              [Gcloud::Datastore::Proto::Key]
+
+    entity = dataset.get "ds-test", 123
+    entity.must_be_kind_of Gcloud::Datastore::Entity
+  end
+
   it "find_all takes several keys" do
     dataset.connection.expect :lookup,
                               lookup_response,
@@ -139,6 +148,20 @@ describe Gcloud::Datastore::Dataset do
 
     key = Gcloud::Datastore::Key.new "ds-test", "thingie"
     entities = dataset.find_all key, key
+    entities.count.must_equal 2
+    entities.each do |entity|
+      entity.must_be_kind_of Gcloud::Datastore::Entity
+    end
+  end
+
+  it "find_all is aliased to lookup" do
+    dataset.connection.expect :lookup,
+                              lookup_response,
+                              [Gcloud::Datastore::Proto::Key,
+                               Gcloud::Datastore::Proto::Key]
+
+    key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+    entities = dataset.lookup key, key
     entities.count.must_equal 2
     entities.each do |entity|
       entity.must_be_kind_of Gcloud::Datastore::Entity


### PR DESCRIPTION
Allow users to use both Google API terminology as well as terms familiar to most rubyists. This means users choose between calling `dataset.get` or `dataset.find`, similar to how users can choose between `dataset.lookup` or `dataset.find_all`.
