### PR TITLE
Allow overriding samples bucket in acceptance tests.

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -273,7 +273,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
   it "imports data from GCS Avro file and creates a new table with load" do
     result = dataset.load(
       table_avro_id,
-      "gs://cloud-samples-data/bigquery/us-states/us-states.avro")
+      "gs://#{samples_bucket}/bigquery/us-states/us-states.avro")
     result.must_equal true
   end
 
@@ -281,7 +281,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     encrypt_config = bigquery.encryption(kms_key: kms_key)
     result = dataset.load(
       table_avro_id,
-      "gs://cloud-samples-data/bigquery/us-states/us-states.avro") do |load|
+      "gs://#{samples_bucket}/bigquery/us-states/us-states.avro") do |load|
       load.write = :truncate
       load.encryption = encrypt_config
     end
@@ -298,7 +298,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
   it "imports data from GCS ORC file and creates a new table with load" do
     result = dataset.load(
         table_orc_id,
-        "gs://cloud-samples-data/bigquery/us-states/us-states.orc")
+        "gs://#{samples_bucket}/bigquery/us-states/us-states.orc")
     result.must_equal true
   end
 
@@ -310,7 +310,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
   it "imports data from GCS Parquet file and creates a new table with load" do
     result = dataset.load(
         table_parquet_id,
-        "gs://cloud-samples-data/bigquery/us-states/us-states.parquet")
+        "gs://#{samples_bucket}/bigquery/us-states/us-states.parquet")
     result.must_equal true
   end
 

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -81,6 +81,7 @@ module Acceptance
     attr_accessor :prefix
     attr_accessor :storage
     attr_accessor :bucket
+    attr_accessor :samples_bucket
     attr_accessor :kms_key
     attr_accessor :kms_key_2
 

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -47,6 +47,11 @@ end
 
 $bucket = safe_gcs_execute { $storage.create_bucket "#{$prefix}_bucket" }
 
+# Allow overriding the samples bucket used for tests via an environment
+# variable. This bucket is public, but access may be restricted when tests are
+# run from a VPC project.
+$samples_bucket = ENV["GCLOUD_TEST_SAMPLES_BUCKET"] || "cloud-samples-data"
+
 # Allow overriding the KMS key used for tests via an environment variable.
 # These keys are public, but access may be restricted when tests are run from a
 # VPC project.
@@ -86,6 +91,7 @@ module Acceptance
       @prefix = $prefix
       @storage = $storage
       @bucket = $bucket
+      @samples_bucket = $samples_bucket
       @kms_key = $kms_key
       @kms_key_2 = $kms_key_2
 
@@ -93,6 +99,7 @@ module Acceptance
       refute_nil @prefix, "You do not have an bigquery prefix to name the datasets and tables with."
       refute_nil @storage, "You do not have an active storage to run the tests."
       refute_nil @bucket, "You do not have a storage bucket to run the tests."
+      refute_nil @samples_bucket, "You do not have a bucket with sample data to run the tests."
       refute_nil @kms_key, "You do not have a kms key to run the tests."
       refute_nil @kms_key_2, "You do not have a second kms key to run the tests."
 


### PR DESCRIPTION
The sample data bucket were are using is public, but access to it may be
restricted when tests are run from a VPC project. These changes will
unblock the Cloud testing team from running the affected tests.

Follow-up to https://github.com/googleapis/google-cloud-ruby/pull/2518