### PR TITLE
Release google-cloud-container 0.3.0

### DIFF
--- a/google-cloud-container/CHANGELOG.md
+++ b/google-cloud-container/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 0.3.0 / 2018-12-10
+
+* Add support for Regional Clusters.
+  * Client methods deprecate many positional arguments in
+    favor of name/parent named argument.
+  * Maintains backwards compatibility.
+
 ### 0.2.2 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-container/google-cloud-container.gemspec
+++ b/google-cloud-container/google-cloud-container.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-container"
-  gem.version       = "0.2.2"
+  gem.version       = "0.3.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Add support for Regional Clusters.
  * Client methods deprecate many positional arguments in
    favor of name/parent named argument.
  * Maintains backwards compatibility.