### PR TITLE
Add BigQuery clustering

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -132,6 +132,8 @@ describe Google::Cloud::Bigquery, :bigquery do
     job.time_partitioning_field.must_be :nil?
     job.time_partitioning_expiration.must_be :nil?
     job.time_partitioning_require_filter?.must_equal false
+    job.clustering?.must_equal false
+    job.clustering_fields.must_be :nil?
 
     job.wait_until_done!
     rows = job.data

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -83,6 +83,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
   let(:local_file) { "acceptance/data/kitten-test-data.json" }
 
   let(:schema_update_options) { ["ALLOW_FIELD_ADDITION", "ALLOW_FIELD_RELAXATION"] }
+  let(:clustering_fields) { ["breed", "name"] }
 
   before do
     table
@@ -184,16 +185,20 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
       job.time_partitioning_field = "dob"
       job.time_partitioning_expiration = 86_400
       job.time_partitioning_require_filter = true
+      job.clustering_fields = clustering_fields
     end
     job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
     job.job_id.must_equal job_id
     job.wait_until_done!
     job.output_rows.must_equal 3
     job.schema_update_options.must_equal schema_update_options
+    job.time_partitioning?.must_equal true
     job.time_partitioning_type.must_equal "DAY"
     job.time_partitioning_field.must_equal "dob"
     job.time_partitioning_expiration.must_equal 86_400
     job.time_partitioning_require_filter?.must_equal true
+    job.clustering?.must_equal true
+    job.clustering_fields.must_equal clustering_fields
   end
 
   it "imports data from a local file and creates a new table with specified schema as an option with load_job" do

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -891,6 +891,8 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     load_job.time_partitioning_field.must_be :nil?
     load_job.time_partitioning_expiration.must_be :nil?
     load_job.time_partitioning_require_filter?.must_equal false
+    load_job.clustering?.must_equal false
+    load_job.clustering_fields.must_be :nil?
     load_job.input_files.must_equal 1
     load_job.input_file_bytes.must_be :>, 0
     load_job.output_rows.must_be :>, 0

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -337,25 +337,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     end
   end
 
-  it "gets and sets time partitioning" do
-    partitioned_table = dataset.table "weekly_kittens"
-    if partitioned_table.nil?
-      partitioned_table = dataset.create_table "weekly_kittens" do |updater|
-        updater.time_partitioning_type = "DAY"
-        updater.time_partitioning_expiration = seven_days
-      end
-    end
-
-    partitioned_table.time_partitioning_expiration = 1
-
-    partitioned_table.reload!
-    partitioned_table.table_id.must_equal "weekly_kittens"
-    partitioned_table.time_partitioning_type.must_equal "DAY"
-    partitioned_table.time_partitioning_field.must_be_nil
-    partitioned_table.time_partitioning_expiration.must_equal 1
-  end
-
-  it "gets and sets time partitioning by field" do
+  it "updates time partitioning expiration" do
     partitioned_table = dataset.table "kittens_field_reference"
     if partitioned_table.nil?
       partitioned_table = dataset.create_table "kittens_field_reference" do |updater|

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -38,6 +38,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
   end
   let(:time_partitioned_table_id) { "daily_kittens"}
   let(:seven_days) { 7 * 24 * 60 * 60 }
+  let(:clustering_fields) { ["last_name", "first_name"] }
   let(:time_partitioned_table) do
     t = dataset.table time_partitioned_table_id
     if t.nil?
@@ -45,8 +46,11 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
         updater.time_partitioning_type = "DAY"
         updater.time_partitioning_field = "dob"
         updater.time_partitioning_expiration = seven_days
+        updater.clustering_fields = clustering_fields
         updater.schema do |schema|
           schema.timestamp "dob",   description: "dob description",   mode: :required
+          schema.string "first_name",   description: "first_name description",   mode: :required
+          schema.string "last_name",   description: "last_name description",   mode: :required
         end
       end
     end
@@ -446,11 +450,12 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     end
   end
 
-  it "allows tables to be created with time_partioning enabled" do
+  it "allows tables to be created with time_partitioning and clustering" do
     table = time_partitioned_table
     table.time_partitioning_type.must_equal "DAY"
     table.time_partitioning_field.must_equal "dob"
     table.time_partitioning_expiration.must_equal seven_days
+    table.clustering_fields.must_equal clustering_fields
   end
 
   it "inserts rows directly and gets its data" do

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -424,6 +424,45 @@ module Google
           tp.require_partition_filter
         end
 
+        ###
+        # Checks if the destination table will be clustered.
+        #
+        # @see https://cloud.google.com/bigquery/docs/clustered-tables
+        #   Introduction to Clustered Tables
+        #
+        # @return [Boolean, nil] `true` when the table will be clustered,
+        #   or `false` otherwise.
+        #
+        # @!group Attributes
+        #
+        def clustering?
+          !@gapi.configuration.load.clustering.nil?
+        end
+
+        ###
+        # One or more fields on which the destination table should be clustered.
+        # Must be specified with time-based partitioning, data in the table will
+        # be first partitioned and subsequently clustered. The order of the
+        # returned fields determines the sort order of the data.
+        #
+        # See {LoadJob::Updater#clustering_fields=}.
+        #
+        # @see https://cloud.google.com/bigquery/docs/partitioned-tables
+        #   Partitioned Tables
+        # @see https://cloud.google.com/bigquery/docs/clustered-tables
+        #   Introduction to Clustered Tables
+        # @see https://cloud.google.com/bigquery/docs/creating-clustered-tables
+        #   Creating and Using Clustered Tables
+        #
+        # @return [Array<String>, nil] The clustering fields, or `nil` if the
+        #   destination table will not be clustered.
+        #
+        # @!group Attributes
+        #
+        def clustering_fields
+          @gapi.configuration.load.clustering.fields if clustering?
+        end
+
         ##
         # Yielded to a block to accumulate changes for a patch request.
         class Updater < LoadJob
@@ -1318,6 +1357,57 @@ module Google
               Google::Apis::BigqueryV2::TimePartitioning.new
             @gapi.configuration.load.time_partitioning.update! \
               require_partition_filter: val
+          end
+
+          ##
+          # Sets one or more fields on which the destination table should be
+          # clustered. Must be specified with time-based partitioning, data in
+          # the table will be first partitioned and subsequently clustered.
+          #
+          # Only top-level, non-repeated, simple-type fields are supported. When
+          # you cluster a table using multiple columns, the order of columns you
+          # specify is important. The order of the specified columns determines
+          # the sort order of the data.
+          #
+          # See {LoadJob#clustering_fields}.
+          #
+          # @see https://cloud.google.com/bigquery/docs/partitioned-tables
+          #   Partitioned Tables
+          # @see https://cloud.google.com/bigquery/docs/clustered-tables
+          #   Introduction to Clustered Tables
+          # @see https://cloud.google.com/bigquery/docs/creating-clustered-tables
+          #   Creating and Using Clustered Tables
+          #
+          # @param [Array<String>] fields The clustering fields. Only top-level,
+          #   non-repeated, simple-type fields are supported.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   gs_url = "gs://my-bucket/file-name.csv"
+          #   load_job = dataset.load_job "my_new_table", gs_url do |job|
+          #     job.time_partitioning_type  = "DAY"
+          #     job.time_partitioning_field = "dob"
+          #     job.schema do |schema|
+          #       schema.timestamp "dob", mode: :required
+          #       schema.string "first_name", mode: :required
+          #       schema.string "last_name", mode: :required
+          #     end
+          #     job.clustering_fields = ["last_name", "first_name"]
+          #   end
+          #
+          #   load_job.wait_until_done!
+          #   load_job.done? #=> true
+          #
+          # @!group Attributes
+          #
+          def clustering_fields= fields
+            @gapi.configuration.load.clustering ||= \
+              Google::Apis::BigqueryV2::Clustering.new
+            @gapi.configuration.load.clustering.fields = fields
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -192,10 +192,6 @@ module Google
         # the example below. BigQuery does not allow you to change partitioning
         # on an existing table.
         #
-        # If the table is not a full resource representation (see
-        # {#resource_full?}), the full representation will be retrieved before
-        # the update to comply with ETag-based optimistic concurrency control.
-        #
         # @param [String] type The partition type. Currently the only
         #   supported value is "DAY".
         #
@@ -248,10 +244,6 @@ module Google
         # You can only set the partitioning field while creating a table as in
         # the example below. BigQuery does not allow you to change partitioning
         # on an existing table.
-        #
-        # If the table is not a full resource representation (see
-        # {#resource_full?}), the full representation will be retrieved before
-        # the update to comply with ETag-based optimistic concurrency control.
         #
         # @param [String] field The partition field. The field must be a
         #   top-level TIMESTAMP or DATE field. Its mode must be NULLABLE or

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -27,6 +27,10 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
   let(:time_partitioning_gapi) do
     Google::Apis::BigqueryV2::TimePartitioning.new type: "DAY", field: "dob", expiration_ms: 5000
   end
+  let(:clustering_fields) { ["last_name", "first_name"] }
+  let(:clustering_gapi) do
+    Google::Apis::BigqueryV2::Clustering.new fields: clustering_fields
+  end
   let(:table_schema) {
     {
       fields: [
@@ -177,12 +181,13 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     table.wont_be :view?
   end
 
-  it "creates a table with time partitioning in a block" do
+  it "creates a table with time partitioning and clustering in a block" do
     mock = Minitest::Mock.new
     insert_table = Google::Apis::BigqueryV2::Table.new(
       table_reference: Google::Apis::BigqueryV2::TableReference.new(
         project_id: project, dataset_id: dataset_id, table_id: table_id),
-      time_partitioning: time_partitioning_gapi)
+      time_partitioning: time_partitioning_gapi,
+      clustering: clustering_gapi)
     mock.expect :insert_table, insert_table, [project, dataset_id, insert_table]
     dataset.service.mocked_service = mock
 
@@ -190,6 +195,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       t.time_partitioning_type = "DAY"
       t.time_partitioning_field = "dob"
       t.time_partitioning_expiration = 5
+      t.clustering_fields = clustering_fields
     end
 
     mock.verify
@@ -199,6 +205,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     table.time_partitioning_type.must_equal "DAY"
     table.time_partitioning_field.must_equal "dob"
     table.time_partitioning_expiration.must_equal 5
+    table.clustering_fields.must_equal clustering_fields
   end
 
   it "creates a table with a schema inline" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -24,6 +24,9 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
   let(:table_id) { "my_table" }
   let(:table_name) { "My Table" }
   let(:table_description) { "This is my table" }
+  let(:time_partitioning_gapi) do
+    Google::Apis::BigqueryV2::TimePartitioning.new type: "DAY", field: "dob", expiration_ms: 5000
+  end
   let(:table_schema) {
     {
       fields: [
@@ -172,6 +175,30 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     table.schema.must_be :empty?
     table.must_be :table?
     table.wont_be :view?
+  end
+
+  it "creates a table with time partitioning in a block" do
+    mock = Minitest::Mock.new
+    insert_table = Google::Apis::BigqueryV2::Table.new(
+      table_reference: Google::Apis::BigqueryV2::TableReference.new(
+        project_id: project, dataset_id: dataset_id, table_id: table_id),
+      time_partitioning: time_partitioning_gapi)
+    mock.expect :insert_table, insert_table, [project, dataset_id, insert_table]
+    dataset.service.mocked_service = mock
+
+    table = dataset.create_table table_id do |t|
+      t.time_partitioning_type = "DAY"
+      t.time_partitioning_field = "dob"
+      t.time_partitioning_expiration = 5
+    end
+
+    mock.verify
+
+    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.table_id.must_equal table_id
+    table.time_partitioning_type.must_equal "DAY"
+    table.time_partitioning_field.must_equal "dob"
+    table.time_partitioning_expiration.must_equal 5
   end
 
   it "creates a table with a schema inline" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
@@ -68,6 +68,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     table.time_partitioning_type.must_be_nil
     table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
+    table.clustering_fields.must_be_nil
     table.id.must_be_nil
     table.name.must_be_nil
     table.etag.must_be_nil

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
@@ -45,6 +45,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.time_partitioning_type.must_be_nil
     table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
+    table.clustering_fields.must_be_nil
 
     table.name = new_table_name
 
@@ -54,6 +55,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.time_partitioning_type.must_be_nil
     table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
+    table.clustering_fields.must_be_nil
 
     mock.verify
   end


### PR DESCRIPTION
This PR adds BigQuery clustering to `Table`, `LoadJob` and `QueryJob`. It also fixes an existing issue (#2520) in the `QueryJob` time partitioning examples.