### PR TITLE
AsyncReporter buffer traces and make batch API calls

### DIFF
--- a/google-cloud-trace/.rubocop.yml
+++ b/google-cloud-trace/.rubocop.yml
@@ -23,6 +23,8 @@ Style/MethodDefParentheses:
 Style/HashSyntax:
   Exclude:
     - "lib/google/cloud/trace/v1/**/*"
+Style/NumericLiterals:
+  Enabled: false
 Style/ClassVars:
   Enabled: false
 Style/TrivialAccessors:

--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "concurrent-ruby", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 
-require "stackdriver/core/async_actor"
+require "monitor"
+require "concurrent"
+require "google/cloud/trace/errors"
 
 module Google
   module Cloud
@@ -22,73 +24,71 @@ module Google
       # # AsyncReporter
       #
       # @private Used by the {Google::Cloud::Trace::Middleware} to
-      # asynchronously update traces to Stackdriver Trace service when used in
-      # a Rack-based application.
+      # asynchronously buffer traces and push batches to Stackdriver Trace
+      # service when used in a Rack-based application.
       class AsyncReporter
-        include Stackdriver::Core::AsyncActor
+        include MonitorMixin
 
         ##
-        # @private Default Maximum blacklog size for the job queue
-        DEFAULT_MAX_QUEUE_SIZE = 1000
+        # @private Implementation accessors
+        attr_reader :service, :max_bytes, :max_count, :max_queue, :interval,
+                    :threads
 
         ##
-        # The {Google::Cloud::Trace::Service} object to patch traces
-        attr_accessor :service
-
-        ##
-        # The max number of items the queue holds
-        attr_accessor :max_queue_size
-
-        ##
-        # @private Construct a new instance of AsyncReporter
-        def initialize service, max_queue_size = DEFAULT_MAX_QUEUE_SIZE
-          super()
-
+        # @private Creates a new AsyncReporter instance.
+        def initialize service, max_count: 1000, max_bytes: 4000000,
+                       max_queue: 100, interval: 5, threads: 10
           @service = service
-          @max_queue_size = max_queue_size
-          @queue = []
-          @queue_resource = new_cond
+
+          @max_count = max_count
+          @max_bytes = max_bytes
+          @max_queue = max_queue
+          @interval  = interval
+          @threads   = threads
+
+          @error_callbacks = []
+
+          @cond = new_cond
+
+          # Make sure all buffered messages are sent when process exits.
+          at_exit { stop! }
+
+          # init MonitorMixin
+          super()
         end
 
         ##
         # Add the traces to the queue to be reported to Stackdriver Trace
         # asynchronously. Signal the child thread to start processing the queue.
+        #
+        # @param [Google::Cloud::Trace::TraceRecord,
+        #     Array{Google::Cloud::Trace::TraceRecord}] traces Either a single
+        #     trace object or an array of trace objects.
         def patch_traces traces
-          ensure_thread
+          if synchronize { @stopped }
+            raise_stopped_error traces
+            return
+          end
 
           synchronize do
-            @queue.push traces
-            @queue_resource.broadcast
+            Array(traces).each do |trace|
+              # Add the trace to the batch
+              @batch ||= Batch.new self
+              next if @batch.try_add trace
 
-            while @max_queue_size && @queue.size > max_queue_size
-              @queue_resource.wait 1
-
-              @queue.pop while @queue.size > max_queue_size
+              # If we can't add to the batch, publish and create a new batch
+              patch_batch!
+              @batch = Batch.new self
+              @batch.add trace
             end
-          end
-        end
 
-        ##
-        # @private Callback function for AsyncActor module to process the queue
-        # in a loop
-        def run_backgrounder
-          traces = wait_next_item
-          return if traces.nil?
+            init_resources!
 
-          begin
-            service.patch_traces traces
-          rescue StandardError => e
-            warn ["#{e.class}: #{e.message}", e.backtrace].join("\n\t")
-            @last_exception = e
-          end
-        end
+            patch_batch! if @batch.ready?
 
-        ##
-        # @private Callback function when the async actor thread state changes
-        def on_async_state_change
-          synchronize do
-            @queue_resource.broadcast
+            @cond.broadcast
           end
+          self
         end
 
         ##
@@ -97,26 +97,253 @@ module Google
           service.project
         end
 
-        private
+        ##
+        # Begins the process of stopping the reporter. Traces already in the
+        # queue will be published, but no new traces can be added. Use {#wait!}
+        # to block until the reporter is fully stopped and all pending traces
+        # have been pushed to the API.
+        #
+        # @return [AsyncReporter] returns self so calls can be chained.
+        def stop
+          synchronize do
+            break if @stopped
+
+            @stopped = true
+            patch_batch!
+            @cond.broadcast
+            @thread_pool.shutdown if @thread_pool
+          end
+
+          self
+        end
 
         ##
-        # @private Wait for the next item from the reporter queue. If there are
-        # no more items, it blocks the child thread until an item is enqueued.
-        def wait_next_item
+        # Stop this asynchronous reporter and block until it has been stopped.
+        #
+        # @param [Number] timeout Timeout in seconds.
+        #
+        def stop! timeout = nil
+          stop
+          wait! timeout
+        end
+
+        ##
+        # Blocks until the reporter is fully stopped, all pending traces have
+        # been published, and all callbacks have completed. Does not stop the
+        # reporter. To stop the reporter, first call {#stop} and then call
+        # {#wait!} to block until the reporter is stopped.
+        #
+        # @return [AsyncReporter] returns self so calls can be chained.
+        def wait! timeout = nil
           synchronize do
-            @queue_resource.wait_while do
-              async_suspended? || (async_running? && @queue.empty?)
+            if @thread_pool
+              @thread_pool.shutdown
+              @thread_pool.wait_for_termination timeout
             end
-            @queue.pop
+          end
+
+          self
+        end
+
+        ##
+        # Forces all traces in the current batch to be patched to the API
+        # immediately.
+        #
+        # @return [AsyncReporter] returns self so calls can be chained.
+        #
+        def flush!
+          synchronize do
+            patch_batch!
+            @cond.broadcast
+          end
+
+          self
+        end
+
+        ##
+        # Whether the reporter has been started.
+        #
+        # @return [boolean] `true` when started, `false` otherwise.
+        #
+        def started?
+          !stopped?
+        end
+
+        ##
+        # Whether the reporter has been stopped.
+        #
+        # @return [boolean] `true` when stopped, `false` otherwise.
+        #
+        def stopped?
+          synchronize { @stopped }
+        end
+
+        ##
+        # Register to be notified of errors when raised.
+        #
+        # If an unhandled error has occurred the reporter will attempt to
+        # recover from the error and resume buffering, batching, and patching
+        # traces.
+        #
+        # Multiple error handlers can be added.
+        #
+        # @yield [callback] The block to be called when an error is raised.
+        # @yieldparam [Exception] error The error raised.
+        #
+        def on_error &block
+          synchronize do
+            @error_callbacks << block
+          end
+        end
+
+        protected
+
+        def init_resources!
+          @thread_pool ||= \
+            Concurrent::CachedThreadPool.new max_threads: @threads,
+                                             max_queue: @max_queue
+          @thread ||= Thread.new { run_background }
+          nil # returning nil because of rubocop...
+        end
+
+        def run_background
+          synchronize do
+            until @stopped
+              if @batch.nil?
+                @cond.wait
+                next
+              end
+
+              if @batch.ready?
+                # interval met, publish the batch...
+                patch_batch!
+                @cond.wait
+              else
+                # still waiting for the interval to publish the batch...
+                @cond.wait(@batch.publish_wait)
+              end
+            end
+          end
+        end
+
+        def patch_batch!
+          return unless @batch
+
+          batch_to_be_patched = @batch
+          @batch = nil
+          patch_traces_async batch_to_be_patched
+        end
+
+        def patch_traces_async batch
+          Concurrent::Promises.future_on(
+            @thread_pool, batch.traces
+          ) do |traces|
+            patch_traces_with traces
+          end
+        rescue Concurrent::RejectedExecutionError => e
+          async_error = AsyncReporterError.new(
+            "Error writing traces: #{e.message}",
+            batch.traces
+          )
+          # Manually set backtrace so we don't have to raise
+          async_error.set_backtrace backtrace
+          error! async_error
+        end
+
+        def patch_traces_with traces
+          service.patch_traces traces
+        rescue StandardError => e
+          patch_error = AsyncPatchTracesError.new(
+            "Error writing traces: #{e.message}",
+            traces
+          )
+          # Manually set backtrace so we don't have to raise
+          patch_error.set_backtrace backtrace
+          error! patch_error
+        end
+
+        def raise_stopped_error traces
+          stopped_error = AsyncReporterError.new(
+            "AsyncReporter is stopped. Cannot patch traces.",
+            traces
+          )
+          # Manually set backtrace so we don't have to raise
+          stopped_error.set_backtrace backtrace
+          error! stopped_error
+        end
+
+        # Calls all error callbacks.
+        def error! error
+          # We shouldn't need to synchronize getting the callbacks.
+          error_callbacks = @error_callbacks
+          error_callbacks = default_error_callbacks if error_callbacks.empty?
+          error_callbacks.each { |error_callback| error_callback.call error }
+        end
+
+        def default_error_callbacks
+          # This is memoized to reduce calls to the configuration.
+          @default_error_callbacks ||= begin
+            error_callback = Google::Cloud::Pubsub.configuration.on_error
+            error_callback ||= Google::Cloud.configure.on_error
+            if error_callback
+              [error_callback]
+            else
+              []
+            end
           end
         end
 
         ##
-        # @private Override the #backgrounder_stoppable? method from AsyncActor
-        # module. The actor can be gracefully stopped when queue is empty.
-        def backgrounder_stoppable?
-          synchronize do
-            @queue.empty?
+        # @private
+        class Batch
+          attr_reader :created_at, :traces
+
+          def initialize reporter
+            @reporter = reporter
+            @traces = []
+            @traces_bytes = reporter.project.bytesize + 4 # initial size
+            @created_at = nil
+          end
+
+          def add trace, addl_bytes: nil
+            addl_bytes ||= addl_bytes_for trace
+            @traces << trace
+            @traces_bytes += addl_bytes
+            @created_at ||= Time.now
+            nil
+          end
+
+          def try_add trace
+            addl_bytes = addl_bytes_for trace
+            new_message_count = @traces.count + 1
+            new_message_bytes = @traces_bytes + addl_bytes
+            if new_message_count > @reporter.max_count ||
+               new_message_bytes >= @reporter.max_bytes
+              return false
+            end
+            add trace, addl_bytes: addl_bytes
+            true
+          end
+
+          def ready?
+            @traces.count >= @reporter.max_count ||
+              @traces_bytes >= @reporter.max_bytes ||
+              (@created_at.nil? || (publish_at < Time.now))
+          end
+
+          def publish_at
+            return nil if @created_at.nil?
+            @created_at + @reporter.interval
+          end
+
+          def publish_wait
+            publish_wait = publish_at - Time.now
+            return 0 if publish_wait < 0
+            publish_wait
+          end
+
+          def addl_bytes_for trace
+            trace.to_grpc.to_proto.bytesize + 2
           end
         end
       end

--- a/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
@@ -246,7 +246,7 @@ module Google
             batch.traces
           )
           # Manually set backtrace so we don't have to raise
-          async_error.set_backtrace backtrace
+          async_error.set_backtrace caller
           error! async_error
         end
 
@@ -258,7 +258,7 @@ module Google
             traces
           )
           # Manually set backtrace so we don't have to raise
-          patch_error.set_backtrace backtrace
+          patch_error.set_backtrace caller
           error! patch_error
         end
 
@@ -268,7 +268,7 @@ module Google
             traces
           )
           # Manually set backtrace so we don't have to raise
-          stopped_error.set_backtrace backtrace
+          stopped_error.set_backtrace caller
           error! stopped_error
         end
 

--- a/google-cloud-trace/lib/google/cloud/trace/errors.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/errors.rb
@@ -1,0 +1,59 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/errors"
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # # AsyncReporterError
+      #
+      # Used to indicate a problem preventing traces from being buffered
+      # asynchronously. This can occur when there are not enough resources
+      # allocated for the amount of usage.
+      #
+      class AsyncReporterError < Google::Cloud::Error
+        # @!attribute [r] count
+        #   @return [Array<Google::Cloud::Trace::TraceRecord>] traces The trace
+        #   objects that were not written to the API due to the error.
+        attr_reader :traces
+
+        def initialize message, traces = nil
+          super(message)
+          @traces = traces if traces
+        end
+      end
+
+      ##
+      # # AsyncPatchTracesError
+      #
+      # Used to indicate a problem when patching traces to the API. This can
+      # occur when the API returns an error.
+      #
+      class AsyncPatchTracesError < Google::Cloud::Error
+        # @!attribute [r] count
+        #   @return [Array<Google::Cloud::Trace::TraceRecord>] traces The trace
+        #   objects that were not written to the API due to the error.
+        attr_reader :traces
+
+        def initialize message, traces = nil
+          super(message)
+          @traces = traces if traces
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Update AsyncReporter to buffer traces and batch API calls.
* Back pressure is applied by limiting the number of queued API calls.
* Errors will now be raised when there are not enough resources.
* Errors are reported using the AsyncReporter#on_error callback.
* Pending traces are sent before the process closes using at_exit.