### PR TITLE
Releases 2018-10-25

### DIFF
--- a/google-cloud-bigquery/CHANGELOG.md
+++ b/google-cloud-bigquery/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+### 1.9.0 / 2018-10-25
+
+* Add clustering fields to LoadJob, QueryJob and Table
+* Add DDL/DML support
+  * Update QueryJob#data to not return table rows for DDL/DML
+  * Add DDL/DML statistics attrs to QueryJob and Data
+* Add #numeric to Table::Updater and LoadJob::Updater (@leklund)
+
 ### 1.8.2 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigquery
-      VERSION = "1.8.2".freeze
+      VERSION = "1.9.0".freeze
     end
   end
 end


### PR DESCRIPTION
Release google-cloud-bigquery 1.9.0

* Add clustering fields to LoadJob, QueryJob and Table
* Add DDL/DML support
  * Update QueryJob#data to not return table rows for DDL/DML
  * Add DDL/DML statistics attrs to QueryJob and Data
* Add #numeric to Table::Updater and LoadJob::Updater (@leklund)