### PR TITLE
Logging compat fixes

### DIFF
--- a/google-cloud-logging/acceptance/logging/logging_test.rb
+++ b/google-cloud-logging/acceptance/logging/logging_test.rb
@@ -281,8 +281,7 @@ describe Google::Cloud::Logging, :logging do
       logger.add :fatal,   "Danger Will Robinson (:fatal)!"
       logger.add :unknown, "Danger Will Robinson (:unknown)!"
 
-      async.stop
-      async.wait_until_stopped 10
+      async.stop! 10
 
       skip "Removed due to inconsistent failure by the service to retrieve written_entries. Reinstate when service stabilizes."
       written_entries = entries_via_backoff("symbol").map &:payload
@@ -306,8 +305,7 @@ describe Google::Cloud::Logging, :logging do
       logger.add "fatal",   "Danger Will Robinson ('fatal')!"
       logger.add "unknown", "Danger Will Robinson ('unknown')!"
 
-      async.stop
-      async.wait_until_stopped 10
+      async.stop! 10
 
       skip "Removed due to inconsistent failure by the service to retrieve written_entries. Reinstate when service stabilizes."
       written_entries = entries_via_backoff("string").map &:payload
@@ -331,8 +329,7 @@ describe Google::Cloud::Logging, :logging do
       logger.add ::Logger::FATAL,   "Danger Will Robinson (FATAL)!"
       logger.add ::Logger::UNKNOWN, "Danger Will Robinson (UNKNOWN)!"
 
-      async.stop
-      async.wait_until_stopped 10
+      async.stop! 10
 
       skip "Removed due to inconsistent failure by the service to retrieve written_entries. Reinstate when service stabilizes."
       written_entries = entries_via_backoff("constant").map &:payload
@@ -356,8 +353,7 @@ describe Google::Cloud::Logging, :logging do
       logger.fatal   "Danger Will Robinson (fatal)!"
       logger.unknown "Danger Will Robinson (unknown)!"
 
-      async.stop
-      async.wait_until_stopped 10
+      async.stop! 10
 
       skip "Removed due to inconsistent failure by the service to retrieve written_entries. Reinstate when service stabilizes."
       written_entries = entries_via_backoff("method").map &:payload

--- a/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
@@ -78,7 +78,6 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
 
     mock.expect :write_log_entries, write_res, write_req_args(["payload1", "payload2"], labels1)
 
-    async_writer.suspend
     async_writer.write_entries(
       entries("payload1"),
       log_name: log_name,
@@ -91,7 +90,6 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
       resource: resource,
       labels: labels1
     )
-    async_writer.resume
     async_writer.stop! 1
 
     mock.verify
@@ -109,7 +107,6 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
 
     mock.expect :write_log_entries, write_res, combined_request
 
-    async_writer.suspend
     async_writer.write_entries(
       entries("payload1", labels1),
       log_name: log_name,
@@ -122,7 +119,6 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
       resource: resource,
       labels: labels2
     )
-    async_writer.resume
     async_writer.stop
 
     wait_result = wait_until_true {

--- a/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
@@ -131,7 +131,7 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
 
     wait_result.must_equal :completed
 
-    async_writer.stop! 1
+    async_writer.wait! 1
 
     mock.verify
   end


### PR DESCRIPTION
This PR cleans up the backwards compatibility of the new `AsyncWriter` implementation. The only methods listed on the [current `AsyncWriter` documentation](http://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/v1.5.7/Google/Cloud/Logging/AsyncWriter.html) are `write_entries`, `logger`, `stop!`, and `last_exception`. The documentation also lists `Stackdriver::Core::AsyncActor` as being included in the class, but `Stackdriver::Core::AsyncActor` is not currently part of `stackdriver-core`'s public API. Therefore I think we are okay to remove compatibility with every `Stackdriver::Core::AsyncActor` method, other than what has already been referenced by `AsyncWriter`'s documentation.