### PR TITLE
Fix remaining Logging documentation warnings

### DIFF
--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -163,7 +163,7 @@ end
 require "yard"
 require "yard/rake/yardoc_task"
 YARD::Rake::YardocTask.new do |y|
-  # y.options << "--fail-on-warning"
+  y.options << "--fail-on-warning"
 end
 
 desc "Run the CI build"

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -172,7 +172,6 @@ task :ci do
   header "google-cloud-logging rubocop", "*"
   Rake::Task[:rubocop].invoke
   header "google-cloud-logging yard", "*"
-  header "logging yard still had warnings", "!"
   Rake::Task[:yard].invoke
   header "google-cloud-logging doctest", "*"
   Rake::Task[:doctest].invoke

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -284,9 +284,6 @@ module Google
         #
         # DEPRECATED. Use #wait_until_async_stopped instead.
         #
-        # @param [Number, nil] timeout Timeout in seconds, or `nil` for no
-        #     timeout.
-        #
         # @return [Boolean] Returns true if the writer is stopped, or false
         #   if the timeout expired.
         #

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -30,8 +30,10 @@ module Google
       # {Google::Cloud::Logging::Logger} instance to be used by the Rails
       # application.
       #
-      # The Middleware is only added when certain conditions are met. See
-      # {use_logging?} for details.
+      # The Middleware is only loaded when certain conditions are met. These
+      # conditions are when `Google::Cloud.configure.use_logging` is set to
+      # `true`, when `Rails.application.config.google_cloud.use_logging` is set
+      # to `true`, or when `Rails.env.production?` is `true`.
       #
       # When loaded, the {Google::Cloud::Logging::Middleware} will be inserted
       # before the `Rails::Rack::Logger Middleware`, which allows it to set the

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -30,10 +30,12 @@ module Google
       # {Google::Cloud::Logging::Logger} instance to be used by the Rails
       # application.
       #
-      # The Middleware is only loaded when certain conditions are met. These
-      # conditions are when `Google::Cloud.configure.use_logging` is set to
-      # `true`, when `Rails.application.config.google_cloud.use_logging` is set
-      # to `true`, or when `Rails.env.production?` is `true`.
+      # The middleware is loaded only when certain conditions are met. These
+      # conditions are when the configuration
+      # `Google::Cloud.configure.use_logging` (also available as
+      # `Rails.application.config.google_cloud.use_logging` for a Rails
+      # application) is set to `true`, or, if the configuration is left unset
+      # but `Rails.env.production?` is `true`.
       #
       # When loaded, the {Google::Cloud::Logging::Middleware} will be inserted
       # before the `Rails::Rack::Logger Middleware`, which allows it to set the


### PR DESCRIPTION
This PR resolves the remaining Logging warnings and enables CI failure when a documentation warning is introduced.

[closes #2308]