### PR TITLE
Update naming convention for dryrun

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -163,7 +163,6 @@ describe Google::Cloud::Bigquery, :bigquery do
     data.statement_type.must_equal "SELECT"
 
     # @gapi.statistics.query
-    job.cache_hit?.must_equal false
     job.bytes_processed.must_be :>, 0 # 155625782
     job.query_plan.must_be :nil?
   end

--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -152,6 +152,8 @@ describe Google::Cloud::Bigquery, :bigquery do
   it "should run a query job with dryrun flag" do
     job = bigquery.query_job publicdata_query, dryrun: true
     job.dryrun?.must_equal true
+    job.dryrun.must_equal true # alias
+    job.dry_run.must_equal true # alias
     job.dry_run?.must_equal true # alias
 
     job.wait_until_done!

--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -149,9 +149,10 @@ describe Google::Cloud::Bigquery, :bigquery do
     job.ddl_target_table.must_be :nil?
   end
 
-  it "should run a query job with dry_run flag" do
-    job = bigquery.query_job publicdata_query, dry_run: true
-    job.dry_run?.must_equal true
+  it "should run a query job with dryrun flag" do
+    job = bigquery.query_job publicdata_query, dryrun: true
+    job.dryrun?.must_equal true
+    job.dry_run?.must_equal true # alias
 
     job.wait_until_done!
     data = job.data

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -750,7 +750,7 @@ module Google
         #   * `append` - BigQuery appends the data to the table.
         #   * `empty` - A 'duplicate' error is returned in the job result if the
         #     table exists and contains data.
-        # @param [Boolean] dry_run If set to true, BigQuery doesn't run the job.
+        # @param [Boolean] dryrun If set to true, BigQuery doesn't run the job.
         #   Instead, if the query is valid, BigQuery returns statistics about
         #   the job such as how many bytes would be processed. If the query is
         #   invalid, an error returns. The default value is false.
@@ -935,13 +935,13 @@ module Google
         #
         def query_job query, params: nil, external: nil,
                       priority: "INTERACTIVE", cache: true, table: nil,
-                      create: nil, write: nil, dry_run: nil, standard_sql: nil,
+                      create: nil, write: nil, dryrun: nil, standard_sql: nil,
                       legacy_sql: nil, large_results: nil, flatten: nil,
                       maximum_billing_tier: nil, maximum_bytes_billed: nil,
                       job_id: nil, prefix: nil, labels: nil, udfs: nil
           ensure_service!
           options = { priority: priority, cache: cache, table: table,
-                      create: create, write: write, dry_run: dry_run,
+                      create: create, write: write, dryrun: dryrun,
                       large_results: large_results, flatten: flatten,
                       legacy_sql: legacy_sql, standard_sql: standard_sql,
                       maximum_billing_tier: maximum_billing_tier,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -344,7 +344,7 @@ module Google
         #   * `append` - BigQuery appends the data to the table.
         #   * `empty` - A 'duplicate' error is returned in the job result if the
         #     table exists and contains data.
-        # @param [Boolean] dry_run If set to true, BigQuery doesn't run the job.
+        # @param [Boolean] dryrun If set to true, BigQuery doesn't run the job.
         #   Instead, if the query is valid, BigQuery returns statistics about
         #   the job such as how many bytes would be processed. If the query is
         #   invalid, an error returns. The default value is false.
@@ -540,14 +540,14 @@ module Google
         #
         def query_job query, params: nil, external: nil,
                       priority: "INTERACTIVE", cache: true, table: nil,
-                      create: nil, write: nil, dry_run: nil, dataset: nil,
+                      create: nil, write: nil, dryrun: nil, dataset: nil,
                       project: nil, standard_sql: nil, legacy_sql: nil,
                       large_results: nil, flatten: nil,
                       maximum_billing_tier: nil, maximum_bytes_billed: nil,
                       job_id: nil, prefix: nil, labels: nil, udfs: nil
           ensure_service!
           options = { priority: priority, cache: cache, table: table,
-                      create: create, write: write, dry_run: dry_run,
+                      create: create, write: write, dryrun: dryrun,
                       large_results: large_results, flatten: flatten,
                       dataset: dataset, project: (project || self.project),
                       legacy_sql: legacy_sql, standard_sql: standard_sql,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -108,9 +108,12 @@ module Google
         # @return [Boolean] `true` when the dry run flag is set for the query
         #   job, `false` otherwise.
         #
-        def dry_run?
+        def dryrun
           @gapi.configuration.dry_run
         end
+        alias dryrun? dryrun
+        alias dry_run dryrun
+        alias dry_run? dryrun
 
         ##
         # Checks if the query job flattens nested and repeated fields in the
@@ -625,7 +628,7 @@ module Google
             updater.create = options[:create]
             updater.write = options[:write]
             updater.table = options[:table]
-            updater.dry_run = options[:dry_run]
+            updater.dry_run = options[:dryrun]
             updater.maximum_bytes_billed = options[:maximum_bytes_billed]
             updater.labels = options[:labels] if options[:labels]
             updater.legacy_sql = Convert.resolve_legacy_sql(
@@ -812,9 +815,10 @@ module Google
           #   would if it wasn't a dry run..
           #
           # @!group Attributes
-          def dry_run= value
+          def dryrun= value
             @gapi.configuration.dry_run = value
           end
+          alias dry_run= dryrun=
 
           ##
           # Sets the destination for the query results table.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -108,12 +108,12 @@ module Google
         # @return [Boolean] `true` when the dry run flag is set for the query
         #   job, `false` otherwise.
         #
-        def dryrun
+        def dryrun?
           @gapi.configuration.dry_run
         end
-        alias dryrun? dryrun
-        alias dry_run dryrun
-        alias dry_run? dryrun
+        alias dryrun dryrun?
+        alias dry_run dryrun?
+        alias dry_run? dryrun?
 
         ##
         # Checks if the query job flattens nested and repeated fields in the
@@ -573,7 +573,7 @@ module Google
         #
         def data token: nil, max: nil, start: nil
           return nil unless done?
-          if dry_run?
+          if dryrun?
             return Data.from_gapi_json({ rows: [] }, nil, @gapi, service)
           end
           if ddl? || dml?
@@ -628,7 +628,7 @@ module Google
             updater.create = options[:create]
             updater.write = options[:write]
             updater.table = options[:table]
-            updater.dry_run = options[:dryrun]
+            updater.dryrun = options[:dryrun]
             updater.maximum_bytes_billed = options[:maximum_bytes_billed]
             updater.labels = options[:labels] if options[:labels]
             updater.legacy_sql = Convert.resolve_legacy_sql(

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
@@ -169,7 +169,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job.job_id.must_equal job_id
   end
 
-  it "queries the data with dry_run flag" do
+  it "queries the data with dryrun flag" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
 
@@ -181,7 +181,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = dataset.query_job query, dry_run: true
+    job = dataset.query_job query, dryrun: true
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
@@ -185,7 +185,10 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.dry_run?.must_equal true
+    job.dryrun?.must_equal true
+    job.dryrun.must_equal true # alias
+    job.dry_run.must_equal true # alias
+    job.dry_run?.must_equal true # alias
   end
 
   it "queries the data with prefix option" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
@@ -145,7 +145,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job.job_id.must_equal job_id
   end
 
-  it "queries the data with dry_run flag" do
+  it "queries the data with dryrun flag" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
 
@@ -153,7 +153,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = bigquery.query_job query, dry_run: true
+    job = bigquery.query_job query, dryrun: true
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
@@ -157,7 +157,10 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.dry_run?.must_equal true
+    job.dryrun?.must_equal true
+    job.dryrun.must_equal true # alias
+    job.dry_run.must_equal true # alias
+    job.dry_run?.must_equal true # alias
   end
 
   it "queries the data with prefix option" do


### PR DESCRIPTION
* Make this usage of `dryrun` argument consistent with existing usage.
* Add aliases to `QueryJob` and `QueryJob::Updater` with alternative naming.