### PR TITLE
Releases 2018-11-15

### DIFF
--- a/google-cloud-bigtable/CHANGELOG.md
+++ b/google-cloud-bigtable/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+### 0.2.0 / 2018-11-15
+
+* Update network configuration.
+* Allow the emulator host to be provided in the BIGTABLE_EMULATOR_HOST
+  environment variable, or the emulator_host argument.
+* Add EMULATOR guide to show how to configure and use the emulator.
+* Update documentation.
+
 ### 0.1.3 / 2018-09-20
 
 * Update connectivity configuration.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/version.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigtable
-      VERSION = "0.1.3".freeze
+      VERSION = "0.2.0".freeze
     end
   end
 end

--- a/google-cloud-debugger/CHANGELOG.md
+++ b/google-cloud-debugger/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.32.6 / 2018-11-15
+
+* Update network configuration.
+
 ### 0.32.5 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-debugger/lib/google/cloud/debugger/version.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Debugger
-      VERSION = "0.32.5".freeze
+      VERSION = "0.32.6".freeze
     end
   end
 end

--- a/google-cloud-dialogflow/CHANGELOG.md
+++ b/google-cloud-dialogflow/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.3 / 2018-11-15
+
+* Update network configuration.
+
 ### 0.2.2 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
+++ b/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dialogflow"
-  gem.version       = "0.2.2"
+  gem.version       = "0.2.3"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-dlp/CHANGELOG.md
+++ b/google-cloud-dlp/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Release History
 
+### 0.8.0 / 2018-11-15
+
+* Add StoredInfoType CRUD+List access methods:
+  * DlpServiceClient#create_stored_info_type
+  * DlpServiceClient#get_stored_info_type
+  * DlpServiceClient#update_stored_info_type
+  * DlpServiceClient#delete_stored_info_type
+  * DlpServiceClient#list_stored_info_types
+* Add BigQueryOptions#excluded_fields value.
+* Add order_by argument to DlpServiceClient#list_dlp_jobs
+* Add ListDlpJobsRequest#order_by
+* Add CloudStorageOptions::FileSet#regex_file_set
+  * Returns newly added CloudStorageRegexFileSet object
+* Update documentation.
+
 ### 0.7.0 / 2018-10-03
 
 * Add order_by argument to the following methods and resources:

--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dlp"
-  gem.version       = "0.7.0"
+  gem.version       = "0.8.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-logging/CHANGELOG.md
+++ b/google-cloud-logging/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.5.7 / 2018-11-15
+
+* Add Google::Logging::V2::LogEntry#trace_sampled.
+* Update low-level documentation.
+
 ### 1.5.6 / 2018-10-03
 
 * Use concurrent-ruby and ThreadLocalVar in Logger.

--- a/google-cloud-logging/lib/google/cloud/logging/version.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Logging
-      VERSION = "1.5.6".freeze
+      VERSION = "1.5.7".freeze
     end
   end
 end

--- a/google-cloud-spanner/CHANGELOG.md
+++ b/google-cloud-spanner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.7.2 / 2018-11-15
+
+* Allow Spanner streams to recover from more errors.
+
 ### 1.7.1 / 2018-10-08
 
 * Add DML and Partitioned DML support

--- a/google-cloud-spanner/lib/google/cloud/spanner/version.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Spanner
-      VERSION = "1.7.1".freeze
+      VERSION = "1.7.2".freeze
     end
   end
 end

--- a/google-cloud-speech/CHANGELOG.md
+++ b/google-cloud-speech/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.32.0 / 2018-11-15
+
+* Add StreamingRecognitionResult#result_end_time value.
+* Update documentation.
+* Update network configuration.
+
 ### 0.31.1 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-speech"
-  gem.version       = "0.31.1"
+  gem.version       = "0.32.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-tasks/CHANGELOG.md
+++ b/google-cloud-tasks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.6 / 2018-11-15
+
+* Update network configuration.
+
 ### 0.2.5 / 2018-10-18
 
 * Release v2beta3.

--- a/google-cloud-tasks/google-cloud-tasks.gemspec
+++ b/google-cloud-tasks/google-cloud-tasks.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-tasks"
-  gem.version       = "0.2.5"
+  gem.version       = "0.2.6"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.33.6 / 2018-11-15
+
+* Update network configuration.
+
 ### 0.33.5 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-trace/lib/google/cloud/trace/version.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Trace
-      VERSION = "0.33.5".freeze
+      VERSION = "0.33.6".freeze
     end
   end
 end


### PR DESCRIPTION
Release google-cloud-trace 0.33.6

* Update network configuration.

Release google-cloud-tasks 0.2.6

* Update network configuration.

Release google-cloud-speech 0.32.0

* Add StreamingRecognitionResult#result_end_time value.
* Update documentation.
* Update network configuration.

Release google-cloud-spanner 1.7.2

* Allow Spanner streams to recover from more errors.

Release google-cloud-logging 1.5.7

* Add Google::Logging::V2::LogEntry#trace_sampled.
* Update low-level documentation.

Release google-cloud-dlp 0.8.0

* Add StoredInfoType CRUD+List access methods:
  * DlpServiceClient#create_stored_info_type
  * DlpServiceClient#get_stored_info_type
  * DlpServiceClient#update_stored_info_type
  * DlpServiceClient#delete_stored_info_type
  * DlpServiceClient#list_stored_info_types
* Add BigQueryOptions#excluded_fields value.
* Add order_by argument to DlpServiceClient#list_dlp_jobs
* Add ListDlpJobsRequest#order_by
* Add CloudStorageOptions::FileSet#regex_file_set
  * Returns newly added CloudStorageRegexFileSet object
* Update documentation.

Release google-cloud-dialogflow 0.2.3

* Update network configuration.

Release google-cloud-debugger 0.32.6

* Update network configuration.

Release google-cloud-bigtable 0.2.0

* Update network configuration.
* Allow the emulator host to be provided in the BIGTABLE_EMULATOR_HOST
  environment variable, or the emulator_host argument.
* Add EMULATOR guide to show how to configure and use the emulator.
* Update documentation.