### PR TITLE
Update Pub/Sub reference/resource documentation

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Pubsub, :pubsub do
 
   let(:new_topic_name)  {  $topic_names[0] }
   let(:topic_names)     {  $topic_names[3..6] }
-  let(:lazy_topic_name) {  $topic_names[7] }
+  let(:reference_topic_name) {  $topic_names[7] }
   let(:labels) { { "foo" => "bar" } }
 
   before do

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -150,7 +150,7 @@ module Google
         def topic topic_name, project: nil, skip_lookup: nil, async: nil
           ensure_service!
           options = { project: project }
-          return Topic.new_lazy(topic_name, service, options) if skip_lookup
+          return Topic.from_name(topic_name, service, options) if skip_lookup
           grpc = service.get_topic topic_name
           Topic.from_grpc grpc, service, async: async
         rescue Google::Cloud::NotFoundError
@@ -282,7 +282,7 @@ module Google
           ensure_service!
           options = { project: project }
           if skip_lookup
-            return Subscription.new_lazy subscription_name, service, options
+            return Subscription.from_name subscription_name, service, options
           end
           grpc = service.get_subscription subscription_name
           Subscription.from_grpc grpc, service

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot.rb
@@ -79,7 +79,7 @@ module Google
         #   snapshot.topic.name #=> "projects/my-project/topics/my-topic"
         #
         def topic
-          Topic.new_lazy @grpc.topic, service
+          Topic.from_name @grpc.topic, service
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -812,7 +812,8 @@ module Google
         end
 
         ##
-        # @private New reference {Topic} object without making an HTTP request.
+        # @private New reference {Subscription} object without making an HTTP
+        # request.
         def self.from_name name, service, options = {}
           name = service.subscription_path name, options
           from_grpc(nil, service).tap do |s|

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -60,18 +60,24 @@ module Google
         def initialize
           @service = nil
           @grpc = nil
-          @lazy = nil
+          @resource_name = nil
           @exists = nil
         end
 
         ##
         # The name of the subscription.
+        #
+        # @return [String]
         def name
+          return @resource_name if reference?
           @grpc.name
         end
 
         ##
         # The {Topic} from which this subscription receives messages.
+        #
+        # Makes an API call to retrieve the topic information when called on a
+        # reference object. See {#reference?}.
         #
         # @return [Topic]
         #
@@ -85,24 +91,36 @@ module Google
         #
         def topic
           ensure_grpc!
-          Topic.new_lazy @grpc.topic, service
+          Topic.from_name @grpc.topic, service
         end
 
         ##
         # This value is the maximum number of seconds after a subscriber
         # receives a message before the subscriber should acknowledge the
         # message.
+        #
+        # Makes an API call to retrieve the deadline value when called on a
+        # reference object. See {#reference?}.
+        #
+        # @return [Integer]
         def deadline
           ensure_grpc!
           @grpc.ack_deadline_seconds
         end
 
+        ##
+        # Sets the maximum number of seconds after a subscriber
+        # receives a message before the subscriber should acknowledge the
+        # message.
+        #
+        # @param [Integer] new_deadline The new deadline value.
+        #
         def deadline= new_deadline
-          update_grpc = @grpc.dup
-          update_grpc.ack_deadline_seconds = new_deadline
+          update_grpc = Google::Pubsub::V1::Subscription.new \
+            name: name, ack_deadline_seconds: new_deadline
           @grpc = service.update_subscription update_grpc,
                                               :ack_deadline_seconds
-          @lazy = nil
+          @resource_name = nil
         end
 
         ##
@@ -110,6 +128,9 @@ module Google
         # messages are not expunged from the subscription's backlog, even if
         # they are acknowledged, until they fall out of the {#retention} window.
         # Default is `false`.
+        #
+        # Makes an API call to retrieve the retain_acked value when called on a
+        # reference object. See {#reference?}.
         #
         # @return [Boolean] Returns `true` if acknowledged messages are
         #   retained.
@@ -119,12 +140,18 @@ module Google
           @grpc.retain_acked_messages
         end
 
+        ##
+        # Sets whether to retain acknowledged messages.
+        #
+        # @param [Boolean] new_retain_acked The new retain acknowledged messages
+        #   value.
+        #
         def retain_acked= new_retain_acked
-          update_grpc = @grpc.dup
-          update_grpc.retain_acked_messages = !(!new_retain_acked)
+          update_grpc = Google::Pubsub::V1::Subscription.new \
+            name: name, retain_acked_messages: !(!new_retain_acked)
           @grpc = service.update_subscription update_grpc,
                                               :retain_acked_messages
-          @lazy = nil
+          @resource_name = nil
         end
 
         ##
@@ -136,6 +163,9 @@ module Google
         # less than 600 seconds (10 minutes). Default is 604,800 seconds (7
         # days).
         #
+        # Makes an API call to retrieve the retention value when called on a
+        # reference object. See {#reference?}.
+        #
         # @return [Numeric] The message retention duration in seconds.
         #
         def retention
@@ -143,18 +173,29 @@ module Google
           Convert.duration_to_number @grpc.message_retention_duration
         end
 
+        ##
+        # Sets the message retention duration in seconds.
+        #
+        # @param [Numeric] new_retention The new retention value.
+        #
         def retention= new_retention
-          update_grpc = @grpc.dup
-          update_grpc.message_retention_duration = \
-            Convert.number_to_duration new_retention
+          new_retention_duration = Convert.number_to_duration new_retention
+          update_grpc = Google::Pubsub::V1::Subscription.new \
+            name: name, message_retention_duration: new_retention_duration
           @grpc = service.update_subscription update_grpc,
                                               :message_retention_duration
-          @lazy = nil
+          @resource_name = nil
         end
 
         ##
         # Returns the URL locating the endpoint to which messages should be
         # pushed.
+        #
+        # Makes an API call to retrieve the endpoint value when called on a
+        # reference object. See {#reference?}.
+        #
+        # @return [String]
+        #
         def endpoint
           ensure_grpc!
           @grpc.push_config.push_endpoint if @grpc.push_config
@@ -162,11 +203,14 @@ module Google
 
         ##
         # Sets the URL locating the endpoint to which messages should be pushed.
+        #
+        # @param [String] new_endpoint The new endpoint value.
+        #
         def endpoint= new_endpoint
           ensure_service!
           service.modify_push_config name, new_endpoint, {}
 
-          return unless @grpc
+          return if reference?
 
           @grpc.push_config = Google::Pubsub::V1::PushConfig.new(
             push_endpoint: new_endpoint,
@@ -182,9 +226,13 @@ module Google
         # The returned hash is frozen and changes are not allowed. Use
         # {#labels=} to update the labels for this subscription.
         #
+        # Makes an API call to retrieve the labels value when called on a
+        # reference object. See {#reference?}.
+        #
         # @return [Hash] The frozen labels hash.
         #
         def labels
+          ensure_grpc!
           @grpc.labels.to_h.freeze
         end
 
@@ -202,16 +250,19 @@ module Google
         #
         def labels= new_labels
           raise ArgumentError, "Value must be a Hash" if new_labels.nil?
-          labels_map = Google::Protobuf::Map.new(:string, :string)
-          Hash(new_labels).each { |k, v| labels_map[String(k)] = String(v) }
-          update_grpc = @grpc.dup
-          update_grpc.labels = labels_map
+          update_grpc = Google::Pubsub::V1::Subscription.new \
+            name: name, labels: new_labels
           @grpc = service.update_subscription update_grpc, :labels
-          @lazy = nil
+          @resource_name = nil
         end
 
         ##
         # Determines whether the subscription exists in the Pub/Sub service.
+        #
+        # Makes an API call to determine whether the subscription resource
+        # exists when called on a reference object. See {#reference?}.
+        #
+        # @return [Boolean]
         #
         # @example
         #   require "google/cloud/pubsub"
@@ -222,31 +273,14 @@ module Google
         #   sub.exists? #=> true
         #
         def exists?
-          # Always true if the object is not set as lazy
-          return true unless lazy?
+          # Always true if the object is not set as reference
+          return true unless reference?
           # If we have a value, return it
           return @exists unless @exists.nil?
           ensure_grpc!
           @exists = true
         rescue Google::Cloud::NotFoundError
           @exists = false
-        end
-
-        ##
-        # @private
-        # Determines whether the subscription object was created with an
-        # HTTP call.
-        #
-        # @example
-        #   require "google/cloud/pubsub"
-        #
-        #   pubsub = Google::Cloud::Pubsub.new
-        #
-        #   sub = pubsub.get_subscription "my-topic-sub"
-        #   sub.lazy? #=> nil
-        #
-        def lazy?
-          @lazy
         end
 
         ##
@@ -370,6 +404,9 @@ module Google
         #   will hold received messages before modifying the message's ack
         #   deadline. The minimum is 10, the maximum is 600. Default is
         #   {#deadline}. Optional.
+        #
+        #   Makes an API call to retrieve the deadline value when called on a
+        #   reference object. See {#reference?}.
         # @param [Integer] streams The number of concurrent streams to open to
         #   pull messages from the subscription. Default is 4. Optional.
         # @param [Integer] inventory The number of received messages to be
@@ -609,6 +646,44 @@ module Google
         end
 
         ##
+        # Determines whether the subscription object was created without
+        # retrieving the resource representation from the Pub/Sub service.
+        #
+        # @return [Boolean] `true` when the subscription was created without a
+        #   resource representation, `false` otherwise.
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::Pubsub.new
+        #
+        #   sub = pubsub.get_subscription "my-topic-sub", skip_lookup: true
+        #   sub.reference? #=> true
+        #
+        def reference?
+          @grpc.nil?
+        end
+
+        ##
+        # Determines whether the subscription object was created with a resource
+        # representation from the Pub/Sub service.
+        #
+        # @return [Boolean] `true` when the subscription was created with a
+        #   resource representation, `false` otherwise.
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::Pubsub.new
+        #
+        #   sub = pubsub.get_subscription "my-topic-sub"
+        #   sub.resource? #=> true
+        #
+        def resource?
+          !@grpc.nil?
+        end
+
+        ##
         # Gets the [Cloud IAM](https://cloud.google.com/iam/) access control
         # policy for this subscription.
         #
@@ -737,12 +812,11 @@ module Google
         end
 
         ##
-        # @private New lazy {Topic} object without making an HTTP request.
-        def self.new_lazy name, service, options = {}
-          lazy_grpc = Google::Pubsub::V1::Subscription.new \
-            name: service.subscription_path(name, options)
-          from_grpc(lazy_grpc, service).tap do |s|
-            s.instance_variable_set :@lazy, true
+        # @private New reference {Topic} object without making an HTTP request.
+        def self.from_name name, service, options = {}
+          name = service.subscription_path name, options
+          from_grpc(nil, service).tap do |s|
+            s.instance_variable_set :@resource_name, name
           end
         end
 
@@ -759,8 +833,8 @@ module Google
         # Ensures a Google::Pubsub::V1::Subscription object exists.
         def ensure_grpc!
           ensure_service!
-          @grpc = service.get_subscription name if lazy?
-          @lazy = nil
+          @grpc = service.get_subscription name if reference?
+          @resource_name = nil
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
@@ -167,7 +167,7 @@ module Google
           # Google::Pubsub::V1::ListTopicSubscriptionsResponse object.
           def self.from_topic_grpc grpc_list, service, topic, max = nil
             subs = new(Array(grpc_list.subscriptions).map do |grpc|
-              Subscription.new_lazy grpc, service
+              Subscription.from_name grpc, service
             end)
             token = grpc_list.next_page_token
             token = nil if token == "".freeze

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -102,7 +102,7 @@ module Google
         # The returned hash is frozen and changes are not allowed. Use
         # {#labels=} to update the labels for this topic.
         #
-        # Makes an API call to retrieve the endpoint value when called on a
+        # Makes an API call to retrieve the labels values when called on a
         # reference object. See {#reference?}.
         #
         # @return [Hash] The frozen labels hash.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/message_test.rb
@@ -30,8 +30,7 @@ describe Google::Cloud::Pubsub::Message, :mock_pubsub do
 
   describe "from gapi" do
     let(:topic_name) { "topic-name-goes-here" }
-    let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
-                                                  pubsub.service }
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
     let(:subscription_name) { "subscription-name-goes-here" }
     let(:subscription_grpc) { Google::Pubsub::V1::Subscription.decode_json(subscription_json(topic_name, subscription_name)) }
     let(:subscription) { Google::Cloud::Pubsub::Subscription.from_grpc subscription_grpc, pubsub.service }

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
@@ -117,7 +117,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     mock.verify
 
     topic.name.must_equal topic_path(topic_name)
-    topic.wont_be :lazy?
+    topic.wont_be :reference?
+    topic.must_be :resource?
   end
 
   it "gets a topic with get_topic alias" do
@@ -133,7 +134,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     mock.verify
 
     topic.name.must_equal topic_path(topic_name)
-    topic.wont_be :lazy?
+    topic.wont_be :reference?
+    topic.must_be :resource?
   end
 
   it "gets a topic with find_topic alias" do
@@ -149,7 +151,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     mock.verify
 
     topic.name.must_equal topic_path(topic_name)
-    topic.wont_be :lazy?
+    topic.wont_be :reference?
+    topic.must_be :resource?
   end
 
   it "returns nil when getting an non-existent topic" do
@@ -173,7 +176,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
     topic = pubsub.find_topic topic_name, skip_lookup: true
     topic.name.must_equal topic_path(topic_name)
-    topic.must_be :lazy?
+    topic.must_be :reference?
+    topic.wont_be :resource?
   end
 
   it "gets a topic with skip_lookup and project options" do
@@ -182,7 +186,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
     topic = pubsub.find_topic topic_name, skip_lookup: true, project: "custom"
     topic.name.must_equal "projects/custom/topics/found-topic"
-    topic.must_be :lazy?
+    topic.must_be :reference?
+    topic.wont_be :resource?
   end
 
   it "lists topics" do
@@ -381,7 +386,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     sub.wont_be :nil?
     sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
     sub.name.must_equal subscription_path(sub_name)
-    sub.wont_be :lazy?
+    sub.wont_be :reference?
+    sub.must_be :resource?
   end
 
   it "gets a subscription with get_subscription alias" do
@@ -399,7 +405,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     sub.wont_be :nil?
     sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
     sub.name.must_equal subscription_path(sub_name)
-    sub.wont_be :lazy?
+    sub.wont_be :reference?
+    sub.must_be :resource?
   end
 
   it "gets a subscription with find_subscription alias" do
@@ -417,7 +424,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     sub.wont_be :nil?
     sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
     sub.name.must_equal subscription_path(sub_name)
-    sub.wont_be :lazy?
+    sub.wont_be :reference?
+    sub.must_be :resource?
   end
 
   it "returns nil when getting an non-existent subscription" do
@@ -443,7 +451,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     sub.wont_be :nil?
     sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
     sub.name.must_equal subscription_path(sub_name)
-    sub.must_be :lazy?
+    sub.must_be :reference?
+    sub.wont_be :resource?
   end
 
   it "gets a subscription with skip_lookup and project options" do
@@ -454,7 +463,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     sub.wont_be :nil?
     sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
     sub.name.must_equal "projects/custom/subscriptions/#{sub_name}"
-    sub.must_be :lazy?
+    sub.must_be :reference?
+    sub.wont_be :resource?
   end
 
   it "lists subscriptions" do
@@ -554,14 +564,16 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     first_subs.next?.must_equal true
     first_subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.wont_be :lazy?
+      sub.wont_be :reference?
+      sub.must_be :resource?
     end
 
     second_subs.count.must_equal 2
     second_subs.next?.must_equal false
     second_subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.wont_be :lazy?
+      sub.wont_be :reference?
+      sub.must_be :resource?
     end
   end
 
@@ -581,14 +593,16 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     first_subs.next?.must_equal true
     first_subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.wont_be :lazy?
+      sub.wont_be :reference?
+      sub.must_be :resource?
     end
 
     second_subs.count.must_equal 2
     second_subs.next?.must_equal false
     second_subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.wont_be :lazy?
+      sub.wont_be :reference?
+      sub.must_be :resource?
     end
   end
 
@@ -606,7 +620,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     subs.count.must_equal 5
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.wont_be :lazy?
+      sub.wont_be :reference?
+      sub.must_be :resource?
     end
   end
 
@@ -624,7 +639,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     subs.count.must_equal 5
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.wont_be :lazy?
+      sub.wont_be :reference?
+      sub.must_be :resource?
     end
   end
 
@@ -642,7 +658,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     subs.count.must_equal 5
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.wont_be :lazy?
+      sub.wont_be :reference?
+      sub.must_be :resource?
     end
   end
 
@@ -660,7 +677,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     subs.count.must_equal 6
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.wont_be :lazy?
+      sub.wont_be :reference?
+      sub.must_be :resource?
     end
   end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
@@ -16,8 +16,7 @@ require "helper"
 
 describe Google::Cloud::Pubsub::ReceivedMessage, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
-                                                pubsub.service }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
   let(:subscription_name) { "subscription-name-goes-here" }
   let(:subscription_grpc) { Google::Pubsub::V1::Subscription.decode_json(subscription_json(topic_name, subscription_name)) }
   let(:subscription) { Google::Cloud::Pubsub::Subscription.from_grpc subscription_grpc, pubsub.service }

--- a/google-cloud-pubsub/test/google/cloud/pubsub/snapshot_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/snapshot_test.rb
@@ -33,7 +33,8 @@ describe Google::Cloud::Pubsub::Snapshot, :mock_pubsub do
 
   it "knows its topic" do
     snapshot.topic.must_be_kind_of Google::Cloud::Pubsub::Topic
-    snapshot.topic.must_be :lazy?
+    snapshot.topic.must_be :reference?
+    snapshot.topic.wont_be :resource?
     snapshot.topic.name.must_equal topic_path(topic_name)
   end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/acknowledge_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/acknowledge_test.rb
@@ -104,9 +104,9 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
     mock.verify
   end
 
-  describe "lazy subscription object of a subscription that does exist" do
+  describe "reference subscription object of a subscription that does exist" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 
@@ -184,9 +184,9 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
     end
   end
 
-  describe "lazy subscription object of a subscription that does not exist" do
+  describe "reference subscription object of a subscription that does not exist" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
@@ -27,7 +27,8 @@ describe Google::Cloud::Pubsub::Subscription, :attributes, :mock_pubsub do
   it "gets topic from the Google API object" do
     # No mocked service means no API calls are happening.
     subscription.topic.must_be_kind_of Google::Cloud::Pubsub::Topic
-    subscription.topic.must_be :lazy?
+    subscription.topic.must_be :reference?
+    subscription.topic.wont_be :resource?
     subscription.topic.name.must_equal topic_path(topic_name)
   end
 
@@ -60,9 +61,9 @@ describe Google::Cloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     mock.verify
   end
 
-  describe "lazy subscription object of a subscription that does exist" do
+  describe "reference subscription object of a subscription that does exist" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 
@@ -76,7 +77,8 @@ describe Google::Cloud::Pubsub::Subscription, :attributes, :mock_pubsub do
 
       mock.verify
 
-      subscription.topic.must_be :lazy?
+      subscription.topic.must_be :reference?
+      subscription.topic.wont_be :resource?
       subscription.topic.name.must_equal topic_path(topic_name)
     end
 
@@ -127,9 +129,9 @@ describe Google::Cloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     end
   end
 
-  describe "lazy subscription object of a subscription that does not exist" do
+  describe "reference subscription object of a subscription that does not exist" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delete_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delete_test.rb
@@ -33,9 +33,9 @@ describe Google::Cloud::Pubsub::Subscription, :delete, :mock_pubsub do
     mock.verify
   end
 
-  describe "lazy subscription object of a subscription that does exist" do
+  describe "reference subscription object of a subscription that does exist" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 
@@ -51,9 +51,9 @@ describe Google::Cloud::Pubsub::Subscription, :delete, :mock_pubsub do
     end
   end
 
-  describe "lazy subscription object of a subscription that does not exist" do
+  describe "reference subscription object of a subscription that does not exist" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/exists_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/exists_test.rb
@@ -29,9 +29,9 @@ describe Google::Cloud::Pubsub::Subscription, :exists, :mock_pubsub do
     subscription.must_be :exists?
   end
 
-  describe "lazy subscription object of a subscription that exists" do
+  describe "reference subscription object of a subscription that exists" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 
@@ -50,9 +50,9 @@ describe Google::Cloud::Pubsub::Subscription, :exists, :mock_pubsub do
     end
   end
 
-  describe "lazy subscription object of a subscription that does not exist" do
+  describe "reference subscription object of a subscription that does not exist" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/lazy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/lazy_test.rb
@@ -22,18 +22,19 @@ describe Google::Cloud::Pubsub::Subscription, :name, :mock_pubsub do
   let(:sub_grpc) { Google::Pubsub::V1::Subscription.decode_json(sub_json) }
   let(:subscription) { Google::Cloud::Pubsub::Subscription.from_grpc sub_grpc, pubsub.service }
 
-  it "is not lazy when created with an HTTP method" do
-    subscription.wont_be :lazy?
+  it "is not reference when created with an HTTP method" do
+    subscription.wont_be :reference?
+    subscription.must_be :resource?
   end
 
-  describe "lazy subscription" do
+  describe "reference subscription" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
-                                            pubsub.service
+      Google::Cloud::Pubsub::Subscription.from_name sub_name, pubsub.service
     end
 
-    it "is lazy" do
-      subscription.must_be :lazy?
+    it "is reference" do
+      subscription.must_be :reference?
+      subscription.wont_be :resource?
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/modify_ack_deadline_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/modify_ack_deadline_test.rb
@@ -105,9 +105,9 @@ describe Google::Cloud::Pubsub::Subscription, :modify_ack_deadline, :mock_pubsub
     mock.verify
   end
 
-  describe "lazy subscription object of a subscription that does exist" do
+  describe "reference subscription object of a subscription that does exist" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 
@@ -189,9 +189,9 @@ describe Google::Cloud::Pubsub::Subscription, :modify_ack_deadline, :mock_pubsub
     end
   end
 
-  describe "lazy subscription object of a subscription that does not exist" do
+  describe "reference subscription object of a subscription that does not exist" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/name_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/name_test.rb
@@ -26,9 +26,9 @@ describe Google::Cloud::Pubsub::Subscription, :name, :mock_pubsub do
     subscription.name.must_equal sub_path
   end
 
-  describe "lazy subscription given the short name" do
+  describe "reference subscription given the short name" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 
@@ -37,9 +37,9 @@ describe Google::Cloud::Pubsub::Subscription, :name, :mock_pubsub do
     end
   end
 
-  describe "lazy subscription object given the full path" do
+  describe "reference subscription object given the full path" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_path,
+      Google::Cloud::Pubsub::Subscription.from_name sub_path,
                                             pubsub.service
     end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_test.rb
@@ -37,9 +37,9 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
     rec_messages.first.message.data.must_equal rec_message_msg
   end
 
-  describe "lazy subscription object of a subscription that does exist" do
+  describe "reference subscription object of a subscription that does exist" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 
@@ -59,9 +59,9 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
     end
   end
 
-  describe "lazy subscription object of a subscription that does not exist" do
+  describe "reference subscription object of a subscription that does not exist" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/seek_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/seek_test.rb
@@ -55,9 +55,9 @@ describe Google::Cloud::Pubsub::Subscription, :seek, :mock_pubsub do
     mock.verify
   end
 
-  describe "lazy subscription object of a subscription that does exist" do
+  describe "reference subscription object of a subscription that does exist" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 
@@ -73,9 +73,9 @@ describe Google::Cloud::Pubsub::Subscription, :seek, :mock_pubsub do
     end
   end
 
-  describe "lazy subscription object of a subscription that does not exist" do
+  describe "reference subscription object of a subscription that does not exist" do
     let :subscription do
-      Google::Cloud::Pubsub::Subscription.new_lazy sub_name,
+      Google::Cloud::Pubsub::Subscription.from_name sub_name,
                                             pubsub.service
     end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription_test.rb
@@ -27,7 +27,8 @@ describe Google::Cloud::Pubsub::Subscription, :mock_pubsub do
 
   it "knows its topic" do
     subscription.topic.must_be_kind_of Google::Cloud::Pubsub::Topic
-    subscription.topic.must_be :lazy?
+    subscription.topic.must_be :reference?
+    subscription.topic.wont_be :resource?
     subscription.topic.name.must_equal topic_path(topic_name)
   end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/autocreate_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/autocreate_test.rb
@@ -14,21 +14,21 @@
 
 require "helper"
 
-describe Google::Cloud::Pubsub::Topic, :lazy, :mock_pubsub do
+describe Google::Cloud::Pubsub::Topic, :reference, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
-                                                pubsub.service }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
 
-  it "will not be lazy when created with an HTTP method" do
-    topic.wont_be :lazy?
+  it "will not be reference when created with an HTTP method" do
+    topic.wont_be :reference?
+    topic.must_be :resource?
   end
 
-  describe "lazy topic" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service }
+  describe "reference topic" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_name topic_name, pubsub.service }
 
-    it "will be lazy when created lazily" do
-      topic.must_be :lazy?
+    it "will be reference when created lazily" do
+      topic.must_be :reference?
+      topic.wont_be :resource?
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/exists_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/exists_test.rb
@@ -16,8 +16,7 @@ require "helper"
 
 describe Google::Cloud::Pubsub::Topic, :exists, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
-                                                pubsub.service }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
 
   it "knows if it exists when created with an HTTP method" do
     # The absense of a mock means this test will fail
@@ -27,9 +26,8 @@ describe Google::Cloud::Pubsub::Topic, :exists, :mock_pubsub do
     topic.must_be :exists?
   end
 
-  describe "lazy topic object of a topic that exists" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service }
+  describe "reference topic object of a topic that exists" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_name topic_name, pubsub.service }
 
     it "checks if the topic exists by making an HTTP call" do
       get_res = Google::Pubsub::V1::Topic.decode_json topic_json(topic_name)
@@ -45,9 +43,8 @@ describe Google::Cloud::Pubsub::Topic, :exists, :mock_pubsub do
     end
   end
 
-  describe "lazy topic object of a topic that does not exist" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service }
+  describe "reference topic object of a topic that does not exist" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_name topic_name, pubsub.service }
 
     it "checks if the topic exists by making an HTTP call" do
       stub = Object.new

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/lazy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/lazy_test.rb
@@ -14,12 +14,12 @@
 
 require "helper"
 
-describe Google::Cloud::Pubsub::Topic, :lazy, :mock_pubsub do
+describe Google::Cloud::Pubsub::Topic, :reference, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
-                                                pubsub.service }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
 
-  it "is not lazy when created with an HTTP method" do
-    topic.wont_be :lazy?
+  it "is not reference when created with an HTTP method" do
+    topic.wont_be :reference?
+    topic.must_be :resource?
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/name_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/name_test.rb
@@ -16,8 +16,7 @@ require "helper"
 
 describe Google::Cloud::Pubsub::Topic, :name, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
-                                                pubsub.service }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
 
   it "gives the name returned from the HTTP method" do
     topic.name.must_equal "projects/#{project}/topics/#{topic_name}"

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
@@ -16,8 +16,7 @@ require "helper"
 
 describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
-                                                pubsub.service }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
 
   it "gets the IAM Policy" do
     policy_json = {

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
@@ -16,8 +16,7 @@ require "helper"
 
 describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
-                                                       pubsub.service }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
 
   it "publishes a message" do
     messages = [
@@ -234,8 +233,8 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
     mock.verify
   end
 
-  describe "lazy topic that exists" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
+  describe "reference topic that exists" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_name topic_name,
                                                  pubsub.service,
                                                  autocreate: false }
 
@@ -318,8 +317,8 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
     end
   end
 
-  describe "lazy topic that does not exist" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
+  describe "reference topic that does not exist" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_name topic_name,
                                                  pubsub.service,
                                                  autocreate: false }
     let(:gax_error) do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
@@ -16,8 +16,7 @@ require "helper"
 
 describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
-                                                pubsub.service }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
   let(:message1) { "new-message-here" }
   let(:message2) { "second-new-message" }
   let(:message3) { "third-new-message" }
@@ -128,9 +127,8 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
     msgs.last.attributes["format"].must_equal "none"
   end
 
-  describe "lazy topic that exists" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service }
+  describe "reference topic that exists" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_name topic_name, pubsub.service }
 
     it "publishes a message" do
      messages = [
@@ -194,9 +192,8 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
     end
   end
 
-  describe "lazy topic that does not exist" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service }
+  describe "reference topic that does not exist" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_name topic_name, pubsub.service }
 
     it "publishes a message" do
       stub = Object.new

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
@@ -16,8 +16,7 @@ require "helper"
 
 describe Google::Cloud::Pubsub::Topic, :subscribe, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
-                                                pubsub.service }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
   let(:new_sub_name) { "new-sub-#{Time.now.to_i}" }
   let(:labels) { { "foo" => "bar" } }
 
@@ -51,9 +50,8 @@ describe Google::Cloud::Pubsub::Topic, :subscribe, :mock_pubsub do
     sub.labels.must_be :frozen?
   end
 
-  describe "lazy topic that exists" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service }
+  describe "reference topic that exists" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_name topic_name, pubsub.service }
 
     it "creates a subscription when calling subscribe" do
       create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
@@ -70,9 +68,8 @@ describe Google::Cloud::Pubsub::Topic, :subscribe, :mock_pubsub do
     end
   end
 
-  describe "lazy topic that does not exist" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service }
+  describe "reference topic that does not exist" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_name topic_name, pubsub.service }
 
     it "raises NotFoundError when calling subscribe" do
       stub = Object.new

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscription_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscription_test.rb
@@ -16,8 +16,7 @@ require "helper"
 
 describe Google::Cloud::Pubsub::Topic, :subscription, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
-                                                pubsub.service }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
   let(:found_sub_name) { "found-sub-#{Time.now.to_i}" }
   let(:not_found_sub_name) { "found-sub-#{Time.now.to_i}" }
 
@@ -32,7 +31,8 @@ describe Google::Cloud::Pubsub::Topic, :subscription, :mock_pubsub do
     mock.verify
 
     sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-    sub.wont_be :lazy?
+    sub.wont_be :reference?
+    sub.must_be :resource?
   end
 
   it "gets an existing subscription with get_subscription alias" do
@@ -46,7 +46,8 @@ describe Google::Cloud::Pubsub::Topic, :subscription, :mock_pubsub do
     mock.verify
 
     sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-    sub.wont_be :lazy?
+    sub.wont_be :reference?
+    sub.must_be :resource?
   end
 
   it "gets an existing subscription with find_subscription alias" do
@@ -60,7 +61,8 @@ describe Google::Cloud::Pubsub::Topic, :subscription, :mock_pubsub do
     mock.verify
 
     sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-    sub.wont_be :lazy?
+    sub.wont_be :reference?
+    sub.must_be :resource?
   end
 
   it "returns nil when getting an non-existant subscription" do
@@ -81,12 +83,12 @@ describe Google::Cloud::Pubsub::Topic, :subscription, :mock_pubsub do
 
     sub = topic.find_subscription found_sub_name, skip_lookup: true
     sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-    sub.must_be :lazy?
+    sub.must_be :reference?
+    sub.wont_be :resource?
   end
 
-  describe "lazy topic that exists" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service }
+  describe "reference topic that exists" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_name topic_name, pubsub.service }
 
     it "gets an existing subscription" do
       get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, found_sub_name)
@@ -99,7 +101,8 @@ describe Google::Cloud::Pubsub::Topic, :subscription, :mock_pubsub do
       mock.verify
 
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.wont_be :lazy?
+      sub.wont_be :reference?
+      sub.must_be :resource?
     end
 
     it "returns nil when getting an non-existant subscription" do
@@ -116,9 +119,8 @@ describe Google::Cloud::Pubsub::Topic, :subscription, :mock_pubsub do
     end
   end
 
-  describe "lazy topic that does not exist" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service }
+  describe "reference topic that does not exist" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_name topic_name, pubsub.service }
 
     it "returns nil when getting an non-existant subscription" do
       stub = Object.new

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
@@ -16,8 +16,7 @@ require "helper"
 
 describe Google::Cloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
-                                                pubsub.service }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
   let(:subscriptions_with_token) do
     response = Google::Pubsub::V1::ListTopicSubscriptionsResponse.decode_json topic_subscriptions_json(3, "next_page_token")
     paged_enum_struct response
@@ -35,13 +34,13 @@ describe Google::Cloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
     subs.count.must_equal 3
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
   end
 
-  describe "lazy topic that exists" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service }
+  describe "reference topic that exists" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_name topic_name, pubsub.service }
 
     it "lists subscriptions" do
       mock = Minitest::Mock.new
@@ -55,14 +54,14 @@ describe Google::Cloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
       subs.count.must_equal 3
       subs.each do |sub|
         sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-        sub.must_be :lazy?
+        sub.must_be :reference?
+        sub.wont_be :resource?
       end
     end
   end
 
-  describe "lazy topic that does not exist" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service }
+  describe "reference topic that does not exist" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_name topic_name, pubsub.service }
 
     it "lists subscriptions" do
       stub = Object.new

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/update_test.rb
@@ -70,11 +70,12 @@ describe Google::Cloud::Pubsub::Topic, :update, :mock_pubsub do
     topic.labels.must_equal labels
   end
 
-  describe :lazy do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name, pubsub.service }
+  describe :reference do
+    let(:topic) { Google::Cloud::Pubsub::Topic.from_name topic_name, pubsub.service }
 
     it "updates labels" do
-      topic.must_be :lazy?
+      topic.must_be :reference?
+      topic.wont_be :resource?
 
       update_grpc = Google::Pubsub::V1::Topic.new \
         name: topic_path(topic_name),
@@ -89,7 +90,8 @@ describe Google::Cloud::Pubsub::Topic, :update, :mock_pubsub do
 
       mock.verify
 
-      topic.wont_be :lazy?
+      topic.wont_be :reference?
+      topic.must_be :resource?
       topic.labels.must_equal new_labels
     end
   end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -17,8 +17,7 @@ require "helper"
 describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:labels) { { "foo" => "bar" } }
-  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name, labels: labels)),
-                                                pubsub.service }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name, labels: labels)), pubsub.service }
   let(:subscriptions_with_token) do
     response = Google::Pubsub::V1::ListTopicSubscriptionsResponse.decode_json topic_subscriptions_json(3, "next_page_token")
     paged_enum_struct response
@@ -211,7 +210,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
     sub.wont_be :nil?
     sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-    sub.wont_be :lazy?
+    sub.wont_be :reference?
+    sub.must_be :resource?
   end
 
   it "gets a subscription with get_subscription alias" do
@@ -228,7 +228,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
     sub.wont_be :nil?
     sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-    sub.wont_be :lazy?
+    sub.wont_be :reference?
+    sub.must_be :resource?
   end
 
   it "gets a subscription with find_subscription alias" do
@@ -245,7 +246,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
     sub.wont_be :nil?
     sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-    sub.wont_be :lazy?
+    sub.wont_be :reference?
+    sub.must_be :resource?
   end
 
   it "lists subscriptions" do
@@ -260,7 +262,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     subs.count.must_equal 3
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
   end
 
@@ -274,7 +277,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     subs.count.must_equal 3
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
   end
 
@@ -290,7 +294,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     subs.count.must_equal 3
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
   end
 
@@ -312,14 +317,16 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     token.must_equal "next_page_token"
     first_subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
 
     second_subs.count.must_equal 2
     second_subs.token.must_be :nil?
     second_subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
   end
 
@@ -338,7 +345,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     token.must_equal "next_page_token"
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
   end
 
@@ -358,14 +366,16 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     first_subs.next?.must_equal true
     first_subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
 
     second_subs.count.must_equal 2
     second_subs.next?.must_equal false
     second_subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
   end
 
@@ -385,14 +395,16 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     first_subs.next?.must_equal true
     first_subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
 
     second_subs.count.must_equal 2
     second_subs.next?.must_equal false
     second_subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
   end
 
@@ -410,7 +422,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     subs.count.must_equal 5
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
   end
 
@@ -428,7 +441,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     subs.count.must_equal 5
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
   end
 
@@ -446,7 +460,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     subs.count.must_equal 5
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
   end
 
@@ -464,7 +479,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     subs.count.must_equal 6
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-      sub.must_be :lazy?
+      sub.must_be :reference?
+      sub.wont_be :resource?
     end
   end
 


### PR DESCRIPTION
This PR updates the documentation to make the behavior of when API calls are made more clear. This is in reaction to #2723.

This change refactors the existing lazy implementation to be more inline with the reference/resource implementations in other libraries. It also adds helper methods to the public API so users will be able to ask objects if they are a reference or resource.

* Add `reference?`/`resource?` helper methods
  * `Topic#reference?`
  * `Topic#resource?`
  * `Subscription#reference?`
  * `Subscription#resource?`
* Add documentation for methods that will make an API call when called on a reference object.
  * `Topic#labels`
  * `Subscription#topic`
  * `Subscription#deadline`
  * `Subscription#retain_acked`
  * `Subscription#retention`
  * `Subscription#endpoint`
  * `Subscription#labels`
  * `Subscription#exists?`
  * `Subscription#listen` (without deadline optional argument)