### PR TITLE
Add exclude_from_indexes to Entity [Fixes #33]

### DIFF
--- a/lib/gcloud/datastore/entity.rb
+++ b/lib/gcloud/datastore/entity.rb
@@ -36,6 +36,7 @@ module Gcloud
         @_entity = Proto::Entity.new
         @_entity.property = []
         @key = Key.new
+        @_exclude_indexes = {}
       end
 
       ##
@@ -43,6 +44,7 @@ module Gcloud
       #
       #   puts entity["name"]
       def [] prop_name
+        prop_name = prop_name.to_s
         prop = Array(@_entity.property).find { |p| p.name == prop_name }
         Proto.from_proto_value prop.value
       rescue
@@ -94,9 +96,7 @@ module Gcloud
       #   task.key.frozen? #=> true
       #   task.key.id = 456789 #=> RuntimeError
       def key= new_key
-        if persisted?
-          fail "This entity's key is immutable."
-        end
+        fail "This entity's key is immutable." if persisted?
         @key = new_key
       end
 
@@ -108,9 +108,65 @@ module Gcloud
       end
 
       ##
+      # Indicates if a property is flagged to be excluded from the
+      # Datastore indexes. The default value is false.
+      #
+      # Single property values will return a single flag setting.
+      #
+      #   entity["age"] = 21
+      #   entity.exclude_from_indexes? "age" #=> false
+      #
+      # Array property values will return an array of flag settings.
+      #
+      #   entity["tags"] = ["ruby", "code"]
+      #   entity.exclude_from_indexes? "tags" #=> true [false, false]
+      def exclude_from_indexes? name
+        value = self[name]
+        flag = @_exclude_indexes[name.to_s]
+        map_exclude_flag_to_value flag, value
+      end
+
+      ##
+      # Flag a property to be excluded from the Datastore indexes.
+      # Setting true will exclude the property from the indexes.
+      # Setting false will include the property on any applicable indexes.
+      # The default value for the flag is false.
+      #
+      #   entity["age"] = 21
+      #   entity.exclude_from_indexes! "age", true
+      #
+      # Properties that are arrays can be given multiple exclude flags.
+      #
+      #   entity["tags"] = ["ruby", "code"]
+      #   entity.exclude_from_indexes! "tags", [true, false]
+      #
+      # Or, array properties can be given a single flag that will be applied
+      # to each item in the array.
+      #
+      #   entity["tags"] = ["ruby", "code"]
+      #   entity.exclude_from_indexes! "tags", true
+      #
+      # Flags can also be set with a block for either single and array values.
+      #
+      #   entity["age"] = 21
+      #   entity.exclude_from_indexes! "age" do |age|
+      #     age > 18
+      #   end
+      def exclude_from_indexes! name, flag = nil, &block
+        name = name.to_s
+        flag = block if block_given?
+        if flag.nil?
+          @_exclude_indexes.delete name
+        else
+          @_exclude_indexes[name] = flag
+        end
+      end
+
+      ##
       # Convert the Entity to a protocol buffer object.
       # This is not part of the public API.
       def to_proto #:nodoc:
+        update_properties_indexed!
         @_entity.key = @key.to_proto
         @_entity
       end
@@ -123,8 +179,71 @@ module Gcloud
         entity = Entity.new
         entity.instance_variable_set :@_entity, proto
         entity.instance_variable_set :@key, key
+        entity.send :update_exclude_indexes!
         entity
       end
+
+      protected
+
+      # rubocop:disable all
+      # Disabled rubocop because this is intentionally complex.
+
+      ##
+      # Map the exclude flag object to value.
+      # The flag object can be a boolean, Proc, or Array.
+      # Procs will be called and passed in the value.
+      # This will return an array of flags for an array value.
+      def map_exclude_flag_to_value flag, value #:nodoc:
+        if value.is_a? Array
+          if flag.is_a? Proc
+            value.map { |v| !!flag.call(v) }
+          elsif flag.is_a? Array
+            (flag + Array.new(value.size)).slice(0, value.size).map { |v| !!v }
+          else
+            value.map { |_| !!flag }
+          end
+        else
+          if flag.is_a? Proc
+            !!flag.call(value)
+          elsif flag.is_a? Array
+            !!flag.first
+          else
+            !!flag
+          end
+        end
+      end
+
+      ##
+      # Update the exclude data after a new object is created.
+      def update_exclude_indexes! #:nodoc:
+        @_exclude_indexes = {}
+        @_entity.property.each do |property|
+          @_exclude_indexes[property.name] = property.value.indexed
+          unless property.value.list_value.nil?
+            exclude = Array(property.value.list_value).map(&:indexed)
+            @_exclude_indexes[property.name] = exclude
+          end
+        end
+      end
+
+      ##
+      # Update the indexed values before the object is saved.
+      def update_properties_indexed! #:nodoc:
+        @_entity.property.each do |property|
+          excluded = exclude_from_indexes? property.name
+          if excluded.is_a? Array
+            # Lists are never indexed
+            property.value.indexed = false
+            property.value.list_value.each_with_index do |value, index|
+              value.indexed = !excluded[index]
+            end
+          else
+            property.value.indexed = !excluded
+          end
+        end
+      end
+
+      # rubocop:enable all
     end
   end
 end

--- a/test/gcloud/datastore/test_entity_exclude.rb
+++ b/test/gcloud/datastore/test_entity_exclude.rb
@@ -1,0 +1,225 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "gcloud/datastore"
+
+describe Gcloud::Datastore::Entity, :exclude_from_indexes do
+
+  let(:entity) do
+    Gcloud::Datastore::Entity.new.tap do |entity|
+      entity.key = Gcloud::Datastore::Key.new "User", "username"
+      entity["name"] = "User McUser"
+      entity["email"] = "user@example.net"
+    end
+  end
+
+  it "doesn't exclude from indexes by default" do
+    refute entity.exclude_from_indexes?("name")
+    refute entity.exclude_from_indexes?("email")
+
+    proto = entity.to_proto
+
+    assert proto.property.find { |p| p.name == "name"  }.value.indexed.must_equal true
+    assert proto.property.find { |p| p.name == "email" }.value.indexed.must_equal true
+  end
+
+  it "excludes when setting a boolean" do
+    entity["age"] = 21
+    entity.exclude_from_indexes! "age", true
+
+    entity.exclude_from_indexes?("age").must_equal true
+
+    proto = entity.to_proto
+
+    proto.property.find { |p| p.name == "age"  }.value.indexed.must_equal false
+  end
+
+  it "excludes when setting a Proc" do
+    entity["age"] = 21
+    entity.exclude_from_indexes! "age" do |age|
+      age > 18
+    end
+
+    entity.exclude_from_indexes?("age").must_equal true
+
+    proto = entity.to_proto
+
+    proto.property.find { |p| p.name == "age"  }.value.indexed.must_equal false
+
+    # And now the inverse, the Proc evaluates to false
+
+    entity.exclude_from_indexes! "age" do |age|
+      age < 18
+    end
+
+    entity.exclude_from_indexes?("age").must_equal false
+
+    proto = entity.to_proto
+
+    proto.property.find { |p| p.name == "age"  }.value.indexed.must_equal true
+  end
+
+  it "excludes when setting an Array on a non array value" do
+    entity["age"] = 21
+    entity.exclude_from_indexes! "age", [true, false, true, false]
+
+    entity.exclude_from_indexes?("age").must_equal true
+
+    proto = entity.to_proto
+
+    proto.property.find { |p| p.name == "age"  }.value.indexed.must_equal false
+
+    # And now the inverse, the first value is false
+
+    entity.exclude_from_indexes! "age", [false, true, false, true]
+
+    entity.exclude_from_indexes?("age").must_equal false
+
+    proto = entity.to_proto
+
+    proto.property.find { |p| p.name == "age"  }.value.indexed.must_equal true
+  end
+
+  describe Array do
+    it "doesn't exclude Array values from indexes by default" do
+      entity["tags"] = ["ruby", "code"]
+
+      entity.exclude_from_indexes?("tags").must_equal [false, false]
+
+      proto = entity.to_proto
+
+      tag_proto = proto.property.find { |p| p.name == "tags"  }.value
+      tag_proto.indexed.must_equal false # list values must always be false
+      tag_proto.list_value.map { |value| value.indexed }.must_equal [true, true]
+    end
+
+    it "excludes an Array when setting a boolean" do
+      entity["tags"] = ["ruby", "code"]
+      entity.exclude_from_indexes! "tags", true
+
+      entity.exclude_from_indexes?("tags").must_equal [true, true]
+
+      proto = entity.to_proto
+
+      tag_proto = proto.property.find { |p| p.name == "tags"  }.value
+      tag_proto.indexed.must_equal false # list values must always be false
+      tag_proto.list_value.map { |value| value.indexed }.must_equal [false, false]
+    end
+
+    it "excludes an Array when setting a Proc" do
+      entity["tags"] = ["ruby", "code"]
+      entity.exclude_from_indexes! "tags" do |tag|
+        tag =~ /r/
+      end
+
+      entity.exclude_from_indexes?("tags").must_equal [true, false]
+
+      proto = entity.to_proto
+
+      tag_proto = proto.property.find { |p| p.name == "tags"  }.value
+      tag_proto.indexed.must_equal false # list values must always be false
+      tag_proto.list_value.map { |value| value.indexed }.must_equal [false, true]
+
+      # And now the inverse, the Proc evaluates to false
+
+      entity["tags"] = ["ruby", "code"]
+      entity.exclude_from_indexes! "tags" do |tag|
+        tag =~ /c/
+      end
+
+      entity.exclude_from_indexes?("tags").must_equal [false, true]
+
+      proto = entity.to_proto
+
+      tag_proto = proto.property.find { |p| p.name == "tags"  }.value
+      tag_proto.indexed.must_equal false # list values must always be false
+      tag_proto.list_value.map { |value| value.indexed }.must_equal [true, false]
+    end
+
+    it "excludes an Array when setting an Array" do
+      entity["tags"] = ["ruby", "code"]
+      entity.exclude_from_indexes! "tags", [true, false]
+
+      entity.exclude_from_indexes?("tags").must_equal [true, false]
+
+      proto = entity.to_proto
+
+      tag_proto = proto.property.find { |p| p.name == "tags"  }.value
+      tag_proto.indexed.must_equal false # list values must always be false
+      tag_proto.list_value.map { |value| value.indexed }.must_equal [false, true]
+    end
+
+    it "excludes an Array when setting an Array that is too small" do
+      entity["tags"] = ["ruby", "code", "google", "cloud"]
+      entity.exclude_from_indexes! "tags", [true, false]
+
+      # the default is to not exclude when the array is too small
+      entity.exclude_from_indexes?("tags").must_equal [true, false, false, false]
+
+      proto = entity.to_proto
+
+      tag_proto = proto.property.find { |p| p.name == "tags"  }.value
+      tag_proto.indexed.must_equal false # list values must always be false
+      tag_proto.list_value.map { |value| value.indexed }.must_equal [false, true, true, true]
+    end
+
+    it "excludes an Array when setting an Array that is too big" do
+      entity["tags"] = ["ruby", "code"]
+      entity.exclude_from_indexes! "tags", [true, false, true, false, true, false]
+
+      entity.exclude_from_indexes?("tags").must_equal [true, false]
+
+      proto = entity.to_proto
+
+      tag_proto = proto.property.find { |p| p.name == "tags"  }.value
+      tag_proto.indexed.must_equal false # list values must always be false
+      tag_proto.list_value.map { |value| value.indexed }.must_equal [false, true]
+
+      # Now add to the entity and get the previously stored exclude values
+
+      entity["tags"] = ["ruby", "code", "google", "cloud"]
+
+      entity.exclude_from_indexes?("tags").must_equal [true, false, true, false]
+
+      proto = entity.to_proto
+
+      tag_proto = proto.property.find { |p| p.name == "tags"  }.value
+      tag_proto.indexed.must_equal false # list values must always be false
+      tag_proto.list_value.map { |value| value.indexed }.must_equal [false, true, false, true]
+    end
+  end
+
+  describe "Edge Cases" do
+    it "recalculates when changing from a single value to an array" do
+      entity["tags"] = "ruby"
+
+      entity.exclude_from_indexes?("tags").must_equal false
+
+      entity.exclude_from_indexes! "tags", true
+
+      entity.exclude_from_indexes?("tags").must_equal true
+
+      entity["tags"] = ["ruby", "code"]
+
+      entity.exclude_from_indexes?("tags").must_equal [true, true]
+
+      entity.exclude_from_indexes! "tags", [false, false]
+
+      entity["tags"] = "ruby"
+
+      entity.exclude_from_indexes?("tags").must_equal false
+    end
+  end
+end


### PR DESCRIPTION
Allow users to flag which property values are to be excluded from the Datastore indexes.

This includes the ability to exclude property values by boolean:

``` ruby
entity["age"] = 21
entity.exclude_from_indexes! "age", true
```

By Proc:

``` ruby
entity["age"] = 21
entity.exclude_from_indexes! "age" do |age|
  age < 18
end
```

And by Array:

``` ruby
entity["tags"] = ["ruby", "code"]
entity.exclude_from_indexes! "tags", [true, false]
```

This does _not_ include the following inline option, as I couldn't defeat the syntax errors it was throwing.

``` ruby
entity["age"] = 21, exclude_from_indexes: true #=>  SyntaxError: syntax error, unexpected tLABEL
# /play sadtrombone
```
