### PR TITLE
Update .rubocop.yml in all gems

### DIFF
--- a/gcloud/.rubocop.yml
+++ b/gcloud/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - "gcloud.gemspec"
     - "Rakefile"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-asset/.rubocop.yml
+++ b/google-cloud-asset/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-bigquery-data_transfer/.rubocop.yml
+++ b/google-cloud-bigquery-data_transfer/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-bigquery/.rubocop.yml
+++ b/google-cloud-bigquery/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - "google-cloud-bigquery.gemspec"
     - "Rakefile"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-bigtable/.rubocop.yml
+++ b/google-cloud-bigtable/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - "test/**/*"
     - "acceptance/**/*"
     - "samples/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: true

--- a/google-cloud-container/.rubocop.yml
+++ b/google-cloud-container/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-core/.rubocop.yml
+++ b/google-cloud-core/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - "google-cloud-core.gemspec"
     - "Rakefile"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-dataproc/.rubocop.yml
+++ b/google-cloud-dataproc/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-datastore/.rubocop.yml
+++ b/google-cloud-datastore/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-debugger/.rubocop.yml
+++ b/google-cloud-debugger/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - "support/**/*"
     - "test/**/*"
     - "tmp/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-dialogflow/.rubocop.yml
+++ b/google-cloud-dialogflow/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-dlp/.rubocop.yml
+++ b/google-cloud-dlp/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-dns/.rubocop.yml
+++ b/google-cloud-dns/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-env/.rubocop.yml
+++ b/google-cloud-env/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - "google-cloud-env.gemspec"
     - "Rakefile"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-error_reporting/.rubocop.yml
+++ b/google-cloud-error_reporting/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-firestore/.rubocop.yml
+++ b/google-cloud-firestore/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
     - "acceptance/**/*"
     - "conformance/*"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-kms/.rubocop.yml
+++ b/google-cloud-kms/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-language/.rubocop.yml
+++ b/google-cloud-language/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-logging/.rubocop.yml
+++ b/google-cloud-logging/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-monitoring/.rubocop.yml
+++ b/google-cloud-monitoring/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-os_login/.rubocop.yml
+++ b/google-cloud-os_login/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-pubsub/.rubocop.yml
+++ b/google-cloud-pubsub/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-redis/.rubocop.yml
+++ b/google-cloud-redis/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-resource_manager/.rubocop.yml
+++ b/google-cloud-resource_manager/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-spanner/.rubocop.yml
+++ b/google-cloud-spanner/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
     - "lib/google/spanner/**/*"
     - "lib/google/cloud/spanner/v1/**/*"
     - "lib/google/cloud/spanner/admin/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-speech/.rubocop.yml
+++ b/google-cloud-speech/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-storage/.rubocop.yml
+++ b/google-cloud-storage/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "support/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-tasks/.rubocop.yml
+++ b/google-cloud-tasks/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-text_to_speech/.rubocop.yml
+++ b/google-cloud-text_to_speech/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-trace/.rubocop.yml
+++ b/google-cloud-trace/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-translate/.rubocop.yml
+++ b/google-cloud-translate/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-video_intelligence/.rubocop.yml
+++ b/google-cloud-video_intelligence/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-vision/.rubocop.yml
+++ b/google-cloud-vision/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
     - "lib/google/cloud/vision/v1p3beta1.rb"
     - "lib/google/cloud/vision/v1p3beta1/**/*"
     - "test/**/*"
+  TargetRubyVersion: 2.2
     
 
 Documentation:

--- a/google-cloud/.rubocop.yml
+++ b/google-cloud/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - "google-cloud.gemspec"
     - "Rakefile"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/stackdriver-core/.rubocop.yml
+++ b/stackdriver-core/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - "stackdriver-core.gemspec"
     - "Rakefile"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/stackdriver/.rubocop.yml
+++ b/stackdriver/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
     - "Rakefile"
     - "lib/legacy_stackdriver.rb"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false


### PR DESCRIPTION
Set `TargetRubyVersion` to `2.2` to avoid cop failures inconsistent with current style.

[fixes #2718]