### PR TITLE
Add new inventory renew lease mechanics

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
@@ -114,7 +114,7 @@ module Google
                 unless delay_gap.positive?
                   delay_target = nil
                   delay_gap = nil # wait until broadcast
-                  stream.delay_inventory!
+                  stream.renew_lease!
                 end
 
                 @wait_cond.wait delay_gap

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -157,6 +157,7 @@ module Google
 
               @subscriber.buffer.renew_lease @subscriber.deadline,
                                              @inventory.ack_ids
+              unpause_streaming!
             end
 
             true

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -151,11 +151,12 @@ module Google
 
           ##
           # @private
-          def delay_inventory!
+          def renew_lease!
             synchronize do
               return true if @inventory.empty?
 
-              @subscriber.buffer.delay subscriber.deadline, @inventory.ack_ids
+              @subscriber.buffer.renew_lease @subscriber.deadline,
+                                             @inventory.ack_ids
             end
 
             true

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -47,9 +47,9 @@ module Google
             @paused  = nil
             @pause_cond = new_cond
 
-            @inventory = Inventory.new self, subscriber.stream_inventory
+            @inventory = Inventory.new self, @subscriber.stream_inventory
             @callback_thread_pool = Concurrent::FixedThreadPool.new \
-              subscriber.callback_threads
+              @subscriber.callback_threads
 
             @stream_keepalive_task = Concurrent::TimerTask.new(
               execution_interval: 30
@@ -133,13 +133,12 @@ module Google
 
             synchronize do
               @inventory.remove mod_ack_ids
-              @subscriber.buffer.delay deadline, mod_ack_ids
+              @subscriber.buffer.modify_ack_deadline deadline, mod_ack_ids
               unpause_streaming!
             end
 
             true
           end
-          alias delay modify_ack_deadline
 
           def push request
             synchronize { @request_queue.push request }
@@ -193,7 +192,7 @@ module Google
             @request_queue = EnumeratorQueue.new self
             @request_queue.push initial_input_request
             old_queue.each { |obj| @request_queue.push obj }
-            enum = subscriber.service.streaming_pull @request_queue.each
+            enum = @subscriber.service.streaming_pull @request_queue.each
 
             @stopped = nil
             @paused  = nil
@@ -218,7 +217,8 @@ module Google
 
                 synchronize do
                   # Create receipt of received messages reception
-                  @subscriber.buffer.delay subscriber.deadline, received_ack_ids
+                  @subscriber.buffer.modify_ack_deadline @subscriber.deadline,
+                                                         received_ack_ids
 
                   # Add received messages to inventory
                   @inventory.add received_ack_ids
@@ -254,7 +254,7 @@ module Google
             retry
           rescue StandardError => e
             synchronize do
-              subscriber.error! e
+              @subscriber.error! e
               start_streaming! unless @stopped
             end
 
@@ -268,9 +268,9 @@ module Google
 
             Concurrent::Future.new(executor: callback_thread_pool) do
               begin
-                subscriber.callback.call rec_msg
+                @subscriber.callback.call rec_msg
               rescue StandardError => callback_error
-                subscriber.error! callback_error
+                @subscriber.error! callback_error
               end
             end.execute
           end
@@ -318,11 +318,11 @@ module Google
 
           def initial_input_request
             Google::Pubsub::V1::StreamingPullRequest.new.tap do |req|
-              req.subscription = subscriber.subscription_name
-              req.stream_ack_deadline_seconds = subscriber.deadline
+              req.subscription = @subscriber.subscription_name
+              req.stream_ack_deadline_seconds = @subscriber.deadline
               req.modify_deadline_ack_ids += @inventory.ack_ids
               req.modify_deadline_seconds += \
-                @inventory.ack_ids.map { subscriber.deadline }
+                @inventory.ack_ids.map { @subscriber.deadline }
             end
           end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
@@ -60,6 +60,17 @@ module Google
           end
           alias delay modify_ack_deadline
 
+          def renew_lease deadline, ack_ids
+            return if ack_ids.empty?
+
+            ack_ids.each do |ack_id|
+              # Do not overwrite pending actions when renewing leased messages.
+              @register[ack_id] ||= deadline
+            end
+
+            true
+          end
+
           def flush!
             # Grab requests from the buffer and release synchronize ASAP
             requests = flush_requests!

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
@@ -29,9 +29,10 @@ module Google
             @max_bytes = max_bytes
             @interval = interval
 
-            # Using a Map ensures there is only one entry for each ack_id in the
-            # buffer. Adding an entry again will overwrite the previous entry.
-            @register = Concurrent::Map.new
+            # Using a Hash ensures there is only one entry for each ack_id in
+            # the buffer. Adding an entry again will overwrite the previous
+            # entry.
+            @register = {}
 
             @task = Concurrent::TimerTask.new(execution_interval: interval) do
               flush!

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
@@ -59,7 +59,6 @@ module Google
 
             true
           end
-          alias delay modify_ack_deadline
 
           def renew_lease deadline, ack_ids
             return if ack_ids.empty?


### PR DESCRIPTION
This change will help avoid race conditions by ensuring that inventory lease renewal actions don't override ack/nack/delay actions made on a received message via the Subscriber callback. An ack/nack/delay action on a received message via the Subscriber callback will overwrite a pending lease renewal in the buffer.