### PR TITLE
Rename execute_query method

### DIFF
--- a/google-cloud-spanner/README.md
+++ b/google-cloud-spanner/README.md
@@ -28,7 +28,7 @@ spanner = Google::Cloud::Spanner.new
 db = spanner.client "my-instance", "my-database"
 
 db.transaction do |tx|
-  results = tx.execute "SELECT * FROM users"
+  results = tx.execute_query "SELECT * FROM users"
 
   results.rows.each do |row|
     puts "User #{row[:id]} is #{row[:name]}"

--- a/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
@@ -36,7 +36,7 @@ describe "Spanner Client", :crud, :spanner do
 
     active_count_sql = "SELECT COUNT(*) AS count FROM accounts WHERE active = true"
 
-    results = db.execute active_count_sql, single_use: { timestamp: timestamp }
+    results = db.execute_query active_count_sql, single_use: { timestamp: timestamp }
     results.rows.first[:count].must_equal 2
     results.timestamp.wont_be :nil?
 
@@ -44,7 +44,7 @@ describe "Spanner Client", :crud, :spanner do
 
     timestamp = db.upsert "accounts", activate_inactive_account
 
-    results = db.execute active_count_sql, single_use: { timestamp: timestamp }
+    results = db.execute_query active_count_sql, single_use: { timestamp: timestamp }
     results.rows.first[:count].must_equal 3
     results.timestamp.wont_be :nil?
 
@@ -72,7 +72,7 @@ describe "Spanner Client", :crud, :spanner do
 
     active_count_sql = "SELECT COUNT(*) AS count FROM accounts WHERE active = true"
 
-    results = db.execute active_count_sql, single_use: { timestamp: timestamp }
+    results = db.execute_query active_count_sql, single_use: { timestamp: timestamp }
     results.rows.first[:count].must_equal 2
     results.timestamp.wont_be :nil?
 
@@ -82,7 +82,7 @@ describe "Spanner Client", :crud, :spanner do
       c.upsert "accounts", activate_inactive_account
     end
 
-    results = db.execute active_count_sql, single_use: { timestamp: timestamp }
+    results = db.execute_query active_count_sql, single_use: { timestamp: timestamp }
     results.rows.first[:count].must_equal 3
     results.timestamp.wont_be :nil?
 
@@ -110,7 +110,7 @@ describe "Spanner Client", :crud, :spanner do
     timestamp = db.transaction do |tx|
       db.read("accounts", ["account_id"]).rows.count.must_equal 3
 
-      tx.execute(active_count_sql).rows.first[:count].must_equal 2
+      tx.execute_query(active_count_sql).rows.first[:count].must_equal 2
 
       activate_inactive_account = { account_id: 3, active: true }
 
@@ -118,7 +118,7 @@ describe "Spanner Client", :crud, :spanner do
     end
 
     timestamp = db.transaction do |tx|
-      tx.execute(active_count_sql).rows.first[:count].must_equal 3
+      tx.execute_query(active_count_sql).rows.first[:count].must_equal 3
 
       tx.delete "accounts", [1, 2, 3]
     end

--- a/google-cloud-spanner/acceptance/spanner/client/dml_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/dml_test.rb
@@ -30,7 +30,7 @@ describe "Spanner Client", :dml, :spanner do
   end
 
   it "executes multiple DML statements in a transaction" do
-    prior_results = db.execute "SELECT * FROM accounts"
+    prior_results = db.execute_sql "SELECT * FROM accounts"
     prior_results.rows.count.must_equal 3
 
     timestamp = db.transaction do |tx|
@@ -42,7 +42,7 @@ describe "Spanner Client", :dml, :spanner do
         params: { account_id: 4, username: "inserted", active: true, reputation: 88.8 }
       insert_row_count.must_equal 1
 
-      insert_results = tx.execute \
+      insert_results = tx.execute_sql \
         "SELECT username FROM accounts WHERE account_id = @account_id",
         params: { account_id: 4 }
       insert_rows = insert_results.rows.to_a
@@ -50,14 +50,14 @@ describe "Spanner Client", :dml, :spanner do
       insert_rows.first[:username].must_equal "inserted"
 
       # Execute a DML using execute_sql and make sure data is updated and correct count is returned.
-      update_results = tx.execute \
+      update_results = tx.execute_sql \
         "UPDATE accounts SET username = @username, active = @active WHERE account_id = @account_id",
         params: { account_id: 4, username: "updated", active: false }
       update_results.rows.to_a # fetch all the results
       update_results.must_be :row_count_exact?
       update_results.row_count.must_equal 1
 
-      update_results = tx.execute \
+      update_results = tx.execute_sql \
         "SELECT username FROM accounts WHERE account_id = @account_id",
         params: { account_id: 4 }
       update_rows = update_results.rows.to_a
@@ -66,12 +66,12 @@ describe "Spanner Client", :dml, :spanner do
     end
     timestamp.must_be_kind_of Time
 
-    post_results = db.execute "SELECT * FROM accounts", single_use: { timestamp: timestamp }
+    post_results = db.execute_sql "SELECT * FROM accounts", single_use: { timestamp: timestamp }
     post_results.rows.count.must_equal 4
   end
 
   it "executes a DML statement, then rollback the transaction" do
-    prior_results = db.execute "SELECT * FROM accounts"
+    prior_results = db.execute_sql "SELECT * FROM accounts"
     prior_results.rows.count.must_equal 3
 
     timestamp = db.transaction do |tx|
@@ -83,7 +83,7 @@ describe "Spanner Client", :dml, :spanner do
         params: { account_id: 4, username: "inserted", active: true, reputation: 88.8 }
       insert_row_count.must_equal 1
 
-      insert_results = tx.execute \
+      insert_results = tx.execute_sql \
         "SELECT username FROM accounts WHERE account_id = @account_id",
         params: { account_id: 4 }
       insert_rows = insert_results.rows.to_a
@@ -95,12 +95,12 @@ describe "Spanner Client", :dml, :spanner do
     end
     timestamp.must_be :nil? # because the transaction was rolled back
 
-    post_results = db.execute "SELECT * FROM accounts"
+    post_results = db.execute_sql "SELECT * FROM accounts"
     post_results.rows.count.must_equal 3
   end
 
   it "executes a DML statement, then a mutation" do
-    prior_results = db.execute "SELECT * FROM accounts"
+    prior_results = db.execute_sql "SELECT * FROM accounts"
     prior_results.rows.count.must_equal 3
 
     timestamp = db.transaction do |tx|
@@ -117,7 +117,7 @@ describe "Spanner Client", :dml, :spanner do
     end
     timestamp.must_be_kind_of Time
 
-    post_results = db.execute "SELECT * FROM accounts", single_use: { timestamp: timestamp }
+    post_results = db.execute_sql "SELECT * FROM accounts", single_use: { timestamp: timestamp }
     post_results.rows.count.must_equal 5
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/edge_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/edge_test.rb
@@ -60,19 +60,19 @@ describe "Spanner Client", :edge, :spanner do
 
   it "queries to a non-existing table fails" do
     assert_raises Google::Cloud::InvalidArgumentError do
-      db.execute "SELECT id, name FROM invalid_table"
+      db.execute_sql "SELECT id, name FROM invalid_table"
     end
   end
 
   it "queries to a non-existing column fails" do
     assert_raises Google::Cloud::InvalidArgumentError do
-      db.execute "SELECT id, name FROM #{table_name}"
+      db.execute_sql "SELECT id, name FROM #{table_name}"
     end
   end
 
   it "queries with bad SQL fails" do
     assert_raises Google::Cloud::InvalidArgumentError do
-      db.execute "SELECT Apples AND Oranges"
+      db.execute_sql "SELECT Apples AND Oranges"
     end
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/execute_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/execute_test.rb
@@ -14,11 +14,11 @@
 
 require "spanner_helper"
 
-describe "Spanner Client", :execute, :spanner do
+describe "Spanner Client", :execute_sql, :spanner do
   let(:db) { spanner_client }
 
   it "runs SELECT 1" do
-    results = db.execute "SELECT 1"
+    results = db.execute_sql "SELECT 1"
     results.must_be_kind_of Google::Cloud::Spanner::Results
 
     results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
@@ -34,7 +34,7 @@ describe "Spanner Client", :execute, :spanner do
   end
 
   it "runs a simple query" do
-    results = db.execute "SELECT 42 AS num"
+    results = db.execute_sql "SELECT 42 AS num"
     results.must_be_kind_of Google::Cloud::Spanner::Results
 
     results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
@@ -50,7 +50,7 @@ describe "Spanner Client", :execute, :spanner do
   end
 
   it "runs a simple query using a single-use strong option" do
-    results = db.execute "SELECT 42 AS num", single_use: { strong: true }
+    results = db.execute_sql "SELECT 42 AS num", single_use: { strong: true }
     results.must_be_kind_of Google::Cloud::Spanner::Results
 
     results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
@@ -66,7 +66,7 @@ describe "Spanner Client", :execute, :spanner do
   end
 
   it "runs a simple query using a single-use timestamp option" do
-    results = db.execute "SELECT 42 AS num", single_use: { timestamp: (Time.now - 60) }
+    results = db.execute_sql "SELECT 42 AS num", single_use: { timestamp: (Time.now - 60) }
     results.must_be_kind_of Google::Cloud::Spanner::Results
 
     results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
@@ -82,7 +82,7 @@ describe "Spanner Client", :execute, :spanner do
   end
 
   it "runs a simple query using a single-use staleness option" do
-    results = db.execute "SELECT 42 AS num", single_use: { staleness: 60 }
+    results = db.execute_sql "SELECT 42 AS num", single_use: { staleness: 60 }
     results.must_be_kind_of Google::Cloud::Spanner::Results
 
     results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
@@ -98,7 +98,7 @@ describe "Spanner Client", :execute, :spanner do
   end
 
   it "runs a simple query using a single-use bounded_timestamp option" do
-    results = db.execute "SELECT 42 AS num", single_use: { bounded_timestamp: (Time.now - 60) }
+    results = db.execute_sql "SELECT 42 AS num", single_use: { bounded_timestamp: (Time.now - 60) }
     results.must_be_kind_of Google::Cloud::Spanner::Results
 
     results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
@@ -114,7 +114,7 @@ describe "Spanner Client", :execute, :spanner do
   end
 
   it "runs a simple query using a single-use bounded_staleness option" do
-    results = db.execute "SELECT 42 AS num", single_use: { bounded_staleness: 60 }
+    results = db.execute_sql "SELECT 42 AS num", single_use: { bounded_staleness: 60 }
     results.must_be_kind_of Google::Cloud::Spanner::Results
 
     results.fields.must_be_kind_of Google::Cloud::Spanner::Fields

--- a/google-cloud-spanner/acceptance/spanner/client/large_data_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/large_data_test.rb
@@ -85,7 +85,7 @@ describe "Spanner Client", :large_data, :spanner do
   it "writes and queries bytes" do
     my_row = random_row
     db.upsert table_name, my_row
-    results = db.execute "SELECT id, string, byte, strings, bytes FROM #{table_name} WHERE id = @id", params: { id: my_row[:id] }
+    results = db.execute_sql "SELECT id, string, byte, strings, bytes FROM #{table_name} WHERE id = @id", params: { id: my_row[:id] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, string: :STRING, byte: :BYTES, strings: [:STRING], bytes: [:BYTES] })

--- a/google-cloud-spanner/acceptance/spanner/client/params/bool_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/bool_test.rb
@@ -18,7 +18,7 @@ describe "Spanner Client", :params, :bool, :spanner do
   let(:db) { spanner_client }
 
   it "queries and returns a bool parameter" do
-    results = db.execute "SELECT @value AS value", params: { value: true }
+    results = db.execute_query "SELECT @value AS value", params: { value: true }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :BOOL
@@ -26,7 +26,7 @@ describe "Spanner Client", :params, :bool, :spanner do
   end
 
   it "queries and returns a NULL bool parameter" do
-    results = db.execute "SELECT @value AS value", params: { value: nil }, types: { value: :BOOL }
+    results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: :BOOL }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :BOOL
@@ -34,7 +34,7 @@ describe "Spanner Client", :params, :bool, :spanner do
   end
 
   it "queries and returns an array of bool parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: [false, true, false] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [false, true, false] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:BOOL]
@@ -42,7 +42,7 @@ describe "Spanner Client", :params, :bool, :spanner do
   end
 
   it "queries and returns an array of bool parameters with a nil value" do
-    results = db.execute "SELECT @value AS value", params: { value: [nil, false, true, false] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [nil, false, true, false] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:BOOL]
@@ -50,7 +50,7 @@ describe "Spanner Client", :params, :bool, :spanner do
   end
 
   it "queries and returns an empty array of bool parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: [] }, types: { value: [:BOOL] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [] }, types: { value: [:BOOL] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:BOOL]
@@ -58,7 +58,7 @@ describe "Spanner Client", :params, :bool, :spanner do
   end
 
   it "queries and returns a NULL array of bool parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: nil }, types: { value: [:BOOL] }
+    results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: [:BOOL] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:BOOL]

--- a/google-cloud-spanner/acceptance/spanner/client/params/bytes_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/bytes_test.rb
@@ -18,7 +18,7 @@ describe "Spanner Client", :params, :bytes, :spanner do
   let(:db) { spanner_client }
 
   it "queries and returns a bytes parameter" do
-    results = db.execute "SELECT @value AS value", params: { value: StringIO.new("hello world!") }
+    results = db.execute_query "SELECT @value AS value", params: { value: StringIO.new("hello world!") }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :BYTES
@@ -28,7 +28,7 @@ describe "Spanner Client", :params, :bytes, :spanner do
   end
 
   it "queries and returns a NULL bytes parameter" do
-    results = db.execute "SELECT @value AS value", params: { value: nil }, types: { value: :BYTES }
+    results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: :BYTES }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :BYTES
@@ -36,7 +36,7 @@ describe "Spanner Client", :params, :bytes, :spanner do
   end
 
   it "queries and returns an array of bytes parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: [StringIO.new("foo"), StringIO.new("bar"), StringIO.new("baz")] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [StringIO.new("foo"), StringIO.new("bar"), StringIO.new("baz")] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:BYTES]
@@ -48,7 +48,7 @@ describe "Spanner Client", :params, :bytes, :spanner do
   end
 
   it "queries and returns an array of bytes parameters with a nil value" do
-    results = db.execute "SELECT @value AS value", params: { value: [nil, StringIO.new("foo"), StringIO.new("bar"), StringIO.new("baz")] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [nil, StringIO.new("foo"), StringIO.new("bar"), StringIO.new("baz")] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:BYTES]
@@ -61,7 +61,7 @@ describe "Spanner Client", :params, :bytes, :spanner do
   end
 
   it "queries and returns an empty array of bytes parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: [] }, types: { value: [:BYTES] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [] }, types: { value: [:BYTES] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:BYTES]
@@ -69,7 +69,7 @@ describe "Spanner Client", :params, :bytes, :spanner do
   end
 
   it "queries and returns a NULL array of bytes parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: nil }, types: { value: [:BYTES] }
+    results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: [:BYTES] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:BYTES]

--- a/google-cloud-spanner/acceptance/spanner/client/params/date_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/date_test.rb
@@ -19,7 +19,7 @@ describe "Spanner Client", :params, :date, :spanner do
   let(:date_value) { Date.today }
 
   it "queries and returns a date parameter" do
-    results = db.execute "SELECT @value AS value", params: { value: date_value }
+    results = db.execute_query "SELECT @value AS value", params: { value: date_value }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :DATE
@@ -27,7 +27,7 @@ describe "Spanner Client", :params, :date, :spanner do
   end
 
   it "queries and returns a NULL date parameter" do
-    results = db.execute "SELECT @value AS value", params: { value: nil }, types: { value: :DATE }
+    results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: :DATE }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :DATE
@@ -35,7 +35,7 @@ describe "Spanner Client", :params, :date, :spanner do
   end
 
   it "queries and returns an array of date parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: [(date_value - 1), date_value, (date_value + 1)] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [(date_value - 1), date_value, (date_value + 1)] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:DATE]
@@ -43,7 +43,7 @@ describe "Spanner Client", :params, :date, :spanner do
   end
 
   it "queries and returns an array of date parameters with a nil value" do
-    results = db.execute "SELECT @value AS value", params: { value: [nil, (date_value - 1), date_value, (date_value + 1)] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [nil, (date_value - 1), date_value, (date_value + 1)] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:DATE]
@@ -51,7 +51,7 @@ describe "Spanner Client", :params, :date, :spanner do
   end
 
   it "queries and returns an empty array of date parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: [] }, types: { value: [:DATE] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [] }, types: { value: [:DATE] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:DATE]
@@ -59,7 +59,7 @@ describe "Spanner Client", :params, :date, :spanner do
   end
 
   it "queries and returns a NULL array of date parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: nil }, types: { value: [:DATE] }
+    results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: [:DATE] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:DATE]

--- a/google-cloud-spanner/acceptance/spanner/client/params/float64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/float64_test.rb
@@ -18,7 +18,7 @@ describe "Spanner Client", :params, :float64, :spanner do
   let(:db) { spanner_client }
 
   it "queries and returns a float64 parameter" do
-    results = db.execute "SELECT @value AS value", params: { value: 12.0 }
+    results = db.execute_query "SELECT @value AS value", params: { value: 12.0 }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :FLOAT64
@@ -26,7 +26,7 @@ describe "Spanner Client", :params, :float64, :spanner do
   end
 
   it "queries and returns a float64 parameter (Infinity)" do
-    results = db.execute "SELECT @value AS value", params: { value: Float::INFINITY }
+    results = db.execute_query "SELECT @value AS value", params: { value: Float::INFINITY }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :FLOAT64
@@ -34,7 +34,7 @@ describe "Spanner Client", :params, :float64, :spanner do
   end
 
   it "queries and returns a float64 parameter (-Infinity)" do
-    results = db.execute "SELECT @value AS value", params: { value: -Float::INFINITY }
+    results = db.execute_query "SELECT @value AS value", params: { value: -Float::INFINITY }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :FLOAT64
@@ -42,7 +42,7 @@ describe "Spanner Client", :params, :float64, :spanner do
   end
 
   it "queries and returns a float64 parameter (-NaN)" do
-    results = db.execute "SELECT @value AS value", params: { value: Float::NAN }
+    results = db.execute_query "SELECT @value AS value", params: { value: Float::NAN }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :FLOAT64
@@ -52,7 +52,7 @@ describe "Spanner Client", :params, :float64, :spanner do
   end
 
   it "queries and returns a NULL float64 parameter" do
-    results = db.execute "SELECT @value AS value", params: { value: nil }, types: { value: :FLOAT64 }
+    results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: :FLOAT64 }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :FLOAT64
@@ -60,7 +60,7 @@ describe "Spanner Client", :params, :float64, :spanner do
   end
 
   it "queries and returns an array of float64 parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: [1.0, 2.2, 3.5] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [1.0, 2.2, 3.5] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:FLOAT64]
@@ -68,7 +68,7 @@ describe "Spanner Client", :params, :float64, :spanner do
   end
 
   it "queries and returns an array of special float64 parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: [Float::INFINITY, -Float::INFINITY, -Float::NAN] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [Float::INFINITY, -Float::INFINITY, -Float::NAN] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:FLOAT64]
@@ -80,7 +80,7 @@ describe "Spanner Client", :params, :float64, :spanner do
   end
 
   it "queries and returns an array of float64 parameters with a nil value" do
-    results = db.execute "SELECT @value AS value", params: { value: [nil, 1.0, 2.2, 3.5] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [nil, 1.0, 2.2, 3.5] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:FLOAT64]
@@ -88,7 +88,7 @@ describe "Spanner Client", :params, :float64, :spanner do
   end
 
   it "queries and returns an empty array of float64 parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: [] }, types: { value: [:FLOAT64] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [] }, types: { value: [:FLOAT64] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:FLOAT64]
@@ -96,7 +96,7 @@ describe "Spanner Client", :params, :float64, :spanner do
   end
 
   it "queries and returns a NULL array of float64 parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: nil }, types: { value: [:FLOAT64] }
+    results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: [:FLOAT64] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:FLOAT64]

--- a/google-cloud-spanner/acceptance/spanner/client/params/int64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/int64_test.rb
@@ -18,7 +18,7 @@ describe "Spanner Client", :params, :int64, :spanner do
   let(:db) { spanner_client }
 
   it "queries and returns a int64 parameter" do
-    results = db.execute "SELECT @value AS value", params: { value: 99 }
+    results = db.execute_query "SELECT @value AS value", params: { value: 99 }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :INT64
@@ -26,7 +26,7 @@ describe "Spanner Client", :params, :int64, :spanner do
   end
 
   it "queries and returns a NULL int64 parameter" do
-    results = db.execute "SELECT @value AS value", params: { value: nil }, types: { value: :INT64 }
+    results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: :INT64 }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :INT64
@@ -34,7 +34,7 @@ describe "Spanner Client", :params, :int64, :spanner do
   end
 
   it "queries and returns an array of int64 parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: [1, 2, 3] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [1, 2, 3] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:INT64]
@@ -42,7 +42,7 @@ describe "Spanner Client", :params, :int64, :spanner do
   end
 
   it "queries and returns an array of int64 parameters with a nil value" do
-    results = db.execute "SELECT @value AS value", params: { value: [nil, 1, 2, 3] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [nil, 1, 2, 3] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:INT64]
@@ -50,7 +50,7 @@ describe "Spanner Client", :params, :int64, :spanner do
   end
 
   it "queries and returns an empty array of int64 parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: [] }, types: { value: [:INT64] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [] }, types: { value: [:INT64] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:INT64]
@@ -58,7 +58,7 @@ describe "Spanner Client", :params, :int64, :spanner do
   end
 
   it "queries and returns a NULL array of int64 parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: nil }, types: { value: [:INT64] }
+    results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: [:INT64] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:INT64]

--- a/google-cloud-spanner/acceptance/spanner/client/params/string_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/string_test.rb
@@ -18,7 +18,7 @@ describe "Spanner Client", :params, :string, :spanner do
   let(:db) { spanner_client }
 
   it "queries and returns a string parameter" do
-    results = db.execute "SELECT @value AS value", params: { value: "hello" }
+    results = db.execute_query "SELECT @value AS value", params: { value: "hello" }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :STRING
@@ -26,7 +26,7 @@ describe "Spanner Client", :params, :string, :spanner do
   end
 
   it "queries and returns a NULL string parameter" do
-    results = db.execute "SELECT @value AS value", params: { value: nil }, types: { value: :STRING }
+    results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: :STRING }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :STRING
@@ -34,7 +34,7 @@ describe "Spanner Client", :params, :string, :spanner do
   end
 
   it "queries and returns an array of string parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: ["foo", "bar", "baz"] }
+    results = db.execute_query "SELECT @value AS value", params: { value: ["foo", "bar", "baz"] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:STRING]
@@ -42,7 +42,7 @@ describe "Spanner Client", :params, :string, :spanner do
   end
 
   it "queries and returns an array of string parameters with a nil value" do
-    results = db.execute "SELECT @value AS value", params: { value: [nil, "foo", "bar", "baz"] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [nil, "foo", "bar", "baz"] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:STRING]
@@ -50,7 +50,7 @@ describe "Spanner Client", :params, :string, :spanner do
   end
 
   it "queries and returns an empty array of string parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: [] }, types: { value: [:STRING] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [] }, types: { value: [:STRING] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:STRING]
@@ -58,7 +58,7 @@ describe "Spanner Client", :params, :string, :spanner do
   end
 
   it "queries and returns a NULL array of string parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: nil }, types: { value: [:STRING] }
+    results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: [:STRING] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:STRING]

--- a/google-cloud-spanner/acceptance/spanner/client/params/struct_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/struct_test.rb
@@ -115,8 +115,8 @@ describe "Spanner Client", :params, :struct, :spanner do
     # SELECT @struct_param=STRUCT<threadf INT64, userf STRING>(1,"bob");
     it "Equality check" do
       struct_value = db.fields(threadf: :INT64, userf: :STRING).struct([1, "bob"])
-      results = db.execute "SELECT @struct_param=STRUCT<threadf INT64, userf STRING>(1,\"bob\")",
-                           params: { struct_param: struct_value }
+      results = db.execute_query "SELECT @struct_param=STRUCT<threadf INT64, userf STRING>(1,\"bob\")",
+                                 params: { struct_param: struct_value }
 
       results.must_be_kind_of Google::Cloud::Spanner::Results
       results.fields.to_h.must_equal({ 0 => :BOOL })
@@ -128,9 +128,8 @@ describe "Spanner Client", :params, :struct, :spanner do
     # SELECT @struct_arr_param IS NULL;
     it "Nullness check" do
       struct_value = db.fields(threadf: :INT64, userf: :STRING).struct([1, "bob"])
-      results = db.execute "SELECT @struct_arr_param IS NULL",
-                           params: { struct_arr_param: [struct_value] }
-                           # params: { struct_arr_param: [{ threadf: 1, userf: "bob" }] }
+      results = db.execute_query "SELECT @struct_arr_param IS NULL",
+                                 params: { struct_arr_param: [struct_value] }
 
       results.must_be_kind_of Google::Cloud::Spanner::Results
       results.fields.to_h.must_equal({ 0 => :BOOL })
@@ -142,8 +141,8 @@ describe "Spanner Client", :params, :struct, :spanner do
     # SELECT a.threadid FROM UNNEST(@struct_param.arraysf) a;
     it "Null array of struct field" do
       struct_value = db.fields(intf: :INT64, arraysf: [db.fields(threadid: :INT64)]).struct([10, nil])
-      results = db.execute "SELECT a.threadid FROM UNNEST(@struct_param.arraysf) a",
-                           params: { struct_param: struct_value }
+      results = db.execute_query "SELECT a.threadid FROM UNNEST(@struct_param.arraysf) a",
+                                 params: { struct_param: struct_value }
 
       results.must_be_kind_of Google::Cloud::Spanner::Results
       results.fields.to_h.must_equal({ threadid: :INT64 })
@@ -155,9 +154,9 @@ describe "Spanner Client", :params, :struct, :spanner do
     # SELECT a.threadid FROM UNNEST(@struct_arr_param) a;
     it "Null array of struct" do
       struct_type = db.fields(threadid: :INT64)
-      results = db.execute "SELECT a.threadid FROM UNNEST(@struct_arr_param) a",
-                           params: { struct_arr_param: nil },
-                           types:  { struct_arr_param: [struct_type] }
+      results = db.execute_query "SELECT a.threadid FROM UNNEST(@struct_arr_param) a",
+                                 params: { struct_arr_param: nil },
+                                 types:  { struct_arr_param: [struct_type] }
 
       results.must_be_kind_of Google::Cloud::Spanner::Results
       results.fields.to_h.must_equal({ threadid: :INT64 })
@@ -174,7 +173,7 @@ describe "Spanner Client", :params, :struct, :spanner do
   end
 
   it "queries a struct parameter and returns string and integer" do
-    results = db.execute "SELECT @value.message AS message, @value.repeat AS repeat", params: { value: { message: "hello", repeat: 1 } }
+    results = db.execute_query "SELECT @value.message AS message, @value.repeat AS repeat", params: { value: { message: "hello", repeat: 1 } }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ message: :STRING, repeat: :INT64 })
@@ -183,7 +182,7 @@ describe "Spanner Client", :params, :struct, :spanner do
 
   it "queries and returns a struct array" do
     struct_sql = "SELECT ARRAY(SELECT AS STRUCT message, repeat FROM (SELECT 'hello' AS message, 1 AS repeat UNION ALL SELECT 'hola' AS message, 2 AS repeat))"
-    results = db.execute struct_sql
+    results = db.execute_query struct_sql
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ 0 => [db.fields(message: :STRING, repeat: :INT64)] })
@@ -192,7 +191,7 @@ describe "Spanner Client", :params, :struct, :spanner do
 
   it "queries and returns an empty struct array" do
     struct_sql = "SELECT ARRAY(SELECT AS STRUCT * FROM (SELECT 'empty', 0) WHERE 0 = 1)"
-    results = db.execute struct_sql
+    results = db.execute_query struct_sql
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ 0 => [db.fields(0 => :STRING, 1 => :INT64)] })

--- a/google-cloud-spanner/acceptance/spanner/client/params/timestamp_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/timestamp_test.rb
@@ -19,7 +19,7 @@ describe "Spanner Client", :params, :timestamp, :spanner do
   let(:timestamp_value) { Time.now }
 
   it "queries and returns a timestamp parameter" do
-    results = db.execute "SELECT @value AS value", params: { value: timestamp_value }
+    results = db.execute_query "SELECT @value AS value", params: { value: timestamp_value }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :TIMESTAMP
@@ -27,7 +27,7 @@ describe "Spanner Client", :params, :timestamp, :spanner do
   end
 
   it "queries and returns a NULL timestamp parameter" do
-    results = db.execute "SELECT @value AS value", params: { value: nil }, types: { value: :TIMESTAMP }
+    results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: :TIMESTAMP }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal :TIMESTAMP
@@ -35,7 +35,7 @@ describe "Spanner Client", :params, :timestamp, :spanner do
   end
 
   it "queries and returns an array of timestamp parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: [(timestamp_value - 180.0), timestamp_value, (timestamp_value - 240.0)] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [(timestamp_value - 180.0), timestamp_value, (timestamp_value - 240.0)] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:TIMESTAMP]
@@ -43,7 +43,7 @@ describe "Spanner Client", :params, :timestamp, :spanner do
   end
 
   it "queries and returns an array of timestamp parameters with a nil value" do
-    results = db.execute "SELECT @value AS value", params: { value: [nil, (timestamp_value - 180.0), timestamp_value, (timestamp_value - 240.0)] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [nil, (timestamp_value - 180.0), timestamp_value, (timestamp_value - 240.0)] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:TIMESTAMP]
@@ -51,7 +51,7 @@ describe "Spanner Client", :params, :timestamp, :spanner do
   end
 
   it "queries and returns an empty array of timestamp parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: [] }, types: { value: [:TIMESTAMP] }
+    results = db.execute_query "SELECT @value AS value", params: { value: [] }, types: { value: [:TIMESTAMP] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:TIMESTAMP]
@@ -59,7 +59,7 @@ describe "Spanner Client", :params, :timestamp, :spanner do
   end
 
   it "queries and returns an NULL array of timestamp parameters" do
-    results = db.execute "SELECT @value AS value", params: { value: nil }, types: { value: [:TIMESTAMP] }
+    results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: [:TIMESTAMP] }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields[:value].must_equal [:TIMESTAMP]
@@ -70,7 +70,7 @@ describe "Spanner Client", :params, :timestamp, :spanner do
     let(:datetime_value) { timestamp_value.to_datetime }
 
     it "queries and returns a timestamp parameter" do
-      results = db.execute "SELECT @value AS value", params: { value: datetime_value }
+      results = db.execute_query "SELECT @value AS value", params: { value: datetime_value }
 
       results.must_be_kind_of Google::Cloud::Spanner::Results
       results.fields[:value].must_equal :TIMESTAMP
@@ -78,7 +78,7 @@ describe "Spanner Client", :params, :timestamp, :spanner do
     end
 
     it "queries and returns an array of timestamp parameters" do
-      results = db.execute "SELECT @value AS value", params: { value: [(datetime_value - 1), datetime_value, (datetime_value + 1)] }
+      results = db.execute_query "SELECT @value AS value", params: { value: [(datetime_value - 1), datetime_value, (datetime_value + 1)] }
 
       results.must_be_kind_of Google::Cloud::Spanner::Results
       results.fields[:value].must_equal [:TIMESTAMP]
@@ -86,7 +86,7 @@ describe "Spanner Client", :params, :timestamp, :spanner do
     end
 
     it "queries and returns an array of timestamp parameters with a nil value" do
-      results = db.execute "SELECT @value AS value", params: { value: [nil, (datetime_value - 1), datetime_value, (datetime_value + 1)] }
+      results = db.execute_query "SELECT @value AS value", params: { value: [nil, (datetime_value - 1), datetime_value, (datetime_value + 1)] }
 
       results.must_be_kind_of Google::Cloud::Spanner::Results
       results.fields[:value].must_equal [:TIMESTAMP]

--- a/google-cloud-spanner/acceptance/spanner/client/pdml_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/pdml_test.rb
@@ -30,13 +30,13 @@ describe "Spanner Client", :pdml, :spanner do
   end
 
   it "executes a simple Partitioned DML statement" do
-    prior_results = db.execute "SELECT * FROM accounts WHERE active = TRUE"
+    prior_results = db.execute_sql "SELECT * FROM accounts WHERE active = TRUE"
     prior_results.rows.count.must_equal 2
 
     pdml_row_count = db.execute_partition_update "UPDATE accounts a SET a.active = TRUE WHERE a.active = FALSE"
     pdml_row_count.must_equal 1
 
-    post_results = db.execute "SELECT * FROM accounts WHERE active = TRUE", single_use: { strong: true }
+    post_results = db.execute_sql "SELECT * FROM accounts WHERE active = TRUE", single_use: { strong: true }
     post_results.rows.count.must_equal 3
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/single_use_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/single_use_test.rb
@@ -31,7 +31,7 @@ describe "Spanner Client", :single_use, :spanner do
   end
 
   it "runs a query with strong option" do
-    results = db.execute "SELECT * FROM accounts", single_use: { strong: true }
+    results = db.execute_sql "SELECT * FROM accounts", single_use: { strong: true }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal fields_hash
@@ -57,7 +57,7 @@ describe "Spanner Client", :single_use, :spanner do
   end
 
   it "runs a query with timestamp option" do
-    results = db.execute "SELECT * FROM accounts", single_use: { timestamp: @setup_timestamp }
+    results = db.execute_sql "SELECT * FROM accounts", single_use: { timestamp: @setup_timestamp }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal fields_hash
@@ -83,7 +83,7 @@ describe "Spanner Client", :single_use, :spanner do
   end
 
   it "runs a query with staleness option" do
-    results = db.execute "SELECT * FROM accounts", single_use: { staleness: 0.0001 }
+    results = db.execute_sql "SELECT * FROM accounts", single_use: { staleness: 0.0001 }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal fields_hash
@@ -109,7 +109,7 @@ describe "Spanner Client", :single_use, :spanner do
   end
 
   it "runs a query with bounded_timestamp option" do
-    results = db.execute "SELECT * FROM accounts", single_use: { bounded_timestamp: @setup_timestamp }
+    results = db.execute_sql "SELECT * FROM accounts", single_use: { bounded_timestamp: @setup_timestamp }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal fields_hash
@@ -135,7 +135,7 @@ describe "Spanner Client", :single_use, :spanner do
   end
 
   it "runs a query with bounded_staleness option" do
-    results = db.execute "SELECT * FROM accounts", single_use: { bounded_staleness: 0.0001 }
+    results = db.execute_sql "SELECT * FROM accounts", single_use: { bounded_staleness: 0.0001 }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal fields_hash

--- a/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
@@ -37,7 +37,7 @@ describe "Spanner Client", :snapshot, :spanner do
       snp.timestamp.wont_be :nil?
       snp.timestamp.must_be_close_to Time.now, 60
 
-      results = snp.execute "SELECT * FROM accounts"
+      results = snp.execute_sql "SELECT * FROM accounts"
     end
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
@@ -71,7 +71,7 @@ describe "Spanner Client", :snapshot, :spanner do
       snp.timestamp.wont_be :nil?
       snp.timestamp.must_be_close_to Time.now, 60
 
-      results = snp.execute "SELECT * FROM accounts"
+      results = snp.execute_sql "SELECT * FROM accounts"
     end
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
@@ -105,7 +105,7 @@ describe "Spanner Client", :snapshot, :spanner do
       snp.timestamp.wont_be :nil?
       snp.timestamp.must_be_close_to Time.now, 60
 
-      results = snp.execute "SELECT * FROM accounts"
+      results = snp.execute_sql "SELECT * FROM accounts"
     end
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
@@ -139,7 +139,7 @@ describe "Spanner Client", :snapshot, :spanner do
       snp.timestamp.wont_be :nil?
       snp.timestamp.must_be_close_to Time.now, 60
 
-      results = snp.execute "SELECT * FROM accounts"
+      results = snp.execute_sql "SELECT * FROM accounts"
     end
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
@@ -199,14 +199,14 @@ describe "Spanner Client", :snapshot, :spanner do
       snp.timestamp.wont_be :nil?
       snp.timestamp.must_be_close_to Time.now, 60
 
-      results = snp.execute "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: sample_row[:account_id] }
+      results = snp.execute_sql "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: sample_row[:account_id] }
       # verify we got the row we were expecting
       results.rows.first.to_h.must_equal sample_row
 
       # outside of the snapshot, update the row!
       db.update "accounts", modified_row
 
-      results2 = snp.execute "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: modified_row[:account_id] }
+      results2 = snp.execute_sql "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: modified_row[:account_id] }
       # verify we got the previous row, not the modified row
       results2.rows.first.to_h.must_equal sample_row
     end
@@ -245,14 +245,14 @@ describe "Spanner Client", :snapshot, :spanner do
       snp.timestamp.wont_be :nil?
       snp.timestamp.must_be_close_to Time.now, 60
 
-      results = snp.execute "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: sample_row[:account_id] }
+      results = snp.execute_sql "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: sample_row[:account_id] }
       # verify we got the row we were expecting
       results.rows.first.to_h.must_equal sample_row
 
       # outside of the snapshot, update the row!
       db.update "accounts", modified_row
 
-      results2 = snp.execute "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: modified_row[:account_id] }
+      results2 = snp.execute_sql "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: modified_row[:account_id] }
       # verify we got the previous row, not the modified row
       results2.rows.first.to_h.must_equal sample_row
     end
@@ -291,14 +291,14 @@ describe "Spanner Client", :snapshot, :spanner do
       snp.timestamp.wont_be :nil?
       snp.timestamp.must_be_close_to Time.now, 60
 
-      results = snp.execute "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: sample_row[:account_id] }
+      results = snp.execute_sql "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: sample_row[:account_id] }
       # verify we got the row we were expecting
       results.rows.first.to_h.must_equal sample_row
 
       # outside of the snapshot, update the row!
       db.update "accounts", modified_row
 
-      results2 = snp.execute "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: modified_row[:account_id] }
+      results2 = snp.execute_sql "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: modified_row[:account_id] }
       # verify we got the previous row, not the modified row
       results2.rows.first.to_h.must_equal sample_row
     end

--- a/google-cloud-spanner/acceptance/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/transaction_test.rb
@@ -169,7 +169,7 @@ describe "Spanner Client", :transaction, :spanner do
   end
 
   it "supports tx isolation with query and update" do
-    results = db.execute query_reputation
+    results = db.execute_sql query_reputation
     original_val = results.rows.first[:reputation]
     begin
       thr_1 = Thread.new do
@@ -183,7 +183,7 @@ describe "Spanner Client", :transaction, :spanner do
       thr_2.join
     end
 
-    results = db.execute query_reputation
+    results = db.execute_sql query_reputation
     results.rows.first[:reputation].must_equal original_val + 2
   end
 
@@ -199,7 +199,7 @@ describe "Spanner Client", :transaction, :spanner do
 
   def query_and_update db
     db.transaction do |tx|
-      tx_results = tx.execute query_reputation
+      tx_results = tx.execute_sql query_reputation
       tx_val = tx_results.rows.first[:reputation]
       sleep 1 # ensure that both threads would have read same value if not read locked
       new_val = tx_val + 1

--- a/google-cloud-spanner/acceptance/spanner/client/types/bool_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/bool_test.rb
@@ -31,7 +31,7 @@ describe "Spanner Client", :types, :bool, :spanner do
   it "writes and queries bool" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, bool: true }
-    results = db.execute "SELECT id, bool FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, bool FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, bool: :BOOL })
@@ -51,7 +51,7 @@ describe "Spanner Client", :types, :bool, :spanner do
   it "writes and queries NULL bool" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, bool: nil }
-    results = db.execute "SELECT id, bool FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, bool FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, bool: :BOOL })
@@ -71,7 +71,7 @@ describe "Spanner Client", :types, :bool, :spanner do
   it "writes and queries array of bool" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, bools: [true, false, true] }
-    results = db.execute "SELECT id, bools FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, bools FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, bools: [:BOOL] })
@@ -91,7 +91,7 @@ describe "Spanner Client", :types, :bool, :spanner do
   it "writes and queries array of bool with NULL" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, bools: [nil, true, false, true] }
-    results = db.execute "SELECT id, bools FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, bools FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, bools: [:BOOL] })
@@ -111,7 +111,7 @@ describe "Spanner Client", :types, :bool, :spanner do
   it "writes and queries empty array of bool" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, bools: [] }
-    results = db.execute "SELECT id, bools FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, bools FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, bools: [:BOOL] })
@@ -131,7 +131,7 @@ describe "Spanner Client", :types, :bool, :spanner do
   it "writes and queries NULL array of bool" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, bools: nil }
-    results = db.execute "SELECT id, bools FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, bools FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, bools: [:BOOL] })

--- a/google-cloud-spanner/acceptance/spanner/client/types/bytes_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/bytes_test.rb
@@ -33,7 +33,7 @@ describe "Spanner Client", :types, :bytes, :spanner do
   it "writes and queries bytes" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, byte: StringIO.new("hello") }
-    results = db.execute "SELECT id, byte FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, byte FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, byte: :BYTES })
@@ -60,7 +60,7 @@ describe "Spanner Client", :types, :bytes, :spanner do
     id = SecureRandom.int64
     random_bytes = StringIO.new(SecureRandom.random_bytes(rand(1024..4096)))
     db.upsert table_name, { id: id, byte: random_bytes }
-    results = db.execute "SELECT id, byte FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, byte FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, byte: :BYTES })
@@ -84,7 +84,7 @@ describe "Spanner Client", :types, :bytes, :spanner do
   it "writes and queries NULL bytes" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, byte: nil }
-    results = db.execute "SELECT id, byte FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, byte FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, byte: :BYTES })
@@ -111,7 +111,7 @@ describe "Spanner Client", :types, :bytes, :spanner do
   it "writes and queries array of bytes" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, bytes: [StringIO.new("howdy"), StringIO.new("hola"), StringIO.new("hello")] }
-    results = db.execute "SELECT id, bytes FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, bytes FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, bytes: [:BYTES] })
@@ -144,7 +144,7 @@ describe "Spanner Client", :types, :bytes, :spanner do
   it "writes and queries array of byte with NULL" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, bytes: [nil, StringIO.new("howdy"), StringIO.new("hola"), StringIO.new("hello")] }
-    results = db.execute "SELECT id, bytes FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, bytes FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, bytes: [:BYTES] })
@@ -171,7 +171,7 @@ describe "Spanner Client", :types, :bytes, :spanner do
   it "writes and queries empty array of byte" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, bytes: [] }
-    results = db.execute "SELECT id, bytes FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, bytes FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, bytes: [:BYTES] })
@@ -191,7 +191,7 @@ describe "Spanner Client", :types, :bytes, :spanner do
   it "writes and queries NULL array of byte" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, bytes: nil }
-    results = db.execute "SELECT id, bytes FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, bytes FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, bytes: [:BYTES] })

--- a/google-cloud-spanner/acceptance/spanner/client/types/date_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/date_test.rb
@@ -31,7 +31,7 @@ describe "Spanner Client", :types, :date, :spanner do
   it "writes and queries date" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, date: Date.parse("2017-01-01") }
-    results = db.execute "SELECT id, date FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, date FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, date: :DATE })
@@ -51,7 +51,7 @@ describe "Spanner Client", :types, :date, :spanner do
   it "writes and queries NULL date" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, date: nil }
-    results = db.execute "SELECT id, date FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, date FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, date: :DATE })
@@ -71,7 +71,7 @@ describe "Spanner Client", :types, :date, :spanner do
   it "writes and queries array of date" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, dates: [Date.parse("2016-12-30"), Date.parse("2016-12-31"), Date.parse("2017-01-01")] }
-    results = db.execute "SELECT id, dates FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, dates FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, dates: [:DATE] })
@@ -91,7 +91,7 @@ describe "Spanner Client", :types, :date, :spanner do
   it "writes and queries array of date with NULL" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, dates: [nil, Date.parse("2016-12-30"), Date.parse("2016-12-31"), Date.parse("2017-01-01")] }
-    results = db.execute "SELECT id, dates FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, dates FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, dates: [:DATE] })
@@ -111,7 +111,7 @@ describe "Spanner Client", :types, :date, :spanner do
   it "writes and queries empty array of date" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, dates: [] }
-    results = db.execute "SELECT id, dates FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, dates FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, dates: [:DATE] })
@@ -131,7 +131,7 @@ describe "Spanner Client", :types, :date, :spanner do
   it "writes and queries NULL array of date" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, dates: nil }
-    results = db.execute "SELECT id, dates FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, dates FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, dates: [:DATE] })

--- a/google-cloud-spanner/acceptance/spanner/client/types/float64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/float64_test.rb
@@ -31,7 +31,7 @@ describe "Spanner Client", :types, :float64, :spanner do
   it "writes and queries float64" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, float: 99.99 }
-    results = db.execute "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_sql "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
@@ -51,7 +51,7 @@ describe "Spanner Client", :types, :float64, :spanner do
   it "writes and queries Infinity float64" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, float: Float::INFINITY }
-    results = db.execute "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_sql "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
@@ -71,7 +71,7 @@ describe "Spanner Client", :types, :float64, :spanner do
   it "writes and queries -Infinity float64" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, float: -Float::INFINITY }
-    results = db.execute "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_sql "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
@@ -94,7 +94,7 @@ describe "Spanner Client", :types, :float64, :spanner do
   it "writes and queries NaN float64" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, float: Float::NAN }
-    results = db.execute "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_sql "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
@@ -117,7 +117,7 @@ describe "Spanner Client", :types, :float64, :spanner do
   it "writes and queries NULL float64" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, float: nil }
-    results = db.execute "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_sql "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
@@ -137,7 +137,7 @@ describe "Spanner Client", :types, :float64, :spanner do
   it "writes and queries array of float64" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, floats: [77.77, 88.88, 99.99] }
-    results = db.execute "SELECT id, floats FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_sql "SELECT id, floats FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, floats: [:FLOAT64] })
@@ -157,7 +157,7 @@ describe "Spanner Client", :types, :float64, :spanner do
   it "writes and queries array of float64 with NULL" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, floats: [nil, 77.77, 88.88, 99.99] }
-    results = db.execute "SELECT id, floats FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_sql "SELECT id, floats FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, floats: [:FLOAT64] })
@@ -177,7 +177,7 @@ describe "Spanner Client", :types, :float64, :spanner do
   it "writes and queries empty array of float64" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, floats: [] }
-    results = db.execute "SELECT id, floats FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_sql "SELECT id, floats FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, floats: [:FLOAT64] })
@@ -197,7 +197,7 @@ describe "Spanner Client", :types, :float64, :spanner do
   it "writes and queries NULL array of float64" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, floats: nil }
-    results = db.execute "SELECT id, floats FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_sql "SELECT id, floats FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, floats: [:FLOAT64] })

--- a/google-cloud-spanner/acceptance/spanner/client/types/int64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/int64_test.rb
@@ -31,7 +31,7 @@ describe "Spanner Client", :types, :int64, :spanner do
   it "writes and queries int64" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, int: 9999 }
-    results = db.execute "SELECT id, int FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, int FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, int: :INT64 })
@@ -51,7 +51,7 @@ describe "Spanner Client", :types, :int64, :spanner do
   it "writes and queries NULL int64" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, int: nil }
-    results = db.execute "SELECT id, int FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, int FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, int: :INT64 })
@@ -71,7 +71,7 @@ describe "Spanner Client", :types, :int64, :spanner do
   it "writes and queries array of int64" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, ints: [9997, 9998, 9999] }
-    results = db.execute "SELECT id, ints FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, ints FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, ints: [:INT64] })
@@ -91,7 +91,7 @@ describe "Spanner Client", :types, :int64, :spanner do
   it "writes and queries array of int64 with NULL" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, ints: [nil, 9997, 9998, 9999] }
-    results = db.execute "SELECT id, ints FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, ints FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, ints: [:INT64] })
@@ -111,7 +111,7 @@ describe "Spanner Client", :types, :int64, :spanner do
   it "writes and queries empty array of int64" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, ints: [] }
-    results = db.execute "SELECT id, ints FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, ints FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, ints: [:INT64] })
@@ -131,7 +131,7 @@ describe "Spanner Client", :types, :int64, :spanner do
   it "writes and queries NULL array of int64" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, ints: nil }
-    results = db.execute "SELECT id, ints FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, ints FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, ints: [:INT64] })

--- a/google-cloud-spanner/acceptance/spanner/client/types/string_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/string_test.rb
@@ -32,7 +32,7 @@ describe "Spanner Client", :types, :string, :spanner do
   it "writes and queries string" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, string: "hello" }
-    results = db.execute "SELECT id, string FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, string FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, string: :STRING })
@@ -52,7 +52,7 @@ describe "Spanner Client", :types, :string, :spanner do
   it "writes and queries NULL string" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, string: nil }
-    results = db.execute "SELECT id, string FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, string FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, string: :STRING })
@@ -72,7 +72,7 @@ describe "Spanner Client", :types, :string, :spanner do
   it "writes and queries array of string" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, strings: ["howdy", "hola", "hello"] }
-    results = db.execute "SELECT id, strings FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, strings FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, strings: [:STRING] })
@@ -92,7 +92,7 @@ describe "Spanner Client", :types, :string, :spanner do
   it "writes and queries array of string with NULL" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, strings: [nil, "howdy", "hola", "hello"] }
-    results = db.execute "SELECT id, strings FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, strings FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, strings: [:STRING] })
@@ -112,7 +112,7 @@ describe "Spanner Client", :types, :string, :spanner do
   it "writes and queries empty array of string" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, strings: [] }
-    results = db.execute "SELECT id, strings FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, strings FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, strings: [:STRING] })
@@ -132,7 +132,7 @@ describe "Spanner Client", :types, :string, :spanner do
   it "writes and queries NULL array of string" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, strings: nil }
-    results = db.execute "SELECT id, strings FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, strings FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, strings: [:STRING] })

--- a/google-cloud-spanner/acceptance/spanner/client/types/struct_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/struct_test.rb
@@ -21,7 +21,7 @@ describe "Spanner Client", :types, :struct, :spanner do
     nested_sql = "SELECT ARRAY(SELECT AS STRUCT C1, C2 " \
       "FROM (SELECT 'a' AS C1, 1 AS C2 UNION ALL SELECT 'b' AS C1, 2 AS C2) " \
       "ORDER BY C1 ASC)"
-    results = db.execute nested_sql
+    results = db.execute_query nested_sql
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ 0 => [db.fields(C1: :STRING, C2: :INT64)] })
@@ -30,7 +30,7 @@ describe "Spanner Client", :types, :struct, :spanner do
 
   it "queries an empty struct" do
     empty_sql = "SELECT ARRAY(SELECT AS STRUCT * FROM (SELECT 'a', 1) WHERE 0 = 1)"
-    results = db.execute empty_sql
+    results = db.execute_query empty_sql
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ 0 => [db.fields(0 => :STRING, 1 => :INT64)] })

--- a/google-cloud-spanner/acceptance/spanner/client/types/timestamp_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/timestamp_test.rb
@@ -42,7 +42,7 @@ describe "Spanner Client", :types, :timestamp, :spanner do
   it "writes and queries timestamp" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, timestamp: Time.parse("2017-01-01 00:00:00Z") }
-    results = db.execute "SELECT id, timestamp FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, timestamp FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, timestamp: :TIMESTAMP })
@@ -52,7 +52,7 @@ describe "Spanner Client", :types, :timestamp, :spanner do
   it "writes and queries commit_timestamp timestamp" do
     id = SecureRandom.int64
     commit_timestamp = db.upsert table_name, { id: id, timestamp: db.commit_timestamp }
-    results = db.execute "SELECT id, timestamp FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, timestamp FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, timestamp: :TIMESTAMP })
@@ -72,7 +72,7 @@ describe "Spanner Client", :types, :timestamp, :spanner do
   it "writes and queries NULL timestamp" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, timestamp: nil }
-    results = db.execute "SELECT id, timestamp FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, timestamp FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, timestamp: :TIMESTAMP })
@@ -92,7 +92,7 @@ describe "Spanner Client", :types, :timestamp, :spanner do
   it "writes and queries array of timestamp" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, timestamps: [Time.parse("2016-12-30 00:00:00Z"), Time.parse("2016-12-31 00:00:00Z"), Time.parse("2017-01-01 00:00:00Z")] }
-    results = db.execute "SELECT id, timestamps FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, timestamps FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
@@ -112,7 +112,7 @@ describe "Spanner Client", :types, :timestamp, :spanner do
   it "writes and queries array of timestamp with NULL" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, timestamps: [nil, Time.parse("2016-12-30 00:00:00Z"), Time.parse("2016-12-31 00:00:00Z"), Time.parse("2017-01-01 00:00:00Z")] }
-    results = db.execute "SELECT id, timestamps FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, timestamps FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
@@ -132,7 +132,7 @@ describe "Spanner Client", :types, :timestamp, :spanner do
   it "writes and queries empty array of timestamp" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, timestamps: [] }
-    results = db.execute "SELECT id, timestamps FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, timestamps FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
@@ -152,7 +152,7 @@ describe "Spanner Client", :types, :timestamp, :spanner do
   it "writes and queries NULL array of timestamp" do
     id = SecureRandom.int64
     db.upsert table_name, { id: id, timestamps: nil }
-    results = db.execute "SELECT id, timestamps FROM #{table_name} WHERE id = @id", params: { id: id }
+    results = db.execute_query "SELECT id, timestamps FROM #{table_name} WHERE id = @id", params: { id: id }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -42,7 +42,7 @@ module Google
       #   db = spanner.client "my-instance", "my-database"
       #
       #   db.transaction do |tx|
-      #     results = tx.execute "SELECT * FROM users"
+      #     results = tx.execute_query "SELECT * FROM users"
       #
       #     results.rows.each do |row|
       #       puts "User #{row[:id]} is #{row[:name]}"
@@ -218,7 +218,7 @@ module Google
         #
         #   db = spanner.client "my-instance", "my-database"
         #
-        #   results = db.execute "SELECT * FROM users"
+        #   results = db.execute_query "SELECT * FROM users"
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}"
@@ -231,8 +231,10 @@ module Google
         #
         #   db = spanner.client "my-instance", "my-database"
         #
-        #   results = db.execute "SELECT * FROM users WHERE active = @active",
-        #                        params: { active: true }
+        #   results = db.execute_query(
+        #     "SELECT * FROM users WHERE active = @active",
+        #     params: { active: true }
+        #   )
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}"
@@ -247,11 +249,13 @@ module Google
         #
         #   user_hash = { id: 1, name: "Charlie", active: false }
         #
-        #   results = db.execute "SELECT * FROM users WHERE " \
-        #                        "ID = @user_struct.id " \
-        #                        "AND name = @user_struct.name " \
-        #                        "AND active = @user_struct.active",
-        #                        params: { user_struct: user_hash }
+        #   results = db.execute_query(
+        #     "SELECT * FROM users WHERE " \
+        #     "ID = @user_struct.id " \
+        #     "AND name = @user_struct.name " \
+        #     "AND active = @user_struct.active",
+        #     params: { user_struct: user_hash }
+        #   )
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}"
@@ -267,12 +271,14 @@ module Google
         #   user_type = db.fields id: :INT64, name: :STRING, active: :BOOL
         #   user_hash = { id: 1, name: nil, active: false }
         #
-        #   results = db.execute "SELECT * FROM users WHERE " \
-        #                        "ID = @user_struct.id " \
-        #                        "AND name = @user_struct.name " \
-        #                        "AND active = @user_struct.active",
-        #                        params: { user_struct: user_hash },
-        #                        types: { user_struct: user_type }
+        #   results = db.execute_query(
+        #     "SELECT * FROM users WHERE " \
+        #     "ID = @user_struct.id " \
+        #     "AND name = @user_struct.name " \
+        #     "AND active = @user_struct.active",
+        #     params: { user_struct: user_hash },
+        #     types: { user_struct: user_type }
+        #   )
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}"
@@ -288,17 +294,19 @@ module Google
         #   user_type = db.fields id: :INT64, name: :STRING, active: :BOOL
         #   user_data = user_type.struct id: 1, name: nil, active: false
         #
-        #   results = db.execute "SELECT * FROM users WHERE " \
-        #                        "ID = @user_struct.id " \
-        #                        "AND name = @user_struct.name " \
-        #                        "AND active = @user_struct.active",
-        #                        params: { user_struct: user_data }
+        #   results = db.execute_query(
+        #     "SELECT * FROM users WHERE " \
+        #     "ID = @user_struct.id " \
+        #     "AND name = @user_struct.name " \
+        #     "AND active = @user_struct.active",
+        #     params: { user_struct: user_data }
+        #   )
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}"
         #   end
         #
-        def execute sql, params: nil, types: nil, single_use: nil
+        def execute_query sql, params: nil, types: nil, single_use: nil
           validate_single_use_args! single_use
           ensure_service!
 
@@ -307,12 +315,14 @@ module Google
           single_use_tx = single_use_transaction single_use
           results = nil
           @pool.with_session do |session|
-            results = session.execute \
+            results = session.execute_query \
               sql, params: params, types: types, transaction: single_use_tx
           end
           results
         end
-        alias query execute
+        alias execute execute_query
+        alias query execute_query
+        alias execute_sql execute_query
 
         ##
         # Executes a Partitioned DML SQL statement.
@@ -478,7 +488,7 @@ module Google
 
           results = nil
           @pool.with_session do |session|
-            results = session.execute \
+            results = session.execute_query \
               sql, params: params, types: types,
                    transaction: pdml_transaction(session)
           end
@@ -495,7 +505,7 @@ module Google
 
         ##
         # Read rows from a database table, as a simple alternative to
-        # {#execute}.
+        # {#execute_query}.
         #
         # @param [String] table The name of the table in the database to be
         #   read.
@@ -943,7 +953,7 @@ module Google
         #   db = spanner.client "my-instance", "my-database"
         #
         #   db.transaction do |tx|
-        #     results = tx.execute "SELECT * FROM users"
+        #     results = tx.execute_query "SELECT * FROM users"
         #
         #     results.rows.each do |row|
         #       puts "User #{row[:id]} is #{row[:name]}"
@@ -1062,7 +1072,7 @@ module Google
         #   db = spanner.client "my-instance", "my-database"
         #
         #   db.snapshot do |snp|
-        #     results = snp.execute "SELECT * FROM users"
+        #     results = snp.execute_query "SELECT * FROM users"
         #
         #     results.rows.each do |row|
         #       puts "User #{row[:id]} is #{row[:name]}"
@@ -1191,7 +1201,7 @@ module Google
         #             types: users_types
         #
         def fields_for table
-          execute("SELECT * FROM #{table} WHERE 1 = 0").fields
+          execute_query("SELECT * FROM #{table} WHERE 1 = 0").fields
         end
 
         ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/data.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/data.rb
@@ -34,7 +34,7 @@ module Google
       #
       #   db = spanner.client "my-instance", "my-database"
       #
-      #   results = db.execute "SELECT * FROM users"
+      #   results = db.execute_query "SELECT * FROM users"
       #
       #   results.rows.each do |row|
       #     puts "User #{row[:id]} is #{row[:name]}"

--- a/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
@@ -33,7 +33,7 @@ module Google
       #
       #   db = spanner.client "my-instance", "my-database"
       #
-      #   results = db.execute "SELECT * FROM users"
+      #   results = db.execute_query "SELECT * FROM users"
       #
       #   results.fields.pairs.each do |name, type|
       #     puts "Column #{name} is type #{type}"

--- a/google-cloud-spanner/lib/google/cloud/spanner/partition.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/partition.rb
@@ -52,11 +52,15 @@ module Google
         def initialize; end
 
         ##
-        # Whether the partition was created for an execute/query operation.
+        # Whether the partition was created for an execute_query/query
+        # operation.
         # @return [Boolean]
-        def execute?
+        def execute_query?
           !@execute.nil?
         end
+        alias execute? execute_query?
+        alias execute_sql? execute_query?
+        alias query? execute_query?
 
         ##
         # Whether the partition was created for a read operation.
@@ -67,7 +71,8 @@ module Google
 
         ##
         # @private
-        # Whether the partition does not have an execute or read operation.
+        # Whether the partition does not have an execute_query or read
+        # operation.
         # @return [Boolean]
         def empty?
           @execute.nil? && @read.nil?
@@ -84,7 +89,7 @@ module Google
         def to_h
           {}.tap do |h|
             h[:execute] = Base64.strict_encode64(@execute.to_proto) if @execute
-            h[:read] = Base64.strict_encode64(@read.to_proto) if @read
+            h[:read]    = Base64.strict_encode64(@read.to_proto)    if @read
           end
         end
 
@@ -163,12 +168,14 @@ module Google
         def self.load data
           data = JSON.parse data, symbolize_names: true unless data.is_a? Hash
 
-          # TODO: raise if hash[:execute].nil? && hash[:read].nil?
+          # TODO: raise if hash[:execute_query].nil? && hash[:read].nil?
           new.tap do |p|
             if data[:execute]
-              execute_grpc = Google::Spanner::V1::ExecuteSqlRequest.decode \
-                Base64.decode64(data[:execute])
-              p.instance_variable_set :@execute, execute_grpc
+              execute_sql_grpc = \
+                Google::Spanner::V1::ExecuteSqlRequest.decode(
+                  Base64.decode64(data[:execute])
+                )
+              p.instance_variable_set :@execute, execute_sql_grpc
             end
             if data[:read]
               read_grpc = Google::Spanner::V1::ReadRequest.decode \
@@ -189,7 +196,7 @@ module Google
         ##
         # @private New Partition from a Google::Spanner::V1::ExecuteSqlRequest
         # object.
-        def self.from_execute_grpc grpc
+        def self.from_execute_sql_grpc grpc
           new.tap do |p|
             p.instance_variable_set :@execute, grpc
           end

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -58,7 +58,7 @@ module Google
       #   db = spanner.client "my-instance", "my-database"
       #
       #   db.transaction do |tx|
-      #     results = tx.execute "SELECT * FROM users"
+      #     results = tx.execute_query "SELECT * FROM users"
       #
       #     results.rows.each do |row|
       #       puts "User #{row[:id]} is #{row[:name]}"
@@ -463,7 +463,7 @@ module Google
         #   db = spanner.client "my-instance", "my-database"
         #
         #   db.transaction do |tx|
-        #     results = tx.execute "SELECT * FROM users"
+        #     results = tx.execute_query "SELECT * FROM users"
         #
         #     results.rows.each do |row|
         #       puts "User #{row[:id]} is #{row[:name]}"

--- a/google-cloud-spanner/lib/google/cloud/spanner/results.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/results.rb
@@ -24,7 +24,7 @@ module Google
       #
       # Represents the result set from an operation returning data.
       #
-      # See {Google::Cloud::Spanner::Client#execute} and
+      # See {Google::Cloud::Spanner::Client#execute_query} and
       # {Google::Cloud::Spanner::Client#read}.
       #
       # @example
@@ -34,7 +34,7 @@ module Google
       #
       #   db = spanner.client "my-instance", "my-database"
       #
-      #   results = db.execute "SELECT * FROM users"
+      #   results = db.execute_query "SELECT * FROM users"
       #
       #   results.fields.pairs.each do |name, type|
       #     puts "Column #{name} is type #{type}"
@@ -63,7 +63,7 @@ module Google
         #
         #   db = spanner.client "my-instance", "my-database"
         #
-        #   results = db.execute "SELECT * FROM users"
+        #   results = db.execute_query "SELECT * FROM users"
         #
         #   results.fields.pairs.each do |name, type|
         #     puts "Column #{name} is type #{type}"
@@ -88,7 +88,7 @@ module Google
         #
         #   db = spanner.client "my-instance", "my-database"
         #
-        #   results = db.execute "SELECT * FROM users"
+        #   results = db.execute_query "SELECT * FROM users"
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}"
@@ -151,10 +151,10 @@ module Google
               end
 
               # Resume the stream from the last known resume_token
-              if @execute_options
-                @enum = @service.streaming_execute_sql \
+              if @execute_query_options
+                @enum = @service.execute_streaming_sql \
                   @session_path, @sql,
-                  @execute_options.merge(resume_token: resume_token)
+                  @execute_query_options.merge(resume_token: resume_token)
               else
                 @enum = @service.streaming_read_table \
                   @session_path, @table, @columns,
@@ -237,17 +237,21 @@ module Google
         end
 
         # @private
-        def self.execute service, session_path, sql, params: nil, types: nil,
-                         transaction: nil, partition_token: nil, seqno: nil
-          execute_options = { transaction: transaction, params: params,
-                              types: types, partition_token: partition_token,
-                              seqno: seqno }
-          enum = service.streaming_execute_sql session_path, sql,
-                                               execute_options
+
+        def self.execute_query service, session_path, sql, params: nil,
+                               types: nil, transaction: nil,
+                               partition_token: nil, seqno: nil
+          execute_query_options = {
+            transaction: transaction, params: params, types: types,
+            partition_token: partition_token, seqno: seqno
+          }
+          enum = service.execute_streaming_sql session_path, sql,
+                                               execute_query_options
           from_enum(enum, service).tap do |results|
-            results.instance_variable_set :@session_path,    session_path
-            results.instance_variable_set :@sql,             sql
-            results.instance_variable_set :@execute_options, execute_options
+            results.instance_variable_set :@session_path, session_path
+            results.instance_variable_set :@sql,          sql
+            results.instance_variable_set :@execute_query_options,
+                                          execute_query_options
           end
         end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -257,7 +257,7 @@ module Google
           end
         end
 
-        def streaming_execute_sql session_name, sql, transaction: nil,
+        def execute_streaming_sql session_name, sql, transaction: nil,
                                   params: nil, types: nil, resume_token: nil,
                                   partition_token: nil, seqno: nil
           opts = default_options_from_session session_name

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -164,7 +164,7 @@ module Google
         #
         #   db = spanner.client "my-instance", "my-database"
         #
-        #   results = db.execute "SELECT * FROM users"
+        #   results = db.execute_query "SELECT * FROM users"
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}"
@@ -177,8 +177,10 @@ module Google
         #
         #   db = spanner.client "my-instance", "my-database"
         #
-        #   results = db.execute "SELECT * FROM users WHERE active = @active",
-        #                        params: { active: true }
+        #   results = db.execute_query(
+        #     "SELECT * FROM users WHERE active = @active",
+        #     params: { active: true }
+        #   )
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}"
@@ -193,11 +195,13 @@ module Google
         #
         #   user_hash = { id: 1, name: "Charlie", active: false }
         #
-        #   results = db.execute "SELECT * FROM users WHERE " \
-        #                        "ID = @user_struct.id " \
-        #                        "AND name = @user_struct.name " \
-        #                        "AND active = @user_struct.active",
-        #                        params: { user_struct: user_hash }
+        #   results = db.execute_query(
+        #     "SELECT * FROM users WHERE " \
+        #     "ID = @user_struct.id " \
+        #     "AND name = @user_struct.name " \
+        #     "AND active = @user_struct.active",
+        #     params: { user_struct: user_hash }
+        #   )
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}"
@@ -213,12 +217,14 @@ module Google
         #   user_type = db.fields id: :INT64, name: :STRING, active: :BOOL
         #   user_hash = { id: 1, name: nil, active: false }
         #
-        #   results = db.execute "SELECT * FROM users WHERE " \
-        #                        "ID = @user_struct.id " \
-        #                        "AND name = @user_struct.name " \
-        #                        "AND active = @user_struct.active",
-        #                        params: { user_struct: user_hash },
-        #                        types: { user_struct: user_type }
+        #   results = db.execute_query(
+        #     "SELECT * FROM users WHERE " \
+        #     "ID = @user_struct.id " \
+        #     "AND name = @user_struct.name " \
+        #     "AND active = @user_struct.active",
+        #     params: { user_struct: user_hash },
+        #     types: { user_struct: user_type }
+        #   )
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}"
@@ -234,32 +240,35 @@ module Google
         #   user_type = db.fields id: :INT64, name: :STRING, active: :BOOL
         #   user_data = user_type.struct id: 1, name: nil, active: false
         #
-        #   results = db.execute "SELECT * FROM users WHERE " \
-        #                        "ID = @user_struct.id " \
-        #                        "AND name = @user_struct.name " \
-        #                        "AND active = @user_struct.active",
-        #                        params: { user_struct: user_struct }
+        #   results = db.execute_query(
+        #     "SELECT * FROM users WHERE " \
+        #     "ID = @user_struct.id " \
+        #     "AND name = @user_struct.name " \
+        #     "AND active = @user_struct.active",
+        #     params: { user_struct: user_struct }
+        #   )
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}"
         #   end
         #
-        def execute sql, params: nil, types: nil, transaction: nil,
-                    partition_token: nil, seqno: nil
+        def execute_query sql, params: nil, types: nil, transaction: nil,
+                          partition_token: nil, seqno: nil
           ensure_service!
 
-          results = Results.execute service, path, sql,
-                                    params: params, types: types,
-                                    transaction: transaction,
-                                    partition_token: partition_token,
-                                    seqno: seqno
+          results = Results.execute_query service, path, sql,
+                                          params: params,
+                                          types: types,
+                                          transaction: transaction,
+                                          partition_token: partition_token,
+                                          seqno: seqno
           @last_updated_at = Time.now
           results
         end
 
         ##
         # Read rows from a database table, as a simple alternative to
-        # {#execute}.
+        # {#execute_query}.
         #
         # @param [String] table The name of the table in the database to be
         #   read.
@@ -615,7 +624,7 @@ module Google
         # Keeps the session alive by executing `"SELECT 1"`.
         def keepalive!
           ensure_service!
-          execute "SELECT 1"
+          execute_query "SELECT 1"
           return true
         rescue Google::Cloud::NotFoundError
           labels = @grpc.labels.to_h unless @grpc.labels.to_h.empty?

--- a/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
@@ -33,7 +33,7 @@ module Google
       #   db = spanner.client "my-instance", "my-database"
       #
       #   db.snapshot do |snp|
-      #     results = snp.execute "SELECT * FROM users"
+      #     results = snp.execute_query "SELECT * FROM users"
       #
       #     results.rows.each do |row|
       #       puts "User #{row[:id]} is #{row[:name]}"
@@ -128,7 +128,7 @@ module Google
         #   db = spanner.client "my-instance", "my-database"
         #
         #   db.snapshot do |snp|
-        #     results = snp.execute "SELECT * FROM users"
+        #     results = snp.execute_query "SELECT * FROM users"
         #
         #     results.rows.each do |row|
         #       puts "User #{row[:id]} is #{row[:name]}"
@@ -142,7 +142,7 @@ module Google
         #   db = spanner.client "my-instance", "my-database"
         #
         #   db.snapshot do |snp|
-        #     results = snp.execute "SELECT * FROM users " \
+        #     results = snp.execute_query "SELECT * FROM users " \
         #                           "WHERE active = @active",
         #                           params: { active: true }
         #
@@ -160,11 +160,13 @@ module Google
         #   db.snapshot do |snp|
         #      user_hash = { id: 1, name: "Charlie", active: false }
         #
-        #     results = snp.execute "SELECT * FROM users WHERE " \
-        #                           "ID = @user_struct.id " \
-        #                           "AND name = @user_struct.name " \
-        #                           "AND active = @user_struct.active",
-        #                           params: { user_struct: user_hash }
+        #     results = snp.execute_query(
+        #       "SELECT * FROM users WHERE " \
+        #       "ID = @user_struct.id " \
+        #       "AND name = @user_struct.name " \
+        #       "AND active = @user_struct.active",
+        #       params: { user_struct: user_hash }
+        #     )
         #
         #     results.rows.each do |row|
         #       puts "User #{row[:id]} is #{row[:name]}"
@@ -181,12 +183,14 @@ module Google
         #      user_type = snp.fields id: :INT64, name: :STRING, active: :BOOL
         #      user_hash = { id: 1, name: nil, active: false }
         #
-        #     results = snp.execute "SELECT * FROM users WHERE " \
-        #                           "ID = @user_struct.id " \
-        #                           "AND name = @user_struct.name " \
-        #                           "AND active = @user_struct.active",
-        #                           params: { user_struct: user_hash },
-        #                           types: { user_struct: user_type }
+        #     results = snp.execute_query(
+        #       "SELECT * FROM users WHERE " \
+        #       "ID = @user_struct.id " \
+        #       "AND name = @user_struct.name " \
+        #       "AND active = @user_struct.active",
+        #       params: { user_struct: user_hash },
+        #       types: { user_struct: user_type }
+        #     )
         #
         #     results.rows.each do |row|
         #       puts "User #{row[:id]} is #{row[:name]}"
@@ -203,30 +207,34 @@ module Google
         #      user_type = snp.fields id: :INT64, name: :STRING, active: :BOOL
         #   user_data = user_type.struct id: 1, name: nil, active: false
         #
-        #     results = snp.execute "SELECT * FROM users WHERE " \
-        #                           "ID = @user_struct.id " \
-        #                           "AND name = @user_struct.name " \
-        #                           "AND active = @user_struct.active",
-        #                           params: { user_struct: user_data }
+        #     results = snp.execute_query(
+        #       "SELECT * FROM users WHERE " \
+        #       "ID = @user_struct.id " \
+        #       "AND name = @user_struct.name " \
+        #       "AND active = @user_struct.active",
+        #       params: { user_struct: user_data }
+        #     )
         #
         #     results.rows.each do |row|
         #       puts "User #{row[:id]} is #{row[:name]}"
         #     end
         #   end
         #
-        def execute sql, params: nil, types: nil
+        def execute_query sql, params: nil, types: nil
           ensure_session!
 
           params, types = Convert.to_input_params_and_types params, types
 
-          session.execute sql, params: params, types: types,
-                               transaction: tx_selector
+          session.execute_query sql, params: params, types: types,
+                                     transaction: tx_selector
         end
-        alias query execute
+        alias execute execute_query
+        alias query execute_query
+        alias execute_sql execute_query
 
         ##
         # Read rows from a database table, as a simple alternative to
-        # {#execute}.
+        # {#execute_query}.
         #
         # @param [String] table The name of the table in the database to be
         #   read.

--- a/google-cloud-spanner/support/doctest_helper.rb
+++ b/google-cloud-spanner/support/doctest_helper.rb
@@ -249,7 +249,31 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Spanner::BatchSnapshot#execute_sql" do
+    mock_spanner do |mock, mock_instances, mock_databases|
+      20.times do
+        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      end
+      5.times do
+        mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
+      end
+      mock.expect :execute_streaming_sql, results_enum, ["session-name", String, Hash]
+      mock.expect :commit, commit_resp, ["session-name", Array, Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Spanner::BatchSnapshot#execute_partition" do
+    mock_spanner do |mock, mock_instances, mock_databases|
+      mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
+      mock.expect :partition_read, OpenStruct.new(partitions: [Google::Spanner::V1::Partition.new(partition_token: "partition-token")]),
+                  ["session-name", "users", Google::Spanner::V1::KeySet, Hash]
+      mock.expect :streaming_read, results_enum, ["session-name", "users", ["id", "name"], Google::Spanner::V1::KeySet, Hash]
+      mock.expect :delete_session, session_grpc, ["session-name", Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Spanner::BatchSnapshot#execute_sql_partition" do
     mock_spanner do |mock, mock_instances, mock_databases|
       mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
@@ -409,6 +433,15 @@ YARD::Doctest.configure do |doctest|
   end
 
   doctest.before "Google::Cloud::Spanner::Client#execute" do
+    mock_spanner do |mock, mock_instances, mock_databases|
+      20.times do
+        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      end
+      mock.expect :execute_streaming_sql, results_enum, ["session-name", String, Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Spanner::Client#execute_sql" do
     mock_spanner do |mock, mock_instances, mock_databases|
       20.times do
         mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
@@ -679,6 +712,19 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Spanner::Snapshot#execute_sql@Query using query parameters:" do
+    mock_spanner do |mock, mock_instances, mock_databases|
+      20.times do
+        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      end
+      5.times do
+        mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
+      end
+      mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users WHERE active = @active", Hash]
+      mock.expect :commit, commit_resp, ["session-name", Array, Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Spanner::Snapshot#range" do
     mock_spanner do |mock, mock_instances, mock_databases|
       20.times do
@@ -742,6 +788,19 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Spanner::Transaction#execute_sql" do
+    mock_spanner do |mock, mock_instances, mock_databases|
+      20.times do
+        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      end
+      5.times do
+        mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
+      end
+      mock.expect :execute_streaming_sql, results_enum, ["session-name", String, Hash]
+      mock.expect :commit, commit_resp, ["session-name", Array, Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Spanner::Transaction#execute_update" do
     mock_spanner do |mock, mock_instances, mock_databases|
       20.times do
@@ -751,6 +810,19 @@ YARD::Doctest.configure do |doctest|
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
       mock.expect :execute_streaming_sql, results_enum, ["session-name", String, Hash]
+      mock.expect :commit, commit_resp, ["session-name", Array, Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Spanner::Transaction#execute_sql@Query using query parameters:" do
+    mock_spanner do |mock, mock_instances, mock_databases|
+      20.times do
+        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      end
+      5.times do
+        mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
+      end
+      mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users WHERE active = @active", Hash]
       mock.expect :commit, commit_resp, ["session-name", Array, Hash]
     end
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
@@ -331,7 +331,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
     else #sql
       params, param_types = Google::Cloud::Spanner::Convert.to_input_params_and_types params, param_types
 
-      execute_grpc = Google::Spanner::V1::ExecuteSqlRequest.new(
+      execute_sql_grpc = Google::Spanner::V1::ExecuteSqlRequest.new(
         {
           session: session.path,
           sql: sql,
@@ -342,7 +342,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
         }.delete_if { |_, v| v.nil? }
       )
 
-      Google::Cloud::Spanner::Partition.from_execute_grpc execute_grpc
+      Google::Cloud::Spanner::Partition.from_execute_sql_grpc execute_sql_grpc
     end
   end
 

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_query_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
+describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
@@ -22,7 +22,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
   let(:transaction_id) { "tx789" }
   let(:transaction_grpc) { Google::Spanner::V1::Transaction.new id: transaction_id }
-  let(:snapshot) { Google::Cloud::Spanner::Snapshot.from_grpc transaction_grpc, session }
+  let(:batch_snapshot) { Google::Cloud::Spanner::BatchSnapshot.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Spanner::V1::TransactionSelector.new id: transaction_id }
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
@@ -65,9 +65,45 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
   it "can execute a simple query" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    batch_snapshot.session.service.mocked_service = mock
 
-    results = snapshot.execute "SELECT * FROM users"
+    results = batch_snapshot.execute_query "SELECT * FROM users"
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can execute a query using execute alias" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    batch_snapshot.session.service.mocked_service = mock
+
+    results = batch_snapshot.execute "SELECT * FROM users"
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can execute a query using execute_sql alias" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    batch_snapshot.session.service.mocked_service = mock
+
+    results = batch_snapshot.execute_sql "SELECT * FROM users"
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can execute a query using query alias" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    batch_snapshot.session.service.mocked_service = mock
+
+    results = batch_snapshot.query "SELECT * FROM users"
 
     mock.verify
 
@@ -77,9 +113,9 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    batch_snapshot.session.service.mocked_service = mock
 
-    results = snapshot.execute "SELECT * FROM users WHERE active = @active", params: { active: true }
+    results = batch_snapshot.execute_query "SELECT * FROM users WHERE active = @active", params: { active: true }
 
     mock.verify
 
@@ -89,9 +125,9 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    batch_snapshot.session.service.mocked_service = mock
 
-    results = snapshot.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }
+    results = batch_snapshot.execute_query "SELECT * FROM users WHERE age = @age", params: { age: 29 }
 
     mock.verify
 
@@ -101,9 +137,9 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    batch_snapshot.session.service.mocked_service = mock
 
-    results = snapshot.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
+    results = batch_snapshot.execute_query "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
 
     mock.verify
 
@@ -115,9 +151,9 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    batch_snapshot.session.service.mocked_service = mock
 
-    results = snapshot.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
+    results = batch_snapshot.execute_query "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
 
     mock.verify
 
@@ -129,9 +165,9 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    batch_snapshot.session.service.mocked_service = mock
 
-    results = snapshot.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
+    results = batch_snapshot.execute_query "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
 
     mock.verify
 
@@ -141,9 +177,9 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    batch_snapshot.session.service.mocked_service = mock
 
-    results = snapshot.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
+    results = batch_snapshot.execute_query "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
 
     mock.verify
 
@@ -155,9 +191,9 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    batch_snapshot.session.service.mocked_service = mock
 
-    results = snapshot.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
+    results = batch_snapshot.execute_query "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
 
     mock.verify
 
@@ -167,9 +203,9 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    batch_snapshot.session.service.mocked_service = mock
 
-    results = snapshot.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
+    results = batch_snapshot.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
 
     mock.verify
 
@@ -179,9 +215,9 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    batch_snapshot.session.service.mocked_service = mock
 
-    results = snapshot.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
+    results = batch_snapshot.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
 
     mock.verify
 
@@ -191,9 +227,9 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    batch_snapshot.session.service.mocked_service = mock
 
-    results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
+    results = batch_snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
 
     mock.verify
 
@@ -202,10 +238,10 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
 
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    batch_snapshot.session.service.mocked_service = mock
 
-    results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
+    results = batch_snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
 
     mock.verify
 
@@ -214,10 +250,10 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
 
   it "can execute a query with an Array of Hashes" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    batch_snapshot.session.service.mocked_service = mock
 
-    results = snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] }
+    results = batch_snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] }
 
     mock.verify
 
@@ -226,11 +262,11 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
 
   it "can execute a query with an Array of STRUCTs" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    batch_snapshot.session.service.mocked_service = mock
 
-    struct_fields = snapshot.fields name: :STRING, email: :STRING
-    results = snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [struct_fields.data(["mike", "mike@example.net"]), struct_fields.data(["chris","chris@example.net"])] }
+    struct_fields = Google::Cloud::Spanner::Fields.new name: :STRING, email: :STRING
+    results = batch_snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [struct_fields.data(["mike", "mike@example.net"]), struct_fields.data(["chris","chris@example.net"])] }
 
     mock.verify
 
@@ -240,9 +276,9 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    session.service.mocked_service = mock
+    batch_snapshot.session.service.mocked_service = mock
 
-    results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
+    results = batch_snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_query_test.rb
@@ -398,6 +398,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :partition_query, :mock_spanner 
 
     partitions.each do |partition|
       partition.must_be :execute?
+      partition.must_be :execute_query?
 
       partition.execute.partition_token.must_equal "partition-token"
       partition.execute.sql.must_equal sql

--- a/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
@@ -52,7 +52,7 @@ describe Google::Cloud::Spanner::Client, :close, :mock_spanner do
     client.close
 
     assert_raises Google::Cloud::Spanner::ClientClosedError do
-      client.execute "SELECT 1"
+      client.execute_query "SELECT 1"
     end
 
     shutdown_pool! pool

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_resume_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Client, :execute, :resume, :mock_spanner do
+describe Google::Cloud::Spanner::Client, :execute_query, :resume, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
@@ -110,7 +110,7 @@ describe Google::Cloud::Spanner::Client, :execute, :resume, :mock_spanner do
     mock.expect :execute_streaming_sql, RaiseableEnumerator.new(results_enum2), [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: "abc123", partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users"
+    results = client.execute_query "SELECT * FROM users"
 
     assert_results results
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_single_use_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
+describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
@@ -61,7 +61,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
   let(:timestamp) { Google::Cloud::Spanner::Convert.time_to_timestamp time_obj }
   let(:duration) { Google::Cloud::Spanner::Convert.number_to_duration 120 }
 
-  it "executes with strong" do
+  it "execute_querys with strong" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
         read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
@@ -75,7 +75,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users", single_use: { strong: true }
+    results = client.execute_query "SELECT * FROM users", single_use: { strong: true }
 
     shutdown_client! client
 
@@ -84,7 +84,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     assert_results results
   end
 
-  it "executes with timestamp" do
+  it "execute_querys with timestamp" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
         read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
@@ -98,7 +98,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users", single_use: { timestamp: time_obj }
+    results = client.execute_query "SELECT * FROM users", single_use: { timestamp: time_obj }
 
     shutdown_client! client
 
@@ -107,7 +107,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     assert_results results
   end
 
-  it "executes with read_timestamp" do
+  it "execute_querys with read_timestamp" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
         read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
@@ -121,7 +121,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users", single_use: { read_timestamp: time_obj }
+    results = client.execute_query "SELECT * FROM users", single_use: { read_timestamp: time_obj }
 
     shutdown_client! client
 
@@ -130,7 +130,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     assert_results results
   end
 
-  it "executes with staleness" do
+  it "execute_querys with staleness" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
         read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
@@ -144,7 +144,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users", single_use: { staleness: 120 }
+    results = client.execute_query "SELECT * FROM users", single_use: { staleness: 120 }
 
     shutdown_client! client
 
@@ -153,7 +153,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     assert_results results
   end
 
-  it "executes with exact_staleness" do
+  it "execute_querys with exact_staleness" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
         read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
@@ -167,7 +167,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users", single_use: { exact_staleness: 120 }
+    results = client.execute_query "SELECT * FROM users", single_use: { exact_staleness: 120 }
 
     shutdown_client! client
 
@@ -176,7 +176,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     assert_results results
   end
 
-  it "executes with bounded_timestamp" do
+  it "execute_querys with bounded_timestamp" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
         read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
@@ -190,7 +190,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users", single_use: { bounded_timestamp: time_obj }
+    results = client.execute_query "SELECT * FROM users", single_use: { bounded_timestamp: time_obj }
 
     shutdown_client! client
 
@@ -199,7 +199,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     assert_results results
   end
 
-  it "executes with min_read_timestamp" do
+  it "execute_querys with min_read_timestamp" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
         read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
@@ -213,7 +213,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users", single_use: { min_read_timestamp: time_obj }
+    results = client.execute_query "SELECT * FROM users", single_use: { min_read_timestamp: time_obj }
 
     shutdown_client! client
 
@@ -222,7 +222,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     assert_results results
   end
 
-  it "executes with bounded_staleness" do
+  it "execute_querys with bounded_staleness" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
         read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
@@ -236,7 +236,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users", single_use: { bounded_staleness: 120 }
+    results = client.execute_query "SELECT * FROM users", single_use: { bounded_staleness: 120 }
 
     shutdown_client! client
 
@@ -245,7 +245,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     assert_results results
   end
 
-  it "executes with max_staleness" do
+  it "execute_querys with max_staleness" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
         read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
@@ -259,7 +259,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users", single_use: { max_staleness: 120 }
+    results = client.execute_query "SELECT * FROM users", single_use: { max_staleness: 120 }
 
     shutdown_client! client
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
+describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
@@ -64,7 +64,52 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
+    results = client.execute_query "SELECT * FROM users"
+
+    shutdown_client! client
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can execute a query using execute alias" do
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
     results = client.execute "SELECT * FROM users"
+
+    shutdown_client! client
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can execute a query using execute_sql alias" do
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.execute_sql "SELECT * FROM users"
+
+    shutdown_client! client
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can execute a query using query alias" do
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.query "SELECT * FROM users"
 
     shutdown_client! client
 
@@ -79,7 +124,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users WHERE active = @active", params: { active: true }
+    results = client.execute_query "SELECT * FROM users WHERE active = @active", params: { active: true }
 
     shutdown_client! client
 
@@ -94,7 +139,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }
+    results = client.execute_query "SELECT * FROM users WHERE age = @age", params: { age: 29 }
 
     shutdown_client! client
 
@@ -109,7 +154,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
+    results = client.execute_query "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
 
     shutdown_client! client
 
@@ -126,7 +171,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
+    results = client.execute_query "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
 
     shutdown_client! client
 
@@ -143,7 +188,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
+    results = client.execute_query "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
 
     shutdown_client! client
 
@@ -158,7 +203,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
+    results = client.execute_query "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
 
     shutdown_client! client
 
@@ -175,7 +220,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
+    results = client.execute_query "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
 
     shutdown_client! client
 
@@ -190,7 +235,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
+    results = client.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
 
     shutdown_client! client
 
@@ -205,7 +250,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
+    results = client.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
 
     shutdown_client! client
 
@@ -220,7 +265,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
+    results = client.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
 
     shutdown_client! client
 
@@ -235,7 +280,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
+    results = client.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
 
     shutdown_client! client
 
@@ -277,7 +322,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
+    results = client.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
 
     shutdown_client! client
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -75,7 +75,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
     results = nil
     client.snapshot do |snp|
       snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
-      results = snp.execute "SELECT * FROM users"
+      results = snp.execute_query "SELECT * FROM users"
     end
 
     shutdown_client! client
@@ -91,7 +91,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     assert_raises ArgumentError do
       client.snapshot strong: true, timestamp: Time.now do |snp|
-        snp.execute "SELECT * FROM users"
+        snp.execute_query "SELECT * FROM users"
       end
     end
 
@@ -113,7 +113,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       results = nil
       client.snapshot strong: true do |snp|
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
-        results = snp.execute "SELECT * FROM users"
+        results = snp.execute_query "SELECT * FROM users"
       end
 
       shutdown_client! client
@@ -140,7 +140,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       results = nil
       client.snapshot timestamp: snapshot_time do |snp|
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
-        results = snp.execute "SELECT * FROM users"
+        results = snp.execute_query "SELECT * FROM users"
       end
 
       shutdown_client! client
@@ -160,7 +160,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       results = nil
       client.snapshot read_timestamp: snapshot_time do |snp|
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
-        results = snp.execute "SELECT * FROM users"
+        results = snp.execute_query "SELECT * FROM users"
       end
 
       shutdown_client! client
@@ -180,7 +180,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       results = nil
       client.snapshot timestamp: snapshot_datetime do |snp|
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
-        results = snp.execute "SELECT * FROM users"
+        results = snp.execute_query "SELECT * FROM users"
       end
 
       shutdown_client! client
@@ -200,7 +200,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       results = nil
       client.snapshot read_timestamp: snapshot_datetime do |snp|
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
-        results = snp.execute "SELECT * FROM users"
+        results = snp.execute_query "SELECT * FROM users"
       end
 
       shutdown_client! client
@@ -226,7 +226,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       results = nil
       client.snapshot staleness: snapshot_staleness do |snp|
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
-        results = snp.execute "SELECT * FROM users"
+        results = snp.execute_query "SELECT * FROM users"
       end
 
       shutdown_client! client
@@ -246,7 +246,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       results = nil
       client.snapshot exact_staleness: snapshot_staleness do |snp|
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
-        results = snp.execute "SELECT * FROM users"
+        results = snp.execute_query "SELECT * FROM users"
       end
 
       shutdown_client! client
@@ -270,11 +270,11 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
     nested_error = assert_raises RuntimeError do
       client.snapshot do |snp|
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
-        results = snp.execute "SELECT * FROM users"
+        results = snp.execute_query "SELECT * FROM users"
 
         client.snapshot do |snp2|
           snp2.must_be_kind_of Google::Cloud::Spanner::Snapshot
-          results2 = snp2.execute "SELECT * FROM other_users"
+          results2 = snp2.execute_query "SELECT * FROM other_users"
         end
       end
     end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -107,7 +107,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     results = nil
     client.transaction do |tx|
       tx.must_be_kind_of Google::Cloud::Spanner::Transaction
-      results = tx.execute "SELECT * FROM users"
+      results = tx.execute_query "SELECT * FROM users"
       tx.update "users", [{ id: 1, name: "Charlie", active: false }]
     end
 
@@ -161,7 +161,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     results = nil
     client.transaction do |tx|
       tx.must_be_kind_of Google::Cloud::Spanner::Transaction
-      results = tx.execute "SELECT * FROM users"
+      results = tx.execute_query "SELECT * FROM users"
       tx.update "users", [{ id: 1, name: "Charlie", active: false }]
     end
 
@@ -215,7 +215,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     results = nil
     client.transaction do |tx|
       tx.must_be_kind_of Google::Cloud::Spanner::Transaction
-      results = tx.execute "SELECT * FROM users"
+      results = tx.execute_query "SELECT * FROM users"
       tx.update "users", [{ id: 1, name: "Charlie", active: false }]
     end
 
@@ -279,7 +279,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     results = nil
     client.transaction do |tx|
       tx.must_be_kind_of Google::Cloud::Spanner::Transaction
-      results = tx.execute "SELECT * FROM users"
+      results = tx.execute_query "SELECT * FROM users"
       tx.update "users", [{ id: 1, name: "Charlie", active: false }]
     end
 
@@ -350,7 +350,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     assert_raises Google::Cloud::AbortedError do
       client.transaction do |tx|
         tx.must_be_kind_of Google::Cloud::Spanner::Transaction
-        results = tx.execute "SELECT * FROM users"
+        results = tx.execute_query "SELECT * FROM users"
         tx.update "users", [{ id: 1, name: "Charlie", active: false }]
       end
     end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
@@ -77,7 +77,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
     results = nil
     timestamp = client.transaction do |tx|
       tx.must_be_kind_of Google::Cloud::Spanner::Transaction
-      results = tx.execute "SELECT * FROM users"
+      results = tx.execute_query "SELECT * FROM users"
       # This mutation will never be committed, so no mocks for it.
       tx.update "users", [{ id: 1, name: "Charlie", active: false }]
       # Cause an error
@@ -106,7 +106,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
     assert_raises ZeroDivisionError do
       client.transaction do |tx|
         tx.must_be_kind_of Google::Cloud::Spanner::Transaction
-        results = tx.execute "SELECT * FROM users"
+        results = tx.execute_query "SELECT * FROM users"
         # This mutation will never be committed, so no mocks for it.
         tx.update "users", [{ id: 1, name: "Charlie", active: false }]
         # Cause an error

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -79,7 +79,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     results = nil
     timestamp = client.transaction do |tx|
       tx.must_be_kind_of Google::Cloud::Spanner::Transaction
-      results = tx.execute "SELECT * FROM users"
+      results = tx.execute_query "SELECT * FROM users"
     end
     timestamp.must_equal commit_time
 

--- a/google-cloud-spanner/test/google/cloud/spanner/session/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/execute_query_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
+describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
@@ -63,7 +63,7 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
     session.service.mocked_service = mock
 
-    results = session.execute "SELECT * FROM users"
+    results = session.execute_query "SELECT * FROM users"
 
     mock.verify
 
@@ -76,7 +76,7 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
     session.service.mocked_service = mock
 
     params, types = params_types({ active: true })
-    results = session.execute "SELECT * FROM users WHERE active = @active", params: params, types: types
+    results = session.execute_query "SELECT * FROM users WHERE active = @active", params: params, types: types
 
     mock.verify
 
@@ -89,7 +89,7 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
     session.service.mocked_service = mock
 
     params, types = params_types({ age: 29 })
-    results = session.execute "SELECT * FROM users WHERE age = @age", params: params, types: types
+    results = session.execute_query "SELECT * FROM users WHERE age = @age", params: params, types: types
 
     mock.verify
 
@@ -102,7 +102,7 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
     session.service.mocked_service = mock
 
     params, types = params_types({ score: 0.9 })
-    results = session.execute "SELECT * FROM users WHERE score = @score", params: params, types: types
+    results = session.execute_query "SELECT * FROM users WHERE score = @score", params: params, types: types
 
     mock.verify
 
@@ -117,7 +117,7 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
     session.service.mocked_service = mock
 
     params, types = params_types({ updated_at: timestamp })
-    results = session.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: params, types: types
+    results = session.execute_query "SELECT * FROM users WHERE updated_at = @updated_at", params: params, types: types
 
     mock.verify
 
@@ -132,7 +132,7 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
     session.service.mocked_service = mock
 
     params, types = params_types({ birthday: date })
-    results = session.execute "SELECT * FROM users WHERE birthday = @birthday", params: params, types: types
+    results = session.execute_query "SELECT * FROM users WHERE birthday = @birthday", params: params, types: types
 
     mock.verify
 
@@ -145,7 +145,7 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
     session.service.mocked_service = mock
 
     params, types = params_types({ name: "Charlie" })
-    results = session.execute "SELECT * FROM users WHERE name = @name", params: params, types: types
+    results = session.execute_query "SELECT * FROM users WHERE name = @name", params: params, types: types
 
     mock.verify
 
@@ -160,7 +160,7 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
     session.service.mocked_service = mock
 
     params, types = params_types({ avatar: file })
-    results = session.execute "SELECT * FROM users WHERE avatar = @avatar", params: params, types: types
+    results = session.execute_query "SELECT * FROM users WHERE avatar = @avatar", params: params, types: types
 
     mock.verify
 
@@ -173,7 +173,7 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
     session.service.mocked_service = mock
 
     params, types = params_types({ list: [1,2,3] })
-    results = session.execute "SELECT * FROM users WHERE project_ids = @list", params: params, types: types
+    results = session.execute_query "SELECT * FROM users WHERE project_ids = @list", params: params, types: types
 
     mock.verify
 
@@ -186,7 +186,7 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
     session.service.mocked_service = mock
 
     params, types = params_types({ list: [] }, { list: [:INT64] })
-    results = session.execute "SELECT * FROM users WHERE project_ids = @list", params: params, types: types
+    results = session.execute_query "SELECT * FROM users WHERE project_ids = @list", params: params, types: types
 
     mock.verify
 
@@ -199,7 +199,7 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
     session.service.mocked_service = mock
 
     params, types = params_types({ dict: { env: :production } })
-    results = session.execute "SELECT * FROM users WHERE settings = @dict", params: params, types: types
+    results = session.execute_query "SELECT * FROM users WHERE settings = @dict", params: params, types: types
 
     mock.verify
 
@@ -212,7 +212,7 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
     session.service.mocked_service = mock
 
     params, types = params_types({ dict: { env: "production", score: 0.9, project_ids: [1,2,3] } })
-    results = session.execute "SELECT * FROM users WHERE settings = @dict", params: params, types: types
+    results = session.execute_query "SELECT * FROM users WHERE settings = @dict", params: params, types: types
 
     mock.verify
 
@@ -225,7 +225,7 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
     session.service.mocked_service = mock
 
     params, types = params_types({ dict: { } })
-    results = session.execute "SELECT * FROM users WHERE settings = @dict", params: params, types: types
+    results = session.execute_query "SELECT * FROM users WHERE settings = @dict", params: params, types: types
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_query_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
+describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
@@ -22,7 +22,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
   let(:transaction_id) { "tx789" }
   let(:transaction_grpc) { Google::Spanner::V1::Transaction.new id: transaction_id }
-  let(:batch_snapshot) { Google::Cloud::Spanner::BatchSnapshot.from_grpc transaction_grpc, session }
+  let(:snapshot) { Google::Cloud::Spanner::Snapshot.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Spanner::V1::TransactionSelector.new id: transaction_id }
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
@@ -65,9 +65,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   it "can execute a simple query" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    session.service.mocked_service = mock
 
-    results = batch_snapshot.execute "SELECT * FROM users"
+    results = snapshot.execute_query "SELECT * FROM users"
 
     mock.verify
 
@@ -77,9 +77,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    session.service.mocked_service = mock
 
-    results = batch_snapshot.execute "SELECT * FROM users WHERE active = @active", params: { active: true }
+    results = snapshot.execute_query "SELECT * FROM users WHERE active = @active", params: { active: true }
 
     mock.verify
 
@@ -89,9 +89,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    session.service.mocked_service = mock
 
-    results = batch_snapshot.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }
+    results = snapshot.execute_query "SELECT * FROM users WHERE age = @age", params: { age: 29 }
 
     mock.verify
 
@@ -101,9 +101,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    session.service.mocked_service = mock
 
-    results = batch_snapshot.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
+    results = snapshot.execute_query "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
 
     mock.verify
 
@@ -115,9 +115,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    session.service.mocked_service = mock
 
-    results = batch_snapshot.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
+    results = snapshot.execute_query "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
 
     mock.verify
 
@@ -129,9 +129,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    session.service.mocked_service = mock
 
-    results = batch_snapshot.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
+    results = snapshot.execute_query "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
 
     mock.verify
 
@@ -141,9 +141,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    session.service.mocked_service = mock
 
-    results = batch_snapshot.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
+    results = snapshot.execute_query "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
 
     mock.verify
 
@@ -155,9 +155,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    session.service.mocked_service = mock
 
-    results = batch_snapshot.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
+    results = snapshot.execute_query "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
 
     mock.verify
 
@@ -167,9 +167,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    session.service.mocked_service = mock
 
-    results = batch_snapshot.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
+    results = snapshot.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
 
     mock.verify
 
@@ -179,9 +179,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    session.service.mocked_service = mock
 
-    results = batch_snapshot.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
+    results = snapshot.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
 
     mock.verify
 
@@ -191,9 +191,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    session.service.mocked_service = mock
 
-    results = batch_snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
+    results = snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
 
     mock.verify
 
@@ -202,10 +202,10 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
 
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    session.service.mocked_service = mock
 
-    results = batch_snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
+    results = snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
 
     mock.verify
 
@@ -214,10 +214,10 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
 
   it "can execute a query with an Array of Hashes" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    session.service.mocked_service = mock
 
-    results = batch_snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] }
+    results = snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] }
 
     mock.verify
 
@@ -226,11 +226,11 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
 
   it "can execute a query with an Array of STRUCTs" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    session.service.mocked_service = mock
 
-    struct_fields = Google::Cloud::Spanner::Fields.new name: :STRING, email: :STRING
-    results = batch_snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [struct_fields.data(["mike", "mike@example.net"]), struct_fields.data(["chris","chris@example.net"])] }
+    struct_fields = snapshot.fields name: :STRING, email: :STRING
+    results = snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [struct_fields.data(["mike", "mike@example.net"]), struct_fields.data(["chris","chris@example.net"])] }
 
     mock.verify
 
@@ -240,9 +240,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    batch_snapshot.session.service.mocked_service = mock
+    session.service.mocked_service = mock
 
-    results = batch_snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
+    results = snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_query_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
+describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
@@ -67,7 +67,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.execute "SELECT * FROM users"
+    results = transaction.execute_query "SELECT * FROM users"
 
     mock.verify
 
@@ -79,7 +79,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.execute "SELECT * FROM users WHERE active = @active", params: { active: true }
+    results = transaction.execute_query "SELECT * FROM users WHERE active = @active", params: { active: true }
 
     mock.verify
 
@@ -91,7 +91,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }
+    results = transaction.execute_query "SELECT * FROM users WHERE age = @age", params: { age: 29 }
 
     mock.verify
 
@@ -103,7 +103,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
+    results = transaction.execute_query "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
 
     mock.verify
 
@@ -117,7 +117,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
+    results = transaction.execute_query "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
 
     mock.verify
 
@@ -131,7 +131,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
+    results = transaction.execute_query "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
 
     mock.verify
 
@@ -143,7 +143,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
+    results = transaction.execute_query "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
 
     mock.verify
 
@@ -157,7 +157,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
+    results = transaction.execute_query "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
 
     mock.verify
 
@@ -169,7 +169,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
+    results = transaction.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
 
     mock.verify
 
@@ -181,7 +181,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
+    results = transaction.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
 
     mock.verify
 
@@ -193,7 +193,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
+    results = transaction.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
 
     mock.verify
 
@@ -205,7 +205,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
+    results = transaction.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
 
     mock.verify
 
@@ -244,7 +244,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
+    results = transaction.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
 
     mock.verify
 


### PR DESCRIPTION
Rename to maintain naming consistency with `execute_update` method.
Maintain compatibility by adding `query`, `execute` and `execute_sql` aliases.