### PR TITLE
Releases for 2018-09-20

### DIFF
--- a/gcloud/CHANGELOG.md
+++ b/gcloud/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.23.3 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.23.2 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/gcloud/lib/gcloud/version.rb
+++ b/gcloud/lib/gcloud/version.rb
@@ -14,5 +14,5 @@
 
 
 module Gcloud
-  GCLOUD_VERSION = "0.23.2".freeze
+  GCLOUD_VERSION = "0.23.3".freeze
 end

--- a/google-cloud-bigquery-data_transfer/CHANGELOG.md
+++ b/google-cloud-bigquery-data_transfer/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.2.3 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.2.2 / 2018-09-10
 
 * Update documentation.

--- a/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec
+++ b/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-bigquery-data_transfer"
-  gem.version       = "0.2.2"
+  gem.version       = "0.2.3"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-bigquery/CHANGELOG.md
+++ b/google-cloud-bigquery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 1.8.2 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+* Fix circular require warning.
+
 ### 1.8.1 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigquery
-      VERSION = "1.8.1".freeze
+      VERSION = "1.8.2".freeze
     end
   end
 end

--- a/google-cloud-bigtable/CHANGELOG.md
+++ b/google-cloud-bigtable/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.1.3 / 2018-09-20
+
+* Update connectivity configuration.
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.1.2 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/version.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigtable
-      VERSION = "0.1.2".freeze
+      VERSION = "0.1.3".freeze
     end
   end
 end

--- a/google-cloud-container/CHANGELOG.md
+++ b/google-cloud-container/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.2.2 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.2.1 / 2018-09-10
 
 * Update documentation.

--- a/google-cloud-container/google-cloud-container.gemspec
+++ b/google-cloud-container/google-cloud-container.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-container"
-  gem.version       = "0.2.1"
+  gem.version       = "0.2.2"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-core/CHANGELOG.md
+++ b/google-cloud-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.2.7 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 1.2.6 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-core/lib/google/cloud/core/version.rb
+++ b/google-cloud-core/lib/google/cloud/core/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Core
-      VERSION = "1.2.6".freeze
+      VERSION = "1.2.7".freeze
     end
   end
 end

--- a/google-cloud-dataproc/CHANGELOG.md
+++ b/google-cloud-dataproc/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.2.2 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.2.1 / 2018-09-10
 
 * Update documentation.

--- a/google-cloud-dataproc/google-cloud-dataproc.gemspec
+++ b/google-cloud-dataproc/google-cloud-dataproc.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dataproc"
-  gem.version       = "0.2.1"
+  gem.version       = "0.2.2"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-datastore/CHANGELOG.md
+++ b/google-cloud-datastore/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 1.4.4 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+* Fix circular require warning.
+
 ### 1.4.3 / 2018-09-12
 
 * Update documentation.

--- a/google-cloud-datastore/lib/google/cloud/datastore/version.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Datastore
-      VERSION = "1.4.3".freeze
+      VERSION = "1.4.4".freeze
     end
   end
 end

--- a/google-cloud-debugger/CHANGELOG.md
+++ b/google-cloud-debugger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.32.5 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+* Fix circular require warning.
+
 ### 0.32.4 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-debugger/lib/google/cloud/debugger/version.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Debugger
-      VERSION = "0.32.4".freeze
+      VERSION = "0.32.5".freeze
     end
   end
 end

--- a/google-cloud-dialogflow/CHANGELOG.md
+++ b/google-cloud-dialogflow/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.2.2 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.2.1 / 2018-09-10
 
 * Update documentation.

--- a/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
+++ b/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dialogflow"
-  gem.version       = "0.2.1"
+  gem.version       = "0.2.2"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-dlp/CHANGELOG.md
+++ b/google-cloud-dlp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.6.2 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.6.1 / 2018-09-10
 
 * Update documentation.

--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dlp"
-  gem.version       = "0.6.1"
+  gem.version       = "0.6.2"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-dns/CHANGELOG.md
+++ b/google-cloud-dns/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.29.4 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+* Fix circular require warning.
+
 ### 0.29.3 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-dns/lib/google/cloud/dns/version.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Dns
-      VERSION = "0.29.3".freeze
+      VERSION = "0.29.4".freeze
     end
   end
 end

--- a/google-cloud-env/CHANGELOG.md
+++ b/google-cloud-env/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.0.5 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 1.0.4 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-env/lib/google/cloud/env/version.rb
+++ b/google-cloud-env/lib/google/cloud/env/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     class Env
-      VERSION = "1.0.4".freeze
+      VERSION = "1.0.5".freeze
     end
   end
 end

--- a/google-cloud-error_reporting/CHANGELOG.md
+++ b/google-cloud-error_reporting/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.30.5 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+* Fix circular require warning.
+
 ### 0.30.4 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module ErrorReporting
-      VERSION = "0.30.4".freeze
+      VERSION = "0.30.5".freeze
     end
   end
 end

--- a/google-cloud-firestore/CHANGELOG.md
+++ b/google-cloud-firestore/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+### 0.24.2 / 2018-09-20
+
+* Add fix for comparing NaN values
+  * NaN values should not be compared, as this may raise with Active Support.
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+* Fix circular require warning.
+
 ### 0.24.1 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-firestore/lib/google/cloud/firestore/version.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Firestore
-      VERSION = "0.24.1".freeze
+      VERSION = "0.24.2".freeze
     end
   end
 end

--- a/google-cloud-kms/CHANGELOG.md
+++ b/google-cloud-kms/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.2.4 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.2.3 / 2018-09-12
 
 * Add Assymetric Sign/Decrypt.

--- a/google-cloud-kms/google-cloud-kms.gemspec
+++ b/google-cloud-kms/google-cloud-kms.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-kms"
-  gem.version       = "0.2.3"
+  gem.version       = "0.2.4"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-language/CHANGELOG.md
+++ b/google-cloud-language/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.31.2 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.31.1 / 2018-09-10
 
 * Update documentation.

--- a/google-cloud-language/google-cloud-language.gemspec
+++ b/google-cloud-language/google-cloud-language.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-language"
-  gem.version       = "0.31.1"
+  gem.version       = "0.31.2"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-logging/CHANGELOG.md
+++ b/google-cloud-logging/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History
 
+### 1.5.5 / 2018-09-20
+
+* Make Logger thread-safe.
+* Update Logging generated files.
+  * Add Metric's MetricDescriptorMetadata.
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+* Fix circular require warning.
+
 ### 1.5.4 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-logging/lib/google/cloud/logging/version.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Logging
-      VERSION = "1.5.4".freeze
+      VERSION = "1.5.5".freeze
     end
   end
 end

--- a/google-cloud-monitoring/CHANGELOG.md
+++ b/google-cloud-monitoring/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 0.29.2 / 2018-09-20
+
+* Update Monitoring generated files.
+  * Add MetricDescriptorMetadata.
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.29.1 / 2018-09-10
 
 * Update documentation.

--- a/google-cloud-monitoring/google-cloud-monitoring.gemspec
+++ b/google-cloud-monitoring/google-cloud-monitoring.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-monitoring"
-  gem.version       = "0.29.1"
+  gem.version       = "0.29.2"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-os_login/CHANGELOG.md
+++ b/google-cloud-os_login/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.2.3 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.2.2 / 2018-09-10
 
 * Update documentation.

--- a/google-cloud-os_login/google-cloud-os_login.gemspec
+++ b/google-cloud-os_login/google-cloud-os_login.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-os_login"
-  gem.version       = "0.2.2"
+  gem.version       = "0.2.3"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 0.33.0 / 2018-09-20
+
+* Add support for user labels to Snapshot, Subscription and Topic.
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+* Fix circular require warning.
+
 ### 0.32.2 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Pubsub
-      VERSION = "0.32.2".freeze
+      VERSION = "0.33.0".freeze
     end
   end
 end

--- a/google-cloud-redis/CHANGELOG.md
+++ b/google-cloud-redis/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.2.3 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.2.2 / 2018-09-12
 
 * Add V1 Client.

--- a/google-cloud-redis/google-cloud-redis.gemspec
+++ b/google-cloud-redis/google-cloud-redis.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-redis"
-  gem.version       = "0.2.2"
+  gem.version       = "0.2.3"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-resource_manager/CHANGELOG.md
+++ b/google-cloud-resource_manager/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.30.3 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+* Fix circular require warning.
+
 ### 0.30.2 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/version.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module ResourceManager
-      VERSION = "0.30.2".freeze
+      VERSION = "0.30.3".freeze
     end
   end
 end

--- a/google-cloud-spanner/CHANGELOG.md
+++ b/google-cloud-spanner/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+### 1.6.4 / 2018-09-20
+
+* Update Spanner generated files.
+  * Add DML/PDML code structures.
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+* Fix circular require warning.
+
 ### 1.6.3 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-spanner/lib/google/cloud/spanner/version.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Spanner
-      VERSION = "1.6.3".freeze
+      VERSION = "1.6.4".freeze
     end
   end
 end

--- a/google-cloud-speech/CHANGELOG.md
+++ b/google-cloud-speech/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.31.1 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.31.0 / 2018-09-10
 
 * Add get_operation to retrieve long running operation resource.

--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-speech"
-  gem.version       = "0.31.0"
+  gem.version       = "0.31.1"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-storage/CHANGELOG.md
+++ b/google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 1.14.2 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+* Fix circular require warning.
+
 ### 1.14.1 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-storage/lib/google/cloud/storage/version.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Storage
-      VERSION = "1.14.1".freeze
+      VERSION = "1.14.2".freeze
     end
   end
 end

--- a/google-cloud-tasks/CHANGELOG.md
+++ b/google-cloud-tasks/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.2.4 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.2.3 / 2018-09-10
 
 * Update documentation.

--- a/google-cloud-tasks/google-cloud-tasks.gemspec
+++ b/google-cloud-tasks/google-cloud-tasks.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-tasks"
-  gem.version       = "0.2.3"
+  gem.version       = "0.2.4"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-text_to_speech/CHANGELOG.md
+++ b/google-cloud-text_to_speech/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.1.3 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.1.2 / 2018-09-10
 
 * Update documentation.

--- a/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
+++ b/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-text_to_speech"
-  gem.version       = "0.1.2"
+  gem.version       = "0.1.3"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.33.5 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+* Fix circular require warning.
+
 ### 0.33.4 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-trace/lib/google/cloud/trace/version.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Trace
-      VERSION = "0.33.4".freeze
+      VERSION = "0.33.5".freeze
     end
   end
 end

--- a/google-cloud-translate/CHANGELOG.md
+++ b/google-cloud-translate/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 1.2.4 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+* Fix circular require warning.
+
 ### 1.2.3 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-translate/lib/google/cloud/translate/version.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Translate
-      VERSION = "1.2.3".freeze
+      VERSION = "1.2.4".freeze
     end
   end
 end

--- a/google-cloud-video_intelligence/CHANGELOG.md
+++ b/google-cloud-video_intelligence/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.1.2 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 1.1.1 / 2018-09-10
 
 * Update documentation.

--- a/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
+++ b/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-video_intelligence"
-  gem.version       = "1.1.1"
+  gem.version       = "1.1.2"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-vision/CHANGELOG.md
+++ b/google-cloud-vision/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.30.4 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+* Fix circular require warning.
+
 ### 0.30.3 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud-vision/lib/google/cloud/vision/version.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Vision
-      VERSION = "0.30.3".freeze
+      VERSION = "0.30.4".freeze
     end
   end
 end

--- a/google-cloud/CHANGELOG.md
+++ b/google-cloud/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 0.56.3 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+  * Add links to dependency google-cloud-* gems to README.
+* Fix circular require warning.
+
 ### 0.56.2 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/google-cloud/lib/google/cloud/version.rb
+++ b/google-cloud/lib/google/cloud/version.rb
@@ -15,6 +15,6 @@
 
 module Google
   module Cloud
-    VERSION = "0.56.2".freeze
+    VERSION = "0.56.3".freeze
   end
 end

--- a/stackdriver-core/CHANGELOG.md
+++ b/stackdriver-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.3.3 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 1.3.2 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/stackdriver-core/lib/stackdriver/core/version.rb
+++ b/stackdriver-core/lib/stackdriver/core/version.rb
@@ -15,6 +15,6 @@
 
 module Stackdriver
   module Core
-    VERSION = "1.3.2".freeze
+    VERSION = "1.3.3".freeze
   end
 end

--- a/stackdriver/CHANGELOG.md
+++ b/stackdriver/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.15.3 / 2018-09-20
+
+* Update documentation.
+  * Change documentation URL to googleapis GitHub org.
+
 ### 0.15.2 / 2018-09-12
 
 * Add missing documentation files to package.

--- a/stackdriver/lib/stackdriver/version.rb
+++ b/stackdriver/lib/stackdriver/version.rb
@@ -14,5 +14,5 @@
 
 
 module Stackdriver
-  VERSION = "0.15.2".freeze
+  VERSION = "0.15.3".freeze
 end


### PR DESCRIPTION
Most of these releases are only to update docs for the org change to googleapis; and for the Veneer gems, the fix for the circular require warning.

In addition:

google-cloud-bigtable 0.1.3
    
    * Update connectivity configuration.

 google-cloud-firestore 0.24.2
    
    * Add fix for comparing NaN values
      * NaN values should not be compared, as this may raise with Active Support.

google-cloud-logging 1.5.5
    
    * Make Logger thread-safe.
    * Update Logging generated files.
      * Add Metric's MetricDescriptorMetadata.

google-cloud-monitoring 0.29.2
    
    * Update Monitoring generated files.

google-cloud-pubsub 0.33.0
    
    * Add support for user labels to Snapshot, Subscription and Topic.

google-cloud-spanner 1.6.4
    
    * Update Spanner generated files.
      * Add DML/PDML code structures.




