### PR TITLE
Pin bundler to 1.17.3 in test environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     - checkout
     - run:
         name: Install bundle
-        command: gem update --system && gem install bundler && bundle update
+        command: gem update --system && gem install bundler --version 1.17.3 && bundle update
     - run: bundle exec rake circleci:release
 
 workflows:

--- a/.kokoro/docker/autosynth/Dockerfile
+++ b/.kokoro/docker/autosynth/Dockerfile
@@ -31,7 +31,8 @@ RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ru
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
-RUN rbenv install 2.5.3 && rbenv global 2.5.3 && gem install bundle rake
+RUN rbenv install 2.5.3 && rbenv global 2.5.3 \
+    && gem install bundler --version 1.17.3 && gem install rake
 
 # Install pyenv
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv

--- a/.kokoro/docker/ruby-multi/Dockerfile
+++ b/.kokoro/docker/ruby-multi/Dockerfile
@@ -30,8 +30,8 @@ RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ru
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
-RUN rbenv install 2.3.8 && rbenv global 2.3.8 && gem install bundle
-RUN rbenv install 2.4.5 && rbenv global 2.4.5 && gem install bundle
-RUN rbenv install 2.5.3 && rbenv global 2.5.3 && gem install bundle
+RUN rbenv install 2.3.8 && rbenv global 2.3.8 && gem install bundler --version 1.17.3
+RUN rbenv install 2.4.5 && rbenv global 2.4.5 && gem install bundler --version 1.17.3
+RUN rbenv install 2.5.3 && rbenv global 2.5.3 && gem install bundler --version 1.17.3
 
 RUN apt-get -y autoremove && apt-get -y autoclean

--- a/.kokoro/osx.sh
+++ b/.kokoro/osx.sh
@@ -27,7 +27,7 @@ function set_failed_status {
     EXIT_STATUS=1
 }
 
-gem install bundle
+gem install bundler --version 1.17.3
 
 if [ "$JOB_TYPE" = "nightly" ]; then
     (bundle update && bundle exec rake kokoro:nightly) || set_failed_status


### PR DESCRIPTION
Bundler 2.0 raises a few issues in our test environment. Specifically, when a Gemfile.lock was bundled by Bundler 1.x, it tries to use that earlier Bundler when doing a bundle install, and that fails if 1.x is not actually present. We may eventually have to deal with this by ensuring that _both_ bundler 1.17 _and_ bundler 2.0 are present in the test environments. But it looks like the bundler team is also wrestling with the implications (and released 2.0.1 a day after 2.0), so while things settle down, I recommend we pin to bundler 1.

This also fixes the gem name. (Many of the scripts are incorrectly installing the `bundle` gem instead of `bundler`.)

@TheRoyalTnetennba Do we need to do anything to rebuild the docker images?