### PR TITLE
add timeouts to kokoro jobs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require "open3"
 require "json"
 require "erb"
 require "fileutils"
+require "timeout"
 
 task :bundleupdate do
   valid_gems.each do |gem|
@@ -570,7 +571,7 @@ namespace :kokoro do
         header "Using Ruby - #{RUBY_VERSION}"
         Rake::Task["kokoro:windows_acceptance_fix"].invoke
         sh "bundle update"
-        sh "bundle exec rake ci"
+        Timeout.timeout(1200) { sh "bundle exec rake ci" }
       end
     end
   end
@@ -592,7 +593,7 @@ namespace :kokoro do
         sh "bundle update"
         command = "bundle exec rake ci"
         command += ":acceptance" if updated
-        sh command
+        Timeout.timeout(1800) { sh command }
       end
     end
   end
@@ -605,7 +606,7 @@ namespace :kokoro do
         header "Using Ruby - #{RUBY_VERSION}"
         Rake::Task["kokoro:windows_acceptance_fix"].invoke
         sh "bundle update"
-        sh "bundle exec rake ci:acceptance"
+        Timeout.timeout(3600) { sh "bundle exec rake ci:acceptance" }
       end
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -567,7 +567,7 @@ namespace :kokoro do
     header_2 ENV["JOB_TYPE"]
     Dir.chdir ENV["PACKAGE"] do
       Bundler.with_clean_env do
-        # Rake::Task["kokoro:load_env_vars"].invoke
+        Rake::Task["kokoro:load_env_vars"].invoke
         header "Using Ruby - #{RUBY_VERSION}"
         Rake::Task["kokoro:windows_acceptance_fix"].invoke
         sh "bundle update"

--- a/Rakefile
+++ b/Rakefile
@@ -571,7 +571,8 @@ namespace :kokoro do
         header "Using Ruby - #{RUBY_VERSION}"
         Rake::Task["kokoro:windows_acceptance_fix"].invoke
         sh "bundle update"
-        run_command_with_timeout "bundle exec rake ci", 1800
+        exit_status = run_command_with_timeout "bundle exec rake ci", 1800
+        exit exit_status
       end
     end
   end
@@ -593,7 +594,8 @@ namespace :kokoro do
         sh "bundle update"
         command = "bundle exec rake ci"
         command += ":acceptance" if updated
-        run_command_with_timeout command, 3600
+        exit_status = run_command_with_timeout command, 3600
+        exit exit_status
       end
     end
   end
@@ -606,7 +608,8 @@ namespace :kokoro do
         header "Using Ruby - #{RUBY_VERSION}"
         Rake::Task["kokoro:windows_acceptance_fix"].invoke
         sh "bundle update"
-        run_command_with_timeout "bundle exec rake ci:acceptance", 3600
+        exit_status = run_command_with_timeout "bundle exec rake ci:acceptance", 3600
+        exit exit_status
       end
     end
   end
@@ -641,10 +644,12 @@ def run_command_with_timeout command, timeout
     Timeout.timeout(timeout) do
       Process.wait(job)
     end
+    return $?.exitstatus
   rescue Timeout::Error
     header_2 "TIMEOUT - #{timeout / 60} minute limit exceeded."
     Process.kill('TERM', job)
   end
+  1
 end
 
 def generate_kokoro_configs

--- a/Rakefile
+++ b/Rakefile
@@ -571,7 +571,7 @@ namespace :kokoro do
         header "Using Ruby - #{RUBY_VERSION}"
         Rake::Task["kokoro:windows_acceptance_fix"].invoke
         sh "bundle update"
-        run_command_with_timeout "bundle exec rake ci", 1200
+        run_command_with_timeout "bundle exec rake ci", 1800
       end
     end
   end
@@ -593,7 +593,7 @@ namespace :kokoro do
         sh "bundle update"
         command = "bundle exec rake ci"
         command += ":acceptance" if updated
-        run_command_with_timeout command, 1800
+        run_command_with_timeout command, 3600
       end
     end
   end

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "bundler/gem_tasks"
+require "timeout"
 
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
@@ -110,16 +111,18 @@ end
 
 desc "Run the CI build"
 task :ci do
-  header "BUILDING google-cloud-vision"
-  header "google-cloud-vision rubocop", "*"
-  Rake::Task[:rubocop].invoke
-  header "google-cloud-vision yard", "*"
-  header "vision yard still had warnings", "!"
-  Rake::Task[:yard].invoke
-  header "google-cloud-vision doctest", "*"
-  Rake::Task[:doctest].invoke
-  header "google-cloud-vision test", "*"
-  Rake::Task[:test].invoke
+  Timeout.timeout(1) do
+    header "BUILDING google-cloud-vision"
+    header "google-cloud-vision rubocop", "*"
+    Rake::Task[:rubocop].invoke
+    header "google-cloud-vision yard", "*"
+    header "vision yard still had warnings", "!"
+    Rake::Task[:yard].invoke
+    header "google-cloud-vision doctest", "*"
+    Rake::Task[:doctest].invoke
+    header "google-cloud-vision test", "*"
+    Rake::Task[:test].invoke
+  end
 end
 namespace :ci do
   desc "Run the CI build, with acceptance tests."

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -1,6 +1,5 @@
 require "bundler/setup"
 require "bundler/gem_tasks"
-require "timeout"
 
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
@@ -111,18 +110,16 @@ end
 
 desc "Run the CI build"
 task :ci do
-  Timeout.timeout(1) do
-    header "BUILDING google-cloud-vision"
-    header "google-cloud-vision rubocop", "*"
-    Rake::Task[:rubocop].invoke
-    header "google-cloud-vision yard", "*"
-    header "vision yard still had warnings", "!"
-    Rake::Task[:yard].invoke
-    header "google-cloud-vision doctest", "*"
-    Rake::Task[:doctest].invoke
-    header "google-cloud-vision test", "*"
-    Rake::Task[:test].invoke
-  end
+  header "BUILDING google-cloud-vision"
+  header "google-cloud-vision rubocop", "*"
+  Rake::Task[:rubocop].invoke
+  header "google-cloud-vision yard", "*"
+  header "vision yard still had warnings", "!"
+  Rake::Task[:yard].invoke
+  header "google-cloud-vision doctest", "*"
+  Rake::Task[:doctest].invoke
+  header "google-cloud-vision test", "*"
+  Rake::Task[:test].invoke
 end
 namespace :ci do
   desc "Run the CI build, with acceptance tests."


### PR DESCRIPTION
Some of the windows jobs take forever and are clogging up the queue. 

Please let me know if you think the timeouts aren't reasonable or conservative enough.