### PR TITLE
Add buffering and batches to AsyncWriter

### DIFF
--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
+gem "google-cloud-error_reporting", path: "../google-cloud-error_reporting"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 gem "stackdriver-core", path: "../stackdriver-core"
 

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -372,8 +372,9 @@ module Google
         protected
 
         def init_resources!
-          @thread_pool ||= Concurrent::FixedThreadPool.new @threads,
-                                                           max_queue: @max_queue
+          @thread_pool ||= \
+            Concurrent::CachedThreadPool.new max_threads: @threads,
+                                             max_queue: @max_queue
           @thread ||= Thread.new { run_background }
           nil # returning nil because of rubocop...
         end

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -77,6 +77,9 @@ module Google
 
           @cond = new_cond
 
+          # Make sure all buffered messages are send when process exits.
+          at_exit { stop }
+
           # init MonitorMixin
           super()
         end

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -146,7 +146,7 @@ module Google
 
             publish_batch! if @batch.ready?
 
-            @cond.signal
+            @cond.broadcast
           end
           self
         end
@@ -209,7 +209,7 @@ module Google
 
             @stopped = true
             publish_batch!
-            @cond.signal
+            @cond.broadcast
             @thread_pool.shutdown if @thread_pool
           end
 
@@ -272,7 +272,7 @@ module Google
         def flush
           synchronize do
             publish_batch!
-            @cond.signal
+            @cond.broadcast
           end
 
           self

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -82,7 +82,7 @@ module Google
 
           @cond = new_cond
 
-          # Make sure all buffered messages are send when process exits.
+          # Make sure all buffered messages are sent when process exits.
           at_exit { stop }
 
           # init MonitorMixin

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -313,6 +313,7 @@ module Google
         #
         # @example
         #   require "google/cloud/logging"
+        #   require "google/cloud/error_reporting"
         #
         #   logging = Google::Cloud::Logging.new
         #
@@ -324,8 +325,8 @@ module Google
         #
         #   # Register to be notified when unhandled errors occur.
         #   async.on_error do |error|
-        #     # log error
-        #     puts error
+        #     # error can be a AsyncWriterError or AsyncWriteEntriesError
+        #     Google::Cloud::ErrorReporting.report error
         #   end
         #
         #   logger = async.logger "my_app_log", resource, env: :production

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 
-require "set"
-require "stackdriver/core/async_actor"
+require "monitor"
+require "concurrent"
 
 module Google
   module Cloud
@@ -22,7 +22,8 @@ module Google
       ##
       # # AsyncWriter
       #
-      # An object that batches and transmits log entries asynchronously.
+      # An object that buffers, batches, and transmits log entries
+      # asynchronously.
       #
       # Use this object to transmit log entries efficiently. It keeps a queue
       # of log entries, and runs a background thread that transmits them to
@@ -54,58 +55,30 @@ module Google
       #                       labels: labels
       #
       class AsyncWriter
-        include Stackdriver::Core::AsyncActor
-
-        DEFAULT_MAX_QUEUE_SIZE = 10000
-        CLEANUP_TIMEOUT = Stackdriver::Core::AsyncActor::CLEANUP_TIMEOUT
-        WAIT_INTERVAL = Stackdriver::Core::AsyncActor::WAIT_INTERVAL
+        include MonitorMixin
 
         ##
-        # @private Item in the log entries queue.
-        QueueItem = Struct.new(:entries, :log_name, :resource, :labels) do
-          def try_combine next_item
-            if log_name == next_item.log_name &&
-               resource == next_item.resource &&
-               labels == next_item.labels
-              entries.concat(next_item.entries)
-              true
-            else
-              false
-            end
-          end
-        end
-
-        ##
-        # @private The logging object.
-        attr_accessor :logging
-
-        ##
-        # @private The maximum size of the entries queue, or nil if not set.
-        attr_accessor :max_queue_size
-
-        ##
-        # The current state. Either :running, :suspended, :stopping, or :stopped
-        #
-        # DEPRECATED. Use #async_state instead.
-        alias state async_state
-
-        ##
-        # The last exception thrown by the background thread, or nil if nothing
-        # has been thrown.
-        attr_reader :last_exception
+        # @private Implementation accessors
+        attr_reader :logging, :max_bytes, :max_count, :interval,
+                    :threads
 
         ##
         # @private Creates a new AsyncWriter instance.
-        def initialize logging, max_queue_size = DEFAULT_MAX_QUEUE_SIZE,
-                       partial_success = false
-          super()
-
+        def initialize logging, max_count: 10000, max_bytes: 10000000,
+                       interval: 5, threads: 2
           @logging = logging
-          @max_queue_size = max_queue_size
-          @partial_success = partial_success
-          @queue_resource = new_cond
-          @queue = []
-          @queue_size = 0
+
+          @max_count = max_count
+          @max_bytes = max_bytes
+          @interval  = interval
+          @threads   = threads.to_i
+
+          @error_callbacks = []
+
+          @cond = new_cond
+
+          # init MonitorMixin
+          super()
         end
 
         ##
@@ -148,23 +121,41 @@ module Google
         #
         #   async.write_entries entry
         #
-        def write_entries entries, log_name: nil, resource: nil, labels: nil
-          ensure_thread
-          entries = Array(entries)
+        def write_entries entries, log_name: nil, resource: nil, labels: nil,
+                          partial_success: nil
           synchronize do
-            raise "AsyncWriter has been stopped" unless writable?
-            queue_item = QueueItem.new entries, log_name, resource, labels
-            if @queue.empty? || !@queue.last.try_combine(queue_item)
-              @queue.push queue_item
+            raise "AsyncWriter has been stopped" if @stopped
+
+            @batch ||= Batch.new self
+            unless @batch.try_add(entries, log_name: log_name,
+                                           resource: resource, labels: labels,
+                                           partial_success: partial_success)
+              publish_batch!
+              @batch = Batch.new self
+              @batch.add(entries, log_name: log_name, resource: resource,
+                                  labels: labels,
+                                  partial_success: partial_success)
             end
-            @queue_size += entries.size
-            @queue_resource.broadcast
-            while @max_queue_size && @queue_size > @max_queue_size
-              @queue_resource.wait
-            end
+
+            init_resources!
+
+            publish_batch! if @batch.ready?
+
+            @cond.signal
           end
           self
         end
+
+        def noop
+          # do nothing
+        end
+        alias state noop
+        alias async_state noop
+        alias suspend noop
+        alias resume noop
+        alias async_suspend noop
+        alias async_resume noop
+        alias async_suspended? noop
 
         ##
         # Creates a logger instance that is API-compatible with Ruby's standard
@@ -201,96 +192,47 @@ module Google
         end
 
         ##
-        # Stops this asynchronous writer.
+        # Begins the process of stopping the writer. Entries already in the
+        # queue will be published, but no new entries can be added. Use {#wait!}
+        # to block until the writer is fully stopped and all pending entries
+        # have been published.
         #
-        # After this call succeeds, the state will change to :stopping, and
-        # you may not issue any additional write_entries calls. Any previously
-        # issued writes will complete. Once any existing backlog has been
-        # cleared, the state will change to :stopped.
-        #
-        # DEPRECATED. Use #async_stop instead.
-        #
-        # @return [Boolean] Returns true if the writer was running, or false
-        #   if the writer had already been stopped.
-        #
-        alias stop async_stop
+        # @return [AsyncWriter] returns self so calls can be chained.
+        def stop
+          synchronize do
+            break if @stopped
+
+            @stopped = true
+            publish_batch!
+            @cond.signal
+            @thread_pool.shutdown if @thread_pool
+          end
+
+          self
+        end
+        alias async_stop stop
 
         ##
-        # Suspends this asynchronous writer.
+        # Blocks until the writer is fully stopped, all pending entries have
+        # been published, and all callbacks have completed. Does not stop the
+        # writer. To stop the writer, first call {#stop} and then call {#wait!}
+        # to block until the writer is stopped.
         #
-        # After this call succeeds, the state will change to :suspended, and
-        # the writer will stop sending RPCs until resumed.
-        #
-        # DEPRECATED. Use #async_suspend instead.
-        #
-        # @return [Boolean] Returns true if the writer had been running and was
-        #   suspended, otherwise false.
-        #
-        alias suspend async_suspend
+        # @return [AsyncWriter] returns self so calls can be chained.
+        def wait! timeout = nil
+          synchronize do
+            if @thread_pool
+              @thread_pool.shutdown
+              @thread_pool.wait_for_termination timeout
+            end
+          end
 
-        ##
-        # Resumes this suspended asynchronous writer.
-        #
-        # After this call succeeds, the state will change to :running, and
-        # the writer will resume sending RPCs.
-        #
-        # DEPRECATED. Use #async_resume instead.
-        #
-        # @return [Boolean] Returns true if the writer had been suspended and
-        #   is now running, otherwise false.
-        #
-        alias resume async_resume
+          self
+        end
+        alias wait_until_async_stopped wait!
+        alias wait_until_stopped wait!
 
-        ##
-        # Returns true if this writer is running.
-        #
-        # DEPRECATED. Use #async_running? instead.
-        #
-        # @return [Boolean] Returns true if the writer is currently running.
-        #
-        alias running? async_running?
-
-        ##
-        # Returns true if this writer is suspended.
-        #
-        # DEPRECATED. Use #async_suspended? instead.
-        #
-        # @return [Boolean] Returns true if the writer is currently suspended.
-        #
-        alias suspended? async_suspended?
-
-        ##
-        # Returns true if this writer is still accepting writes. This means
-        # it is either running or suspended.
-        #
-        # DEPRECATED. Use #async_working? instead.
-        #
-        # @return [Boolean] Returns true if the writer is accepting writes.
-        #
-        alias writable? async_working?
-
-        ##
-        # Returns true if this writer is fully stopped.
-        #
-        # DEPRECATED. Use #async_stopped? instead.
-        #
-        # @return [Boolean] Returns true if the writer is fully stopped.
-        #
-        alias stopped? async_stopped?
-
-        ##
-        # Blocks until this asynchronous writer has been stopped, or the given
-        # timeout (if present) has elapsed.
-        #
-        # DEPRECATED. Use #wait_until_async_stopped instead.
-        #
-        # @param [Number, nil] timeout Timeout in seconds, or `nil` for no
-        #     timeout.
-        #
-        # @return [Boolean] Returns true if the writer is stopped, or false
-        #   if the timeout expired.
-        #
-        alias wait_until_stopped wait_until_async_stopped
+        # rubocop:disable Lint/UnusedMethodArgument
 
         ##
         # Stop this asynchronous writer and block until it has been stopped.
@@ -308,75 +250,307 @@ module Google
         #     during the timeout period, `:timeout` if it is still running
         #     after the timeout, or `:forced` if it was forcibly killed.
         #
-        def stop! timeout, force: false
-          @cleanup_options[:timeout] = timeout unless timeout.nil?
-          @cleanup_options[:force] = force unless force.nil?
+        def stop! timeout = nil, force: nil
+          stop
+          wait! timeout
 
-          async_stop!
+          # TODO: match the return type
+        end
+
+        # rubocop:enable Lint/UnusedMethodArgument
+
+        ##
+        # Forces all entries in the current batch to be published
+        # immediately.
+        #
+        # @return [AsyncWriter] returns self so calls can be chained.
+        def flush
+          synchronize do
+            publish_batch!
+            @cond.signal
+          end
+
+          self
         end
 
         ##
-        # @private Callback function when the async actor thread state changes
-        def on_async_state_change
+        # Whether the writer has been started.
+        #
+        # @return [boolean] `true` when started, `false` otherwise.
+        def started?
+          !stopped?
+        end
+        alias running? started?
+        alias writable? started?
+        alias async_running? started?
+        alias async_working? started?
+
+        ##
+        # Whether the writer has been stopped.
+        #
+        # @return [boolean] `true` when stopped, `false` otherwise.
+        def stopped?
+          synchronize { @stopped }
+        end
+        alias async_stopped? stopped?
+
+        ##
+        # Register to be notified of errors when raised.
+        #
+        # If an unhandled error has occurred the writer will attempt to
+        # recover from the error and resume buffering, batching, and
+        # transmitting log entries
+        #
+        # Multiple error handlers can be added.
+        #
+        # @yield [callback] The block to be called when an error is raised.
+        # @yieldparam [Exception] error The error raised.
+        #
+        # @example
+        #   require "google/cloud/logging"
+        #
+        #   logging = Google::Cloud::Logging.new
+        #
+        #   resource = logging.resource "gae_app",
+        #                               module_id: "1",
+        #                               version_id: "20150925t173233"
+        #
+        #   async = logging.async_writer
+        #
+        #   # Register to be notified when unhandled errors occur.
+        #   async.on_error do |error|
+        #     # log error
+        #     puts error
+        #   end
+        #
+        #   logger = async.logger "my_app_log", resource, env: :production
+        #   logger.info "Job started."
+        #
+        def on_error &block
           synchronize do
-            @queue_resource.broadcast
+            @error_callbacks << block
           end
         end
+
+        ##
+        # The most recent unhandled error to occur while transmitting log
+        # entries.
+        #
+        # If an unhandled error has occurred the subscriber will attempt to
+        # recover from the error and resume buffering, batching, and
+        # transmitting log entries.
+        #
+        # @return [Exception, nil] error The most recent error raised.
+        #
+        # @example
+        #   require "google/cloud/logging"
+        #
+        #   logging = Google::Cloud::Logging.new
+        #
+        #   resource = logging.resource "gae_app",
+        #                               module_id: "1",
+        #                               version_id: "20150925t173233"
+        #
+        #   async = logging.async_writer
+        #
+        #   logger = async.logger "my_app_log", resource, env: :production
+        #   logger.info "Job started."
+        #
+        #   # If an error was raised, it can be retrieved here:
+        #   async.last_error #=> nil
+        #
+        def last_error
+          synchronize { @last_error }
+        end
+        alias last_exception last_error
 
         protected
 
+        def init_resources!
+          @thread_pool ||= Concurrent::FixedThreadPool.new @threads
+          @thread ||= Thread.new { run_background }
+          nil # returning nil because of rubocop...
+        end
+
+        def run_background
+          synchronize do
+            until @stopped
+              if @batch.nil?
+                @cond.wait
+                next
+              end
+
+              if @batch.ready?
+                # interval met, publish the batch...
+                publish_batch!
+                @cond.wait
+              else
+                # still waiting for the interval to publish the batch...
+                @cond.wait(@batch.publish_wait)
+              end
+            end
+          end
+        end
+
+        def publish_batch!
+          return unless @batch
+
+          publish_batch_async @batch
+          @batch = nil
+        end
+
+        # Sets the last_error and calls all error callbacks.
+        def error! error
+          error_callbacks = synchronize do
+            @last_error = error
+            @error_callbacks
+          end
+          error_callbacks.each { |error_callback| error_callback.call error }
+        end
+
+        def publish_batch_async batch
+          return unless @thread_pool.running?
+
+          batch.values.each do |value|
+            Concurrent::Future.new(executor: @thread_pool) do
+              begin
+                logging.write_entries(
+                  value.entries,
+                  log_name: value.log_name,
+                  resource: value.resource,
+                  labels: value.labels,
+                  partial_success: value.partial_success
+                )
+              rescue StandardError => e
+                error! e
+              end
+            end.execute
+          end
+        end
+
         ##
-        # @private The background thread implementation, which continuously
-        # waits for and performs work, and returns only when fully stopped.
-        #
-        def run_backgrounder
-          queue_item = wait_next_item
-          return unless queue_item
-          begin
-            logging.write_entries(
-              queue_item.entries,
-              log_name: queue_item.log_name,
-              resource: queue_item.resource,
-              labels: queue_item.labels,
-              partial_success: @partial_success
+        # @private
+        class Batch
+          attr_reader :created_at, :entries
+
+          def initialize writer
+            @writer = writer
+            @entries = {}
+            @total_message_bytes = 0
+            @created_at = nil
+          end
+
+          def add entries, log_name: nil, resource: nil, labels: nil,
+                  partial_success: nil
+            entries_key = [log_name, resource, labels, partial_success]
+            @entries[entries_key] ||= Batch::EntryGroup.new(
+              log_name: log_name, resource: resource, labels: labels,
+              partial_success: partial_success
             )
-          rescue StandardError => e
-            # Ignore any exceptions thrown from the background thread, but
-            # keep running to ensure its state behavior remains consistent.
-            @last_exception = e
+            bytes_added = @entries[entries_key].add entries
+            @total_message_bytes += bytes_added
+            @created_at ||= Time.now
+            nil
           end
-        end
 
-        ##
-        # @private Wait for and dequeue the next set of log entries to transmit.
-        #
-        # @return [QueueItem, nil] Returns the next set of entries. If
-        #   the writer has been stopped and no more entries are left in the
-        #   queue, returns `nil`.
-        #
-        def wait_next_item
-          synchronize do
-            while state == :suspended ||
-                  (state == :running && @queue.empty?)
-              @queue_resource.wait
+          def try_add entries, log_name: nil, resource: nil, labels: nil,
+                      partial_success: nil
+            new_message_count = total_message_count + 1
+            addl_message_bytes = \
+              estimated_bytes_for entries, log_name: log_name,
+                                           resource: resource,
+                                           labels: labels,
+                                           partial_success: partial_success
+            new_message_bytes = total_message_bytes + addl_message_bytes
+            if new_message_count > @writer.max_count ||
+               new_message_bytes >= @writer.max_bytes
+              return false
             end
-            queue_item = nil
-            unless @queue.empty?
-              queue_item = @queue.shift
-              @queue_size -= queue_item.entries.size
-            end
-            @queue_resource.broadcast
-            queue_item
+            add entries, log_name: log_name, resource: resource, labels: labels,
+                         partial_success: partial_success
+            true
           end
-        end
 
-        ##
-        # @private Override the #backgrounder_stoppable? method from AsyncActor
-        # module. The actor can be gracefully stopped when queue is
-        # empty.
-        def backgrounder_stoppable?
-          synchronize do
-            @queue.empty?
+          def ready?
+            total_message_count >= @writer.max_count ||
+              total_message_bytes >= @writer.max_bytes ||
+              (@created_at.nil? || (publish_at < Time.now))
+          end
+
+          def publish_at
+            return nil if @created_at.nil?
+            @created_at + @writer.interval
+          end
+
+          def publish_wait
+            publish_wait = publish_at - Time.now
+            return 0 if publish_wait < 0
+            publish_wait
+          end
+
+          def total_message_count
+            @entries.values.map(&:count).sum
+          end
+
+          def total_message_bytes
+            @entries.values.map(&:message_bytes).sum
+          end
+
+          def estimated_bytes_for entries, log_name: nil, resource: nil,
+                                  labels: nil, partial_success: nil
+            entries = Array(entries).map(&:to_grpc)
+            resource = resource.to_grpc if resource
+            if labels
+              labels = Hash[labels.map { |k, v| [String(k), String(v)] }]
+            end
+            Google::Logging::V2::WriteLogEntriesRequest.new({
+              entries: entries,
+              log_name: log_name,
+              resource: resource,
+              labels: labels,
+              partial_success: partial_success
+            }.delete_if { |_, v| v.nil? }).to_proto.bytesize
+          end
+
+          def values
+            @entries.values
+          end
+
+          class EntryGroup
+            attr_reader :log_name, :resource, :labels, :partial_success,
+                        :message_bytes, :entries
+
+            def initialize log_name: nil, resource: nil, labels: nil,
+                           partial_success: nil
+              @log_name = log_name
+              @resource = resource
+              @labels = labels
+              @partial_success = partial_success
+              @message_bytes = 0
+              @message_bytes += log_name.bytesize if log_name
+              @message_bytes += resource.to_grpc.to_proto.bytesize if resource
+              if labels
+                labels_dup = Hash[labels.map { |k, v| [String(k), String(v)] }]
+                @message_bytes += labels_dup.to_a.to_s.bytesize # estimate
+              end
+
+              @entries = []
+            end
+
+            def add entries
+              entries = Array entries
+              added_bytes = entries.map(&:to_grpc)
+                                   .map(&:to_proto)
+                                   .map(&:bytesize)
+                                   .sum
+              @entries += entries
+              @message_bytes += added_bytes
+              added_bytes
+            end
+
+            def count
+              @entries.count
+            end
           end
         end
       end

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -29,7 +29,7 @@ module Google
       # Batches that cannot be delivered immediately are queued. When the queue
       # is full new batch requests will raise errors that can be consumed using
       # the {#on_error} callback. This provides back pressure in case the writer
-      # keep up with requests.
+      # cannot keep up with requests.
       #
       # This object is thread-safe; it may accept write requests from
       # multiple threads simultaneously, and will serialize them when

--- a/google-cloud-logging/lib/google/cloud/logging/errors.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/errors.rb
@@ -1,0 +1,101 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/errors"
+
+module Google
+  module Cloud
+    module Logging
+      ##
+      # # AsyncWriterError
+      #
+      # Used to indicate a problem preventing {AsyncWriter} from asynchronously
+      # calling the API. This can occur when the {AsyncWriter} has too few
+      # resources allocated for the amount of usage.
+      #
+      # @example
+      #   require "google/cloud/logging"
+      #   require "google/cloud/error_reporting"
+      #
+      #   logging = Google::Cloud::Logging.new
+      #
+      #   resource = logging.resource "gae_app",
+      #                               module_id: "1",
+      #                               version_id: "20150925t173233"
+      #
+      #   async = logging.async_writer
+      #
+      #   # Register to be notified when unhandled errors occur.
+      #   async.on_error do |error|
+      #     # error can be a AsyncWriterError, with entries
+      #     Google::Cloud::ErrorReporting.report error
+      #   end
+      #
+      #   logger = async.logger "my_app_log", resource, env: :production
+      #   logger.info "Job started."
+      #
+      class AsyncWriterError < Google::Cloud::Error
+        # @!attribute [r] count
+        #   @return [Array<Google::Cloud::Logging::Entry>] entries The entry
+        #   objects that were not written to the API due to the error.
+        attr_reader :entries
+
+        def initialize message, entries = nil
+          super(message)
+          @entries = entries if entries
+        end
+      end
+
+      ##
+      # # AsyncWriteEntriesError
+      #
+      # Used to indicate a problem when {AsyncWriter} writes log entries to the
+      # API. This can occur when the API returns an error.
+      #
+      # @example
+      #   require "google/cloud/logging"
+      #   require "google/cloud/error_reporting"
+      #
+      #   logging = Google::Cloud::Logging.new
+      #
+      #   resource = logging.resource "gae_app",
+      #                               module_id: "1",
+      #                               version_id: "20150925t173233"
+      #
+      #   async = logging.async_writer
+      #
+      #   # Register to be notified when unhandled errors occur.
+      #   async.on_error do |error|
+      #     # error can be a AsyncWriteEntriesError, with entries
+      #     Google::Cloud::ErrorReporting.report error
+      #   end
+      #
+      #   logger = async.logger "my_app_log", resource, env: :production
+      #   logger.info "Job started."
+      #
+      class AsyncWriteEntriesError < Google::Cloud::Error
+        # @!attribute [r] count
+        #   @return [Array<Google::Cloud::Logging::Entry>] entries The entry
+        #   objects that were not written to the API due to the error.
+        attr_reader :entries
+
+        def initialize message, entries = nil
+          super(message)
+          @entries = entries if entries
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -240,8 +240,8 @@ module Google
         #   `entries`, except when a log entry specifies its own `key:value`
         #   item with the same key. See also {Entry#labels=}.
         # @param [Boolean] partial_success Whether valid entries should be
-        #   written even if some other entries fail due to INVALID_ARGUMENT or
-        #   PERMISSION_DENIED errors when communicating to the Stackdriver
+        #   written even if some other entries fail due to `INVALID_ARGUMENT` or
+        #   `PERMISSION_DENIED` errors when communicating to the Stackdriver
         #   Logging API.
         #
         # @return [Boolean] Returns `true` if the entries were written.
@@ -327,6 +327,10 @@ module Google
         #   before a batch is written. Default is 5.
         # @param [Integer] threads The number of threads used to make
         #   batched write_entries requests. Default is 10.
+        # @param [Boolean] partial_success Whether valid entries should be
+        #   written even if some other entries fail due to `INVALID_ARGUMENT` or
+        #   `PERMISSION_DENIED` errors when communicating to the Stackdriver
+        #   Logging API.
         #
         # @return [Google::Cloud::Logging::AsyncWriter] an AsyncWriter object
         #   that buffers, batches, and transmits log entries efficiently.
@@ -352,12 +356,14 @@ module Google
         #                       labels: labels
         #
         def async_writer max_batch_count: 10000, max_batch_bytes: 10000000,
-                         max_queue_size: 100, interval: 5, threads: 10
+                         max_queue_size: 100, interval: 5, threads: 10,
+                         partial_success: false
 
           AsyncWriter.new self, max_count: max_batch_count,
                                 max_bytes: max_batch_bytes,
                                 max_queue: max_queue_size,
-                                interval: interval, threads: threads
+                                interval: interval, threads: threads,
+                                partial_success: partial_success
         end
 
         ##

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -311,7 +311,7 @@ module Google
         # Batches that cannot be delivered immediately are queued. When the
         # queue is full new batch requests will raise errors that can be
         # consumed using the {AsyncWriter#on_error} callback. This provides back
-        # pressure in case the writer keep up with requests.
+        # pressure in case the writer cannot keep up with requests.
         #
         # This object is thread-safe; it may accept write requests from
         # multiple threads simultaneously, and will serialize them when

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -310,8 +310,8 @@ module Google
         #
         # Batches that cannot be delivered immediately are queued. When the
         # queue is full new batch requests will raise errors that can be
-        # consumed using the {#on_error} callback. This provides back pressure
-        # in case the writer keep up with requests.
+        # consumed using the {AsyncWriter#on_error} callback. This provides back
+        # pressure in case the writer keep up with requests.
         #
         # This object is thread-safe; it may accept write requests from
         # multiple threads simultaneously, and will serialize them when

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -304,22 +304,32 @@ module Google
         end
 
         ##
-        # Creates an object that batches and transmits log entries
-        # asynchronously.
+        # Creates an object that buffers, batches, and transmits log entries
+        # efficiently. Writing log entries to this object is asynchronous and
+        # will not block.
         #
-        # Use this object to transmit log entries efficiently. It keeps a queue
-        # of log entries, and runs a background thread that transmits them to
-        # the logging service in batches. Generally, adding to the queue will
-        # not block.
+        # Batches that cannot be delivered immediately are queued. When the
+        # queue is full new batch requests will raise errors that can be
+        # consumed using the {#on_error} callback. This provides back pressure
+        # in case the writer keep up with requests.
         #
         # This object is thread-safe; it may accept write requests from
         # multiple threads simultaneously, and will serialize them when
         # executing in the background thread.
         #
-        # @param [Integer] max_queue_size The maximum number of log entries
-        #   that may be queued before write requests will begin to block.
-        #   This provides back pressure in case the transmitting thread cannot
-        #   keep up with requests.
+        # @param [Integer] max_batch_count The maximum number of log entries
+        #   that may be buffered and sent in a batch.
+        # @param [Integer] max_batch_bytes The maximum byte size of log entries
+        #   that may be buffered and sent in a batch.
+        # @param [Integer] max_queue_size The maximum number of pending
+        #   write_entries requests that may be queued.
+        # @param [Numeric] interval The number of seconds to buffer log entries
+        #   before a batch is written. Default is 5.
+        # @param [Integer] threads The number of threads used to make
+        #   batched write_entries requests. Default is 10.
+        #
+        # @return [Google::Cloud::Logging::AsyncWriter] an AsyncWriter object
+        #   that buffers, batches, and transmits log entries efficiently.
         #
         # @example
         #   require "google/cloud/logging"
@@ -341,10 +351,12 @@ module Google
         #                       resource: resource,
         #                       labels: labels
         #
-        def async_writer max_queue_size: 10000, max_queue_bytes: 10000000,
-                         interval: 5, threads: 2
-          AsyncWriter.new self, max_count: max_queue_size,
-                                max_bytes: max_queue_bytes,
+        def async_writer max_batch_count: 10000, max_batch_bytes: 10000000,
+                         max_queue_size: 100, interval: 5, threads: 10
+
+          AsyncWriter.new self, max_count: max_batch_count,
+                                max_bytes: max_batch_bytes,
+                                max_queue: max_queue_size,
                                 interval: interval, threads: threads
         end
 

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -341,8 +341,11 @@ module Google
         #                       resource: resource,
         #                       labels: labels
         #
-        def async_writer max_queue_size: AsyncWriter::DEFAULT_MAX_QUEUE_SIZE
-          AsyncWriter.new self, max_queue_size
+        def async_writer max_queue_size: 10000, max_queue_bytes: 10000000,
+                         interval: 5, threads: 2
+          AsyncWriter.new self, max_count: max_queue_size,
+                                max_bytes: max_queue_bytes,
+                                interval: interval, threads: threads
         end
 
         ##

--- a/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
   let(:labels1) { { "env" => "production" } }
   let(:labels2) { { "env" => "staging" } }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
-  let(:async_writer) { Google::Cloud::Logging::AsyncWriter.new logging, Google::Cloud::Logging::AsyncWriter::DEFAULT_MAX_QUEUE_SIZE, true }
+  let(:async_writer) { Google::Cloud::Logging::AsyncWriter.new logging }
 
   def entries payload, labels = labels1
     Array(payload).map { |str|
@@ -41,7 +41,7 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
     }
   end
 
-  def write_req_args payload, labels = labels1
+  def write_req_args payload, labels = labels1, partial_success = true
     full_log_name = "projects/test/logs/#{log_name}"
     entries = Array(payload).map do |str|
       Google::Logging::V2::LogEntry.new(
@@ -52,7 +52,7 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
         labels: labels
       )
     end
-    [entries, log_name: full_log_name, resource: resource.to_grpc, labels: labels, partial_success: true, options: default_options]
+    [entries, log_name: full_log_name, resource: resource.to_grpc, labels: labels, partial_success: partial_success, options: default_options]
   end
 
   it "writes a single entry" do
@@ -65,7 +65,8 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
       entries("payload1"),
       log_name: log_name,
       resource: resource,
-      labels: labels1
+      labels: labels1,
+      partial_success: true
     )
     async_writer.stop! 1
 
@@ -83,13 +84,15 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
       entries("payload1"),
       log_name: log_name,
       resource: resource,
-      labels: labels1
+      labels: labels1,
+      partial_success: true
     )
     async_writer.write_entries(
       entries("payload2"),
       log_name: log_name,
       resource: resource,
-      labels: labels1
+      labels: labels1,
+      partial_success: true
     )
     async_writer.resume
     async_writer.stop! 1
@@ -102,25 +105,28 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
     logging.service.mocked_logging = mock
 
     mock.expect :write_log_entries, write_res, write_req_args(["payload1"], labels1)
-    mock.expect :write_log_entries, write_res, write_req_args("payload2", labels2)
+    mock.expect :write_log_entries, write_res, write_req_args("payload2", labels2, false)
 
     async_writer.suspend
     async_writer.write_entries(
       entries("payload1", labels1),
       log_name: log_name,
       resource: resource,
-      labels: labels1
+      labels: labels1,
+      partial_success: true
     )
     async_writer.write_entries(
       entries("payload2", labels2),
       log_name: log_name,
       resource: resource,
-      labels: labels2
+      labels: labels2,
+      partial_success: false
     )
     async_writer.resume
+    async_writer.stop
 
     wait_result = wait_until_true {
-      async_writer.instance_variable_get(:@queue).size == 0
+      async_writer.instance_variable_get(:@batch).nil?
     }
 
     wait_result.must_equal :completed

--- a/google-cloud-logging/test/google/cloud/logging/project/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/async_writer_test.rb
@@ -21,17 +21,19 @@ describe Google::Cloud::Logging::Project, :async_writer, :mock_logging do
     async.logging.must_be_same_as logging
     async.max_count.must_equal 10000
     async.max_bytes.must_equal 10000000
+    async.max_queue.must_equal 100
     async.interval.must_equal 5
-    async.threads.must_equal 2
+    async.threads.must_equal 10
     async.must_be :started?
   end
 
   it "creates an async writer object with custom options" do
-    async = logging.async_writer max_queue_size: 42, max_queue_bytes: 5000000, interval:10, threads: 1
+    async = logging.async_writer max_batch_count: 42, max_batch_bytes: 5000000, max_queue_size: 123, interval:10, threads: 1
     async.must_be_kind_of Google::Cloud::Logging::AsyncWriter
     async.logging.must_be_same_as logging
     async.max_count.must_equal 42
     async.max_bytes.must_equal 5000000
+    async.max_queue.must_equal 123
     async.interval.must_equal 10
     async.threads.must_equal 1
     async.must_be :started?

--- a/google-cloud-logging/test/google/cloud/logging/project/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/async_writer_test.rb
@@ -19,16 +19,21 @@ describe Google::Cloud::Logging::Project, :async_writer, :mock_logging do
     async = logging.async_writer
     async.must_be_kind_of Google::Cloud::Logging::AsyncWriter
     async.logging.must_be_same_as logging
-    async.max_queue_size.must_equal \
-      Google::Cloud::Logging::AsyncWriter::DEFAULT_MAX_QUEUE_SIZE
-    async.state.must_be_nil
+    async.max_count.must_equal 10000
+    async.max_bytes.must_equal 10000000
+    async.interval.must_equal 5
+    async.threads.must_equal 2
+    async.must_be :started?
   end
 
-  it "creates an async writer object with a max queue size" do
-    async = logging.async_writer max_queue_size: 42
+  it "creates an async writer object with custom options" do
+    async = logging.async_writer max_queue_size: 42, max_queue_bytes: 5000000, interval:10, threads: 1
     async.must_be_kind_of Google::Cloud::Logging::AsyncWriter
     async.logging.must_be_same_as logging
-    async.max_queue_size.must_equal 42
-    async.state.must_be_nil
+    async.max_count.must_equal 42
+    async.max_bytes.must_equal 5000000
+    async.interval.must_equal 10
+    async.threads.must_equal 1
+    async.must_be :started?
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/project/shared_async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/shared_async_writer_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Logging::Project, :shared_async_writer, :mock_logging do
     async1.max_count.must_equal 10000
     async1.max_bytes.must_equal 10000000
     async1.interval.must_equal 5
-    async1.threads.must_equal 2
+    async1.threads.must_equal 10
     async2 = logging.shared_async_writer
     async2.must_be_same_as async1
   end

--- a/google-cloud-logging/test/google/cloud/logging/project/shared_async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/shared_async_writer_test.rb
@@ -19,8 +19,10 @@ describe Google::Cloud::Logging::Project, :shared_async_writer, :mock_logging do
     async1 = logging.shared_async_writer
     async1.must_be_kind_of Google::Cloud::Logging::AsyncWriter
     async1.logging.must_be_same_as logging
-    async1.max_queue_size.must_equal \
-      Google::Cloud::Logging::AsyncWriter::DEFAULT_MAX_QUEUE_SIZE
+    async1.max_count.must_equal 10000
+    async1.max_bytes.must_equal 10000000
+    async1.interval.must_equal 5
+    async1.threads.must_equal 2
     async2 = logging.shared_async_writer
     async2.must_be_same_as async1
   end


### PR DESCRIPTION
Update `AsyncWriter` to buffer log entries. The previous implementation was making API requests as fast as it could. This change allows the writer to buffer the entries longer and send in more batches. Also add configuration for the max number of entries to buffer, and well as the max byte size to buffer before the batch is sent.

Deprecate suspend and resume, which are less useful now.