### PR TITLE
Allow overriding KMS keys in acceptance tests.

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -278,9 +278,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
   end
 
   it "imports data from GCS Avro file and creates a new table with encryption with load" do
-    encrypt_config = bigquery.encryption(
-      kms_key: "projects/cloud-samples-tests/locations/us-central1" +
-                "/keyRings/test/cryptoKeys/test")
+    encrypt_config = bigquery.encryption(kms_key: kms_key)
     result = dataset.load(
       table_avro_id,
       "gs://cloud-samples-data/bigquery/us-states/us-states.avro") do |load|

--- a/google-cloud-bigquery/acceptance/bigquery/query_destination_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/query_destination_test.rb
@@ -43,9 +43,7 @@ describe Google::Cloud::Bigquery, :bigquery do
   end
 
   it "sends query results to destination table with encryption" do
-    encrypt_config = bigquery.encryption(
-      kms_key: "projects/cloud-samples-tests/locations/us-central1" +
-                "/keyRings/test/cryptoKeys/test")
+    encrypt_config = bigquery.encryption(kms_key: kms_key)
     rows = bigquery.query "SELECT 456 AS value", standard_sql: true do |query|
       query.write = :truncate
       query.table = table

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -166,9 +166,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
 
   it "create table with cmek sets encryption" do
     begin
-      encrypt_config = bigquery.encryption(
-        kms_key: "projects/cloud-samples-tests/locations/us-central1" +
-                 "/keyRings/test/cryptoKeys/test")
+      encrypt_config = bigquery.encryption(kms_key: kms_key)
       cmek_table = dataset.create_table "cmek_kittens" do |updater|
         updater.encryption = encrypt_config
       end
@@ -177,9 +175,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
       cmek_table.table_id.must_equal "cmek_kittens"
       cmek_table.encryption.must_equal encrypt_config
 
-      new_encrypt_config = bigquery.encryption(
-        kms_key: "projects/cloud-samples-tests/locations/us-central1" +
-                 "/keyRings/test/cryptoKeys/otherkey")
+      new_encrypt_config = bigquery.encryption(kms_key: kms_key_2)
       cmek_table.encryption = new_encrypt_config
 
       cmek_table.reload!
@@ -853,10 +849,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
   end
 
   it "copies itself to another table with copy with encryption" do
-    encrypt_config = bigquery.encryption(
-      kms_key: "projects/cloud-samples-tests/locations/us-central1" +
-                "/keyRings/test/cryptoKeys/test")
-
+    encrypt_config = bigquery.encryption(kms_key: kms_key)
     result = table.copy target_table_4_id, create: :needed,
                                            write: :truncate do |copy|
       copy.encryption = encrypt_config

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -47,6 +47,17 @@ end
 
 $bucket = safe_gcs_execute { $storage.create_bucket "#{$prefix}_bucket" }
 
+# Allow overriding the KMS key used for tests via an environment variable.
+# These keys are public, but access may be restricted when tests are run from a
+# VPC project.
+$kms_key = ENV["GCLOUD_TEST_KMS_KEY"] || (
+  "projects/cloud-samples-tests/locations/us-central1" +
+  "/keyRings/test/cryptoKeys/test")
+
+$kms_key_2 = ENV["GCLOUD_TEST_KMS_KEY_2"] || (
+  "projects/cloud-samples-tests/locations/us-central1" +
+  "/keyRings/test/cryptoKeys/otherkey")
+
 module Acceptance
   ##
   # Test class for running against a BigQuery instance.
@@ -65,6 +76,8 @@ module Acceptance
     attr_accessor :prefix
     attr_accessor :storage
     attr_accessor :bucket
+    attr_accessor :kms_key
+    attr_accessor :kms_key_2
 
     ##
     # Setup project based on available ENV variables
@@ -73,11 +86,15 @@ module Acceptance
       @prefix = $prefix
       @storage = $storage
       @bucket = $bucket
+      @kms_key = $kms_key
+      @kms_key_2 = $kms_key_2
 
       refute_nil @bigquery, "You do not have an active bigquery to run the tests."
       refute_nil @prefix, "You do not have an bigquery prefix to name the datasets and tables with."
       refute_nil @storage, "You do not have an active storage to run the tests."
       refute_nil @bucket, "You do not have a storage bucket to run the tests."
+      refute_nil @kms_key, "You do not have a kms key to run the tests."
+      refute_nil @kms_key_2, "You do not have a second kms key to run the tests."
 
       super
     end


### PR DESCRIPTION
The keys were are using are public, but access to it may be restricted
when tests are run from a VPC project. These changes will unblock the
Cloud testing team from running the affected tests.

/CC @jesselovelace @silverdev