### PR TITLE
Improve middleware error handling

### DIFF
--- a/google-cloud-trace/lib/google-cloud-trace.rb
+++ b/google-cloud-trace/lib/google-cloud-trace.rb
@@ -142,4 +142,5 @@ Google::Cloud.configure.add_config! :trace do |config|
   config.add_field! :span_id_generator, nil, match: Proc
   config.add_field! :notifications, nil, match: Array
   config.add_field! :max_data_length, nil, match: Integer
+  config.add_field! :on_error, nil, match: Proc
 end

--- a/google-cloud-trace/lib/google/cloud/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace.rb
@@ -138,6 +138,9 @@ module Google
       #   recorded with ActiveSupport notification events. Rails-only option.
       #   Default:
       #   `Google::Cloud::Trace::Notifications::DEFAULT_MAX_DATA_LENGTH`
+      # * `on_error` - (Proc) A Proc to be run when an error is encountered
+      #   during the reporting of traces by the middleware. The Proc must take
+      #   the error object as the single argument.
       #
       # See the {file:INSTRUMENTATION.md Configuration Guide} for full
       # configuration parameters.

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -109,7 +109,7 @@ module Google
       #
       # Google::Cloud::Trace.configure do |config|
       #   config.on_error = lambda do |error|
-      #     Google::Cloud::ErrorReporting.report exception
+      #     Google::Cloud::ErrorReporting.report error
       #   end
       # end
       #


### PR DESCRIPTION
Add an `on_error` Proc to the configuration that will be used when an error is encountered in the middleware. This will allow users to handle the errors proactively, instead of scanning their logs for signs of problems.

```ruby
# Configure error handling

require "sinatra"
require "google/cloud/trace"
require "google/cloud/error_reporting"

Google::Cloud::Trace.configure do |config|
  config.on_error = lambda do |error|
    Google::Cloud::ErrorReporting.report error
  end
end

use Google::Cloud::Trace::Middleware

get "/" do
  Google::Cloud::Trace.in_span "Sleeping on the job!" do
    sleep rand
  end
  "Hello World!"
end
```

[refs #2096]