### PR TITLE
Allow override of KMS keys in storage acceptance tests

### DIFF
--- a/google-cloud-storage/acceptance/storage/bucket_encryption_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_encryption_test.rb
@@ -18,11 +18,11 @@ describe Google::Cloud::Storage::Bucket, :encryption, :storage do
   let(:bucket_name) { "#{$bucket_names[1]}-encryption" }
   let(:bucket_location) { "us-central1" }
   let(:kms_key) {
-    ENV["GCLOUD_RUBY_TEST_KEY_1"] ||
+    ENV["GCLOUD_TEST_STORAGE_KMS_KEY_1"] ||
       "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-1"
   }
   let(:kms_key_2) {
-    ENV["GCLOUD_RUBY_TEST_KEY_2"] ||
+    ENV["GCLOUD_TEST_STORAGE_KMS_KEY_2"] ||
       "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-2"
   }
   let :bucket do

--- a/google-cloud-storage/acceptance/storage/bucket_encryption_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_encryption_test.rb
@@ -17,8 +17,14 @@ require "storage_helper"
 describe Google::Cloud::Storage::Bucket, :encryption, :storage do
   let(:bucket_name) { "#{$bucket_names[1]}-encryption" }
   let(:bucket_location) { "us-central1" }
-  let(:kms_key) { "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-1" }
-  let(:kms_key_2) { "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-2" }
+  let(:kms_key) {
+    ENV["GCLOUD_RUBY_TEST_KEY_1"] ||
+      "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-1"
+  }
+  let(:kms_key_2) {
+    ENV["GCLOUD_RUBY_TEST_KEY_2"] ||
+      "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-2"
+  }
   let :bucket do
     b = safe_gcs_execute { storage.create_bucket(bucket_name, location: bucket_location) }
     b.default_kms_key = kms_key

--- a/google-cloud-storage/acceptance/storage/bucket_encryption_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_encryption_test.rb
@@ -19,11 +19,11 @@ describe Google::Cloud::Storage::Bucket, :encryption, :storage do
   let(:bucket_location) { "us-central1" }
   let(:kms_key) {
     ENV["GCLOUD_TEST_STORAGE_KMS_KEY_1"] ||
-      "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-1"
+      "projects/#{storage.project_id}/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-1"
   }
   let(:kms_key_2) {
     ENV["GCLOUD_TEST_STORAGE_KMS_KEY_2"] ||
-      "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-2"
+      "projects/#{storage.project_id}/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-2"
   }
   let :bucket do
     b = safe_gcs_execute { storage.create_bucket(bucket_name, location: bucket_location) }

--- a/google-cloud-storage/acceptance/storage/file_encryption_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_encryption_test.rb
@@ -160,11 +160,11 @@ describe Google::Cloud::Storage::File, :storage do
 
   describe "KMS customer-managed encryption key (CMEK)" do
     let(:kms_key) {
-      ENV["GCLOUD_RUBY_TEST_KEY_1"] ||
+      ENV["GCLOUD_TEST_STORAGE_KMS_KEY_1"] ||
         "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-1"
     }
     let(:kms_key_2) {
-      ENV["GCLOUD_RUBY_TEST_KEY_2"] ||
+      ENV["GCLOUD_TEST_STORAGE_KMS_KEY_2"] ||
         "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-2"
     }
 

--- a/google-cloud-storage/acceptance/storage/file_encryption_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_encryption_test.rb
@@ -159,8 +159,14 @@ describe Google::Cloud::Storage::File, :storage do
   end
 
   describe "KMS customer-managed encryption key (CMEK)" do
-    let(:kms_key) { "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-1" }
-    let(:kms_key_2) { "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-2" }
+    let(:kms_key) {
+      ENV["GCLOUD_RUBY_TEST_KEY_1"] ||
+        "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-1"
+    }
+    let(:kms_key_2) {
+      ENV["GCLOUD_RUBY_TEST_KEY_2"] ||
+        "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-2"
+    }
 
     it "should upload and download a file with default_kms_key" do
       bucket.default_kms_key = kms_key

--- a/google-cloud-storage/acceptance/storage/file_encryption_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_encryption_test.rb
@@ -161,11 +161,11 @@ describe Google::Cloud::Storage::File, :storage do
   describe "KMS customer-managed encryption key (CMEK)" do
     let(:kms_key) {
       ENV["GCLOUD_TEST_STORAGE_KMS_KEY_1"] ||
-        "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-1"
+        "projects/#{storage.project_id}/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-1"
     }
     let(:kms_key_2) {
       ENV["GCLOUD_TEST_STORAGE_KMS_KEY_2"] ||
-        "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-2"
+        "projects/#{storage.project_id}/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-2"
     }
 
     it "should upload and download a file with default_kms_key" do


### PR DESCRIPTION
Access to the keys currently hard-coded in the tests, may be restricted when tests are run from a VPC project. These changes allow tests to be invoked with a different set of keys, which will unblock the Cloud testing team from running the affected tests in a restricted environment.

See https://github.com/googleapis/google-cloud-ruby/pull/2518
