### PR TITLE
Move ErrorReporting to use concurrent-ruby

### DIFF
--- a/google-cloud-error_reporting/acceptance/error_reporting_helper.rb
+++ b/google-cloud-error_reporting/acceptance/error_reporting_helper.rb
@@ -23,6 +23,11 @@ require "grpc"
 er_credentials = Google::Cloud::ErrorReporting::Credentials.default
 $error_stats_vtk_client = Google::Cloud::ErrorReporting::V1beta1::ErrorStatsServiceClient.new credentials: er_credentials
 
+Google::Cloud::ErrorReporting.configure do |config|
+  error_callback = ->(error) { raise error }
+  config.on_error = error_callback
+end
+
 module Acceptance
   class ErrorReportingTest < Minitest::Test
     ##

--- a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
+++ b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "google-gax", "~> 1.0"
+  gem.add_dependency "concurrent-ruby", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-error_reporting/lib/google-cloud-error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google-cloud-error_reporting.rb
@@ -163,4 +163,5 @@ Google::Cloud.configure.add_config! :error_reporting do |config|
   config.add_field! :service_version, default_version,
                     match: String, allow_nil: true
   config.add_field! :ignore_classes, nil, match: Array
+  config.add_field! :on_error, nil, match: Proc
 end

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
@@ -123,6 +123,13 @@ module Google
       # * `service_version` - (String) Version identifier for the application.
       # * `ignore_classes` - (Array<Exception>) Array of exception types that
       #   should not be reported.
+      # * `on_error` - (Proc) A Proc to be run when an error is encountered
+      #   on a background thread, such as {ErrorReporting.report} or
+      #   {Middleware}. The Proc must take the error object as the single
+      #   argument. If ErrorReporting is being used to report errors using
+      #   `Google::Cloud::cofigure.on_error`, then this `on_error` should be
+      #   configured to report errors raised when reporting through
+      #   ErrorReporting.
       #
       # See the [Configuration
       # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
@@ -13,12 +13,50 @@
 # limitations under the License.
 
 
-require "stackdriver/core/async_actor"
-
+require "concurrent"
+require "google/cloud/errors"
 
 module Google
   module Cloud
     module ErrorReporting
+      ##
+      # # AsyncErrorReporterError
+      #
+      # @private Used to indicate a problem reporting errors asynchronously.
+      # This can occur when there are not enough resources allocated for the
+      # amount of usage.
+      #
+      class AsyncErrorReporterError < Google::Cloud::Error
+        # @!attribute [r] error_event
+        #   @return [Array<Google::Cloud::ErrorReporting::ErrorEvent>] The
+        #   individual error event that was not reported to Stackdriver Error
+        #   Reporting service.
+        attr_reader :error_event
+
+        def initialize message, error_event = nil
+          super(message)
+          @error_event = error_event
+        end
+      end
+      ##
+      # # ErrorReporterError
+      #
+      # @private Used to indicate a problem reporting errors. This can occur
+      # when the calling the API returns an error.
+      #
+      class ErrorReporterError < Google::Cloud::Error
+        # @!attribute [r] error_event
+        #   @return [Array<Google::Cloud::ErrorReporting::ErrorEvent>] The
+        #   individual error event that was not reported to Stackdriver Error
+        #   Reporting service.
+        attr_reader :error_event
+
+        def initialize message, error_event = nil
+          super(message)
+          @error_event = error_event
+        end
+      end
+
       ##
       # # AsyncErrorReporter
       #
@@ -27,98 +65,144 @@ module Google
       # error events to Stackdriver Error Reporting service when used in
       # Ruby applications.
       class AsyncErrorReporter
-        include Stackdriver::Core::AsyncActor
+        ##
+        # @private Implementation accessors
+        attr_reader :error_reporting, :max_queue, :threads, :thread_pool
 
         ##
-        # @private Default maximum backlog size for the job queue
-        DEFAULT_MAX_QUEUE_SIZE = 1000
-
-        ##
-        # The {Google::Cloud::ErrorReporting::Project} object to submit events
-        # with.
-        attr_accessor :error_reporting
-
-        ##
-        # The max number of items the queue holds
-        attr_accessor :max_queue_size
-
-        ##
-        # @private Construct a new instance of AsyncErrorReporter
-        def initialize error_reporting, max_queue_size = DEFAULT_MAX_QUEUE_SIZE
-          super()
+        # @private Creates a new AsyncErrorReporter instance.
+        def initialize error_reporting, max_queue: 1000, threads: 10
           @error_reporting = error_reporting
-          @max_queue_size = max_queue_size
-          @queue = []
-          @queue_resource = new_cond
+
+          @max_queue = max_queue
+          @threads   = threads
+
+          @thread_pool = Concurrent::CachedThreadPool.new max_threads: @threads,
+                                                          max_queue: @max_queue
+
+          @error_callbacks = []
+
+          # Make sure all queued calls are completed when process exits.
+          at_exit { stop! }
         end
 
         ##
-        # Add the error event to the queue. Signal the child thread an item
-        # has been added.
+        # Add the error event to the queue. This will raise if there are no
+        # resources available to make the API call.
         def report error_event
-          async_start
+          Concurrent::Promises.future_on(@thread_pool, error_event) do |error|
+            report_sync error
+          end
+        rescue Concurrent::RejectedExecutionError => e
+          raise AsyncErrorReporterError,
+                "Error reporting error_event asynchronously: #{e.message}",
+                error_event
+        end
 
-          synchronize do
-            @queue.push error_event
-            @queue_resource.broadcast
+        ##
+        # Begins the process of stopping the reporter. ErrorEvents already
+        # in the queue will be published, but no new ErrorEvent can be added.
+        # Use {#wait!} to block until the reporter is fully stopped and all
+        # pending error_events have been pushed to the API.
+        #
+        # @return [AsyncErrorReporter] returns self so calls can be chained.
+        def stop
+          @thread_pool.shutdown if @thread_pool
 
-            retries = 0
-            while @max_queue_size && @queue.size > @max_queue_size
-              retries += 1
-              @queue_resource.wait 1
+          self
+        end
 
-              # Drop early queue entries when have waited long enough.
-              @queue.pop while @queue.size > @max_queue_size && retries > 3
+        ##
+        # Stop this asynchronous reporter and block until it has been stopped.
+        #
+        # @param [Number] timeout Timeout in seconds.
+        #
+        def stop! timeout = nil
+          stop
+          wait! timeout
+        end
+
+        ##
+        # Blocks until the reporter is fully stopped, all pending error_events
+        # have been published, and all callbacks have completed. Does not stop
+        # the reporter. To stop the reporter, first call {#stop} and then call
+        # {#wait!} to block until the reporter is stopped.
+        #
+        # @return [AsyncErrorReporter] returns self so calls can be chained.
+        def wait! timeout = nil
+          if @thread_pool
+            @thread_pool.shutdown
+            @thread_pool.wait_for_termination timeout
+          end
+
+          self
+        end
+
+        ##
+        # Whether the reporter has been started.
+        #
+        # @return [boolean] `true` when started, `false` otherwise.
+        #
+        def started?
+          @thread_pool.running? if @thread_pool
+        end
+
+        ##
+        # Whether the reporter has been stopped.
+        #
+        # @return [boolean] `true` when stopped, `false` otherwise.
+        #
+        def stopped?
+          !started?
+        end
+
+        ##
+        # Register to be notified of errors when raised.
+        #
+        # If an unhandled error has occurred the reporter will attempt to
+        # recover from the error and resume reporting error_events.
+        #
+        # Multiple error handlers can be added.
+        #
+        # @yield [callback] The block to be called when an error is raised.
+        # @yieldparam [Exception] error The error raised.
+        #
+        def on_error &block
+          @error_callbacks << block
+        end
+
+        protected
+
+        # Calls all error callbacks.
+        def error! error
+          error_callbacks = @error_callbacks
+          error_callbacks = default_error_callbacks if error_callbacks.empty?
+          error_callbacks.each { |error_callback| error_callback.call error }
+        end
+
+        def default_error_callbacks
+          # This is memoized to reduce calls to the configuration.
+          @default_error_callbacks ||= begin
+            error_cb = Google::Cloud::ErrorReporting.configuration.on_error
+            error_cb ||= Google::Cloud.configure.on_error
+            if error_cb
+              [error_cb]
+            else
+              []
             end
           end
         end
 
-        ##
-        # @private Callback fucntion for AsyncActor module to run the async
-        # job in a loop
-        def run_backgrounder
-          error_event = wait_next_item
-          return if error_event.nil?
-          begin
-            error_reporting.report error_event
-          rescue StandardError => e
-            warn error_event.message if error_event.message
-            warn ["#{e.class}: #{e.message}", e.backtrace].join("\n\t")
-            @last_exception = e
-          end
-        end
-
-        ##
-        # @private Callback function when the async actor thread state changes
-        def on_async_state_change
-          synchronize do
-            @queue_resource.broadcast
-          end
-        end
-
-        private
-
-        ##
-        # @private The the next item from the reporter queue. If there are
-        # no more item, it blocks the reporter thread until an item is
-        # enqueued
-        def wait_next_item
-          synchronize do
-            @queue_resource.wait_while do
-              async_suspended? || (async_running? && @queue.empty?)
-            end
-            @queue.pop
-          end
-        end
-
-        ##
-        # @private Override the #backgrounder_stoppable? method from AsyncActor
-        # module. The actor can be gracefully stopped when queue is
-        # empty.
-        def backgrounder_stoppable?
-          synchronize do
-            @queue.empty?
-          end
+        def report_sync error_event
+          error_reporting.report error_event
+        rescue StandardError => e
+          sync_error = ErrorReporterError.new(
+            "Error reporting error_event: #{e.message}",
+            error_event
+          )
+          # Manually set backtrace so we don't have to raise
+          sync_error.set_backtrace backtrace
+          error! sync_error
         end
       end
     end

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
@@ -38,6 +38,7 @@ module Google
           @error_event = error_event
         end
       end
+
       ##
       # # ErrorReporterError
       #

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
@@ -201,7 +201,7 @@ module Google
             error_event
           )
           # Manually set backtrace so we don't have to raise
-          sync_error.set_backtrace backtrace
+          sync_error.set_backtrace caller
           error! sync_error
         end
       end

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/async_error_reporter_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/async_error_reporter_test.rb
@@ -16,51 +16,37 @@
 require "helper"
 
 describe Google::Cloud::ErrorReporting::AsyncErrorReporter, :mock_error_reporting do
-  let(:reporter) {
-    Google::Cloud::ErrorReporting::AsyncErrorReporter.new error_reporting
-  }
+  let(:mocked_error_reporting) { Minitest::Mock.new }
+  let(:reporter) { Google::Cloud::ErrorReporting::AsyncErrorReporter.new mocked_error_reporting }
 
-  describe "report" do
-    let(:queue) { reporter.instance_variable_get :@queue }
-    let(:queue_resource) { reporter.instance_variable_get :@queue_resource }
-
-    it "puts the error event on queue" do
-      event = Object.new
-
-      reporter.async_suspend
-
-      reporter.report event
-      queue.pop.must_equal event
+  before do
+    reporter.on_error do |error|
+      raise error.inspect
     end
+  end
 
-    it "doesn't exceed max_queue_size" do
-      max_queue_size = 3
-      reporter.max_queue_size = max_queue_size
-      reporter.async_suspend
+  it "reports a single error" do
+    event = Object.new
 
-      max_queue_size.times do |i|
-        reporter.report i
-      end
+    mocked_error_reporting.expect :report, nil, [event]
 
-      reporter.report nil
+    reporter.report event
+    reporter.stop! 10
 
-      queue.size.must_equal max_queue_size
-    end
+    mocked_error_reporting.verify
+  end
 
-    it "wakes up the child thread to dequeue the events" do
-      event = Object.new
-      mocked_error_reporting = Minitest::Mock.new
-      mocked_error_reporting.expect :report, nil, [event]
+  it "reports multiple errors" do
+    event1 = Object.new
+    event2 = Object.new
 
-      reporter = Google::Cloud::ErrorReporting::AsyncErrorReporter.new mocked_error_reporting
+    mocked_error_reporting.expect :report, nil, [event1]
+    mocked_error_reporting.expect :report, nil, [event2]
 
-      reporter.report event
+    reporter.report event1
+    reporter.report event2
+    reporter.stop! 10
 
-      wait_until_true do
-        reporter.instance_variable_get(:@queue).size == 0
-      end
-
-      mocked_error_reporting.verify
-    end
+    mocked_error_reporting.verify
   end
 end

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/async_error_reporter_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/async_error_reporter_test.rb
@@ -40,8 +40,9 @@ describe Google::Cloud::ErrorReporting::AsyncErrorReporter, :mock_error_reportin
     event1 = Object.new
     event2 = Object.new
 
-    mocked_error_reporting.expect :report, nil, [event1]
-    mocked_error_reporting.expect :report, nil, [event2]
+    # Use class for report arguments, since they can be reported out of order
+    mocked_error_reporting.expect :report, nil, [Object]
+    mocked_error_reporting.expect :report, nil, [Object]
 
     reporter.report event1
     reporter.report event2


### PR DESCRIPTION
Replace `Stackdriver::Core::AsyncActor` with `Concurrent::CachedThreadPool`.

[refs #2084]