### PR TITLE
Spanner Performance Improvements

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/data.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/data.rb
@@ -151,16 +151,7 @@ module Google
         #
         def to_h
           raise DuplicateNameError if fields.duplicate_names?
-          hashified_pairs = pairs.map do |key, value|
-            if value.is_a? Data
-              [key, value.to_h]
-            elsif value.is_a? Array
-              [key, value.map { |v| v.is_a?(Data) ? v.to_h : v }]
-            else
-              [key, value]
-            end
-          end
-          Hash[hashified_pairs]
+          Hash[keys.zip to_a]
         end
 
         # @private

--- a/google-cloud-spanner/lib/google/cloud/spanner/data.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/data.rb
@@ -122,11 +122,15 @@ module Google
         end
 
         ##
-        # Returns the values as an array.
+        # Returns the values as an array. This method will raise
+        # {DuplicateNameError} if nested data has more than one member with the
+        # same name, unless `skip_dup_check` is set to `true`, in which case it
+        # will lose values.
         #
         # @param [Boolean] skip_dup_check Skip the check for whether nested data
-        #   contains duplicate names. When skipped, the nested hash may lose
-        #   values. Default is `false`. Optional.
+        #   contains duplicate names, which will improve performance. When
+        #   skipped, the nested hash may lose values. Default is `false`.
+        #   Optional.
         #
         # @raise [Google::Cloud::Spanner::DuplicateNameError] if nested data
         #   contains duplicate names.
@@ -149,12 +153,14 @@ module Google
 
         ##
         # Returns the names or indexes and corresponding values of the data as a
-        # hash. This method will raise or lose values if the data has more than
-        # one member with the same name.
+        # hash. This method will raise {DuplicateNameError} if the data has more
+        # than one member with the same name, unless `skip_dup_check` is set to
+        # `true`, in which case it will lose values.
         #
         # @param [Boolean] skip_dup_check Skip the check for whether the data
-        #   contains duplicate names. When skipped, the returned hash may lose
-        #   values. Default is `false`. Optional.
+        #   contains duplicate names, which will improve performance. When
+        #   skipped, the returned hash may lose values. Default is `false`.
+        #   Optional.
         #
         # @raise [Google::Cloud::Spanner::DuplicateNameError] if the data
         #   contains duplicate names.

--- a/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
@@ -171,7 +171,7 @@ module Google
         # @return [Boolean] Returns `true` if there are duplicate names.
         #
         def duplicate_names?
-          keys.count != keys.uniq.count
+          keys.group_by { |e| e }.select { |_k, v| v.size > 1 }.any?
         end
 
         ##

--- a/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_struct_test.rb
@@ -58,8 +58,10 @@ describe Google::Cloud::Spanner::Results, :duplicate_struct, :mock_spanner do
     assert_raises Google::Cloud::Spanner::DuplicateNameError do
       row.to_a
     end
+    row.to_a skip_dup_check: true # does not raise
     assert_raises Google::Cloud::Spanner::DuplicateNameError do
       row.to_h
     end
+    row.to_h skip_dup_check: true # does not raise
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_test.rb
@@ -70,9 +70,11 @@ describe Google::Cloud::Spanner::Results, :duplicate, :mock_spanner do
     assert_raises Google::Cloud::Spanner::DuplicateNameError do
       rows.first.to_h
     end
+    rows.first.to_h skip_dup_check: true # does not raise
     assert_raises Google::Cloud::Spanner::DuplicateNameError do
       rows.last.to_h
     end
+    rows.last.to_h skip_dup_check: true # does not raise
     rows.first.pairs.must_equal [[:num, 1], [:str, 2], [:num, "hello"], [:str, "world"]]
     rows.last.pairs.must_equal [[:num, 3], [:str, 4], [:num, "hola"], [:str, "mundo"]]
   end


### PR DESCRIPTION
We have received feedback that Spanner's serialization to a Ruby Hash is not as performant as expected. While there are micro-optimizations that can be made, the largest improvement in performance can be made by optionally skipping the check for duplicate names. Spanner data can contain duplicate names, or no names, which makes representing it in a Ruby Hash difficult. Consider the following example:

```ruby
hash = { foo: :bar, foo: :baz } #=> {:foo=>:baz}
```

The former value of `:bar` was dropped in favor of the latter value of `:baz`. To ensure that values are not dropped, Spanner data will raise `DuplicateNameError` when serializing to a Ruby Hash. This PR adds the optional `skip_dup_check` argument that will avoid the check for users that want the most performance and are willing to manage the risk of losing values.

```ruby
require "google/cloud/spanner"

spanner = Google::Cloud::Spanner.new

db = spanner.client "my-instance", "my-database"

dup_type = db.fields [[:x, :INT64], [:x, :STRING], [:x, :BOOL]]
dup_data = dup_type.struct [42, nil, false]

dup_data.to_h # raises Google::Cloud::Spanner::DuplicateNameError

dup_data.to_h skip_dup_check: true #=> {:x=>false}
```

Here are the performance numbers for master, the performance tweaks, and the performance tweaks with skipping the duplicate name check:

```
                        user     system      total        real
master (GC on)      0.260000   0.000000   0.260000 (  0.269273)
perf only (GC on)   0.240000   0.000000   0.240000 (  0.245119)
perf skip (GC on)   0.140000   0.000000   0.140000 (  0.148022)
master (GC off)     0.220000   0.020000   0.240000 (  0.232874)
perf only (GC off)  0.200000   0.010000   0.210000 (  0.216652)
perf skip (GC off)  0.130000   0.000000   0.130000 (  0.141780)
```