### PR TITLE
Raise if dataset_id or table_id is nil in Table#new_reference

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1798,7 +1798,7 @@ module Google
         ##
         # @private New lazy Dataset object without making an HTTP request.
         def self.new_reference project_id, dataset_id, service
-          # TODO: raise if dataset_id is nil?
+          raise ArgumentError, "dataset_id is required" unless dataset_id
           new.tap do |b|
             reference_gapi = Google::Apis::BigqueryV2::DatasetReference.new(
               project_id: project_id,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -2184,8 +2184,8 @@ module Google
         ##
         # @private New lazy Table object without making an HTTP request.
         def self.new_reference project_id, dataset_id, table_id, service
-          raise ArgumentError, "dataset_id must be a String" unless dataset_id
-          raise ArgumentError, "table_id must be a String" unless table_id
+          raise ArgumentError, "dataset_id is required" unless dataset_id
+          raise ArgumentError, "table_id is required" unless table_id
           new.tap do |b|
             reference_gapi = Google::Apis::BigqueryV2::TableReference.new(
               project_id: project_id,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -2184,7 +2184,8 @@ module Google
         ##
         # @private New lazy Table object without making an HTTP request.
         def self.new_reference project_id, dataset_id, table_id, service
-          # TODO: raise if dataset_id or table_id is nil?
+          raise ArgumentError, "dataset_id must be a String" unless dataset_id
+          raise ArgumentError, "table_id must be a String" unless table_id
           new.tap do |b|
             reference_gapi = Google::Apis::BigqueryV2::TableReference.new(
               project_id: project_id,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -706,6 +706,29 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     table.table_id.must_equal found_table_id
   end
 
+  it "finds a table with skip_lookup option" do
+    table_id = "found_table"
+    # No HTTP mock needed, since the lookup is not made
+
+    table = dataset.table table_id, skip_lookup: true
+
+    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be :reference?
+    table.wont_be :resource?
+    table.wont_be :resource_partial?
+    table.wont_be :resource_full?
+  end
+
+  it "finds a table with skip_lookup option if table_id is nil" do
+    table_id = nil
+    # No HTTP mock needed, since the lookup is not made
+
+    error = expect do
+      dataset.table table_id, skip_lookup: true
+    end.must_raise ArgumentError
+    error.message.must_equal "table_id must be a String"
+  end
+
   def create_table_gapi id, name = nil, description = nil
     Google::Apis::BigqueryV2::Table.from_json random_table_hash(dataset_id, id, name, description).to_json
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -726,7 +726,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     error = expect do
       dataset.table table_id, skip_lookup: true
     end.must_raise ArgumentError
-    error.message.must_equal "table_id must be a String"
+    error.message.must_equal "table_id is required"
   end
 
   def create_table_gapi id, name = nil, description = nil

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
@@ -571,6 +571,15 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
   end
 
+  it "finds a dataset with skip_lookup option if dataset_id is nil" do
+    dataset_id = nil
+
+    error = expect do
+      bigquery.dataset dataset_id, skip_lookup: true
+    end.must_raise ArgumentError
+    error.message.must_equal "dataset_id is required"
+  end
+
   it "lists jobs" do
     mock = Minitest::Mock.new
     mock.expect :list_jobs, list_jobs_gapi(3),


### PR DESCRIPTION
- Raise if `dataset_id` or `table_id` which is arguments `Table#new_reference` is nil.
- Implement this TODO
https://github.com/googleapis/google-cloud-ruby/blob/69608a3ec0e5cb2c33b75b2d1af04d4f09bde184/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb#L2187