### PR TITLE
Refactor Logging buffer

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -134,7 +134,7 @@ module Google
             raise "AsyncWriter has been stopped" if @stopped
 
             Array(entries).each do |entry|
-              # Update the entry to have all the data direclty on it
+              # Update the entry to have all the data directly on it
               entry.log_name ||= log_name
               if entry.resource.nil? || entry.resource.empty?
                 entry.resource = resource

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -461,7 +461,7 @@ module Google
 
           def initialize writer
             @writer = writer
-            @entries = Concurrent::Array.new
+            @entries = []
             @entries_bytes = 2 # initial size w/ partial_success
             @created_at = nil
           end

--- a/google-cloud-logging/lib/google/cloud/logging/entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry.rb
@@ -456,6 +456,7 @@ module Google
         # @private Formats the labels so they can be saved to a
         # Google::Logging::V2::LogEntry object.
         def labels_grpc
+          return {} if labels.nil?
           # Coerce symbols to strings
           Hash[labels.map do |k, v|
             v = String(v) if v.is_a? Symbol

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -206,8 +206,10 @@ module Google
         #
         def entry log_name: nil, resource: nil, timestamp: nil, severity: nil,
                   insert_id: nil, labels: nil, payload: nil
+          ensure_service!
+
           e = Entry.new
-          e.log_name = log_name if log_name
+          e.log_name = service.log_path(log_name) if log_name
           e.resource = resource if resource
           e.timestamp = timestamp if timestamp
           e.severity = severity if severity

--- a/google-cloud-logging/lib/google/cloud/logging/service.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/service.rb
@@ -248,6 +248,13 @@ module Google
           end
         end
 
+        def log_path log_name
+          return nil if log_name.nil?
+          return log_name if log_name.empty?
+          return log_name if log_name.to_s.include? "/"
+          "#{project_path}/logs/#{log_name}"
+        end
+
         def inspect
           "#{self.class}(#{@project})"
         end
@@ -256,13 +263,6 @@ module Google
 
         def project_path
           "projects/#{@project}"
-        end
-
-        def log_path log_name
-          return nil if log_name.nil?
-          return log_name if log_name.empty?
-          return log_name if log_name.to_s.include? "/"
-          "#{project_path}/logs/#{log_name}"
         end
 
         def sink_path sink_name

--- a/google-cloud-logging/test/google/cloud/logging/project_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project_test.rb
@@ -24,6 +24,15 @@ describe Google::Cloud::Logging::Project, :mock_logging do
     entry = logging.entry
     entry.must_be_kind_of Google::Cloud::Logging::Entry
     entry.resource.must_be_kind_of Google::Cloud::Logging::Resource
+
+    entry.must_be_kind_of Google::Cloud::Logging::Entry
+    entry.log_name.must_be :nil?
+    entry.resource.must_be :empty?
+    entry.timestamp.must_be :nil?
+    entry.severity.must_equal :DEFAULT
+    entry.insert_id.must_be :nil?
+    entry.labels.must_be :empty?
+    entry.payload.must_be :nil?
   end
 
   it "creates an entry with all attributes" do
@@ -46,7 +55,7 @@ describe Google::Cloud::Logging::Project, :mock_logging do
                           payload: payload
 
     entry.must_be_kind_of Google::Cloud::Logging::Entry
-    entry.log_name.must_equal log_name
+    entry.log_name.must_equal "projects/#{project}/logs/#{log_name}"
     entry.resource.must_equal resource
     entry.timestamp.must_equal timestamp
     entry.severity.must_equal severity


### PR DESCRIPTION
This PR makes some structural changes to how log entries are buffered in order to optimization on the number of API calls made by AsyncWriter. Instead of making separate API calls for each combination of `log_name`, `resource`, and `labels` (as provided by the call to `#write_entries`), the new buffer combines those values on the log entry object, and makes the batch call to `write_log_entries` API using only entries, and not specifying `log_name`, `resource`, or `labels`.