### PR TITLE
Use ThreadLocalVar for RequestInfo

### DIFF
--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "google-gax", "~> 1.3"
   gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"
+  gem.add_dependency "concurrent-ruby", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-logging/test/google/cloud/logging/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger_test.rb
@@ -166,25 +166,6 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
       logger.request_info.must_equal request_info
     end
 
-    it "doesn't record more than 10_000 RequestInfo records" do
-      last_thread_id = first_thread_id = 1
-      stubbed_thread_id = ->(){
-        last_thread_id += 1
-      }
-
-      # Stubbing Thread.current breaks minitest APIs. So record result and
-      # evaluate outside the block
-      logger.stub :current_thread_id, stubbed_thread_id do
-        10_001.times do
-          logger.add_request_info info: request_info
-        end
-        request_info_map = logger.instance_variable_get :@request_info_map
-        request_info_map.size.must_equal 10_000
-        request_info_map[first_thread_id].must_be_nil
-        request_info_map[last_thread_id].must_equal request_info
-      end
-    end
-
     it "passes request info to log writes" do
       mock = Minitest::Mock.new
       trace_id = "my_trace_id"


### PR DESCRIPTION
Remove Monitor and synchronize blocks in favor it concurrent-ruby and the ThreadLocalVar object. This allows a RequestInfo to be set on a parent thread, but be overridden by a child thread. The ThreadLocalVar object is thread-safe.