### PR TITLE
Allow overriding bigquery table in acceptance tests

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -211,12 +211,10 @@ describe Google::Cloud::Bigquery, :bigquery do
   end
 
   it "extracts a readonly table to a GCS url with extract" do
-    public_table_id = "bigquery-public-data.samples.shakespeare"
-
     Tempfile.open "empty_extract_file.csv" do |tmp|
       dest_file_name = random_file_destination_name
       extract_url = "gs://#{bucket.name}/#{dest_file_name}"
-      result = bigquery.extract public_table_id, extract_url do |j|
+      result = bigquery.extract samples_public_table, extract_url do |j|
         j.location = "US"
       end
       result.must_equal true
@@ -228,8 +226,7 @@ describe Google::Cloud::Bigquery, :bigquery do
   end
 
   it "copies a readonly table to another table with copy" do
-    public_table_id = "bigquery-public-data.samples.shakespeare"
-    result = bigquery.copy public_table_id, "#{dataset_id}.shakespeare_copy", create: :needed, write: :empty do |j|
+    result = bigquery.copy samples_public_table, "#{dataset_id}.shakespeare_copy", create: :needed, write: :empty do |j|
       j.location = "US"
     end
     result.must_equal true

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -53,10 +53,13 @@ end
 
 $bucket = safe_gcs_execute { $storage.create_bucket "#{$prefix}_bucket" }
 
-# Allow overriding the samples bucket used for tests via an environment
-# variable. This bucket is public, but access may be restricted when tests are
-# run from a VPC project.
+# Allow overriding the samples bucket and table used for tests via an
+# environment variable. This bucket is public, but access may be restricted
+# when tests are run from a VPC project.
 $samples_bucket = ENV["GCLOUD_TEST_SAMPLES_BUCKET"] || "cloud-samples-data"
+
+$samples_public_table = ENV["GCLOUD_TEST_SAMPLES_PUBLIC_TABLE"] || "bigquery-public-data.samples.shakespeare"
+
 
 # Allow overriding the KMS key used for tests via an environment variable.
 # These keys are public, but access may be restricted when tests are run from a
@@ -88,6 +91,7 @@ module Acceptance
     attr_accessor :storage
     attr_accessor :bucket
     attr_accessor :samples_bucket
+    attr_accessor :samples_public_table
     attr_accessor :kms_key
     attr_accessor :kms_key_2
 
@@ -99,6 +103,7 @@ module Acceptance
       @storage = $storage
       @bucket = $bucket
       @samples_bucket = $samples_bucket
+      @samples_public_table = $samples_public_table
       @kms_key = $kms_key
       @kms_key_2 = $kms_key_2
 
@@ -107,6 +112,7 @@ module Acceptance
       refute_nil @storage, "You do not have an active storage to run the tests."
       refute_nil @bucket, "You do not have a storage bucket to run the tests."
       refute_nil @samples_bucket, "You do not have a bucket with sample data to run the tests."
+      refute_nil @samples_public_table, "You do not have a table with sample data to run the tests."
       refute_nil @kms_key, "You do not have a kms key to run the tests."
       refute_nil @kms_key_2, "You do not have a second kms key to run the tests."
 


### PR DESCRIPTION
Tests in bigquery_test would fail when tested in VPC environment. 

Add the choice to override the bigquery table id with GCLOUD_TEST_SAMPLES_PUBLIC_TABLE, so we can let the test access sample tables within VPC