### PR TITLE
Upgrade Rubocop to 0.59.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "minitest-focus", "~> 1.1"
 gem "minitest-rg", "~> 5.2"
 gem "autotest-suffix", "~> 1.1"
 gem "redcarpet", "~> 3.0"
-gem "rubocop", "~> 0.50.0"
+gem "rubocop", "~> 0.59.2"
 gem "simplecov", "~> 0.16"
 gem "codecov", "~> 0.1", require: false
 gem "yard", "~> 0.9"

--- a/gcloud/gcloud.gemspec
+++ b/gcloud/gcloud.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-asset/google-cloud-asset.gemspec
+++ b/google-cloud-asset/google-cloud-asset.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec
+++ b/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-bigquery/.rubocop.yml
+++ b/google-cloud-bigquery/.rubocop.yml
@@ -37,3 +37,5 @@ Layout/EmptyLines: # for the extra line between copyright and code
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-bigquery.rb"
+Naming/UncommunicativeMethodParamName:
+  Enabled: false

--- a/google-cloud-bigquery/.rubocop.yml
+++ b/google-cloud-bigquery/.rubocop.yml
@@ -30,6 +30,8 @@ Metrics/MethodLength:
   Max: 30
 Metrics/ParameterLists:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-bigtable/.rubocop.yml
+++ b/google-cloud-bigtable/.rubocop.yml
@@ -40,6 +40,8 @@ Metrics/MethodLength:
   Max: 30
 Metrics/ParameterLists:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-bigtable/google-cloud-bigtable.gemspec
+++ b/google-cloud-bigtable/google-cloud-bigtable.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
@@ -491,7 +491,6 @@ module Google
         #   ).delete_from_column("cf2", "field02")
         #
         #   table.mutate_row(entry)
-
         #
         def table table_id, view: nil, perform_lookup: nil, app_profile_id: nil
           ensure_service!

--- a/google-cloud-container/google-cloud-container.gemspec
+++ b/google-cloud-container/google-cloud-container.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-core/.rubocop.yml
+++ b/google-cloud-core/.rubocop.yml
@@ -35,6 +35,6 @@ Layout/EmptyLines: # for the extra line between copyright and code
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-core.rb"
-Lint/RescueWithoutErrorClass:
+Style/RescueStandardError:
   Exclude:
     - "lib/google/cloud/credentials.rb"

--- a/google-cloud-core/.rubocop.yml
+++ b/google-cloud-core/.rubocop.yml
@@ -30,6 +30,8 @@ Metrics/ClassLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-core/google-cloud-core.gemspec
+++ b/google-cloud-core/google-cloud-core.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-core/lib/google/cloud/config.rb
+++ b/google-cloud-core/lib/google/cloud/config.rb
@@ -434,10 +434,10 @@ module Google
           str = data.strip
           return str if ::File.file? str
           json = begin
-            ::JSON.parse str
-          rescue ::StandardError
-            nil
-          end
+                   ::JSON.parse str
+                 rescue ::StandardError
+                   nil
+                 end
           return json if json.is_a? ::Hash
         end
         nil

--- a/google-cloud-dataproc/google-cloud-dataproc.gemspec
+++ b/google-cloud-dataproc/google-cloud-dataproc.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-datastore/.rubocop.yml
+++ b/google-cloud-datastore/.rubocop.yml
@@ -34,3 +34,5 @@ Layout/EmptyLines: # for the extra line between copyright and code
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-datastore.rb"
+Naming/UncommunicativeMethodParamName:
+  Enabled: false

--- a/google-cloud-datastore/.rubocop.yml
+++ b/google-cloud-datastore/.rubocop.yml
@@ -27,6 +27,8 @@ Metrics/MethodLength:
   Max: 25
 Metrics/ParameterLists:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-datastore/google-cloud-datastore.gemspec
+++ b/google-cloud-datastore/google-cloud-datastore.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-debugger/.rubocop.yml
+++ b/google-cloud-debugger/.rubocop.yml
@@ -38,6 +38,8 @@ Metrics/ParameterLists:
   Enabled: false
 Metrics/ModuleLength:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.8"

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
@@ -82,7 +82,7 @@ module Google
           ##
           # @private Predefined regex. Saves time during runtime.
           FULL_BYTE_CODE_BLACKLIST_REGEX = /^\d+ #{
-              [*BYTE_CODE_BLACKLIST, *LOCAL_BYTE_CODE_BLACKLIST].join '|'
+            [*BYTE_CODE_BLACKLIST, *LOCAL_BYTE_CODE_BLACKLIST].join '|'
           }/
 
           ##
@@ -953,6 +953,8 @@ module Google
             """
           end
 
+          # rubocop:disable Layout/RescueEnsureAlignment
+
           ##
           # @private Evaluation tracing callback function. This is called
           # everytime a Ruby function is called during evaluation of
@@ -990,6 +992,8 @@ module Google
               Google::Cloud::Debugger::EvaluationError::PROHIBITED_YARV
             )
           end
+
+          # rubocop:enable Layout/RescueEnsureAlignment
 
           ##
           # @private Evaluation tracing callback function. This is called

--- a/google-cloud-debugger/lib/google/cloud/debugger/service.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/service.rb
@@ -38,7 +38,7 @@ module Google
 
         def cloud_debugger
           return mocked_debugger if mocked_debugger
-          @debugger ||=
+          @cloud_debugger ||=
             V2::Controller2Client.new(
               credentials: credentials,
               timeout: timeout,

--- a/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
+++ b/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-dns/.rubocop.yml
+++ b/google-cloud-dns/.rubocop.yml
@@ -25,6 +25,8 @@ Metrics/MethodLength:
   Max: 20
 Metrics/ParameterLists:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-dns/google-cloud-dns.gemspec
+++ b/google-cloud-dns/google-cloud-dns.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-dns/lib/google/cloud/dns/importer.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/importer.rb
@@ -112,19 +112,16 @@ module Google
           @zone.record zf_soa[:origin], "SOA", ttl, data
         end
 
-        # rubocop:disable Performance/UnneededSort
-
         ##
         # From a collection of records, take the lowest ttl
         def ttl_from_zonefile_records zf_records
           ttls = zf_records.map do |zf_record|
             ttl_to_i(zf_record[:ttl])
           end
-          min_ttl = ttls.compact.sort.first
+          min_ttl = ttls.compact.min
           min_ttl || ttl_to_i(@zonefile.ttl)
         end
 
-        # rubocop:enable Performance/UnneededSort
         # rubocop:disable all
 
         ##

--- a/google-cloud-dns/lib/google/cloud/dns/importer.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/importer.rb
@@ -112,6 +112,8 @@ module Google
           @zone.record zf_soa[:origin], "SOA", ttl, data
         end
 
+        # rubocop:disable Performance/UnneededSort
+
         ##
         # From a collection of records, take the lowest ttl
         def ttl_from_zonefile_records zf_records
@@ -122,6 +124,7 @@ module Google
           min_ttl || ttl_to_i(@zonefile.ttl)
         end
 
+        # rubocop:enable Performance/UnneededSort
         # rubocop:disable all
 
         ##

--- a/google-cloud-env/google-cloud-env.gemspec
+++ b/google-cloud-env/google-cloud-env.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-error_reporting/.rubocop.yml
+++ b/google-cloud-error_reporting/.rubocop.yml
@@ -36,6 +36,8 @@ Metrics/MethodLength:
     - "lib/google/cloud/error_reporting.rb"
 Metrics/ParameterLists:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
+++ b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "railties", "~> 4.0"
   gem.add_development_dependency "rack", ">= 0.1"
   gem.add_development_dependency "simplecov", "~> 0.9"

--- a/google-cloud-firestore/.rubocop.yml
+++ b/google-cloud-firestore/.rubocop.yml
@@ -44,3 +44,5 @@ Naming/FileName:
 Style/RescueStandardError:
   Exclude:
   - "lib/google/cloud/firestore/client.rb"
+Naming/UncommunicativeMethodParamName:
+  Enabled: false

--- a/google-cloud-firestore/.rubocop.yml
+++ b/google-cloud-firestore/.rubocop.yml
@@ -34,6 +34,8 @@ Metrics/MethodLength:
   Max: 25
 Metrics/ParameterLists:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-firestore/.rubocop.yml
+++ b/google-cloud-firestore/.rubocop.yml
@@ -39,6 +39,6 @@ Layout/EmptyLines: # for the extra line between copyright and code
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-firestore.rb"
-Lint/RescueWithoutErrorClass:
+Style/RescueStandardError:
   Exclude:
   - "lib/google/cloud/firestore/client.rb"

--- a/google-cloud-firestore/google-cloud-firestore.gemspec
+++ b/google-cloud-firestore/google-cloud-firestore.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -1031,6 +1031,8 @@ module Google
           values_to_cursor values, query
         end
 
+        # rubocop:disable Performance/ReverseEach
+
         def ensure_inequality_field_paths_in_order_by! query
           inequality_paths = inequality_filter_field_paths query
           orig_order = order_by_field_paths query
@@ -1046,6 +1048,8 @@ module Google
             )
           end
         end
+
+        # rubocop:enable Performance/ReverseEach
 
         def ensure_document_id_in_order_by! query
           return if order_by_field_paths(query).include? doc_id_path

--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -1031,13 +1031,11 @@ module Google
           values_to_cursor values, query
         end
 
-        # rubocop:disable Performance/ReverseEach
-
         def ensure_inequality_field_paths_in_order_by! query
           inequality_paths = inequality_filter_field_paths query
           orig_order = order_by_field_paths query
 
-          inequality_paths.reverse.each do |field_path|
+          inequality_paths.reverse_each do |field_path|
             next if orig_order.include? field_path
 
             query.order_by.unshift StructuredQuery::Order.new(
@@ -1048,8 +1046,6 @@ module Google
             )
           end
         end
-
-        # rubocop:enable Performance/ReverseEach
 
         def ensure_document_id_in_order_by! query
           return if order_by_field_paths(query).include? doc_id_path

--- a/google-cloud-firestore/lib/google/cloud/firestore/watch/enumerator_queue.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/watch/enumerator_queue.rb
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-require "thread"
-
 module Google
   module Cloud
     module Firestore

--- a/google-cloud-firestore/lib/google/cloud/firestore/watch/listener.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/watch/listener.rb
@@ -18,7 +18,6 @@ require "google/cloud/firestore/convert"
 require "google/cloud/firestore/watch/enumerator_queue"
 require "google/cloud/firestore/watch/inventory"
 require "monitor"
-require "thread"
 
 module Google
   module Cloud

--- a/google-cloud-kms/google-cloud-kms.gemspec
+++ b/google-cloud-kms/google-cloud-kms.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-language/google-cloud-language.gemspec
+++ b/google-cloud-language/google-cloud-language.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-logging/.rubocop.yml
+++ b/google-cloud-logging/.rubocop.yml
@@ -34,6 +34,8 @@ Metrics/MethodLength:
   Max: 25
 Metrics/ParameterLists:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -14,7 +14,6 @@
 
 
 require "logger"
-require "thread"
 require "concurrent"
 
 module Google

--- a/google-cloud-monitoring/google-cloud-monitoring.gemspec
+++ b/google-cloud-monitoring/google-cloud-monitoring.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-os_login/google-cloud-os_login.gemspec
+++ b/google-cloud-os_login/google-cloud-os_login.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-pubsub/.rubocop.yml
+++ b/google-cloud-pubsub/.rubocop.yml
@@ -35,6 +35,8 @@ Metrics/MethodLength:
     - "lib/google/cloud/pubsub.rb"
 Metrics/ParameterLists:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
@@ -189,6 +189,8 @@ module Google
 
         protected
 
+        # rubocop:disable Naming/MemoizedInstanceVariableName
+
         def init_resources!
           @first_published_at   ||= Time.now
           @publish_thread_pool  ||= Concurrent::FixedThreadPool.new \
@@ -197,6 +199,8 @@ module Google
             @callback_threads
           @thread ||= Thread.new { run_background }
         end
+
+        # rubocop:enable Naming/MemoizedInstanceVariableName
 
         def run_background
           synchronize do

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/enumerator_queue.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/enumerator_queue.rb
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-require "thread"
-
 module Google
   module Cloud
     module Pubsub

--- a/google-cloud-redis/google-cloud-redis.gemspec
+++ b/google-cloud-redis/google-cloud-redis.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-resource_manager/.rubocop.yml
+++ b/google-cloud-resource_manager/.rubocop.yml
@@ -27,6 +27,8 @@ Metrics/MethodLength:
   Max: 20
 Metrics/ParameterLists:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
+++ b/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-spanner/.rubocop.yml
+++ b/google-cloud-spanner/.rubocop.yml
@@ -36,6 +36,8 @@ Metrics/ParameterLists:
   Enabled: false
 Lint/HandleExceptions:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-spanner/.rubocop.yml
+++ b/google-cloud-spanner/.rubocop.yml
@@ -43,3 +43,5 @@ Layout/EmptyLines: # for the extra line between copyright and code
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-spanner.rb"
+Naming/UncommunicativeMethodParamName:
+  Enabled: false

--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -1396,7 +1396,7 @@ module Google
           delay_from_aborted(err.cause)
         rescue StandardError
           # Any error indicates the backoff should be handled elsewhere
-          return nil
+          nil
         end
       end
     end

--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-require "thread"
 require "concurrent"
 require "google/cloud/spanner/errors"
 require "google/cloud/spanner/session"

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -607,7 +607,7 @@ module Google
           ensure_service!
           @grpc = service.get_session path
           @last_updated_at = Time.now
-          return self
+          self
         rescue Google::Cloud::NotFoundError
           labels = @grpc.labels.to_h unless @grpc.labels.to_h.empty?
           @grpc = service.create_session \
@@ -616,7 +616,7 @@ module Google
             ),
             labels: labels
           @last_updated_at = Time.now
-          return self
+          self
         end
 
         ##
@@ -625,7 +625,7 @@ module Google
         def keepalive!
           ensure_service!
           execute_query "SELECT 1"
-          return true
+          true
         rescue Google::Cloud::NotFoundError
           labels = @grpc.labels.to_h unless @grpc.labels.to_h.empty?
           @grpc = service.create_session \
@@ -633,7 +633,7 @@ module Google
               project_id, instance_id, database_id
             ),
             labels: labels
-          return false
+          false
         end
 
         ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1.rb
@@ -1,4 +1,3 @@
-
 # Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-storage/.rubocop.yml
+++ b/google-cloud-storage/.rubocop.yml
@@ -29,6 +29,8 @@ Metrics/MethodLength:
   Max: 25
 Metrics/ParameterLists:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/VariableNumber:

--- a/google-cloud-storage/.rubocop.yml
+++ b/google-cloud-storage/.rubocop.yml
@@ -36,6 +36,6 @@ Naming/VariableNumber:
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-storage.rb"
-Lint/RescueWithoutErrorClass:
+Style/RescueStandardError:
   Exclude:
   - "lib/google/cloud/storage/policy.rb"

--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -1720,6 +1720,8 @@ module Google
           [dest_bucket, dest_path]
         end
 
+        # rubocop:disable Style/MultipleComparison
+
         def verify_file! file, verify = :md5
           verify_md5    = verify == :md5    || verify == :all
           verify_crc32c = verify == :crc32c || verify == :all
@@ -1727,6 +1729,8 @@ module Google
           Verifier.verify_crc32c! self, file if verify_crc32c && crc32c
           file
         end
+
+        # rubocop:enable Style/MultipleComparison
 
         # @return [IO] Returns an IO object representing the file data. This
         #   will either be a `::File` object referencing the local file

--- a/google-cloud-tasks/google-cloud-tasks.gemspec
+++ b/google-cloud-tasks/google-cloud-tasks.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
+++ b/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-trace/.rubocop.yml
+++ b/google-cloud-trace/.rubocop.yml
@@ -50,6 +50,8 @@ Metrics/ParameterLists:
 Lint/RescueException:
   Exclude:
     - "lib/google/cloud/trace/rails.rb"
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "faraday", "~> 0.8"
   gem.add_development_dependency "railties", "~> 4.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest" #, "~> 0.1.6"

--- a/google-cloud-translate/.rubocop.yml
+++ b/google-cloud-translate/.rubocop.yml
@@ -27,6 +27,8 @@ Metrics/MethodLength:
     - "lib/google/cloud/translate.rb"
 Metrics/ParameterLists:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-translate/google-cloud-translate.gemspec
+++ b/google-cloud-translate/google-cloud-translate.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
+++ b/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-vision/.rubocop.yml
+++ b/google-cloud-vision/.rubocop.yml
@@ -33,6 +33,8 @@ Metrics/MethodLength:
     - "lib/google/cloud/vision.rb"
 Metrics/ParameterLists:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:

--- a/google-cloud-vision/.rubocop.yml
+++ b/google-cloud-vision/.rubocop.yml
@@ -40,3 +40,5 @@ Layout/EmptyLines: # for the extra line between copyright and code
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-vision.rb"
+Naming/UncommunicativeMethodParamName:
+  Enabled: false

--- a/google-cloud-vision/google-cloud-vision.gemspec
+++ b/google-cloud-vision/google-cloud-vision.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-vision/lib/google/cloud/vision/annotation.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation.rb
@@ -476,6 +476,8 @@ module Google
           !web.nil?
         end
 
+        # rubocop:disable Naming/MemoizedInstanceVariableName
+
         ##
         # The results of object localizations detection.
         #
@@ -495,6 +497,8 @@ module Google
             ObjectLocalization.from_grpc ol
           end
         end
+
+        # rubocop:enable Naming/MemoizedInstanceVariableName
 
         ##
         # Whether there is a result for object localizations detection.

--- a/google-cloud-vision/lib/google/cloud/vision/annotation.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation.rb
@@ -476,8 +476,6 @@ module Google
           !web.nil?
         end
 
-        # rubocop:disable Naming/MemoizedInstanceVariableName
-
         ##
         # The results of object localizations detection.
         #
@@ -493,12 +491,11 @@ module Google
         #   object_localizations = annotation.object_localizations
         #
         def object_localizations
-          @ol ||= @grpc.localized_object_annotations.map do |ol|
-            ObjectLocalization.from_grpc ol
-          end
+          @object_localizations ||= \
+            @grpc.localized_object_annotations.map do |ol|
+              ObjectLocalization.from_grpc ol
+            end
         end
-
-        # rubocop:enable Naming/MemoizedInstanceVariableName
 
         ##
         # Whether there is a result for object localizations detection.

--- a/google-cloud/google-cloud.gemspec
+++ b/google-cloud/google-cloud.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/stackdriver-core/.rubocop.yml
+++ b/stackdriver-core/.rubocop.yml
@@ -28,6 +28,8 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/ParameterLists:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/AccessorMethodName:

--- a/stackdriver-core/stackdriver-core.gemspec
+++ b/stackdriver-core/stackdriver-core.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "redcarpet", "~> 3.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"

--- a/stackdriver/stackdriver.gemspec
+++ b/stackdriver/stackdriver.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.59.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.6"


### PR DESCRIPTION
Upgrade all gems to the [latest rubocop](https://rubygems.org/gems/rubocop/versions). Disable cops or fix problems in code as appropriate to fix failing cops.

Note: This PR removes `require "thread"` statements in the final commit.