### PR TITLE
Add #numeric Google::Cloud::Bigquery::Table::Updater

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -639,6 +639,36 @@ module Google
           end
 
           ##
+          # Adds a numeric number field to the schema. Numeric is a
+          # fixed-precision numeric type with 38 decimal digits, 9 that follow
+          # the decimal point.
+          #
+          # See {Schema#numeric}
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   job = dataset.load_job "my_table", "gs://abc/file" do |schema|
+          #     schema.numeric "total_cost", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def numeric name, description: nil, mode: :nullable
+            schema.numeric name, description: description, mode: mode
+          end
+
+          ##
           # Adds a boolean field to the schema.
           #
           # See {Schema#boolean}.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -2684,6 +2684,36 @@ module Google
           end
 
           ##
+          # Adds a numeric number field to the schema. Numeric is a
+          # fixed-precision numeric type with 38 decimal digits, 9 that follow
+          # the decimal point.
+          #
+          # See {Schema#numeric}
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   table = dataset.create_table "my_table" do |schema|
+          #     schema.numeric "total_cost", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def numeric name, description: nil, mode: :nullable
+            schema.numeric name, description: description, mode: mode
+          end
+
+          ##
           # Adds a boolean field to the schema.
           #
           # See {Schema#boolean}.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
@@ -41,6 +41,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
         { mode: "REQUIRED", name: "name", type: "STRING", description: nil, fields: [] },
         { mode: "NULLABLE", name: "age", type: "INTEGER", description: nil, fields: [] },
         { mode: "NULLABLE", name: "score", type: "FLOAT", description: "A score from 0.0 to 10.0", fields: [] },
+        { mode: "NULLABLE", name: "price", type: "NUMERIC", description: nil, fields: [] },
         { mode: "NULLABLE", name: "active", type: "BOOLEAN", description: nil, fields: [] },
         { mode: "NULLABLE", name: "avatar", type: "BYTES", description: nil, fields: [] },
         { mode: "REQUIRED", name: "dob", type: "TIMESTAMP", description: nil, fields: [] }
@@ -90,6 +91,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
       job.schema.string "name", mode: :required
       job.schema.integer "age"
       job.schema.float "score", description: "A score from 0.0 to 10.0"
+      job.schema.numeric "price"
       job.schema.boolean "active"
       job.schema.bytes "avatar"
       job.schema.timestamp "dob", mode: :required
@@ -127,6 +129,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
     schema.string "name", mode: :required
     schema.integer "age"
     schema.float "score", description: "A score from 0.0 to 10.0"
+    schema.numeric "price"
     schema.boolean "active"
     schema.bytes "avatar"
     schema.timestamp "dob", mode: :required
@@ -164,6 +167,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
 
     job = dataset.load_job table_id, load_file, create: :needed, schema: schema do |schema|
       schema.float "score", description: "A score from 0.0 to 10.0"
+      schema.numeric "price"
       schema.boolean "active"
       schema.bytes "avatar"
       schema.timestamp "dob", mode: :required
@@ -172,7 +176,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
     job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
     job.schema_update_options.must_equal schema_update_options
 
-    mock.verify
+    #mock.verify
   end
 
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
@@ -176,7 +176,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
     job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
     job.schema_update_options.must_equal schema_update_options
 
-    #mock.verify
+    mock.verify
   end
 
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -252,6 +252,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "cost",          type: "NUMERIC", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "creation_date", type: "TIMESTAMP", description: nil, fields: []),
@@ -271,6 +272,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       schema.string "name", mode: :required
       schema.integer "age"
       schema.float "score", description: "A score from 0.0 to 10.0"
+      schema.numeric "cost"
       schema.boolean "active"
       schema.bytes "avatar"
       schema.timestamp "creation_date"


### PR DESCRIPTION
The [docs](http://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigquery/latest/Google/Cloud/Bigquery/Table.html) for `Google::Bigquery::Table` show that you can create a table with this syntax:

```
table = dataset.create_table "my_table" do |schema|
  schema.string "first_name", mode: :required
  schema.record "cities_lived", mode: :repeated do |nested_schema|
    nested_schema.string "place", mode: :required
    nested_schema.integer "number_of_years", mode: :required
  end
end
```

However if you use a `numeric` field:

```
table = dataset.create_table "my_table" do |schema|
  schema.numeric 'price'
end
```

an error is raised: 

```
NoMethodError: undefined method `numeric' for #<Google::Cloud::Bigquery::Table::Updater:0x00007f858ad03d30>
```

The same issues exists for `Google::Cloud::Bigquery::LoadJob::Update`.

This works if you explicitly use the schema object but I find this way of creating tables a bit more readable hence this PR.

This PR adds numeric support to the `Table::Updater` class and the `LoadJob::Updater` class