### PR TITLE
Ensure the reported exception has a backtrace

### DIFF
--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
@@ -206,6 +206,9 @@ module Google
         service_name ||= Project.default_service_name
         service_version ||= Project.default_service_version
 
+        # Ensure the reported exception has a backtrace
+        exception.set_backtrace caller if exception.backtrace.nil?
+
         error_event = ErrorEvent.from_exception(exception).tap do |event|
           event.service_name = service_name
           event.service_version = service_version

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting_test.rb
@@ -161,6 +161,27 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
         Google::Cloud::ErrorReporting.report exception
       end
     end
+
+    it "sets exception backtrace when missing" do
+      Google::Cloud::ErrorReporting.configure do |config|
+        config.service_name = "test-service-name"
+        config.service_version = "test-service-version"
+      end
+      mocked_client = Minitest::Mock.new
+      mocked_client.expect :report, nil do |event|
+        event.service_name.must_equal "test-service-name"
+        event.service_version.must_equal "test-service-version"
+        event.file_path.must_equal "error_reporting.rb"
+        event.line_number.must_equal 123
+        event.function_name.must_equal "report"
+      end
+
+      Google::Cloud::ErrorReporting.stub :default_client, mocked_client do
+        Google::Cloud::ErrorReporting.stub :caller, ["error_reporting.rb:123:in `report'"] do
+          Google::Cloud::ErrorReporting.report exception
+        end
+      end
+    end
   end
 
   describe ".default_client" do


### PR DESCRIPTION
This PR ensures that errors without backtrace are reported. This will allow the code example given in #2746 to work as expected:

```ruby
# The exception object has no backtrace.
Google::Cloud::ErrorReporting.report Exception.new("from console")
```