### PR TITLE
Releases 2018-12-05

### DIFF
--- a/google-cloud-bigquery/CHANGELOG.md
+++ b/google-cloud-bigquery/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+### 1.10.0 / 2018-12-06
+
+* Add dryrun param to Project#query_job and Dataset#query_job
+* Add copy and extract methods to Project
+  * Add Project#extract and Project#extract_job
+  * Add Project#copy and Project#copy_job
+  * Deprecate dryrun param in Table#copy_job, Table#extract_job and 
+    Table#load_job
+* Fix memoization in Dataset#exists? and Table#exists?
+  * Add force param to Dataset#exists? and Table#exists?
+
 ### 1.9.0 / 2018-10-25
 
 * Add clustering fields to LoadJob, QueryJob and Table

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigquery
-      VERSION = "1.9.0".freeze
+      VERSION = "1.10.0".freeze
     end
   end
 end


### PR DESCRIPTION
Release google-cloud-bigquery 1.10.0

* Add dryrun param to Project#query_job and Dataset#query_job
* Add copy and extract methods to Project
  * Add Project#extract and Project#extract_job
  * Add Project#copy and Project#copy_job
  * Deprecate dryrun param in Table#copy_job, Table#extract_job and
    Table#load_job
* Fix memoization in Dataset#exists? and Table#exists?
  * Add force param to Dataset#exists? and Table#exists?