### PR TITLE
Releases 2018-10-01

### DIFF
--- a/google-cloud-dlp/CHANGELOG.md
+++ b/google-cloud-dlp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.6.3 / 2018-10-01
+
+* Update google-cloud-dlp generated files (#2481)
+* Re-generate library using google-cloud-dlp/synth.py (#2478)
+
 ### 0.6.2 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dlp"
-  gem.version       = "0.6.2"
+  gem.version       = "0.6.3"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.33.1 / 2018-10-01
+
+* Re-generate library using google-cloud-pubsub/synth.py (#2497)
+* Re-generate library using google-cloud-pubsub/synth.py (#2480)
+
 ### 0.33.0 / 2018-09-20
 
 * Add support for user labels to Snapshot, Subscription and Topic.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Pubsub
-      VERSION = "0.33.0".freeze
+      VERSION = "0.33.1".freeze
     end
   end
 end


### PR DESCRIPTION
Release google-cloud-pubsub 0.33.1

* Re-generate library using google-cloud-pubsub/synth.py (#2497)
* Re-generate library using google-cloud-pubsub/synth.py (#2480)

Release google-cloud-dlp 0.6.3

* Update google-cloud-dlp generated files (#2481)
* Re-generate library using google-cloud-dlp/synth.py (#2478)