### PR TITLE
Rename modify ack deadline method

### DIFF
--- a/google-cloud-pubsub/OVERVIEW.md
+++ b/google-cloud-pubsub/OVERVIEW.md
@@ -269,7 +269,7 @@ subscriber = sub.listen do |received_message|
   puts received_message.message.data
 
   # Delay for 2 minutes
-  received_message.delay! 120
+  received_message.modify_ack_deadline! 120
 end
 
 # Start background threads that will call the block passed to listen.
@@ -311,7 +311,7 @@ pubsub = Google::Cloud::Pubsub.new
 
 sub = pubsub.subscription "my-topic-sub"
 received_messages = sub.pull
-sub.delay 120, received_messages
+sub.modify_ack_deadline 120, received_messages
 ```
 
 ## Creating a snapshot and using seek

--- a/google-cloud-pubsub/OVERVIEW.md
+++ b/google-cloud-pubsub/OVERVIEW.md
@@ -257,7 +257,8 @@ A message must be acknowledged after it is pulled, or Pub/Sub will mark the
 message for redelivery. The message acknowledgement deadline can delayed if more
 time is needed. This will allow more time to process the message before the
 message is marked for redelivery. (See
-{Google::Cloud::Pubsub::ReceivedMessage#delay! ReceivedMessage#delay!})
+{Google::Cloud::Pubsub::ReceivedMessage#modify_ack_deadline!
+ReceivedMessage#modify_ack_deadline!})
 
 ```ruby
 require "google/cloud/pubsub"
@@ -302,7 +303,8 @@ subscriber.stop.wait!
 ```
 
 Multiple messages can be delayed or made available for immediate redelivery:
-(See {Google::Cloud::Pubsub::Subscription#delay Subscription#delay})
+(See {Google::Cloud::Pubsub::Subscription#modify_ack_deadline
+Subscription#modify_ack_deadline})
 
 ```ruby
 require "google/cloud/pubsub"

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -147,7 +147,7 @@ module Google
         #     puts received_message.message.data
         #
         #     # Delay for 2 minutes
-        #     received_message.delay! 120
+        #     received_message.modify_ack_deadline! 120
         #   end
         #
         #   # Start background threads that will call block passed to listen.
@@ -156,11 +156,11 @@ module Google
         #   # Shut down the subscriber when ready to stop receiving messages.
         #   subscriber.stop.wait!
         #
-        def delay! new_deadline
+        def modify_ack_deadline! new_deadline
           ensure_subscription!
-          subscription.delay new_deadline, ack_id
+          subscription.modify_ack_deadline new_deadline, ack_id
         end
-        alias modify_ack_deadline! delay!
+        alias delay! modify_ack_deadline!
 
         ##
         # Resets the acknowledge deadline for the message without acknowledging

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -57,7 +57,8 @@ module Google
       #   handle the received messages. Default is 8.
       # @attr_reader [Integer] push_threads The number of threads to handle
       #   acknowledgement ({ReceivedMessage#ack!}) and delay messages
-      #   ({ReceivedMessage#nack!}, {ReceivedMessage#delay!}). Default is 4.
+      #   ({ReceivedMessage#nack!}, {ReceivedMessage#modify_ack_deadline!}).
+      #   Default is 4.
       #
       class Subscriber
         include MonitorMixin

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_stream_pusher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_stream_pusher.rb
@@ -68,7 +68,7 @@ module Google
             nil
           end
 
-          def delay deadline, ack_ids
+          def modify_ack_deadline deadline, ack_ids
             return true if ack_ids.empty?
 
             synchronize do
@@ -93,6 +93,7 @@ module Google
 
             nil
           end
+          alias delay modify_ack_deadline
 
           def start
             synchronize do

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_unary_pusher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_unary_pusher.rb
@@ -68,7 +68,7 @@ module Google
             nil
           end
 
-          def delay deadline, ack_ids
+          def modify_ack_deadline deadline, ack_ids
             return true if ack_ids.empty?
 
             synchronize do
@@ -93,6 +93,7 @@ module Google
 
             nil
           end
+          alias delay modify_ack_deadline
 
           def start
             synchronize do

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -144,7 +144,7 @@ module Google
 
           ##
           # @private
-          def delay deadline, *messages
+          def modify_ack_deadline deadline, *messages
             mod_ack_ids = coerce_ack_ids messages
             return true if mod_ack_ids.empty?
 
@@ -157,6 +157,7 @@ module Google
 
             true
           end
+          alias delay modify_ack_deadline
 
           def async_pusher
             synchronize { @async_pusher }

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -491,15 +491,15 @@ module Google
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   received_messages = sub.pull
-        #   sub.delay 120, received_messages
+        #   sub.modify_ack_deadline 120, received_messages
         #
-        def delay new_deadline, *messages
+        def modify_ack_deadline new_deadline, *messages
           ack_ids = coerce_ack_ids messages
           ensure_service!
           service.modify_ack_deadline name, ack_ids, new_deadline
           true
         end
-        alias modify_ack_deadline delay
+        alias delay modify_ack_deadline
 
         ##
         # Creates a new {Snapshot} from the subscription. The created snapshot

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/modify_ack_deadline_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/modify_ack_deadline_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
+describe Google::Cloud::Pubsub::Subscriber, :modify_ack_deadline, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
   let(:sub_json) { subscription_json topic_name, sub_name }
@@ -29,7 +29,7 @@ describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
   let(:rec_msg3_grpc) { Google::Pubsub::V1::ReceivedMessage.decode_json \
                           rec_message_json("rec_message3-msg-goes-here", 1113) }
 
-  it "can delay a single message" do
+  it "can modify_ack_deadline a single message" do
     rec_message_msg = "pulled-message"
     rec_message_ack_id = 123456789
     pull_res = Google::Pubsub::V1::StreamingPullResponse.decode_json rec_messages_json(rec_message_msg, rec_message_ack_id)
@@ -44,7 +44,7 @@ describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
       assert_equal rec_message_msg, msg.data
       assert_equal "ack-id-#{rec_message_ack_id}", msg.ack_id
 
-      msg.delay! 42
+      msg.modify_ack_deadline! 42
       called = true
     end
     subscriber.start
@@ -73,7 +73,7 @@ describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
     ]
   end
 
-  it "can delay multiple messages" do
+  it "can modify_ack_deadline multiple messages" do
     pull_res = Google::Pubsub::V1::StreamingPullResponse.new received_messages: [rec_msg1_grpc, rec_msg2_grpc, rec_msg3_grpc]
     response_groups = [[pull_res]]
 
@@ -83,7 +83,7 @@ describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
     subscription.service.mocked_subscriber = stub
     subscriber = subscription.listen streams: 1 do |msg|
       assert_kind_of Google::Cloud::Pubsub::ReceivedMessage, msg
-      msg.delay! 42
+      msg.modify_ack_deadline! 42
       called +=1
     end
     subscriber.start

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/modify_ack_deadline_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/modify_ack_deadline_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
+describe Google::Cloud::Pubsub::Subscription, :modify_ack_deadline, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
   let(:sub_json) { subscription_json topic_name, sub_name }
@@ -28,7 +28,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
   let(:rec_message2) { Google::Cloud::Pubsub::ReceivedMessage.from_grpc rec_msg2_grpc, subscription }
   let(:rec_message3) { Google::Cloud::Pubsub::ReceivedMessage.from_grpc rec_msg3_grpc, subscription }
 
-  it "can delay an ack id" do
+  it "can modify_ack_deadline an ack id" do
     ack_id = rec_message1.ack_id
     new_deadline = 42
     mad_res = nil
@@ -36,12 +36,12 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [ack_id], new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
 
-    subscription.delay new_deadline, ack_id
+    subscription.modify_ack_deadline new_deadline, ack_id
 
     mock.verify
   end
 
-  it "can delay many ack ids" do
+  it "can modify_ack_deadline many ack ids" do
     ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
     new_deadline = 42
     mad_res = nil
@@ -49,12 +49,12 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
 
-    subscription.delay new_deadline, *ack_ids
+    subscription.modify_ack_deadline new_deadline, *ack_ids
 
     mock.verify
   end
 
-  it "can delay many ack ids in an array" do
+  it "can modify_ack_deadline many ack ids in an array" do
     ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
     new_deadline = 42
     mad_res = nil
@@ -62,24 +62,24 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
 
-    subscription.delay new_deadline, ack_ids
+    subscription.modify_ack_deadline new_deadline, ack_ids
 
     mock.verify
   end
 
-  it "can delay a message" do
+  it "can modify_ack_deadline a message" do
     new_deadline = 42
     mad_res = nil
     mock = Minitest::Mock.new
     mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [rec_message1.ack_id], new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
 
-    subscription.delay new_deadline, rec_message1
+    subscription.modify_ack_deadline new_deadline, rec_message1
 
     mock.verify
   end
 
-  it "can delay many messages" do
+  it "can modify_ack_deadline many messages" do
     rec_messages = [rec_message1, rec_message3, rec_message3]
     new_deadline = 42
     mad_res = nil
@@ -87,12 +87,12 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
 
-    subscription.delay new_deadline, *rec_messages
+    subscription.modify_ack_deadline new_deadline, *rec_messages
 
     mock.verify
   end
 
-  it "can delay many messages in an array" do
+  it "can modify_ack_deadline many messages in an array" do
     rec_messages = [rec_message1, rec_message3, rec_message3]
     new_deadline = 42
     mad_res = nil
@@ -100,7 +100,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
 
-    subscription.delay new_deadline, rec_messages
+    subscription.modify_ack_deadline new_deadline, rec_messages
 
     mock.verify
   end
@@ -111,7 +111,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
                                             pubsub.service
     end
 
-    it "can delay an ack id" do
+    it "can modify_ack_deadline an ack id" do
       ack_id = rec_message1.ack_id
       new_deadline = 42
       mad_res = nil
@@ -119,12 +119,12 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [ack_id], new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      subscription.delay new_deadline, ack_id
+      subscription.modify_ack_deadline new_deadline, ack_id
 
       mock.verify
     end
 
-    it "can delay many ack ids" do
+    it "can modify_ack_deadline many ack ids" do
       ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
       new_deadline = 42
       mad_res = nil
@@ -132,12 +132,12 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      subscription.delay new_deadline, *ack_ids
+      subscription.modify_ack_deadline new_deadline, *ack_ids
 
       mock.verify
     end
 
-    it "can delay many ack ids in an array" do
+    it "can modify_ack_deadline many ack ids in an array" do
       ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
       new_deadline = 42
       mad_res = nil
@@ -145,24 +145,24 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      subscription.delay new_deadline, ack_ids
+      subscription.modify_ack_deadline new_deadline, ack_ids
 
       mock.verify
     end
 
-    it "can delay a message" do
+    it "can modify_ack_deadline a message" do
       new_deadline = 42
       mad_res = nil
       mock = Minitest::Mock.new
       mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [rec_message1.ack_id], new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      subscription.delay new_deadline, rec_message1
+      subscription.modify_ack_deadline new_deadline, rec_message1
 
       mock.verify
     end
 
-    it "can delay many messages" do
+    it "can modify_ack_deadline many messages" do
       rec_messages = [rec_message1, rec_message3, rec_message3]
       new_deadline = 42
       mad_res = nil
@@ -170,12 +170,12 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      subscription.delay new_deadline, *rec_messages
+      subscription.modify_ack_deadline new_deadline, *rec_messages
 
       mock.verify
     end
 
-    it "can delay many messages in an array" do
+    it "can modify_ack_deadline many messages in an array" do
       rec_messages = [rec_message1, rec_message3, rec_message3]
       new_deadline = 42
       mad_res = nil
@@ -183,7 +183,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      subscription.delay new_deadline, rec_messages
+      subscription.modify_ack_deadline new_deadline, rec_messages
 
       mock.verify
     end
@@ -195,7 +195,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
                                             pubsub.service
     end
 
-    it "raises NotFoundError when delaying an ack id" do
+    it "raises NotFoundError when modify_ack_deadlineing an ack id" do
       ack_id = rec_message1.ack_id
       new_deadline = 42
 
@@ -208,11 +208,11 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       subscription.service.mocked_subscriber = stub
 
       expect do
-        subscription.delay new_deadline, ack_id
+        subscription.modify_ack_deadline new_deadline, ack_id
       end.must_raise Google::Cloud::NotFoundError
     end
 
-    it "raises NotFoundError when delaying many ack ids" do
+    it "raises NotFoundError when modify_ack_deadlineing many ack ids" do
       ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
       new_deadline = 42
 
@@ -225,11 +225,11 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       subscription.service.mocked_subscriber = stub
 
       expect do
-        subscription.delay new_deadline, *ack_ids
+        subscription.modify_ack_deadline new_deadline, *ack_ids
       end.must_raise Google::Cloud::NotFoundError
     end
 
-    it "raises NotFoundError when delaying many ack ids in an array" do
+    it "raises NotFoundError when modify_ack_deadlineing many ack ids in an array" do
       ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
       new_deadline = 42
 
@@ -242,11 +242,11 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       subscription.service.mocked_subscriber = stub
 
       expect do
-        subscription.delay new_deadline, ack_ids
+        subscription.modify_ack_deadline new_deadline, ack_ids
       end.must_raise Google::Cloud::NotFoundError
     end
 
-    it "raises NotFoundError when delaying a message" do
+    it "raises NotFoundError when modify_ack_deadlineing a message" do
       new_deadline = 42
 
       stub = Object.new
@@ -258,11 +258,11 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       subscription.service.mocked_subscriber = stub
 
       expect do
-        subscription.delay new_deadline, rec_message1
+        subscription.modify_ack_deadline new_deadline, rec_message1
       end.must_raise Google::Cloud::NotFoundError
     end
 
-    it "raises NotFoundError when delaying many messages" do
+    it "raises NotFoundError when modify_ack_deadlineing many messages" do
       rec_messages = [rec_message1, rec_message3, rec_message3]
       new_deadline = 42
 
@@ -275,11 +275,11 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       subscription.service.mocked_subscriber = stub
 
       expect do
-        subscription.delay new_deadline, *rec_messages
+        subscription.modify_ack_deadline new_deadline, *rec_messages
       end.must_raise Google::Cloud::NotFoundError
     end
 
-    it "raises NotFoundError when delaying many messages in an array" do
+    it "raises NotFoundError when modify_ack_deadlineing many messages in an array" do
       rec_messages = [rec_message1, rec_message3, rec_message3]
       new_deadline = 42
 
@@ -292,7 +292,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       subscription.service.mocked_subscriber = stub
 
       expect do
-        subscription.delay new_deadline, rec_messages
+        subscription.modify_ack_deadline new_deadline, rec_messages
       end.must_raise Google::Cloud::NotFoundError
     end
   end


### PR DESCRIPTION
* Rename delay methods to modify_ack_deadline
* Rename modify_ack_deadling aliases to delay
* This maintains backwards compatibility