### PR TITLE
Changes to Rails default Logger

### DIFF
--- a/google-cloud-logging/lib/google-cloud-logging.rb
+++ b/google-cloud-logging/lib/google-cloud-logging.rb
@@ -134,10 +134,9 @@ Google::Cloud.configure.add_config! :logging do |config|
     ENV["LOGGING_PROJECT"]
   end
   default_creds = Google::Cloud::Config.deferred do
-    Google::Cloud::Config.credentials_from_env(
+    Google::Cloud::Config.credentials_from_env \
       "LOGGING_CREDENTIALS", "LOGGING_CREDENTIALS_JSON",
       "LOGGING_KEYFILE", "LOGGING_KEYFILE_JSON"
-    )
   end
 
   config.add_field! :project_id, default_project, match: String, allow_nil: true
@@ -156,4 +155,5 @@ Google::Cloud.configure.add_config! :logging do |config|
     mrconfig.add_field! :type, nil, match: String
     mrconfig.add_field! :labels, nil, match: Hash
   end
+  config.add_field! :set_default_logger_on_rails_init, nil, enum: [true, false]
 end

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -141,8 +141,9 @@ module Google
       #   gRPC connections on Rails initialization. This should only be used
       #   with a non-forking web server. Web servers such as Puma and Unicorn
       #   should not set this, and instead set the Rails logger to a Google
-      #   Cloud Logging Logger object on the worker process at the appropriate
-      #   time, such as a post-fork hook.
+      #   Cloud Logging Logger object on the worker process by calling
+      #   {Railtie.set_default_logger} at the appropriate time, such as a
+      #   post-fork hook.
       #
       # See the [Configuration
       # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -136,6 +136,13 @@ module Google
       # * `labels` - (Hash) User defined labels. A `Hash` of label names to
       #   string label values or callables/`Proc` which are functions of the
       #   Rack environment.
+      # * `set_default_logger_on_rails_init` - (Boolean) Whether it is safe for
+      #   the Google Cloud Logging Logger to start background threads and open
+      #   gRPC connections on Rails initialization. This should only be used
+      #   with a non-forking web server. Web servers such as Puma and Unicorn
+      #   should not set this, and instead set the Rails logger to a Google
+      #   Cloud Logging Logger object on the worker process at the appropriate
+      #   time, such as a post-fork hook.
       #
       # See the [Configuration
       # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -136,9 +136,9 @@ module Google
       # * `labels` - (Hash) User defined labels. A `Hash` of label names to
       #   string label values or callables/`Proc` which are functions of the
       #   Rack environment.
-      # * `set_default_logger_on_rails_init` - (Boolean) Whether it is safe for
-      #   the Google Cloud Logging Logger to start background threads and open
-      #   gRPC connections on Rails initialization. This should only be used
+      # * `set_default_logger_on_rails_init` - (Boolean) Whether Google Cloud
+      #   Logging Logger should be allowed to start background threads and open
+      #   gRPC connections during Rails initialization. This should only be used
       #   with a non-forking web server. Web servers such as Puma and Unicorn
       #   should not set this, and instead set the Rails logger to a Google
       #   Cloud Logging Logger object on the worker process by calling

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -44,6 +44,8 @@ module Google
         #   to track Stackdriver request trace ID. It also properly sets
         #   env["rack.logger"] to this assigned logger for accessing. If not
         #   specified, a default logger with be used.
+        # @param [Proc] on_init A callback to be invoked when the middleware is
+        #   initialized. The callback takes no arguments. Optional.
         # @param [Hash] kwargs Hash of configuration settings. Used for
         #   backward API compatibility. See the [Configuration
         #   Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
@@ -52,7 +54,7 @@ module Google
         # @return [Google::Cloud::Logging::Middleware] A new
         #   Google::Cloud::Logging::Middleware instance
         #
-        def initialize app, logger: nil, **kwargs
+        def initialize app, logger: nil, on_init: nil, **kwargs
           @app = app
 
           load_config kwargs
@@ -68,6 +70,8 @@ module Google
             )
             Middleware.logger = logging.logger log_name, resource
           end
+
+          on_init.call if on_init
 
           @logger = logger
         end

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -57,9 +57,8 @@ module Google
 
           load_config kwargs
 
-          if logger
-            @logger = logger
-          else
+          logger ||= Middleware.logger
+          logger ||= begin
             log_name = configuration.log_name
             logging = Logging.new project_id: configuration.project_id,
                                   credentials: configuration.credentials
@@ -67,8 +66,10 @@ module Google
               configuration.monitored_resource.type,
               configuration.monitored_resource.labels
             )
-            @logger = logging.logger log_name, resource
+            Middleware.logger = logging.logger log_name, resource
           end
+
+          @logger = logger
         end
 
         ##
@@ -184,6 +185,12 @@ module Google
           else
             default_monitored_resource
           end
+        end
+
+        class << self
+          ##
+          # @private Global logger object
+          attr_accessor :logger
         end
 
         ##

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -76,10 +76,12 @@ module Google
             Logging::Middleware.build_monitored_resource resource_type,
                                                          resource_labels
 
-          app.config.logger = logging.logger log_name, resource, labels
+          Middleware.logger = logging.logger log_name, resource, labels
+          # Set the default Rails logger
+          app.config.logger = Middleware.logger
           app.middleware.insert_before Rails::Rack::Logger,
                                        Google::Cloud::Logging::Middleware,
-                                       logger: app.config.logger
+                                       logger: Middleware.logger
         end
 
         ##

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -78,7 +78,9 @@ module Google
 
           Middleware.logger = logging.logger log_name, resource, labels
           # Set the default Rails logger
-          app.config.logger = Middleware.logger
+          if Logging.configure.set_default_logger_on_rails_init
+            app.config.logger = Middleware.logger
+          end
           app.middleware.insert_before Rails::Rack::Logger,
                                        Google::Cloud::Logging::Middleware,
                                        logger: Middleware.logger
@@ -138,6 +140,10 @@ module Google
               log_config.monitored_resource.type
             config.monitored_resource.labels ||=
               log_config.monitored_resource.labels.to_h
+            if config.set_default_logger_on_rails_init.nil?
+              config.set_default_logger_on_rails_init = \
+                log_config.set_default_logger_on_rails_init
+            end
           end
         end
 

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -81,9 +81,11 @@ module Google
           if Logging.configure.set_default_logger_on_rails_init
             set_default_logger
           end
+          init_callback = -> { set_default_logger }
           app.middleware.insert_before Rails::Rack::Logger,
                                        Google::Cloud::Logging::Middleware,
-                                       logger: Middleware.logger
+                                       logger: Middleware.logger,
+                                       on_init: init_callback
         end
 
         ##

--- a/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
@@ -78,6 +78,18 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
     it "uses the logger provided if given" do
       middleware.logger.must_equal logger
     end
+
+    it "invokes the on_init callback when provided" do
+      mock = Minitest::Mock.new
+      mock.expect :callback_was_called, nil
+
+      on_init_callback = -> { mock.callback_was_called }
+
+      middleware = Google::Cloud::Logging::Middleware.new \
+        rack_app, logger: logger, on_init: on_init_callback
+
+      mock.verify
+    end
   end
 
   describe "#call" do


### PR DESCRIPTION
Add a new configuration setting and method to call for users that are using a forking web server with Rails. This change would allow the following configuration for Puma in a `config/puma.rb` file:

```ruby
workers Integer(ENV['WEB_CONCURRENCY'] || 2)
threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
threads threads_count, threads_count

preload_app!

rackup      DefaultRackup
port        ENV['PORT']     || 3000
environment ENV['RACK_ENV'] || 'development'

on_worker_boot do
  # Update the worker's default logger
  Google::Cloud::Logging::Railtie.set_default_logger
end
```

This will address some issues folks are having using Google Cloud Logging in Rails. We need this to work around issues with gRPC unable to reset its resources after a process is forked. So the change allows the Rails app to avoid using Google Cloud Logging until post-fork.