### PR TITLE
Releases 2018-10-03

### DIFF
--- a/google-cloud-dlp/CHANGELOG.md
+++ b/google-cloud-dlp/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Release History
 
+### 0.7.0 / 2018-10-03
+
+* Add order_by argument to the following methods and resources:
+  * DlpServiceClient#list_inspect_templates
+  * DlpServiceClient#list_deidentify_templates
+  * ListInspectTemplatesRequest#order_by
+  * ListDeidentifyTemplatesRequest#order_by
+  * ListStoredInfoTypesRequest#order_by
+* Add InspectConfig#rule_set
+  * Add InspectionRuleSet, InspectionRule, ExclusionRule,
+    ExcludeInfoTypes, and MatchingType resources.
+* Add CustomInfoType#exclusion_type
+  * Add ExclusionType resource.
+* Update documentation.
+* Add new GAPIC config, which is not yet used.
+
 ### 0.6.2 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dlp"
-  gem.version       = "0.6.2"
+  gem.version       = "0.7.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-logging/CHANGELOG.md
+++ b/google-cloud-logging/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 1.5.6 / 2018-10-03
+
+* Use concurrent-ruby and ThreadLocalVar in Logger.
+  * Remove Monitor and synchronize blocks.
+  * Logger#thread_ids now only returns the current thread.
+
 ### 1.5.5 / 2018-09-20
 
 * Make Logger thread-safe.

--- a/google-cloud-logging/lib/google/cloud/logging/version.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Logging
-      VERSION = "1.5.5".freeze
+      VERSION = "1.5.6".freeze
     end
   end
 end

--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.33.1 / 2018-10-03
+
+* Update connection configuration.
+  * Treat Acknowledge as idempotent.
+
 ### 0.33.0 / 2018-09-20
 
 * Add support for user labels to Snapshot, Subscription and Topic.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Pubsub
-      VERSION = "0.33.0".freeze
+      VERSION = "0.33.1".freeze
     end
   end
 end

--- a/google-cloud-storage/CHANGELOG.md
+++ b/google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+### 1.15.0 / 2018-10-03
+
+* Add Bucket retention policy
+  * Add retention_policy fields and default_event_based_hold to Bucket.
+  * Add retention_policy and hold fields to File.
+  * Add Bucket#lock_retention_policy!
+  * Add Bucket#metageneration.
+  * Add Bucket#retention_policy_locked?
+  * Add File#(set|release)_temporary_hold!
+  * Add File#(set|release)_event_based_hold!
+
 ### 1.14.2 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-storage/lib/google/cloud/storage/version.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Storage
-      VERSION = "1.14.2".freeze
+      VERSION = "1.15.0".freeze
     end
   end
 end


### PR DESCRIPTION
Release google-cloud-storage 1.15.0

* Add Bucket retention policy
  * Add retention_policy fields and default_event_based_hold to Bucket.
  * Add retention_policy and hold fields to File.
  * Add Bucket#lock_retention_policy!
  * Add Bucket#metageneration.
  * Add Bucket#retention_policy_locked?
  * Add File#(set|release)_temporary_hold!
  * Add File#(set|release)_event_based_hold!

Release google-cloud-pubsub 0.33.1

* Update connection configuration.
  * Treat Acknowledge as idempotent.

Release google-cloud-logging 1.5.6

* Use concurrent-ruby and ThreadLocalVar in Logger.
  * Remove Monitor and synchronize blocks.
  * Logger#thread_ids now only returns the current thread.

Release google-cloud-dlp 0.7.0

* Add order_by argument to the following methods and resources:
  * DlpServiceClient#list_inspect_templates
  * DlpServiceClient#list_deidentify_templates
  * ListInspectTemplatesRequest#order_by
  * ListDeidentifyTemplatesRequest#order_by
  * ListStoredInfoTypesRequest#order_by
* Add InspectConfig#rule_set
  * Add InspectionRuleSet, InspectionRule, ExclusionRule,
    ExcludeInfoTypes, and MatchingType resources.
* Add CustomInfoType#exclusion_type
  * Add ExclusionType resource.
* Update documentation.
* Add new GAPIC config, which is not yet used.