### PR TITLE
Release google-cloud-vision 0.31.1

### DIFF
--- a/google-cloud-dlp/CHANGELOG.md
+++ b/google-cloud-dlp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.6.3 / 2018-09-28
+
+* Update google-cloud-dlp generated files (#2481)
+* Re-generate library using google-cloud-dlp/synth.py (#2478)
+
 ### 0.6.2 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dlp"
-  gem.version       = "0.6.2"
+  gem.version       = "0.6.3"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-monitoring/CHANGELOG.md
+++ b/google-cloud-monitoring/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.29.3 / 2018-09-28
+
+* Re-generate library using google-cloud-monitoring/synth.py (#2479)
+
 ### 0.29.2 / 2018-09-20
 
 * Update Monitoring generated files.

--- a/google-cloud-monitoring/google-cloud-monitoring.gemspec
+++ b/google-cloud-monitoring/google-cloud-monitoring.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-monitoring"
-  gem.version       = "0.29.2"
+  gem.version       = "0.29.3"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.33.1 / 2018-09-28
+
+* Re-generate library using google-cloud-pubsub/synth.py (#2480)
+
 ### 0.33.0 / 2018-09-20
 
 * Add support for user labels to Snapshot, Subscription and Topic.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Pubsub
-      VERSION = "0.33.0".freeze
+      VERSION = "0.33.1".freeze
     end
   end
 end

--- a/google-cloud-vision/CHANGELOG.md
+++ b/google-cloud-vision/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.31.1 / 2018-09-28
+
+* Remove focus from acceptance tests (#2490)
+
 ### 0.31.0 / 2018-09-26
 
 * Add Object Localization.

--- a/google-cloud-vision/lib/google/cloud/vision/version.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Vision
-      VERSION = "0.31.0".freeze
+      VERSION = "0.31.1".freeze
     end
   end
 end


### PR DESCRIPTION
* Remove focus from acceptance tests (#2490)

This pull request was generated using releasetool.