### PR TITLE
Allow overriding storage bucket in acceptance tests

### DIFF
--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -29,7 +29,9 @@ describe Google::Cloud::Storage::File, :storage do
       big:  { path: "acceptance/data/three-mb-file.tif" } }
   end
 
-  let(:bucket_public_test_name) { "storage-library-test-bucket" }
+  let(:bucket_public_test_name) {
+    ENV["GCLOUD_TEST_STORAGE_BUCKET"] || "storage-library-test-bucket"
+  }
   let(:file_public_test_gzip_name) { "gzipped-text.txt" }  # content is "hello world"
 
   before do

--- a/google-cloud-storage/acceptance/storage/filename_test.rb
+++ b/google-cloud-storage/acceptance/storage/filename_test.rb
@@ -15,7 +15,9 @@
 require "storage_helper"
 
 describe Google::Cloud::Storage::File, :storage do
-  let(:bucket_name) { "storage-library-test-bucket" }
+  let(:bucket_name) {
+    ENV["GCLOUD_TEST_STORAGE_BUCKET"] || "storage-library-test-bucket"
+  }
   let :bucket do
     storage.bucket(bucket_name)
   end


### PR DESCRIPTION
Access to the bucket currently hard-coded in the tests, may be restricted when tests are run from a VPC project. These changes allow tests to be invoked with a different bucket, which will unblock the Cloud testing team from running the affected tests in a restricted environment.

See #2522 
