### PR TITLE
Releases 2018-10-29

### DIFF
--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.33.2 / 2018-10-29
+
+* Rename delay methods to modify_ack_deadline
+  * Rename modify_ack_deadling aliases to delay
+  * This maintains backwards compatibility
+
 ### 0.33.1 / 2018-10-03
 
 * Update connection configuration.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Pubsub
-      VERSION = "0.33.1".freeze
+      VERSION = "0.33.2".freeze
     end
   end
 end


### PR DESCRIPTION
Release google-cloud-pubsub 0.33.2

* Rename delay methods to modify_ack_deadline
  * Rename modify_ack_deadling aliases to delay
  * This maintains backwards compatibility