### PR TITLE
Add copy and extract methods to BigQuery Project

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -102,19 +102,19 @@ describe Google::Cloud::Bigquery, :bigquery do
     assert fresh.access.writer_special? :all
   end
 
-  it "should run an query" do
+  it "should run a query" do
     rows = bigquery.query publicdata_query
     rows.class.must_equal Google::Cloud::Bigquery::Data
     rows.count.must_equal 100
   end
 
-  it "should run an query without legacy SQL syntax" do
+  it "should run a query without legacy SQL syntax" do
     rows = bigquery.query publicdata_query, legacy_sql: false
     rows.class.must_equal Google::Cloud::Bigquery::Data
     rows.count.must_equal 100
   end
 
-  it "should run an query with standard SQL syntax" do
+  it "should run a query with standard SQL syntax" do
     rows = bigquery.query publicdata_query, standard_sql: true
     rows.class.must_equal Google::Cloud::Bigquery::Data
     rows.count.must_equal 100
@@ -187,6 +187,23 @@ describe Google::Cloud::Bigquery, :bigquery do
       project.datasets.each do |ds|
         ds.must_be_kind_of Google::Cloud::Bigquery::Dataset
       end
+    end
+  end
+
+  it "extracts a readonly table object to a GCS url with extract" do
+    public_table_id = "bigquery-public-data.samples.shakespeare"
+
+    Tempfile.open "empty_extract_file.csv" do |tmp|
+      dest_file_name = random_file_destination_name
+      extract_url = "gs://#{bucket.name}/#{dest_file_name}"
+      result = bigquery.extract public_table_id, extract_url do |j|
+        j.location = "US"
+      end
+      result.must_equal true
+
+      extract_file = bucket.file dest_file_name
+      downloaded_file = extract_file.download tmp.path
+      downloaded_file.size.must_be :>, 0
     end
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -190,7 +190,7 @@ describe Google::Cloud::Bigquery, :bigquery do
     end
   end
 
-  it "extracts a readonly table object to a GCS url with extract" do
+  it "extracts a readonly table to a GCS url with extract" do
     public_table_id = "bigquery-public-data.samples.shakespeare"
 
     Tempfile.open "empty_extract_file.csv" do |tmp|
@@ -205,5 +205,13 @@ describe Google::Cloud::Bigquery, :bigquery do
       downloaded_file = extract_file.download tmp.path
       downloaded_file.size.must_be :>, 0
     end
+  end
+
+  it "copies a readonly table to another table with copy" do
+    public_table_id = "bigquery-public-data.samples.shakespeare"
+    result = bigquery.copy public_table_id, "#{dataset_id}.shakespeare_copy", create: :needed, write: :empty do |j|
+      j.location = "US"
+    end
+    result.must_equal true
   end
 end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -797,7 +797,8 @@ module Google
         #   contain lowercase letters, numeric characters, underscores and
         #   dashes. International characters are allowed. Label values are
         #   optional. Label keys must start with a letter and each label in the
-        #   list must have a different key.
+        #   list must have a different key. See [Requirements for
+        #   labels](https://cloud.google.com/bigquery/docs/creating-managing-labels#requirements).
         # @param [Array<String>, String] udfs User-defined function resources
         #   used in the query. May be either a code resource to load from a
         #   Google Cloud Storage URI (`gs://bucket/path`), or an inline resource
@@ -1343,8 +1344,8 @@ module Google
         #   contain lowercase letters, numeric characters, underscores and
         #   dashes. International characters are allowed. Label values are
         #   optional. Label keys must start with a letter and each label in the
-        #   list must have a different key.
-        #
+        #   list must have a different key. See [Requirements for
+        #   labels](https://cloud.google.com/bigquery/docs/creating-managing-labels#requirements).
         # @yield [updater] A block for setting the schema and other
         #   options for the destination table. The schema can be omitted if the
         #   destination table already exists, or if you're loading data from a

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1315,6 +1315,9 @@ module Google
         #   file that BigQuery will skip when loading the data. The default
         #   value is `0`. This property is useful if you have header rows in the
         #   file that should be skipped.
+        # @param [Boolean] dryrun  If set, don't actually run this job. Behavior
+        #   is undefined however for non-query jobs and may result in an error.
+        #   Deprecated.
         # @param [Google::Cloud::Bigquery::Schema] schema The schema for the
         #   destination table. Optional. The schema can be omitted if the
         #   destination table already exists, or if you're loading data from a

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
@@ -191,10 +191,12 @@ module Google
           ##
           # Add reader access to a view.
           #
-          # @param [Google::Cloud::Bigquery::Table, String] view A table object
-          #   or a string identifier as specified by the [Query
-          #   Reference](https://cloud.google.com/bigquery/query-reference#from):
-          #   `project_name:datasetId.tableId`.
+          # @param [Google::Cloud::Bigquery::Table, String] view A table object,
+          #   or a string identifier as specified by the [Standard SQL Query
+          #   Reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#from-clause)
+          #   (`project-name.dataset_id.table_id`) or the [Legacy SQL Query
+          #   Reference](https://cloud.google.com/bigquery/query-reference#from)
+          #   (`project-name:dataset_id.table_id`).
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -450,10 +452,12 @@ module Google
           ##
           # Remove reader access from a view.
           #
-          # @param [Google::Cloud::Bigquery::Table, String] view A table object
-          #   or a string identifier as specified by the [Query
-          #   Reference](https://cloud.google.com/bigquery/query-reference#from):
-          #   `project_name:datasetId.tableId`.
+          # @param [Google::Cloud::Bigquery::Table, String] view A table object,
+          #   or a string identifier as specified by the [Standard SQL Query
+          #   Reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#from-clause)
+          #   (`project-name.dataset_id.table_id`) or the [Legacy SQL Query
+          #   Reference](https://cloud.google.com/bigquery/query-reference#from)
+          #   (`project-name:dataset_id.table_id`).
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -705,10 +709,12 @@ module Google
           ##
           # Checks reader access for a view.
           #
-          # @param [Google::Cloud::Bigquery::Table, String] view A table object
-          #   or a string identifier as specified by the [Query
-          #   Reference](https://cloud.google.com/bigquery/query-reference#from):
-          #   `project_name:datasetId.tableId`.
+          # @param [Google::Cloud::Bigquery::Table, String] view A table object,
+          #   or a string identifier as specified by the [Standard SQL Query
+          #   Reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#from-clause)
+          #   (`project-name.dataset_id.table_id`) or the [Legacy SQL Query
+          #   Reference](https://cloud.google.com/bigquery/query-reference#from)
+          #   (`project-name:dataset_id.table_id`).
           #
           # @example
           #   require "google/cloud/bigquery"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
@@ -923,7 +923,7 @@ module Google
             if view.respond_to? :table_ref
               view.table_ref
             else
-              Service.table_ref_from_s view, @dataset_reference
+              Service.table_ref_from_s view, default_ref: @dataset_reference
             end
           end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -171,10 +171,13 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
+        #   source_table_id = "bigquery-public-data.samples.shakespeare"
         #   destination_table = dataset.table "my_destination_table"
         #
-        #   bigquery.copy "bigquery-public-data.samples.shakespeare",
-        #                 destination_table
+        #   copy_job = bigquery.copy_job source_table_id, destination_table
+        #
+        #   copy_job.wait_until_done!
+        #   copy_job.done? #=> true
         #
         # @!group Data
         #
@@ -1347,6 +1350,8 @@ module Google
         #   table_id = "bigquery-public-data.samples.shakespeare"
         #   extract_job = bigquery.extract_job table_id,
         #                                      "gs://my-bucket/shakespeare.csv"
+        #   extract_job.wait_until_done!
+        #   extract_job.done? #=> true
         #
         # @!group Data
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -159,7 +159,8 @@ module Google
         #   contain lowercase letters, numeric characters, underscores and
         #   dashes. International characters are allowed. Label values are
         #   optional. Label keys must start with a letter and each label in the
-        #   list must have a different key.
+        #   list must have a different key. See [Requirements for
+        #   labels](https://cloud.google.com/bigquery/docs/creating-managing-labels#requirements).
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::CopyJob::Updater] job a job
         #   configuration object for setting additional options.
@@ -398,7 +399,8 @@ module Google
         #   contain lowercase letters, numeric characters, underscores and
         #   dashes. International characters are allowed. Label values are
         #   optional. Label keys must start with a letter and each label in the
-        #   list must have a different key.
+        #   list must have a different key. See [Requirements for
+        #   labels](https://cloud.google.com/bigquery/docs/creating-managing-labels#requirements).
         # @param [Array<String>, String] udfs User-defined function resources
         #   used in the query. May be either a code resource to load from a
         #   Google Cloud Storage URI (`gs://bucket/path`), or an inline resource
@@ -1335,7 +1337,8 @@ module Google
         #   contain lowercase letters, numeric characters, underscores and
         #   dashes. International characters are allowed. Label values are
         #   optional. Label keys must start with a letter and each label in the
-        #   list must have a different key.
+        #   list must have a different key. See [Requirements for
+        #   labels](https://cloud.google.com/bigquery/docs/creating-managing-labels#requirements).
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::ExtractJob::Updater] job a job
         #   configuration object for setting additional options.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -183,10 +183,10 @@ module Google
         # @!group Data
         #
         def copy_job source_table, destination_table, create: nil, write: nil,
-                     dryrun: nil, job_id: nil, prefix: nil, labels: nil
+                     job_id: nil, prefix: nil, labels: nil
           ensure_service!
-          options = { create: create, write: write, dryrun: dryrun,
-                      labels: labels, job_id: job_id, prefix: prefix }
+          options = { create: create, write: write, labels: labels,
+                      job_id: job_id, prefix: prefix }
 
           updater = CopyJob::Updater.from_options(
             service,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -1359,12 +1359,12 @@ module Google
         # @!group Data
         #
         def extract_job table, extract_url, format: nil, compression: nil,
-                        delimiter: nil, header: nil, dryrun: nil, job_id: nil,
-                        prefix: nil, labels: nil
+                        delimiter: nil, header: nil, job_id: nil, prefix: nil,
+                        labels: nil
           ensure_service!
           options = { format: format, compression: compression,
-                      delimiter: delimiter, header: header, dryrun: dryrun,
-                      job_id: job_id, prefix: prefix, labels: labels }
+                      delimiter: delimiter, header: header, job_id: job_id,
+                      prefix: prefix, labels: labels }
 
           table_ref = Service.get_table_ref table, default_ref: project_ref
           updater = ExtractJob::Updater.from_options service, table_ref,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -324,14 +324,26 @@ module Google
           end
         end
 
+        def self.get_table_ref table, default_ref: nil
+          if table.respond_to? :table_ref
+            table.table_ref
+          else
+            table_ref_from_s table, default_ref: default_ref
+          end
+        end
+
         ##
         # Extracts at least `tbl` group, and possibly `dts` and `prj` groups,
         # from strings in the formats: "my_table", "my_dataset.my_table", or
         # "my-project:my_dataset.my_table". Then merges project_id and
         # dataset_id from the default table if they are missing.
-        def self.table_ref_from_s str, default_table_ref
+        #
+        # The regex matches both Standard SQL
+        # ("bigquery-public-data.samples.shakespeare") and Legacy SQL
+        # ("bigquery-public-data:samples.shakespeare").
+        def self.table_ref_from_s str, default_ref: nil
           str = str.to_s
-          m = /\A(((?<prj>\S*):)?(?<dts>\S*)\.)?(?<tbl>\S*)\z/.match str
+          m = /\A(((?<prj>\S*)(:|\.))?(?<dts>\S*)\.)?(?<tbl>\S*)\z/.match str
           unless m
             raise ArgumentError, "unable to identify table from #{str.inspect}"
           end
@@ -340,8 +352,10 @@ module Google
             dataset_id: m["dts"],
             table_id:   m["tbl"]
           }.delete_if { |_, v| v.nil? }
-          new_table_ref_hash = default_table_ref.to_h.merge str_table_ref_hash
-          Google::Apis::BigqueryV2::TableReference.new new_table_ref_hash
+          if default_ref
+            str_table_ref_hash = default_ref.to_h.merge str_table_ref_hash
+          end
+          Google::Apis::BigqueryV2::TableReference.new str_table_ref_hash
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -371,9 +371,10 @@ module Google
         ##
         # The combined Project ID, Dataset ID, and Table ID for this table, in
         # the format specified by the [Legacy SQL Query
-        # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # `project_name:datasetId.tableId`. To use this value in queries see
-        # {#query_id}.
+        # Reference](https://cloud.google.com/bigquery/query-reference#from)
+        # (`project-name:dataset_id.table_id`). This is useful for referencing
+        # tables in other projects and datasets. To use this value in queries
+        # see {#query_id}.
         #
         # @return [String, nil] The combined ID, or `nil` if the object is a
         #   reference (see {#reference?}).
@@ -386,10 +387,9 @@ module Google
         end
 
         ##
-        # The value returned by {#id}, wrapped in square brackets if the Project
-        # ID contains dashes, as specified by the [Query
-        # Reference](https://cloud.google.com/bigquery/query-reference#from).
-        # Useful in queries.
+        # The value returned by {#id}, wrapped in backticks (Standard SQL) or s
+        # quare brackets (Legacy SQL) to accommodate project IDs
+        # containing dashes. Useful in queries.
         #
         # @param [Boolean] standard_sql Specifies whether to use BigQuery's
         #   [standard
@@ -1191,9 +1191,11 @@ module Google
         #
         # @param [Table, String] destination_table The destination for the
         #   copied data. This can also be a string identifier as specified by
-        #   the [Query
-        #   Reference](https://cloud.google.com/bigquery/query-reference#from):
-        #   `project_name:datasetId.tableId`. This is useful for referencing
+        #   the [Standard SQL Query
+        #   Reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#from-clause)
+        #   (`project-name.dataset_id.table_id`) or the [Legacy SQL Query
+        #   Reference](https://cloud.google.com/bigquery/query-reference#from)
+        #   (`project-name:dataset_id.table_id`). This is useful for referencing
         #   tables in other projects and datasets.
         # @param [String] create Specifies whether the job is allowed to create
         #   new tables. The default value is `needed`.
@@ -1295,9 +1297,11 @@ module Google
         #
         # @param [Table, String] destination_table The destination for the
         #   copied data. This can also be a string identifier as specified by
-        #   the [Query
-        #   Reference](https://cloud.google.com/bigquery/query-reference#from):
-        #   `project_name:datasetId.tableId`. This is useful for referencing
+        #   the [Standard SQL Query
+        #   Reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#from-clause)
+        #   (`project-name.dataset_id.table_id`) or the [Legacy SQL Query
+        #   Reference](https://cloud.google.com/bigquery/query-reference#from)
+        #   (`project-name:dataset_id.table_id`). This is useful for referencing
         #   tables in other projects and datasets.
         # @param [String] create Specifies whether the job is allowed to create
         #   new tables. The default value is `needed`.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1261,6 +1261,9 @@ module Google
         #
         #   copy_job = table.copy_job "other-project:other_dataset.other_table"
         #
+        #   copy_job.wait_until_done!
+        #   copy_job.done? #=> true
+        #
         # @!group Data
         #
         def copy_job destination_table, create: nil, write: nil, dryrun: nil,
@@ -1425,7 +1428,9 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   extract_job = table.extract_job "gs://my-bucket/file-name.json",
-        #                               format: "json"
+        #                                   format: "json"
+        #   extract_job.wait_until_done!
+        #   extract_job.done? #=> true
         #
         # @!group Data
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1214,6 +1214,9 @@ module Google
         #   * `append` - BigQuery appends the data to the table.
         #   * `empty` - An error will be returned if the destination table
         #     already contains data.
+        # @param [Boolean] dryrun  If set, don't actually run this job. Behavior
+        #   is undefined however for non-query jobs and may result in an error.
+        #   Deprecated.
         # @param [String] job_id A user-defined ID for the copy job. The ID
         #   must contain only letters (a-z, A-Z), numbers (0-9), underscores
         #   (_), or dashes (-). The maximum length is 1,024 characters. If

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1269,7 +1269,7 @@ module Google
           updater = CopyJob::Updater.from_options(
             service,
             table_ref,
-            get_table_ref(destination_table),
+            Service.get_table_ref(destination_table, default_ref: table_ref),
             options
           )
           updater.location = location if location # may be table reference
@@ -2472,16 +2472,6 @@ module Google
               resource.inline_code = uri_or_code
             end
             resource
-          end
-        end
-
-        private
-
-        def get_table_ref table
-          if table.respond_to? :table_ref
-            table.table_ref
-          else
-            Service.table_ref_from_s table, table_ref
           end
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1235,7 +1235,8 @@ module Google
         #   contain lowercase letters, numeric characters, underscores and
         #   dashes. International characters are allowed. Label values are
         #   optional. Label keys must start with a letter and each label in the
-        #   list must have a different key.
+        #   list must have a different key. See [Requirements for
+        #   labels](https://cloud.google.com/bigquery/docs/creating-managing-labels#requirements).
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::CopyJob::Updater] job a job
         #   configuration object for setting additional options.
@@ -1413,7 +1414,8 @@ module Google
         #   contain lowercase letters, numeric characters, underscores and
         #   dashes. International characters are allowed. Label values are
         #   optional. Label keys must start with a letter and each label in the
-        #   list must have a different key.
+        #   list must have a different key. See [Requirements for
+        #   labels](https://cloud.google.com/bigquery/docs/creating-managing-labels#requirements).
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::ExtractJob::Updater] job a job
         #   configuration object for setting additional options.
@@ -1652,7 +1654,8 @@ module Google
         #   contain lowercase letters, numeric characters, underscores and
         #   dashes. International characters are allowed. Label values are
         #   optional. Label keys must start with a letter and each label in the
-        #   list must have a different key.
+        #   list must have a different key. See [Requirements for
+        #   labels](https://cloud.google.com/bigquery/docs/creating-managing-labels#requirements).
         # @yield [load_job] a block for setting the load job
         # @yieldparam [LoadJob] load_job the load job object to be updated
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1396,6 +1396,9 @@ module Google
         #   exported data. Default is <code>,</code>.
         # @param [Boolean] header Whether to print out a header row in the
         #   results. Default is `true`.
+        # @param [Boolean] dryrun  If set, don't actually run this job. Behavior
+        #   is undefined however for non-query jobs and may result in an error.
+        #   Deprecated.
         # @param [String] job_id A user-defined ID for the extract job. The ID
         #   must contain only letters (a-z, A-Z), numbers (0-9), underscores
         #   (_), or dashes (-). The maximum length is 1,024 characters. If
@@ -1636,6 +1639,9 @@ module Google
         #   file that BigQuery will skip when loading the data. The default
         #   value is `0`. This property is useful if you have header rows in the
         #   file that should be skipped.
+        # @param [Boolean] dryrun  If set, don't actually run this job. Behavior
+        #   is undefined however for non-query jobs and may result in an error.
+        #   Deprecated.
         # @param [String] job_id A user-defined ID for the load job. The ID
         #   must contain only letters (a-z, A-Z), numbers (0-9), underscores
         #   (_), or dashes (-). The maximum length is 1,024 characters. If

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -571,6 +571,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::Project#extract" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+      mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
+    end
+  end
+
   # Google::Cloud::Bigquery::Project::List#all@Iterating each result by passing a block:
   # Google::Cloud::Bigquery::Project::List#all@Limit the number of API calls made:
   # Google::Cloud::Bigquery::Project::List#all@Using the enumerator by not passing a block:

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -489,6 +489,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::Project#copy" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_destination_table"]
+      mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
+    end
+  end
+
   # Google::Cloud::Bigquery::Project#create_dataset
   # Google::Cloud::Bigquery::Project#create_dataset@A name and description can be provided:
   # Google::Cloud::Bigquery::Project#create_dataset@Access rules can be provided with the `access` option:

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_storage_test.rb
@@ -248,7 +248,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     mock.verify
   end
 
-  it "can load itself as a dryrun" do
+  it "can load itself as a dryrun (deprecated)" do
     mock = Minitest::Mock.new
     job_gapi = load_job_url_gapi table_reference, load_url
     job_gapi.configuration.dry_run = true

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_copy_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_copy_job_test.rb
@@ -90,20 +90,6 @@ describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
     job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
-  it "can copy a table as a dryrun" do
-    mock = Minitest::Mock.new
-    bigquery.service.mocked_service = mock
-
-    job_gapi = copy_job_gapi(source_table, target_table, location: nil)
-    job_gapi.configuration.dry_run = true
-    mock.expect :insert_job, job_gapi, [project, job_gapi]
-
-    job = bigquery.copy_job source_table, target_table, dryrun: true
-    mock.verify
-
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-  end
-
   it "can copy a table with create disposition" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_copy_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_copy_job_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -89,8 +89,6 @@ describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
 
     job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
-  #<Google::Apis::BigqueryV2::Job:0x00007faf64d1a630 @configuration=#<Google::Apis::BigqueryV2::JobConfiguration:0x00007faf64d196b8 @copy=#<Google::Apis::BigqueryV2::JobConfigurationTableCopy:0x00007faf64d18f38 @create_disposition=nil, @destination_table=#<Google::Apis::BigqueryV2::TableReference:0x00007faf64d18010 @dataset_id="source_dataset", @project_id="test-project", @table_id="new_target_table_id">, @source_table=#<Google::Apis::BigqueryV2::TableReference:0x00007faf64d13268 @dataset_id="source_dataset", @project_id="test-project", @table_id="source_table_id">, @write_disposition=nil>, @dry_run=nil>, @job_reference=#<Google::Apis::BigqueryV2::JobReference:0x00007faf64d0b450 @job_id="job_9876543210", @project_id="test-project">>
-  #<Google::Apis::BigqueryV2::Job:0x00007faf64d08160 @configuration=#<Google::Apis::BigqueryV2::JobConfiguration:0x00007faf64d082a0 @copy=#<Google::Apis::BigqueryV2::JobConfigurationTableCopy:0x00007faf64d083e0 @create_disposition=nil, @destination_table=#<Google::Apis::BigqueryV2::TableReference:0x00007faf64d086d8 @project_id="test-project", @table_id="new_target_table_id">, @source_table=#<Google::Apis::BigqueryV2::TableReference:0x00007faf64d301d8 @dataset_id="source_dataset", @project_id="test-project", @table_id="source_table_id">, @write_disposition=nil>, @dry_run=nil>, @job_reference=#<Google::Apis::BigqueryV2::JobReference:0x00007faf64d08520 @job_id="job_9876543210", @project_id="test-project">>
 
   it "can copy a table as a dryrun" do
     mock = Minitest::Mock.new

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_copy_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_copy_job_test.rb
@@ -1,0 +1,244 @@
+# Copyright 2015 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
+  let(:source_dataset) { "source_dataset" }
+  let(:source_table_id) { "source_table_id" }
+  let(:source_table_name) { "Source Table" }
+  let(:source_description) { "This is the source table" }
+  let(:source_table_gapi) { random_table_gapi source_dataset,
+                                              source_table_id,
+                                              source_table_name,
+                                              source_description }
+  let(:source_table) { Google::Cloud::Bigquery::Table.from_gapi source_table_gapi,
+                                                         bigquery.service }
+  let(:target_dataset) { "target_dataset" }
+  let(:target_table_id) { "target_table_id" }
+  let(:target_table_name) { "Target Table" }
+  let(:target_description) { "This is the target table" }
+  let(:target_table_gapi) { random_table_gapi target_dataset,
+                                              target_table_id,
+                                              target_table_name,
+                                              target_description }
+  let(:target_table) { Google::Cloud::Bigquery::Table.from_gapi target_table_gapi,
+                                                         bigquery.service }
+  let(:target_table_other_proj_gapi) { random_table_gapi target_dataset,
+                                              target_table_id,
+                                              target_table_name,
+                                              target_description,
+                                              "target-project" }
+  let(:target_table_other_proj) { Google::Cloud::Bigquery::Table.from_gapi target_table_other_proj_gapi,
+                                                         bigquery.service }
+  let(:labels) { { "foo" => "bar" } }
+  let(:region) { "asia-northeast1" }
+
+  it "can copy" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = copy_job_gapi(source_table, target_table, location: nil)
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.copy_job source_table, target_table
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+  end
+
+  it "can copy to a table identified by a string" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table_other_proj, location: nil)
+    mock.expect :insert_job, job_gapi, ["test-project", job_gapi]
+
+    job = bigquery.copy_job source_table, "target-project:target_dataset.target_table_id"
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+  end
+
+  it "can copy to a dataset ID and table name string only" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    new_target_table = Google::Cloud::Bigquery::Table.from_gapi(
+      random_table_gapi(source_dataset,
+                        "new_target_table_id",
+                        target_table_name,
+                        target_description),
+      bigquery.service
+    )
+
+    job_gapi = copy_job_gapi(source_table, new_target_table, location: nil)
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.copy_job source_table, "source_dataset.new_target_table_id"
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+  end
+  #<Google::Apis::BigqueryV2::Job:0x00007faf64d1a630 @configuration=#<Google::Apis::BigqueryV2::JobConfiguration:0x00007faf64d196b8 @copy=#<Google::Apis::BigqueryV2::JobConfigurationTableCopy:0x00007faf64d18f38 @create_disposition=nil, @destination_table=#<Google::Apis::BigqueryV2::TableReference:0x00007faf64d18010 @dataset_id="source_dataset", @project_id="test-project", @table_id="new_target_table_id">, @source_table=#<Google::Apis::BigqueryV2::TableReference:0x00007faf64d13268 @dataset_id="source_dataset", @project_id="test-project", @table_id="source_table_id">, @write_disposition=nil>, @dry_run=nil>, @job_reference=#<Google::Apis::BigqueryV2::JobReference:0x00007faf64d0b450 @job_id="job_9876543210", @project_id="test-project">>
+  #<Google::Apis::BigqueryV2::Job:0x00007faf64d08160 @configuration=#<Google::Apis::BigqueryV2::JobConfiguration:0x00007faf64d082a0 @copy=#<Google::Apis::BigqueryV2::JobConfigurationTableCopy:0x00007faf64d083e0 @create_disposition=nil, @destination_table=#<Google::Apis::BigqueryV2::TableReference:0x00007faf64d086d8 @project_id="test-project", @table_id="new_target_table_id">, @source_table=#<Google::Apis::BigqueryV2::TableReference:0x00007faf64d301d8 @dataset_id="source_dataset", @project_id="test-project", @table_id="source_table_id">, @write_disposition=nil>, @dry_run=nil>, @job_reference=#<Google::Apis::BigqueryV2::JobReference:0x00007faf64d08520 @job_id="job_9876543210", @project_id="test-project">>
+
+  it "can copy a table as a dryrun" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table, location: nil)
+    job_gapi.configuration.dry_run = true
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.copy_job source_table, target_table, dryrun: true
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+  end
+
+  it "can copy a table with create disposition" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table, location: nil)
+    job_gapi.configuration.copy.create_disposition = "CREATE_NEVER"
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.copy_job source_table, target_table, create: "CREATE_NEVER"
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+  end
+
+  it "can copy a table with create disposition symbol" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table, location: nil)
+    job_gapi.configuration.copy.create_disposition = "CREATE_NEVER"
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.copy_job source_table, target_table, create: :never
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+  end
+
+
+  it "can copy a table with write disposition" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table, location: nil)
+    job_gapi.configuration.copy.write_disposition = "WRITE_TRUNCATE"
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.copy_job source_table, target_table, write: "WRITE_TRUNCATE"
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+  end
+
+  it "can copy a table with write disposition symbol" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table, location: nil)
+    job_gapi.configuration.copy.write_disposition = "WRITE_TRUNCATE"
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.copy_job source_table, target_table, write: :truncate
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+  end
+
+  it "can copy a table with job_id option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_id = "my_test_job_id"
+    job_gapi = copy_job_gapi(source_table, target_table, job_id: job_id, location: nil)
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.copy_job source_table, target_table, job_id: job_id
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.job_id.must_equal job_id
+  end
+
+  it "can copy a table with prefix option" do
+    generated_id = "9876543210"
+    prefix = "my_test_job_prefix_"
+    job_id = prefix + generated_id
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = copy_job_gapi(source_table, target_table, job_id: job_id, location: nil)
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.copy_job source_table, target_table, prefix: prefix
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.job_id.must_equal job_id
+  end
+
+  it "can copy a table with job_id option if both job_id and prefix options are provided" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_id = "my_test_job_id"
+    job_gapi = copy_job_gapi(source_table, target_table, job_id: job_id, location: nil)
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.copy_job source_table, target_table, job_id: job_id, prefix: "IGNORED"
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.job_id.must_equal job_id
+  end
+
+  it "can copy a table with the job labels option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = copy_job_gapi(source_table, target_table, location: nil)
+    job_gapi.configuration.labels = labels
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.copy_job source_table, target_table, labels: labels
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.labels.must_equal labels
+  end
+
+  it "can copy a table with the location option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = copy_job_gapi(source_table, target_table, location: region)
+    job_gapi.job_reference.location = region
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.copy_job source_table, target_table do |j|
+      j.location = region
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.location.must_equal region
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_copy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_copy_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_copy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_copy_test.rb
@@ -1,0 +1,161 @@
+# Copyright 2015 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Project, :copy, :mock_bigquery do
+  let(:source_dataset) { "source_dataset" }
+  let(:source_table_id) { "source_table_id" }
+  let(:source_table_name) { "Source Table" }
+  let(:source_description) { "This is the source table" }
+  let(:source_table_gapi) { random_table_gapi source_dataset,
+                                              source_table_id,
+                                              source_table_name,
+                                              source_description }
+  let(:source_table) { Google::Cloud::Bigquery::Table.from_gapi source_table_gapi,
+                                                         bigquery.service }
+  let(:target_dataset) { "target_dataset" }
+  let(:target_table_id) { "target_table_id" }
+  let(:target_table_name) { "Target Table" }
+  let(:target_description) { "This is the target table" }
+  let(:target_table_gapi) { random_table_gapi target_dataset,
+                                              target_table_id,
+                                              target_table_name,
+                                              target_description }
+  let(:target_table) { Google::Cloud::Bigquery::Table.from_gapi target_table_gapi,
+                                                         bigquery.service }
+  let(:target_table_other_proj_gapi) { random_table_gapi target_dataset,
+                                              target_table_id,
+                                              target_table_name,
+                                              target_description,
+                                              "target-project" }
+  let(:target_table_other_proj) { Google::Cloud::Bigquery::Table.from_gapi target_table_other_proj_gapi,
+                                                         bigquery.service }
+
+  it "can copy a table" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = copy_job_gapi(source_table, target_table, location: nil)
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.copy source_table, target_table
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can copy to a table identified by a string" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table_other_proj, location: nil)
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+    mock.expect :insert_job, job_resp_gapi, ["test-project", job_gapi]
+
+    result = bigquery.copy source_table, "target-project:target_dataset.target_table_id"
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can copy to a dataset ID and table name string only" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    new_target_table = Google::Cloud::Bigquery::Table.from_gapi(
+      random_table_gapi(source_dataset,
+                        "new_target_table_id",
+                        target_table_name,
+                        target_description),
+      bigquery.service
+    )
+
+    job_gapi = copy_job_gapi(source_table, new_target_table, location: nil)
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.copy source_table, "source_dataset.new_target_table_id"
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can copy a table with create disposition" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table, location: nil)
+    job_gapi.configuration.copy.create_disposition = "CREATE_NEVER"
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.copy source_table, target_table, create: "CREATE_NEVER"
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can copy a table with create disposition symbol" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table, location: nil)
+    job_gapi.configuration.copy.create_disposition = "CREATE_NEVER"
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.copy source_table, target_table, create: :never
+    mock.verify
+
+    result.must_equal true
+  end
+
+
+  it "can copy a table with write disposition" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table, location: nil)
+    job_gapi.configuration.copy.write_disposition = "WRITE_TRUNCATE"
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.copy source_table, target_table, write: "WRITE_TRUNCATE"
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can copy a table with write disposition symbol" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table, location: nil)
+    job_gapi.configuration.copy.write_disposition = "WRITE_TRUNCATE"
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.copy source_table, target_table, write: :truncate
+    mock.verify
+
+    result.must_equal true
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_job_test.rb
@@ -92,20 +92,6 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
-  it "can extract a table as a dryrun" do
-    mock = Minitest::Mock.new
-    bigquery.service.mocked_service = mock
-    job_gapi = extract_job_gapi table, extract_file, location: nil
-    job_gapi.configuration.dry_run = true
-
-    mock.expect :insert_job, job_gapi, [project, job_gapi]
-
-    job = bigquery.extract_job table, extract_url, dryrun: true
-    mock.verify
-
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-  end
-
   it "can extract a table and determine the csv format" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_job_test.rb
@@ -1,0 +1,339 @@
+# Copyright 2015 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
+  let(:credentials) { OpenStruct.new }
+  let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
+  let(:extract_bucket_gapi) {  Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
+  let(:extract_bucket) { Google::Cloud::Storage::Bucket.from_gapi extract_bucket_gapi,
+                                                           storage.service }
+  let(:extract_file_gapi) { Google::Apis::StorageV1::Object.from_json random_file_hash(extract_bucket.name).to_json }
+  let(:extract_file) { Google::Cloud::Storage::File.from_gapi extract_file_gapi,
+                                                       storage.service }
+  let(:extract_url) { extract_file.to_gs_url }
+
+  let(:dataset) { "dataset" }
+  let(:table_id) { "table_id" }
+  let(:table_name) { "Target Table" }
+  let(:description) { "This is the target table" }
+  let(:table_gapi) { random_table_gapi dataset,
+                                       table_id,
+                                       table_name,
+                                       description }
+  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi,
+                                                  bigquery.service }
+  let(:table_id_standard_sql) { "#{table.project_id}.#{table.dataset_id}.#{table.table_id}" }
+  let(:table_id_legacy_sql) { "#{table.project_id}:#{table.dataset_id}.#{table.table_id}" }
+  let(:labels) { { "foo" => "bar" } }
+  let(:region) { "asia-northeast1" }
+
+  it "can extract a table to a storage file using a Standard SQL table id" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi table, extract_file, location: nil
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table_id_standard_sql, extract_file
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract a table to a storage file using a Legacy SQL table id" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi table, extract_file, location: nil
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table_id_legacy_sql, extract_file
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract a table to a storage file" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi table, extract_file, location: nil
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table, extract_file
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract a table to a storage url" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi table, extract_file, location: nil
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table, extract_url
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract a table as a dryrun" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi table, extract_file, location: nil
+    job_gapi.configuration.dry_run = true
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table, extract_url, dryrun: true
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract a table and determine the csv format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi table, extract_file, location: nil
+    job_gapi.configuration.extract.destination_format = "CSV"
+    job_gapi.configuration.extract.destination_uris = [job_gapi.configuration.extract.destination_uris.first + ".csv"]
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table, "#{extract_url}.csv"
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract a table and specify the csv format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi table, extract_file, location: nil
+    job_gapi.configuration.extract.destination_format = "CSV"
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table, extract_url, format: :csv
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract a table and specify the csv format and options" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi table, extract_file, location: nil
+    job_gapi.configuration.extract.destination_format = "CSV"
+    job_gapi.configuration.extract.compression = "GZIP"
+    job_gapi.configuration.extract.field_delimiter = "\t"
+    job_gapi.configuration.extract.print_header = false
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table, extract_url, format: :csv, compression: "GZIP", delimiter: "\t", header: false
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract a table and determine the json format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi table, extract_file, location: nil
+    job_gapi.configuration.extract.destination_format = "NEWLINE_DELIMITED_JSON"
+    job_gapi.configuration.extract.destination_uris = [job_gapi.configuration.extract.destination_uris.first + ".json"]
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table, "#{extract_url}.json"
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract a table and specify the json format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi table, extract_file, location: nil
+    job_gapi.configuration.extract.destination_format = "NEWLINE_DELIMITED_JSON"
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table, extract_url, format: :json
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract a table and determine the avro format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi table, extract_file, location: nil
+    job_gapi.configuration.extract.destination_format = "AVRO"
+    job_gapi.configuration.extract.destination_uris = [job_gapi.configuration.extract.destination_uris.first + ".avro"]
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table, "#{extract_url}.avro"
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract a table and specify the avro format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi table, extract_file, location: nil
+    job_gapi.configuration.extract.destination_format = "AVRO"
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table, extract_url, format: :avro
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract a table with job_id option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_id = "my_test_job_id"
+    job_gapi = extract_job_gapi table, extract_file, job_id: job_id, location: nil
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table, extract_url, job_id: job_id
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.job_id.must_equal job_id
+  end
+
+  it "can extract a table with prefix option" do
+    generated_id = "9876543210"
+    prefix = "my_test_job_prefix_"
+    job_id = prefix + generated_id
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi table, extract_file, job_id: job_id, location: nil
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table, extract_url, prefix: prefix
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.job_id.must_equal job_id
+  end
+
+  it "can extract a table with job_id option if both job_id and prefix options are provided" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_id = "my_test_job_id"
+    job_gapi = extract_job_gapi table, extract_file, job_id: job_id, location: nil
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table, extract_url, job_id: job_id, prefix: "IGNORED"
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.job_id.must_equal job_id
+  end
+
+  it "can extract a table with the job labels option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi table, extract_file, location: nil
+    job_gapi.configuration.labels = labels
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = bigquery.extract_job table, extract_file, labels: labels
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.labels.must_equal labels
+  end
+
+  it "can extract a table with the location option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    insert_job_gapi = extract_job_gapi(table, extract_file)
+    return_job_gapi = extract_job_gapi(table, extract_file)
+    insert_job_gapi.job_reference.location = region
+    return_job_gapi.job_reference.location = region
+
+    mock.expect :insert_job, return_job_gapi, [project, insert_job_gapi]
+
+    job = bigquery.extract_job table, extract_file do |j|
+      j.location = region
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.location.must_equal region
+  end
+
+  # Borrowed from MockStorage, extract to a common module?
+
+  def random_bucket_hash name=random_bucket_name
+    {"kind"=>"storage#bucket",
+     "id"=>name,
+     "selfLink"=>"https://www.googleapis.com/storage/v1/b/#{name}",
+     "projectNumber"=>"1234567890",
+     "name"=>name,
+     "timeCreated"=>::Time.now,
+     "metageneration"=>"1",
+     "owner"=>{"entity"=>"project-owners-1234567890"},
+     "location"=>"US",
+     "storageClass"=>"STANDARD",
+     "etag"=>"CAE=" }
+  end
+
+  def random_file_hash bucket=random_bucket_name, name=random_file_path
+    {"kind"=>"storage#object",
+     "id"=>"#{bucket}/#{name}/1234567890",
+     "selfLink"=>"https://www.googleapis.com/storage/v1/b/#{bucket}/o/#{name}",
+     "name"=>"#{name}",
+     "bucket"=>"#{bucket}",
+     "generation"=>"1234567890",
+     "metageneration"=>"1",
+     "contentType"=>"text/plain",
+     "updated"=>::Time.now,
+     "storageClass"=>"STANDARD",
+     "size"=>rand(10_000),
+     "md5Hash"=>"HXB937GQDFxDFqUGi//weQ==",
+     "mediaLink"=>"https://www.googleapis.com/download/storage/v1/b/#{bucket}/o/#{name}?generation=1234567890&alt=media",
+     "owner"=>{"entity"=>"user-1234567890", "entityId"=>"abc123"},
+     "crc32c"=>"Lm1F3g==",
+     "etag"=>"CKih16GjycICEAE="}
+  end
+
+  def random_bucket_name
+    (0...50).map { ("a".."z").to_a[rand(26)] }.join
+  end
+
+  def random_file_path
+    [(0...10).map { ("a".."z").to_a[rand(26)] }.join,
+     (0...10).map { ("a".."z").to_a[rand(26)] }.join,
+     (0...10).map { ("a".."z").to_a[rand(26)] }.join + ".txt"].join "/"
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_job_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_test.rb
@@ -1,0 +1,291 @@
+# Copyright 2015 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
+  let(:credentials) { OpenStruct.new }
+  let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
+  let(:extract_bucket_gapi) {  Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
+  let(:extract_bucket) { Google::Cloud::Storage::Bucket.from_gapi extract_bucket_gapi,
+                                                           storage.service }
+  let(:extract_file_gapi) { Google::Apis::StorageV1::Object.from_json random_file_hash(extract_bucket.name).to_json }
+  let(:extract_file) { Google::Cloud::Storage::File.from_gapi extract_file_gapi,
+                                                       storage.service }
+  let(:extract_url) { extract_file.to_gs_url }
+
+  let(:dataset) { "dataset" }
+  let(:table_id) { "table_id" }
+  let(:table_name) { "Target Table" }
+  let(:description) { "This is the target table" }
+  let(:table_gapi) { random_table_gapi dataset,
+                                       table_id,
+                                       table_name,
+                                       description }
+  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi,
+                                                  bigquery.service }
+  let(:table_id_standard_sql) { "#{table.project_id}.#{table.dataset_id}.#{table.table_id}" }
+  let(:table_id_legacy_sql) { "#{table.project_id}:#{table.dataset_id}.#{table.table_id}" }
+
+  it "can extract a table to a storage file using a Standard SQL table id" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.extract table_id_standard_sql, extract_file
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract a table to a storage file using a Legacy SQL table id" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.extract table_id_legacy_sql, extract_file
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract a table to a storage file" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.extract table, extract_file
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract a table to a storage url" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.extract table, extract_url
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract a table and determine the csv format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "CSV"
+    job_gapi.configuration.extract.destination_uris = [job_gapi.configuration.extract.destination_uris.first + ".csv"]
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.extract table, "#{extract_url}.csv"
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract a table and specify the csv format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "CSV"
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.extract table, extract_url, format: :csv
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract a table and specify the csv format and options" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "CSV"
+    job_gapi.configuration.extract.compression = "GZIP"
+    job_gapi.configuration.extract.field_delimiter = "\t"
+    job_gapi.configuration.extract.print_header = false
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.extract table, extract_url, format: :csv, compression: "GZIP", delimiter: "\t", header: false
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract a table and determine the json format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "NEWLINE_DELIMITED_JSON"
+    job_gapi.configuration.extract.destination_uris = [job_gapi.configuration.extract.destination_uris.first + ".json"]
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.extract table, "#{extract_url}.json"
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract a table and specify the json format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "NEWLINE_DELIMITED_JSON"
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.extract table, extract_url, format: :json
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract a table and determine the avro format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "AVRO"
+    job_gapi.configuration.extract.destination_uris = [job_gapi.configuration.extract.destination_uris.first + ".avro"]
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.extract table, "#{extract_url}.avro"
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract a table and specify the avro format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "AVRO"
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = bigquery.extract table, extract_url, format: :avro
+    mock.verify
+
+    result.must_equal true
+  end
+
+  def extract_job_gapi table, extract_file, job_id: "job_9876543210", location: nil
+    Google::Apis::BigqueryV2::Job.from_json extract_job_json(table, extract_file, job_id, location: location)
+  end
+
+  def extract_job_json table, extract_file, job_id, location: nil
+    {
+      "jobReference" => {
+        "projectId" => project,
+        "jobId" => job_id
+      },
+      "configuration" => {
+        "extract" => {
+          "destinationUris" => [extract_file.to_gs_url],
+          "sourceTable" => {
+            "projectId" => table.project_id,
+            "datasetId" => table.dataset_id,
+            "tableId" => table.table_id
+          },
+          "printHeader" => nil,
+          "compression" => nil,
+          "fieldDelimiter" => nil,
+          "destinationFormat" => nil
+        },
+        "dryRun" => nil
+      }
+    }.to_json
+  end
+
+  # Borrowed from MockStorage, extract to a common module?
+
+  def random_bucket_hash name=random_bucket_name
+    {"kind"=>"storage#bucket",
+     "id"=>name,
+     "selfLink"=>"https://www.googleapis.com/storage/v1/b/#{name}",
+     "projectNumber"=>"1234567890",
+     "name"=>name,
+     "timeCreated"=>::Time.now,
+     "metageneration"=>"1",
+     "owner"=>{"entity"=>"project-owners-1234567890"},
+     "location"=>"US",
+     "storageClass"=>"STANDARD",
+     "etag"=>"CAE=" }
+  end
+
+  def random_file_hash bucket=random_bucket_name, name=random_file_path
+    {"kind"=>"storage#object",
+     "id"=>"#{bucket}/#{name}/1234567890",
+     "selfLink"=>"https://www.googleapis.com/storage/v1/b/#{bucket}/o/#{name}",
+     "name"=>"#{name}",
+     "bucket"=>"#{bucket}",
+     "generation"=>"1234567890",
+     "metageneration"=>"1",
+     "contentType"=>"text/plain",
+     "updated"=>::Time.now,
+     "storageClass"=>"STANDARD",
+     "size"=>rand(10_000),
+     "md5Hash"=>"HXB937GQDFxDFqUGi//weQ==",
+     "mediaLink"=>"https://www.googleapis.com/download/storage/v1/b/#{bucket}/o/#{name}?generation=1234567890&alt=media",
+     "owner"=>{"entity"=>"user-1234567890", "entityId"=>"abc123"},
+     "crc32c"=>"Lm1F3g==",
+     "etag"=>"CKih16GjycICEAE="}
+  end
+
+  def random_bucket_name
+    (0...50).map { ("a".."z").to_a[rand(26)] }.join
+  end
+
+  def random_file_path
+    [(0...10).map { ("a".."z").to_a[rand(26)] }.join,
+     (0...10).map { ("a".."z").to_a[rand(26)] }.join,
+     (0...10).map { ("a".."z").to_a[rand(26)] }.join + ".txt"].join "/"
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_test.rb
@@ -41,7 +41,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
   it "can extract a table to a storage file using a Standard SQL table id" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi = extract_job_gapi table, extract_file, location: nil
     job_resp_gapi = job_gapi.dup
     job_resp_gapi.status = status "done"
 
@@ -56,7 +56,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
   it "can extract a table to a storage file using a Legacy SQL table id" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi = extract_job_gapi table, extract_file, location: nil
     job_resp_gapi = job_gapi.dup
     job_resp_gapi.status = status "done"
 
@@ -71,7 +71,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
   it "can extract a table to a storage file" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi = extract_job_gapi table, extract_file, location: nil
     job_resp_gapi = job_gapi.dup
     job_resp_gapi.status = status "done"
 
@@ -86,7 +86,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
   it "can extract a table to a storage url" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi = extract_job_gapi table, extract_file, location: nil
     job_resp_gapi = job_gapi.dup
     job_resp_gapi.status = status "done"
 
@@ -101,7 +101,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
   it "can extract a table and determine the csv format" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi = extract_job_gapi table, extract_file, location: nil
     job_gapi.configuration.extract.destination_format = "CSV"
     job_gapi.configuration.extract.destination_uris = [job_gapi.configuration.extract.destination_uris.first + ".csv"]
     job_resp_gapi = job_gapi.dup
@@ -118,7 +118,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
   it "can extract a table and specify the csv format" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi = extract_job_gapi table, extract_file, location: nil
     job_gapi.configuration.extract.destination_format = "CSV"
     job_resp_gapi = job_gapi.dup
     job_resp_gapi.status = status "done"
@@ -134,7 +134,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
   it "can extract a table and specify the csv format and options" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi = extract_job_gapi table, extract_file, location: nil
     job_gapi.configuration.extract.destination_format = "CSV"
     job_gapi.configuration.extract.compression = "GZIP"
     job_gapi.configuration.extract.field_delimiter = "\t"
@@ -153,7 +153,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
   it "can extract a table and determine the json format" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi = extract_job_gapi table, extract_file, location: nil
     job_gapi.configuration.extract.destination_format = "NEWLINE_DELIMITED_JSON"
     job_gapi.configuration.extract.destination_uris = [job_gapi.configuration.extract.destination_uris.first + ".json"]
     job_resp_gapi = job_gapi.dup
@@ -170,7 +170,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
   it "can extract a table and specify the json format" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi = extract_job_gapi table, extract_file, location: nil
     job_gapi.configuration.extract.destination_format = "NEWLINE_DELIMITED_JSON"
     job_resp_gapi = job_gapi.dup
     job_resp_gapi.status = status "done"
@@ -186,7 +186,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
   it "can extract a table and determine the avro format" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi = extract_job_gapi table, extract_file, location: nil
     job_gapi.configuration.extract.destination_format = "AVRO"
     job_gapi.configuration.extract.destination_uris = [job_gapi.configuration.extract.destination_uris.first + ".avro"]
     job_resp_gapi = job_gapi.dup
@@ -203,7 +203,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
   it "can extract a table and specify the avro format" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi = extract_job_gapi table, extract_file, location: nil
     job_gapi.configuration.extract.destination_format = "AVRO"
     job_resp_gapi = job_gapi.dup
     job_resp_gapi.status = status "done"
@@ -214,34 +214,6 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
     mock.verify
 
     result.must_equal true
-  end
-
-  def extract_job_gapi table, extract_file, job_id: "job_9876543210", location: nil
-    Google::Apis::BigqueryV2::Job.from_json extract_job_json(table, extract_file, job_id, location: location)
-  end
-
-  def extract_job_json table, extract_file, job_id, location: nil
-    {
-      "jobReference" => {
-        "projectId" => project,
-        "jobId" => job_id
-      },
-      "configuration" => {
-        "extract" => {
-          "destinationUris" => [extract_file.to_gs_url],
-          "sourceTable" => {
-            "projectId" => table.project_id,
-            "datasetId" => table.dataset_id,
-            "tableId" => table.table_id
-          },
-          "printHeader" => nil,
-          "compression" => nil,
-          "fieldDelimiter" => nil,
-          "destinationFormat" => nil
-        },
-        "dryRun" => nil
-      }
-    }.to_json
   end
 
   # Borrowed from MockStorage, extract to a common module?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/service_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/service_test.rb
@@ -1,0 +1,106 @@
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Service do
+  Service = Google::Cloud::Bigquery::Service
+  let(:project_id) { "my-project" }
+  let(:dataset_id) { "my_dataset" }
+  let(:table_id) { "my_table" }
+  let(:project_id_default) { "my-project-default" }
+  let(:dataset_id_default) { "my_dataset_default" }
+  let(:table_id_default) { "my_table_default" }
+  let(:project_default_ref) { Google::Apis::BigqueryV2::ProjectReference.new project_id: project_id_default }
+  let(:dataset_default_ref) { Google::Apis::BigqueryV2::DatasetReference.new project_id: project_id_default, dataset_id: dataset_id_default }
+  let(:table_default_ref) { Google::Apis::BigqueryV2::TableReference.new project_id: project_id_default, dataset_id: dataset_id_default, table_id: table_id_default }
+
+  it "returns table ref from standard sql format with project, dataset, table and no default ref" do
+    table_ref = Service.table_ref_from_s "#{project_id}.#{dataset_id}.#{table_id}"
+    table_ref.must_be_kind_of Google::Apis::BigqueryV2::TableReference
+    table_ref.project_id.must_equal project_id
+    table_ref.dataset_id.must_equal dataset_id
+    table_ref.table_id.must_equal table_id
+  end
+
+  it "returns table ref from legacy sql format with project, dataset, table and no default ref" do
+    table_ref = Service.table_ref_from_s "#{project_id}:#{dataset_id}.#{table_id}"
+    table_ref.project_id.must_equal project_id
+    table_ref.dataset_id.must_equal dataset_id
+    table_ref.table_id.must_equal table_id
+  end
+
+  it "returns table ref from standard sql format with project, dataset, table and project default ref" do
+    table_ref = Service.table_ref_from_s "#{project_id}.#{dataset_id}.#{table_id}", default_ref: project_default_ref
+    table_ref.project_id.must_equal project_id
+    table_ref.dataset_id.must_equal dataset_id
+    table_ref.table_id.must_equal table_id
+  end
+
+  it "returns table ref from standard sql format with project, dataset, table and dataset default ref" do
+    table_ref = Service.table_ref_from_s "#{project_id}.#{dataset_id}.#{table_id}", default_ref: dataset_default_ref
+    table_ref.project_id.must_equal project_id
+    table_ref.dataset_id.must_equal dataset_id
+    table_ref.table_id.must_equal table_id
+  end
+
+  it "returns table ref from standard sql format with project, dataset, table and table default ref" do
+    table_ref = Service.table_ref_from_s "#{project_id}.#{dataset_id}.#{table_id}", default_ref: table_default_ref
+    table_ref.project_id.must_equal project_id
+    table_ref.dataset_id.must_equal dataset_id
+    table_ref.table_id.must_equal table_id
+  end
+
+  it "returns table ref from standard sql format with dataset, table and project default ref" do
+    table_ref = Service.table_ref_from_s "#{dataset_id}.#{table_id}", default_ref: project_default_ref
+    table_ref.project_id.must_equal project_id_default
+    table_ref.dataset_id.must_equal dataset_id
+    table_ref.table_id.must_equal table_id
+  end
+
+  it "returns table ref from standard sql format with dataset, table and dataset default ref" do
+    table_ref = Service.table_ref_from_s "#{dataset_id}.#{table_id}", default_ref: dataset_default_ref
+    table_ref.project_id.must_equal project_id_default
+    table_ref.dataset_id.must_equal dataset_id
+    table_ref.table_id.must_equal table_id
+  end
+
+  it "returns table ref from standard sql format with dataset, table and table default ref" do
+    table_ref = Service.table_ref_from_s "#{dataset_id}.#{table_id}", default_ref: table_default_ref
+    table_ref.project_id.must_equal project_id_default
+    table_ref.dataset_id.must_equal dataset_id
+    table_ref.table_id.must_equal table_id
+  end
+
+  it "raises from standard sql format with table and project default ref" do
+    err = expect do
+      Service.table_ref_from_s table_id, default_ref: project_default_ref
+    end.must_raise ArgumentError
+    err.message.must_equal "TableReference is missing dataset_id"
+  end
+
+  it "returns table ref from standard sql format with table and dataset default ref" do
+    table_ref = Service.table_ref_from_s table_id, default_ref: dataset_default_ref
+    table_ref.project_id.must_equal project_id_default
+    table_ref.dataset_id.must_equal dataset_id_default
+    table_ref.table_id.must_equal table_id
+  end
+
+  it "returns table ref from standard sql format with table and table default ref" do
+    table_ref = Service.table_ref_from_s table_id, default_ref: table_default_ref
+    table_ref.project_id.must_equal project_id_default
+    table_ref.dataset_id.must_equal dataset_id_default
+    table_ref.table_id.must_equal table_id
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/service_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/service_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_test.rb
@@ -89,7 +89,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
-  it "can copy itself as a dryrun" do
+  it "can copy itself as a dryrun (deprecated)" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_test.rb
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
-  it "can extract itself as a dryrun" do
+  it "can extract itself as a dryrun (deprecated)" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     job_gapi = extract_job_gapi(table, extract_file)

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_storage_test.rb
@@ -229,7 +229,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     mock.verify
   end
 
-  it "can load itself as a dryrun" do
+  it "can load itself as a dryrun (deprecated)" do
     mock = Minitest::Mock.new
     job_gapi = load_job_url_gapi table_gapi.table_reference, load_url
     job_gapi.configuration.dry_run = true


### PR DESCRIPTION
`Project#copy` example:

```ruby
require "google/cloud/bigquery"

bigquery = Google::Cloud::Bigquery.new
dataset = bigquery.dataset "my_dataset"
destination_table = dataset.table "my_destination_table"

bigquery.copy "bigquery-public-data.samples.shakespeare",
              destination_table
```

`Project#extract` example:

```ruby
require "google/cloud/bigquery"

bigquery = Google::Cloud::Bigquery.new

bigquery.extract "bigquery-public-data.samples.shakespeare",
                 "gs://my-bucket/shakespeare.csv"
```

Table objects are also accepted for the source table param.

[fixes #2609]