### PR TITLE
Enable Rubocop cop to omit parentheses from one-line method calls

### DIFF
--- a/google-cloud-bigquery/.rubocop.yml
+++ b/google-cloud-bigquery/.rubocop.yml
@@ -13,6 +13,11 @@ Documentation:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true
+  AllowParenthesesInCamelCaseMethod: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Style/NumericLiterals:

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -8,4 +8,3 @@ gem "google-cloud-storage", path: "../google-cloud-storage"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake", "~> 12.3"
-gem "rubocop", git: "git@github.com:rubocop-hq/rubocop.git", branch: "master"

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -8,3 +8,4 @@ gem "google-cloud-storage", path: "../google-cloud-storage"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake", "~> 12.3"
+gem "rubocop", git: "git@github.com:rubocop-hq/rubocop.git", branch: "master"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -360,6 +360,20 @@ module Google
           return "DATASTORE_BACKUP"       if path.end_with? ".backup_info"
           nil
         end
+
+        ##
+        # @private
+        #
+        # Converts a primitive time value in milliseconds to a Ruby Time object.
+        #
+        # @return [Time, nil] The Ruby Time object, or nil if the given argument
+        #   is nil.
+        def self.millis_to_time time_millis
+          return nil unless time_millis
+          time_millis = Integer time_millis
+          time_secs = time_millis / 1000.0
+          ::Time.at time_secs
+        end
       end
 
       # rubocop:enable Metrics/ModuleLength

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -439,9 +439,9 @@ module Google
         #
         def all request_limit: nil
           request_limit = request_limit.to_i if request_limit
-          unless block_given?
-            return enum_for(:all, request_limit: request_limit)
-          end
+
+          return enum_for :all, request_limit: request_limit unless block_given?
+
           results = self
           loop do
             results.each { |r| yield r }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -238,7 +238,7 @@ module Google
           return nil if reference?
           ensure_full_data!
           begin
-            ::Time.at(Integer(@gapi.creation_time) / 1000.0)
+            ::Time.at Integer(@gapi.creation_time) / 1000.0
           rescue StandardError
             nil
           end
@@ -256,7 +256,7 @@ module Google
           return nil if reference?
           ensure_full_data!
           begin
-            ::Time.at(Integer(@gapi.last_modified_time) / 1000.0)
+            ::Time.at Integer(@gapi.last_modified_time) / 1000.0
           rescue StandardError
             nil
           end
@@ -2261,7 +2261,7 @@ module Google
           return [] if array_or_str.nil?
           Array(array_or_str).map do |uri_or_code|
             resource = Google::Apis::BigqueryV2::UserDefinedFunctionResource.new
-            if uri_or_code.start_with?("gs://")
+            if uri_or_code.start_with? "gs://"
               resource.resource_uri = uri_or_code
             else
               resource.inline_code = uri_or_code

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -20,6 +20,7 @@ require "google/cloud/bigquery/table"
 require "google/cloud/bigquery/external"
 require "google/cloud/bigquery/dataset/list"
 require "google/cloud/bigquery/dataset/access"
+require "google/cloud/bigquery/convert"
 require "google/apis/bigquery_v2"
 
 module Google
@@ -237,11 +238,7 @@ module Google
         def created_at
           return nil if reference?
           ensure_full_data!
-          begin
-            ::Time.at Integer(@gapi.creation_time) / 1000.0
-          rescue StandardError
-            nil
-          end
+          Convert.millis_to_time @gapi.creation_time
         end
 
         ##
@@ -255,11 +252,7 @@ module Google
         def modified_at
           return nil if reference?
           ensure_full_data!
-          begin
-            ::Time.at Integer(@gapi.last_modified_time) / 1000.0
-          rescue StandardError
-            nil
-          end
+          Convert.millis_to_time @gapi.last_modified_time
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
@@ -935,10 +935,10 @@ module Google
 
           # @private
           def add_access_role_scope_value role, scope, value
-            role = validate_role(role)
+            role = validate_role role
             scope = validate_scope scope
             # If scope is special group, make sure value is in the list
-            value = validate_special_group(value) if scope == :special_group
+            value = validate_special_group value if scope == :special_group
             # Remove any rules of this scope and value
             @rules.reject!(&find_by_scope_and_value(scope, value))
             # Add new rule for this role, scope, and value
@@ -949,7 +949,7 @@ module Google
           # @private
           def add_access_view value
             # scope is view, make sure value is in the right format
-            value = validate_view(value)
+            value = validate_view value
             # Remove existing view rule, if any
             @rules.reject!(&find_view(value))
             # Add new rule for this role, scope, and value
@@ -959,10 +959,10 @@ module Google
 
           # @private
           def remove_access_role_scope_value role, scope, value
-            role = validate_role(role)
+            role = validate_role role
             scope = validate_scope scope
             # If scope is special group, make sure value is in the list
-            value = validate_special_group(value) if scope == :special_group
+            value = validate_special_group value if scope == :special_group
             # Remove any rules of this role, scope, and value
             @rules.reject!(
               &find_by_role_and_scope_and_value(role, scope, value)
@@ -972,17 +972,17 @@ module Google
           # @private
           def remove_access_view value
             # scope is view, make sure value is in the right format
-            value = validate_view(value)
+            value = validate_view value
             # Remove existing view rule, if any
             @rules.reject!(&find_view(value))
           end
 
           # @private
           def lookup_access_role_scope_value role, scope, value
-            role = validate_role(role)
+            role = validate_role role
             scope = validate_scope scope
             # If scope is special group, make sure value is in the list
-            value = validate_special_group(value) if scope == :special_group
+            value = validate_special_group value if scope == :special_group
             # Detect any rules of this role, scope, and value
             !(!@rules.detect(
               &find_by_role_and_scope_and_value(role, scope, value)
@@ -992,7 +992,7 @@ module Google
           # @private
           def lookup_access_view value
             # scope is view, make sure value is in the right format
-            value = validate_view(value)
+            value = validate_view value
             # Detect view rule, if any
             !(!@rules.detect(&find_view(value)))
           end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/list.rb
@@ -124,7 +124,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -16,6 +16,7 @@
 require "google/cloud/errors"
 require "google/cloud/bigquery/service"
 require "google/cloud/bigquery/job/list"
+require "google/cloud/bigquery/convert"
 require "json"
 
 module Google
@@ -172,9 +173,7 @@ module Google
         # @return [Time, nil] The creation time from the job statistics.
         #
         def created_at
-          ::Time.at Integer(@gapi.statistics.creation_time) / 1000.0
-        rescue StandardError
-          nil
+          Convert.millis_to_time @gapi.statistics.creation_time
         end
 
         ##
@@ -185,9 +184,7 @@ module Google
         # @return [Time, nil] The start time from the job statistics.
         #
         def started_at
-          ::Time.at Integer(@gapi.statistics.start_time) / 1000.0
-        rescue StandardError
-          nil
+          Convert.millis_to_time @gapi.statistics.start_time
         end
 
         ##
@@ -197,9 +194,7 @@ module Google
         # @return [Time, nil] The end time from the job statistics.
         #
         def ended_at
-          ::Time.at Integer(@gapi.statistics.end_time) / 1000.0
-        rescue StandardError
-          nil
+          Convert.millis_to_time @gapi.statistics.end_time
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -172,7 +172,7 @@ module Google
         # @return [Time, nil] The creation time from the job statistics.
         #
         def created_at
-          ::Time.at(Integer(@gapi.statistics.creation_time) / 1000.0)
+          ::Time.at Integer(@gapi.statistics.creation_time) / 1000.0
         rescue StandardError
           nil
         end
@@ -185,7 +185,7 @@ module Google
         # @return [Time, nil] The start time from the job statistics.
         #
         def started_at
-          ::Time.at(Integer(@gapi.statistics.start_time) / 1000.0)
+          ::Time.at Integer(@gapi.statistics.start_time) / 1000.0
         rescue StandardError
           nil
         end
@@ -197,7 +197,7 @@ module Google
         # @return [Time, nil] The end time from the job statistics.
         #
         def ended_at
-          ::Time.at(Integer(@gapi.statistics.end_time) / 1000.0)
+          ::Time.at Integer(@gapi.statistics.end_time) / 1000.0
         rescue StandardError
           nil
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job/list.rb
@@ -124,7 +124,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project/list.rb
@@ -125,7 +125,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -1178,7 +1178,7 @@ module Google
             Array(array_or_str).map do |uri_or_code|
               resource =
                 Google::Apis::BigqueryV2::UserDefinedFunctionResource.new
-              if uri_or_code.start_with?("gs://")
+              if uri_or_code.start_with? "gs://"
                 resource.resource_uri = uri_or_code
               else
                 resource.inline_code = uri_or_code

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -90,7 +90,9 @@ module Google
         # Returns the dataset specified by datasetID.
         def get_dataset dataset_id
           # The get operation is considered idempotent
-          execute(backoff: true) { service.get_dataset @project, dataset_id }
+          execute backoff: true do
+            service.get_dataset @project, dataset_id
+          end
         end
 
         ##
@@ -253,7 +255,7 @@ module Google
         # Cancel the job specified by jobId.
         def cancel_job job_id, location: nil
           # The BigQuery team has told us cancelling is considered idempotent
-          execute(backoff: true) do
+          execute backoff: true do
             service.cancel_job @project, job_id, location: location
           end
         end
@@ -262,7 +264,7 @@ module Google
         # Returns the job specified by jobID.
         def get_job job_id, location: nil
           # The get operation is considered idempotent
-          execute(backoff: true) do
+          execute backoff: true do
             service.get_job @project, job_id, location: location
           end
         end
@@ -273,7 +275,9 @@ module Google
             configuration: config
           )
           # Jobs have generated id, so this operation is considered idempotent
-          execute(backoff: true) { service.insert_job @project, job_object }
+          execute backoff: true do
+            service.insert_job @project, job_object
+          end
         end
 
         def query_job query_job_gapi
@@ -414,7 +418,7 @@ module Google
 
         # Generate a random string similar to the BigQuery service job IDs.
         def generate_id
-          SecureRandom.urlsafe_base64(21)
+          SecureRandom.urlsafe_base64 21
         end
 
         def mime_type_for file
@@ -432,7 +436,7 @@ module Google
             yield
           end
         rescue Google::Apis::Error => e
-          raise Google::Cloud::Error.from_error(e)
+          raise Google::Cloud::Error.from_error e
         end
 
         class Backoff

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -559,7 +559,7 @@ module Google
           return nil if reference?
           ensure_full_data!
           begin
-            ::Time.at(Integer(@gapi.creation_time) / 1000.0)
+            ::Time.at Integer(@gapi.creation_time) / 1000.0
           rescue StandardError
             nil
           end
@@ -579,7 +579,7 @@ module Google
           return nil if reference?
           ensure_full_data!
           begin
-            ::Time.at(Integer(@gapi.expiration_time) / 1000.0)
+            ::Time.at Integer(@gapi.expiration_time) / 1000.0
           rescue StandardError
             nil
           end
@@ -597,7 +597,7 @@ module Google
           return nil if reference?
           ensure_full_data!
           begin
-            ::Time.at(Integer(@gapi.last_modified_time) / 1000.0)
+            ::Time.at Integer(@gapi.last_modified_time) / 1000.0
           rescue StandardError
             nil
           end
@@ -988,7 +988,7 @@ module Google
           return nil unless @gapi.streaming_buffer
           oldest_entry_time = @gapi.streaming_buffer.oldest_entry_time
           begin
-            ::Time.at(Integer(oldest_entry_time) / 1000.0)
+            ::Time.at Integer(oldest_entry_time) / 1000.0
           rescue StandardError
             nil
           end
@@ -1747,7 +1747,7 @@ module Google
 
           job_gapi = updater.to_gapi
 
-          return load_local(files, job_gapi) if local_file? files
+          return load_local files, job_gapi if local_file? files
           load_storage files, job_gapi
         end
 
@@ -2490,7 +2490,7 @@ module Google
           return [] if array_or_str.nil?
           Array(array_or_str).map do |uri_or_code|
             resource = Google::Apis::BigqueryV2::UserDefinedFunctionResource.new
-            if uri_or_code.start_with?("gs://")
+            if uri_or_code.start_with? "gs://"
               resource.resource_uri = uri_or_code
             else
               resource.inline_code = uri_or_code

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -22,6 +22,7 @@ require "google/cloud/bigquery/encryption_configuration"
 require "google/cloud/bigquery/external"
 require "google/cloud/bigquery/insert_response"
 require "google/cloud/bigquery/table/async_inserter"
+require "google/cloud/bigquery/convert"
 require "google/apis/bigquery_v2"
 
 module Google
@@ -558,11 +559,7 @@ module Google
         def created_at
           return nil if reference?
           ensure_full_data!
-          begin
-            ::Time.at Integer(@gapi.creation_time) / 1000.0
-          rescue StandardError
-            nil
-          end
+          Convert.millis_to_time @gapi.creation_time
         end
 
         ##
@@ -578,11 +575,7 @@ module Google
         def expires_at
           return nil if reference?
           ensure_full_data!
-          begin
-            ::Time.at Integer(@gapi.expiration_time) / 1000.0
-          rescue StandardError
-            nil
-          end
+          Convert.millis_to_time @gapi.expiration_time
         end
 
         ##
@@ -596,11 +589,7 @@ module Google
         def modified_at
           return nil if reference?
           ensure_full_data!
-          begin
-            ::Time.at Integer(@gapi.last_modified_time) / 1000.0
-          rescue StandardError
-            nil
-          end
+          Convert.millis_to_time @gapi.last_modified_time
         end
 
         ##
@@ -987,11 +976,7 @@ module Google
           ensure_full_data!
           return nil unless @gapi.streaming_buffer
           oldest_entry_time = @gapi.streaming_buffer.oldest_entry_time
-          begin
-            ::Time.at Integer(oldest_entry_time) / 1000.0
-          rescue StandardError
-            nil
-          end
+          Convert.millis_to_time oldest_entry_time
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -231,7 +231,8 @@ module Google
                 time_since_first_publish = ::Time.now - @batch_created_at
                 if time_since_first_publish < @interval
                   # still waiting for the interval to insert the batch...
-                  @cond.wait @interval - time_since_first_publish
+                  timeout = @interval - time_since_first_publish
+                  @cond.wait timeout
                 else
                   # interval met, insert the batch...
                   push_batch_request!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -231,7 +231,7 @@ module Google
                 time_since_first_publish = ::Time.now - @batch_created_at
                 if time_since_first_publish < @interval
                   # still waiting for the interval to insert the batch...
-                  @cond.wait(@interval - time_since_first_publish)
+                  @cond.wait @interval - time_since_first_publish
                 else
                   # interval met, insert the batch...
                   push_batch_request!
@@ -247,7 +247,7 @@ module Google
             orig_rows = @batch.rows
             json_rows = @batch.json_rows
             insert_ids = @batch.insert_ids
-            Concurrent::Future.new(executor: @thread_pool) do
+            Concurrent::Future.new executor: @thread_pool do
               begin
                 raise ArgumentError, "No rows provided" if json_rows.empty?
                 options = { skip_invalid:   @skip_invalid,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/list.rb
@@ -134,7 +134,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/convert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/convert_test.rb
@@ -1,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Convert do
+  it "converts nil to nil with no error" do
+    t = Google::Cloud::Bigquery::Convert.millis_to_time nil
+    t.must_be :nil?
+  end
+
+  it "converts time in millis to a Time object with same value in seconds" do
+    t = Google::Cloud::Bigquery::Convert.millis_to_time 3333
+    t.must_be_kind_of ::Time
+    t.to_i.must_equal 3
+    t.to_f.must_equal 3.333
+  end
+end

--- a/google-cloud-core/.rubocop.yml
+++ b/google-cloud-core/.rubocop.yml
@@ -10,6 +10,11 @@ Documentation:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true
+  AllowParenthesesInCamelCaseMethod: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Style/RescueModifier:

--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -7,3 +7,4 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-gax", "~> 1.0"
 
 gem "rake", "~> 12.3"
+gem "rubocop", git: "git@github.com:rubocop-hq/rubocop.git", branch: "master"

--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -7,4 +7,3 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-gax", "~> 1.0"
 
 gem "rake", "~> 12.3"
-gem "rubocop", git: "git@github.com:rubocop-hq/rubocop.git", branch: "master"

--- a/google-cloud-core/lib/google/cloud.rb
+++ b/google-cloud-core/lib/google/cloud.rb
@@ -209,7 +209,7 @@ module Google
     def self.loaded_files
       files = Array(caller).map do |backtrace_line|
         until backtrace_line.split(":").size < 2 || File.file?(backtrace_line)
-          backtrace_line = backtrace_line.split(":")[0..-2].join(":")
+          backtrace_line = backtrace_line.split(":")[0..-2].join ":"
         end
         backtrace_line
       end

--- a/google-cloud-core/lib/google/cloud/errors.rb
+++ b/google-cloud-core/lib/google/cloud/errors.rb
@@ -29,12 +29,12 @@ module Google
       end
 
       # Add Error#cause (introduced in 2.1) to Ruby 2.0.
-      unless respond_to?(:cause)
+      unless respond_to? :cause
         ##
         # The previous exception at the time this exception was raised. This is
         # useful for wrapping exceptions and retaining the original exception
         # information.
-        define_method(:cause) do
+        define_method :cause do
           @cause
         end
       end

--- a/google-cloud-datastore/.rubocop.yml
+++ b/google-cloud-datastore/.rubocop.yml
@@ -14,6 +14,11 @@ Documentation:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true
+  AllowParenthesesInCamelCaseMethod: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Metrics/CyclomaticComplexity:

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -6,3 +6,4 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
 gem "rake", "~> 12.3"
+gem "rubocop", git: "git@github.com:rubocop-hq/rubocop.git", branch: "master"

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -6,4 +6,3 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
 gem "rake", "~> 12.3"
-gem "rubocop", git: "git@github.com:rubocop-hq/rubocop.git", branch: "master"

--- a/google-cloud-datastore/lib/google/cloud/datastore/cursor.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/cursor.rb
@@ -63,7 +63,7 @@ module Google
 
         # @private byte array as a string
         def to_grpc
-          Convert.decode_bytes(@cursor)
+          Convert.decode_bytes @cursor
         end
 
         # @private byte array as a string

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -296,7 +296,7 @@ module Google
           returned_keys = commit_res.mutation_results.map(&:key)
           returned_keys.each_with_index do |key, index|
             next if entities[index].nil?
-            entities[index].key = Key.from_grpc(key) unless key.nil?
+            entities[index].key = Key.from_grpc key unless key.nil?
           end
           entities.each { |e| e.key.freeze unless e.persisted? }
           entities
@@ -540,7 +540,7 @@ module Google
             raise err if Time.now - start_time > deadline
 
             # Sleep with incremental backoff
-            sleep(backoff *= 1.3)
+            sleep backoff *= 1.3
 
             # Create new transaction and retry the block
             tx = Transaction.new service, previous_transaction: tx.id

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/lookup_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/lookup_results.rb
@@ -170,7 +170,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
@@ -211,7 +211,7 @@ module Google
           #   end
           #
           def each_with_cursor
-            return enum_for(:each_with_cursor) unless block_given?
+            return enum_for :each_with_cursor unless block_given?
             zip(cursors).each { |r, c| yield [r, c] }
           end
 
@@ -269,7 +269,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do
@@ -338,7 +338,7 @@ module Google
           def all_with_cursor request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all_with_cursor, request_limit: request_limit)
+              return enum_for :all_with_cursor, request_limit: request_limit
             end
             results = self
 

--- a/google-cloud-datastore/lib/google/cloud/datastore/key.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/key.rb
@@ -277,9 +277,9 @@ module Google
             elsif pe_id_or_name.is_a? String
               path_args[:name] = pe_id_or_name unless pe_id_or_name.empty?
             end
-            Google::Datastore::V1::Key::PathElement.new(path_args)
+            Google::Datastore::V1::Key::PathElement.new path_args
           end
-          grpc = Google::Datastore::V1::Key.new(path: grpc_path)
+          grpc = Google::Datastore::V1::Key.new path: grpc_path
           if project || namespace
             grpc.partition_id = Google::Datastore::V1::PartitionId.new(
               project_id: project.to_s, namespace_id: namespace.to_s
@@ -305,7 +305,7 @@ module Google
             key.project = key_grpc.partition_id.project_id
             key.namespace = key_grpc.partition_id.namespace_id
           end
-          key.parent = Key.from_grpc(key_grpc) if key_grpc.path.count > 0
+          key.parent = Key.from_grpc key_grpc if key_grpc.path.count > 0
           # Freeze the key to make it immutable.
           key.freeze
           key

--- a/google-cloud-datastore/lib/google/cloud/datastore/query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/query.rb
@@ -298,7 +298,7 @@ module Google
         #   tasks = datastore.run query
         #
         def limit num
-          @grpc.limit = Google::Protobuf::Int32Value.new(value: num)
+          @grpc.limit = Google::Protobuf::Int32Value.new value: num
 
           self
         end

--- a/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
@@ -333,7 +333,7 @@ module Google
           returned_keys = commit_res.mutation_results.map(&:key)
           returned_keys.each_with_index do |key, index|
             next if entities[index].nil?
-            entities[index].key = Key.from_grpc(key) unless key.nil?
+            entities[index].key = Key.from_grpc key unless key.nil?
           end
           # Make sure all entity keys are frozen so all show as persisted
           entities.each { |e| e.key.freeze unless e.persisted? }

--- a/google-cloud-debugger/.rubocop.yml
+++ b/google-cloud-debugger/.rubocop.yml
@@ -18,6 +18,11 @@ Documentation:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true
+  AllowParenthesesInCamelCaseMethod: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Style/NumericLiterals:

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -8,3 +8,4 @@ gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake", "~> 12.3"
+gem "rubocop", git: "git@github.com:rubocop-hq/rubocop.git", branch: "master"

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -8,4 +8,3 @@ gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake", "~> 12.3"
-gem "rubocop", git: "git@github.com:rubocop-hq/rubocop.git", branch: "master"

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
@@ -823,7 +823,7 @@ module Google
           #
           def readonly_eval_expression binding, expression
             compilation_result = validate_compiled_expression expression
-            return compilation_result if compilation_result.is_a?(Exception)
+            return compilation_result if compilation_result.is_a? Exception
 
             readonly_eval_expression_exec binding, expression
           rescue StandardError => e
@@ -1080,7 +1080,7 @@ module Google
 
         def initialize msg = nil, mutation_cause = UNKNOWN_CAUSE
           @mutation_cause = mutation_cause
-          super(msg)
+          super msg
         end
 
         def inspect

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
@@ -354,7 +354,7 @@ module Google
           # compound variables.
           def self.add_member_vars var, members, limit: nil
             members.each_with_index do |member, i|
-              member_var = yield(member, i, limit)
+              member_var = yield member, i, limit
 
               limit = deduct_limit limit, member_var.total_size
 
@@ -491,7 +491,7 @@ module Google
             unless @total_size
               vars = [self, *(unique_members || [])]
 
-              @total_size = vars.inject(payload_size) do |sum, var|
+              @total_size = vars.inject payload_size do |sum, var|
                 if var.var_table && var.var_table_index
                   sum + var.var_table[var.var_table_index].total_size
                 else
@@ -515,7 +515,7 @@ module Google
                               value.to_s.bytesize
 
               unless members.nil?
-                @payload_size = members.inject(@payload_size) do |sum, member|
+                @payload_size = members.inject @payload_size do |sum, member|
                   sum + member.payload_size
                 end
               end

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint_manager.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint_manager.rb
@@ -132,7 +132,7 @@ module Google
               !new_breakpoints.empty? ||
               (before_breakpoints_count != after_breakpoints_acount)
 
-            on_breakpoints_change.call(@active_breakpoints) if
+            on_breakpoints_change.call @active_breakpoints if
               on_breakpoints_change.respond_to?(:call) && breakpoints_updated
           end
         end

--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
@@ -123,7 +123,7 @@ module Google
               Google::Cloud::Debugger::RequestQuotaManager.new
           end
 
-          Middleware.deferred_start(@debugger)
+          Middleware.deferred_start @debugger
         end
 
         ##

--- a/google-cloud-debugger/lib/google/cloud/debugger/snappoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/snappoint.rb
@@ -169,17 +169,17 @@ module Google
         # @private Compute the total size of all the evaluated variables in
         # this breakpoint.
         def calculate_total_size
-          result = evaluated_expressions.inject(0) do |sum, exp|
+          result = evaluated_expressions.inject 0 do |sum, exp|
             sum + exp.payload_size
           end
 
           stack_frames.each do |stack_frame|
-            result = stack_frame.locals.inject(result) do |sum, local|
+            result = stack_frame.locals.inject result do |sum, local|
               sum + local.payload_size
             end
           end
 
-          result = variable_table.variables.inject(result) do |sum, var|
+          result = variable_table.variables.inject result do |sum, var|
             sum + var.payload_size
           end
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
@@ -34,7 +34,7 @@ module Google
         attr_reader :breakpoint
 
         def initialize message, breakpoint = nil
-          super(message)
+          super message
           @breakpoint = breakpoint
         end
       end
@@ -93,7 +93,7 @@ module Google
         # @raise [TransmitterError] if there are no resources available to make
         #   queue the API call on the thread pool.
         def submit breakpoint
-          Concurrent::Promises.future_on(@thread_pool, breakpoint) do |bp|
+          Concurrent::Promises.future_on @thread_pool, breakpoint do |bp|
             submit_sync bp
           end
         rescue Concurrent::RejectedExecutionError => e

--- a/google-cloud-env/.rubocop.yml
+++ b/google-cloud-env/.rubocop.yml
@@ -10,6 +10,11 @@ Documentation:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true
+  AllowParenthesesInCamelCaseMethod: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Metrics/CyclomaticComplexity:

--- a/google-cloud-env/Gemfile
+++ b/google-cloud-env/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+gem "rubocop", git: "git@github.com:rubocop-hq/rubocop.git", branch: "master"

--- a/google-cloud-env/Gemfile
+++ b/google-cloud-env/Gemfile
@@ -3,4 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
-gem "rubocop", git: "git@github.com:rubocop-hq/rubocop.git", branch: "master"

--- a/google-cloud-env/lib/google/cloud/env.rb
+++ b/google-cloud-env/lib/google/cloud/env.rb
@@ -318,7 +318,7 @@ module Google
       # @return [Boolean]
       #
       def metadata?
-        unless metadata_cache.include?(METADATA_ROOT_PATH)
+        unless metadata_cache.include? METADATA_ROOT_PATH
           begin
             resp = connection.get METADATA_ROOT_PATH
             metadata_cache[METADATA_ROOT_PATH] = \

--- a/google-cloud-error_reporting/.rubocop.yml
+++ b/google-cloud-error_reporting/.rubocop.yml
@@ -16,6 +16,11 @@ Documentation:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true
+  AllowParenthesesInCamelCaseMethod: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Style/ClassVars:

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
@@ -34,7 +34,7 @@ module Google
         attr_reader :error_event
 
         def initialize message, error_event = nil
-          super(message)
+          super message
           @error_event = error_event
         end
       end
@@ -53,7 +53,7 @@ module Google
         attr_reader :error_event
 
         def initialize message, error_event = nil
-          super(message)
+          super message
           @error_event = error_event
         end
       end
@@ -91,7 +91,7 @@ module Google
         # Add the error event to the queue. This will raise if there are no
         # resources available to make the API call.
         def report error_event
-          Concurrent::Promises.future_on(@thread_pool, error_event) do |error|
+          Concurrent::Promises.future_on @thread_pool, error_event do |error|
             report_sync error
           end
         rescue Concurrent::RejectedExecutionError => e

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
@@ -220,7 +220,7 @@ module Google
 
             message = "#{error_location}: #{message}\n\t" +
                       backtrace.drop(1).join("\n\t")
-            file_path, line_number, function_name = error_location.split(":")
+            file_path, line_number, function_name = error_location.split ":"
             function_name = function_name.to_s[/`(.*)'/, 1]
           end
 

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -147,7 +147,7 @@ module Google
           error_event.http_url = rack_request.url
           error_event.http_user_agent = rack_request.user_agent
           error_event.http_referrer = rack_request.referrer
-          error_event.http_status = http_status(exception)
+          error_event.http_status = http_status exception
           error_event.http_remote_ip = rack_request.ip
 
           error_event

--- a/google-cloud-firestore/.rubocop.yml
+++ b/google-cloud-firestore/.rubocop.yml
@@ -17,6 +17,11 @@ Documentation:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true
+  AllowParenthesesInCamelCaseMethod: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Style/RescueModifier:

--- a/google-cloud-firestore/lib/google/cloud/firestore/client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/client.rb
@@ -102,10 +102,10 @@ module Google
         def cols
           ensure_service!
 
-          return enum_for(:cols) unless block_given?
+          return enum_for :cols unless block_given?
 
           collection_ids = service.list_collections "#{path}/documents"
-          collection_ids.each { |collection_id| yield col(collection_id) }
+          collection_ids.each { |collection_id| yield col collection_id }
         end
         alias collections cols
         alias list_collections cols
@@ -217,7 +217,7 @@ module Google
           ensure_service!
 
           unless block_given?
-            return enum_for(:get_all, docs, field_mask: field_mask)
+            return enum_for :get_all, docs, field_mask: field_mask
           end
 
           doc_paths = Array(docs).flatten.map do |doc_path|
@@ -235,7 +235,7 @@ module Google
           results = service.get_documents doc_paths, mask: mask
           results.each do |result|
             next if result.result.nil?
-            yield DocumentSnapshot.from_batch_result(result, self)
+            yield DocumentSnapshot.from_batch_result result, self
           end
         end
         alias get_docs get_all

--- a/google-cloud-firestore/lib/google/cloud/firestore/collection_reference.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/collection_reference.rb
@@ -75,7 +75,7 @@ module Google
         ##
         # @private The parent path for the collection.
         def parent_path
-          path.split("/")[0...-1].join("/")
+          path.split("/")[0...-1].join "/"
         end
 
         # @!group Access

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
@@ -91,10 +91,10 @@ module Google
         def cols
           ensure_service!
 
-          return enum_for(:cols) unless block_given?
+          return enum_for :cols unless block_given?
 
           collection_ids = service.list_collections path
-          collection_ids.each { |collection_id| yield col(collection_id) }
+          collection_ids.each { |collection_id| yield col collection_id }
         end
         alias collections cols
         alias list_collections cols
@@ -473,7 +473,7 @@ module Google
         ##
         # @private
         def parent_path
-          path.split("/")[0...-1].join("/")
+          path.split("/")[0...-1].join "/"
         end
 
         ##

--- a/google-cloud-firestore/lib/google/cloud/firestore/field_path.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/field_path.rb
@@ -110,7 +110,7 @@ module Google
         #
         def formatted_string
           escaped_fields = @fields.map { |field| escape_field_for_path field }
-          escaped_fields.join(".")
+          escaped_fields.join "."
         end
 
         ##
@@ -175,16 +175,17 @@ module Google
           end
 
           if dotted_string.is_a? Array
-            return @memoized_field_paths[dotted_string] = new(dotted_string)
+            @memoized_field_paths[dotted_string] = new dotted_string
+            return @memoized_field_paths[dotted_string]
           end
 
-          fields = String(dotted_string).split(".")
+          fields = String(dotted_string).split "."
 
           if fields.grep(INVALID_FIELD_PATH_CHARS).any?
             raise ArgumentError, "invalid character, use FieldPath instead"
           end
 
-          @memoized_field_paths[dotted_string] = new(fields)
+          @memoized_field_paths[dotted_string] = new fields
         end
 
         ##

--- a/google-cloud-firestore/lib/google/cloud/firestore/generate.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/generate.rb
@@ -25,7 +25,7 @@ module Google
 
         def self.unique_id length: 20, chars: CHARS
           size = chars.size
-          Array.new(length) do
+          Array.new length do
             chars[SecureRandom.random_number(size)]
           end.join
         end

--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -378,7 +378,7 @@ module Google
           new_query = @query.dup
           new_query ||= StructuredQuery.new
 
-          new_query.limit = Google::Protobuf::Int32Value.new(value: num)
+          new_query.limit = Google::Protobuf::Int32Value.new value: num
 
           Query.start new_query, parent_path, client
         end
@@ -825,12 +825,12 @@ module Google
         def get
           ensure_service!
 
-          return enum_for(:get) unless block_given?
+          return enum_for :get unless block_given?
 
           results = service.run_query parent_path, @query
           results.each do |result|
             next if result.document.nil?
-            yield DocumentSnapshot.from_query_result(result, client)
+            yield DocumentSnapshot.from_query_result result, client
           end
         end
         alias run get
@@ -923,13 +923,13 @@ module Google
         ].freeze
 
         def value_nil? value
-          [nil, :null, :nil].include?(value)
+          [nil, :null, :nil].include? value
         end
 
         def value_nan? value
           # Comparing NaN values raises, so check for #nan? first.
           return true if value.respond_to?(:nan?) && value.nan?
-          [:nan].include?(value)
+          [:nan].include? value
         end
 
         def value_unary? value
@@ -994,7 +994,7 @@ module Google
 
         def values_to_cursor values, query
           if values.count == 1 && values.first.is_a?(DocumentSnapshot)
-            return snapshot_to_cursor(values.first, query)
+            return snapshot_to_cursor values.first, query
           end
 
           # pair values with their field_paths to ensure correct formatting

--- a/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
@@ -131,7 +131,7 @@ module Google
           ensure_service!
 
           unless block_given?
-            return enum_for(:get_all, docs, field_mask: field_mask)
+            return enum_for :get_all, docs, field_mask: field_mask
           end
 
           doc_paths = Array(docs).flatten.map do |doc_path|
@@ -151,7 +151,7 @@ module Google
           results.each do |result|
             extract_transaction_from_result! result
             next if result.result.nil?
-            yield DocumentSnapshot.from_batch_result(result, client)
+            yield DocumentSnapshot.from_batch_result result, client
           end
         end
         alias get_docs get_all
@@ -251,20 +251,20 @@ module Google
 
           obj = coalesce_get_argument obj
 
-          if obj.is_a?(DocumentReference)
+          if obj.is_a? DocumentReference
             doc = get_all([obj]).first
             yield doc if block_given?
             return doc
           end
 
-          return enum_for(:get, obj) unless block_given?
+          return enum_for :get, obj unless block_given?
 
           results = service.run_query obj.parent_path, obj.query,
                                       transaction: transaction_or_create
           results.each do |result|
             extract_transaction_from_result! result
             next if result.document.nil?
-            yield DocumentSnapshot.from_query_result(result, client)
+            yield DocumentSnapshot.from_query_result result, client
           end
         end
         alias run get

--- a/google-cloud-firestore/lib/google/cloud/firestore/watch/enumerator_queue.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/watch/enumerator_queue.rb
@@ -30,7 +30,7 @@ module Google
           end
 
           def each
-            return enum_for(:each) unless block_given?
+            return enum_for :each unless block_given?
 
             loop do
               obj = @queue.pop

--- a/google-cloud-firestore/lib/google/cloud/firestore/watch/order.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/watch/order.rb
@@ -77,9 +77,9 @@ module Google
               return value if value.is_a? String
               return value.string if value.is_a? StringIO
               if value.is_a? DocumentReference
-                return value.path.split("/".freeze)
+                return value.path.split "/".freeze
               end
-              return value.map { |v| field_comparison(v) } if value.is_a? Array
+              return value.map { |v| field_comparison v } if value.is_a? Array
               if value.is_a? Hash
                 geo_pairs = Convert.hash_is_geo_point? value
                 return geo_pairs.map(&:last) if geo_pairs

--- a/google-cloud-logging/.rubocop.yml
+++ b/google-cloud-logging/.rubocop.yml
@@ -20,6 +20,10 @@ Style/MethodCallWithArgsParentheses:
   Enabled: true
   EnforcedStyle: omit_parentheses
   AllowParenthesesInMultilineCall: true
+  IgnoredMethods:
+    - "Array"
+    - "DelegateClass"
+    - "String"
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Style/NumericLiterals:

--- a/google-cloud-logging/.rubocop.yml
+++ b/google-cloud-logging/.rubocop.yml
@@ -20,10 +20,7 @@ Style/MethodCallWithArgsParentheses:
   Enabled: true
   EnforcedStyle: omit_parentheses
   AllowParenthesesInMultilineCall: true
-  IgnoredMethods:
-    - "Array"
-    - "DelegateClass"
-    - "String"
+  AllowParenthesesInCamelCaseMethod: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Style/NumericLiterals:

--- a/google-cloud-logging/.rubocop.yml
+++ b/google-cloud-logging/.rubocop.yml
@@ -16,6 +16,10 @@ Documentation:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Style/NumericLiterals:

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -382,7 +382,7 @@ module Google
                 @cond.wait
               else
                 # still waiting for the interval to publish the batch...
-                @cond.wait(@batch.publish_wait)
+                @cond.wait @batch.publish_wait
               end
             end
           end

--- a/google-cloud-logging/lib/google/cloud/logging/convert.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/convert.rb
@@ -32,7 +32,7 @@ module Google
         def self.array_to_list array
           # TODO: ArgumentError if array is not an Array
           Google::Protobuf::ListValue.new \
-            values: array.map { |o| object_to_value(o) }
+            values: array.map { |o| object_to_value o }
         end
 
         ##

--- a/google-cloud-logging/lib/google/cloud/logging/entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry.rb
@@ -488,7 +488,7 @@ module Google
           return {} if labels.nil?
           # Coerce symbols to strings
           Hash[labels.map do |k, v|
-            v = String(v) if v.is_a? Symbol
+            v = String v if v.is_a? Symbol
             [String(k), v]
           end]
         end

--- a/google-cloud-logging/lib/google/cloud/logging/entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry.rb
@@ -488,7 +488,7 @@ module Google
           return {} if labels.nil?
           # Coerce symbols to strings
           Hash[labels.map do |k, v|
-            v = String v if v.is_a? Symbol
+            v = String(v) if v.is_a? Symbol
             [String(k), v]
           end]
         end

--- a/google-cloud-logging/lib/google/cloud/logging/entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry.rb
@@ -449,11 +449,11 @@ module Google
           return new if grpc.nil?
           new.tap do |e|
             e.log_name = grpc.log_name
-            e.timestamp = extract_timestamp(grpc)
+            e.timestamp = extract_timestamp grpc
             e.severity = grpc.severity
             e.insert_id = grpc.insert_id
-            e.labels = Convert.map_to_hash(grpc.labels)
-            e.payload = extract_payload(grpc)
+            e.labels = Convert.map_to_hash grpc.labels
+            e.payload = extract_payload grpc
             e.instance_variable_set :@resource,
                                     Resource.from_grpc(grpc.resource)
             e.instance_variable_set :@http_request,

--- a/google-cloud-logging/lib/google/cloud/logging/entry/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/list.rb
@@ -21,7 +21,7 @@ module Google
       class Entry
         ##
         # Entry::List is a special case Array with additional values.
-        class List < DelegateClass ::Array
+        class List < DelegateClass(::Array)
           ##
           # If not empty, indicates that there are more records that match
           # the request and this value should be passed to continue.

--- a/google-cloud-logging/lib/google/cloud/logging/entry/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/list.rb
@@ -21,7 +21,7 @@ module Google
       class Entry
         ##
         # Entry::List is a special case Array with additional values.
-        class List < DelegateClass(::Array)
+        class List < DelegateClass ::Array
           ##
           # If not empty, indicates that there are more records that match
           # the request and this value should be passed to continue.
@@ -129,7 +129,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-logging/lib/google/cloud/logging/errors.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/errors.rb
@@ -53,7 +53,7 @@ module Google
         attr_reader :entries
 
         def initialize message, entries = nil
-          super(message)
+          super message
           @entries = entries if entries
         end
       end
@@ -92,7 +92,7 @@ module Google
         attr_reader :entries
 
         def initialize message, entries = nil
-          super(message)
+          super message
           @entries = entries if entries
         end
       end

--- a/google-cloud-logging/lib/google/cloud/logging/log/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/log/list.rb
@@ -21,7 +21,7 @@ module Google
       class Log
         ##
         # Log::List is a special case Array with additional values.
-        class List < DelegateClass ::Array
+        class List < DelegateClass(::Array)
           ##
           # If not empty, indicates that there are more records that match
           # the request and this value should be passed to continue.

--- a/google-cloud-logging/lib/google/cloud/logging/log/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/log/list.rb
@@ -21,7 +21,7 @@ module Google
       class Log
         ##
         # Log::List is a special case Array with additional values.
-        class List < DelegateClass(::Array)
+        class List < DelegateClass ::Array
           ##
           # If not empty, indicates that there are more records that match
           # the request and this value should be passed to continue.
@@ -113,7 +113,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do
@@ -131,7 +131,7 @@ module Google
           # @private New Log::List from a
           # Google::Logging::V2::ListLogsResponse object.
           def self.from_grpc grpc_list, service, resource: nil, max: nil
-            logs = new(Array(grpc_list.log_names))
+            logs = new Array(grpc_list.log_names)
             token = grpc_list.next_page_token
             token = nil if token == "".freeze
             logs.instance_variable_set :@token,    token

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -539,7 +539,7 @@ module Google
         def write_entry severity, message
           entry = Entry.new.tap do |e|
             e.timestamp = Time.now
-            e.severity = gcloud_severity(severity)
+            e.severity = gcloud_severity severity
             e.payload = message
           end
 
@@ -572,7 +572,7 @@ module Google
 
           request_env = info && info.env || {}
 
-          compute_labels(request_env).merge(merged_labels)
+          compute_labels(request_env).merge merged_labels
         end
 
         ##

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -621,8 +621,8 @@ module Google
         # @private Compute individual label value.
         # Value can be a Proc (function of the request env) or a static value.
         def compute_label_value request_env, value_or_proc
-          if value_or_proc.respond_to?(:call)
-            value_or_proc.call(request_env)
+          if value_or_proc.respond_to? :call
+            value_or_proc.call request_env
           else
             value_or_proc
           end

--- a/google-cloud-logging/lib/google/cloud/logging/metric/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/metric/list.rb
@@ -21,7 +21,7 @@ module Google
       class Metric
         ##
         # Metric::List is a special case Array with additional values.
-        class List < DelegateClass ::Array
+        class List < DelegateClass(::Array)
           ##
           # If not empty, indicates that there are more records that match
           # the request and this value should be passed to continue.

--- a/google-cloud-logging/lib/google/cloud/logging/metric/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/metric/list.rb
@@ -21,7 +21,7 @@ module Google
       class Metric
         ##
         # Metric::List is a special case Array with additional values.
-        class List < DelegateClass(::Array)
+        class List < DelegateClass ::Array
           ##
           # If not empty, indicates that there are more records that match
           # the request and this value should be passed to continue.
@@ -126,7 +126,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -209,7 +209,7 @@ module Google
           ensure_service!
 
           e = Entry.new
-          e.log_name = service.log_path(log_name) if log_name
+          e.log_name = service.log_path log_name if log_name
           e.resource = resource if resource
           e.timestamp = timestamp if timestamp
           e.severity = severity if severity

--- a/google-cloud-logging/lib/google/cloud/logging/resource.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource.rb
@@ -76,7 +76,7 @@ module Google
           return new if grpc.nil?
           new.tap do |r|
             r.type = grpc.type
-            r.labels = Convert.map_to_hash(grpc.labels)
+            r.labels = Convert.map_to_hash grpc.labels
           end
         end
       end

--- a/google-cloud-logging/lib/google/cloud/logging/resource_descriptor/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource_descriptor/list.rb
@@ -22,7 +22,7 @@ module Google
         ##
         # ResourceDescriptor::List is a special case Array with additional
         # values.
-        class List < DelegateClass ::Array
+        class List < DelegateClass(::Array)
           ##
           # If not empty, indicates that there are more records that match
           # the request and this value should be passed to continue.

--- a/google-cloud-logging/lib/google/cloud/logging/resource_descriptor/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource_descriptor/list.rb
@@ -22,7 +22,7 @@ module Google
         ##
         # ResourceDescriptor::List is a special case Array with additional
         # values.
-        class List < DelegateClass(::Array)
+        class List < DelegateClass ::Array
           ##
           # If not empty, indicates that there are more records that match
           # the request and this value should be passed to continue.
@@ -131,7 +131,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-logging/lib/google/cloud/logging/service.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/service.rb
@@ -101,7 +101,7 @@ module Google
                           partial_success: nil
           # Fix log names so they are the full path
           entries = Array(entries).each do |entry|
-            entry.log_name = log_path(entry.log_name)
+            entry.log_name = log_path entry.log_name
           end
           resource = resource.to_grpc if resource
           labels = Hash[labels.map { |k, v| [String(k), String(v)] }] if labels

--- a/google-cloud-logging/lib/google/cloud/logging/sink/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/sink/list.rb
@@ -21,7 +21,7 @@ module Google
       class Sink
         ##
         # Sink::List is a special case Array with additional values.
-        class List < DelegateClass ::Array
+        class List < DelegateClass(::Array)
           ##
           # If not empty, indicates that there are more records that match
           # the request and this value should be passed to continue.

--- a/google-cloud-logging/lib/google/cloud/logging/sink/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/sink/list.rb
@@ -21,7 +21,7 @@ module Google
       class Sink
         ##
         # Sink::List is a special case Array with additional values.
-        class List < DelegateClass(::Array)
+        class List < DelegateClass ::Array
           ##
           # If not empty, indicates that there are more records that match
           # the request and this value should be passed to continue.
@@ -125,7 +125,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-pubsub/.rubocop.yml
+++ b/google-cloud-pubsub/.rubocop.yml
@@ -16,6 +16,11 @@ Documentation:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true
+  AllowParenthesesInCamelCaseMethod: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Style/NumericLiterals:

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -150,7 +150,7 @@ module Google
         def topic topic_name, project: nil, skip_lookup: nil, async: nil
           ensure_service!
           options = { project: project }
-          return Topic.from_name(topic_name, service, options) if skip_lookup
+          return Topic.from_name topic_name, service, options if skip_lookup
           grpc = service.get_topic topic_name
           Topic.from_grpc grpc, service, async: async
         rescue Google::Cloud::NotFoundError

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -168,7 +168,7 @@ module Google
         ##
         # Gets the details of a subscription.
         def get_subscription subscription_name, options = {}
-          subscription = subscription_path(subscription_name, options)
+          subscription = subscription_path subscription_name, options
           execute do
             subscriber.get_subscription subscription, options: default_options
           end
@@ -218,8 +218,8 @@ module Google
         ##
         # Creates a subscription on a given topic for a given subscriber.
         def create_subscription topic, subscription_name, options = {}
-          name = subscription_path(subscription_name, options)
-          topic = topic_path(topic)
+          name = subscription_path subscription_name, options
+          topic = topic_path topic
           push_config = if options[:endpoint]
                           Google::Cloud::PubSub::V1::PushConfig.new \
                             push_endpoint: options[:endpoint],
@@ -263,7 +263,7 @@ module Google
         ##
         # Pulls a single message from the server.
         def pull subscription, options = {}
-          subscription = subscription_path(subscription, options)
+          subscription = subscription_path subscription, options
           max_messages = options.fetch(:max, 100).to_i
           return_immediately = !(!options.fetch(:immediate, true))
 
@@ -293,7 +293,7 @@ module Google
         ##
         # Modifies the PushConfig for a specified subscription.
         def modify_push_config subscription, endpoint, attributes
-          subscription = subscription_path(subscription)
+          subscription = subscription_path subscription
           # Convert attributes to strings to match the protobuf definition
           attributes = Hash[attributes.map { |k, v| [String(k), String(v)] }]
           push_config = Google::Cloud::PubSub::V1::PushConfig.new(
@@ -370,7 +370,7 @@ module Google
         ##
         # Adjusts the given subscription to a time or snapshot.
         def seek subscription, time_or_snapshot
-          subscription = subscription_path(subscription)
+          subscription = subscription_path subscription
           execute do
             if a_time? time_or_snapshot
               time = Convert.time_to_timestamp time_or_snapshot
@@ -394,7 +394,7 @@ module Google
         end
 
         def set_topic_policy topic_name, new_policy, options = {}
-          resource = topic_path(topic_name, options)
+          resource = topic_path topic_name, options
 
           execute do
             publisher.set_iam_policy resource, new_policy,
@@ -403,7 +403,7 @@ module Google
         end
 
         def test_topic_permissions topic_name, permissions, options = {}
-          resource = topic_path(topic_name, options)
+          resource = topic_path topic_name, options
 
           execute do
             publisher.test_iam_permissions resource, permissions,
@@ -412,7 +412,7 @@ module Google
         end
 
         def get_subscription_policy subscription_name, options = {}
-          resource = subscription_path(subscription_name, options)
+          resource = subscription_path subscription_name, options
 
           execute do
             subscriber.get_iam_policy resource, options: default_options
@@ -420,7 +420,7 @@ module Google
         end
 
         def set_subscription_policy subscription_name, new_policy, options = {}
-          resource = subscription_path(subscription_name, options)
+          resource = subscription_path subscription_name, options
 
           execute do
             subscriber.set_iam_policy resource, new_policy,
@@ -430,7 +430,7 @@ module Google
 
         def test_subscription_permissions subscription_name,
                                           permissions, options = {}
-          resource = subscription_path(subscription_name, options)
+          resource = subscription_path subscription_name, options
 
           execute do
             subscriber.test_iam_permissions resource, permissions,
@@ -445,19 +445,19 @@ module Google
 
         def topic_path topic_name, options = {}
           return topic_name if topic_name.to_s.include? "/"
-          "#{project_path(options)}/topics/#{topic_name}"
+          "#{project_path options}/topics/#{topic_name}"
         end
 
         def subscription_path subscription_name, options = {}
           return subscription_name if subscription_name.to_s.include? "/"
-          "#{project_path(options)}/subscriptions/#{subscription_name}"
+          "#{project_path options}/subscriptions/#{subscription_name}"
         end
 
         def snapshot_path snapshot_name, options = {}
           if snapshot_name.nil? || snapshot_name.to_s.include?("/")
             return snapshot_name
           end
-          "#{project_path(options)}/snapshots/#{snapshot_name}"
+          "#{project_path options}/snapshots/#{snapshot_name}"
         end
 
         def inspect

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot.rb
@@ -138,7 +138,7 @@ module Google
         #
         def labels= new_labels
           raise ArgumentError, "Value must be a Hash" if new_labels.nil?
-          labels_map = Google::Protobuf::Map.new(:string, :string)
+          labels_map = Google::Protobuf::Map.new :string, :string
           Hash(new_labels).each { |k, v| labels_map[String(k)] = String(v) }
           update_grpc = @grpc.dup
           update_grpc.labels = labels_map

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot/list.rb
@@ -128,7 +128,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -91,7 +91,7 @@ module Google
           @started = nil
           @stopped = nil
 
-          stream_pool = Array.new(@streams) do
+          stream_pool = Array.new @streams do
             Thread.new { Stream.new self }
           end
           @stream_pool = stream_pool.map(&:value)

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/enumerator_queue.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/enumerator_queue.rb
@@ -37,7 +37,7 @@ module Google
           end
 
           def each
-            return enum_for(:each) unless block_given?
+            return enum_for :each unless block_given?
 
             loop do
               obj = @queue.pop

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -266,7 +266,7 @@ module Google
           def perform_callback_async rec_msg
             return unless callback_thread_pool.running?
 
-            Concurrent::Future.new(executor: callback_thread_pool) do
+            Concurrent::Future.new executor: callback_thread_pool do
               begin
                 @subscriber.callback.call rec_msg
               rescue StandardError => callback_error

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
@@ -34,7 +34,7 @@ module Google
             # entry.
             @register = {}
 
-            @task = Concurrent::TimerTask.new(execution_interval: interval) do
+            @task = Concurrent::TimerTask.new execution_interval: interval do
               flush!
             end
           end
@@ -204,7 +204,7 @@ module Google
           end
 
           def add_future pool
-            Concurrent::Future.new(executor: pool) do
+            Concurrent::Future.new executor: pool do
               begin
                 yield
               rescue StandardError => error

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
@@ -133,7 +133,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -422,7 +422,7 @@ module Google
         def publish_async data = nil, attributes = {}, &block
           ensure_service!
 
-          @async_publisher ||= AsyncPublisher.new(name, service, @async_opts)
+          @async_publisher ||= AsyncPublisher.new name, service, @async_opts
           @async_publisher.publish data, attributes, &block
         end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic/list.rb
@@ -127,7 +127,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-resource_manager/.rubocop.yml
+++ b/google-cloud-resource_manager/.rubocop.yml
@@ -14,6 +14,11 @@ Documentation:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true
+  AllowParenthesesInCamelCaseMethod: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Metrics/CyclomaticComplexity:

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager.rb
@@ -69,7 +69,7 @@ module Google
         retries ||= configure.retries
         timeout ||= configure.timeout
         credentials ||= keyfile
-        credentials ||= default_credentials(scope: scope)
+        credentials ||= default_credentials scope: scope
         unless credentials.is_a? Google::Auth::Credentials
           credentials = ResourceManager::Credentials.new credentials,
                                                          scope: scope

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/list.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/list.rb
@@ -125,7 +125,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-spanner/.rubocop.yml
+++ b/google-cloud-spanner/.rubocop.yml
@@ -17,6 +17,11 @@ Documentation:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true
+  AllowParenthesesInCamelCaseMethod: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Style/NumericLiterals:

--- a/google-cloud-spanner/lib/google/cloud/spanner/batch_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/batch_client.rb
@@ -409,7 +409,7 @@ module Google
               project_id, instance_id, database_id
             ),
             labels: @session_labels
-          Session.from_grpc(grpc, @project.service)
+          Session.from_grpc grpc, @project.service
         end
 
         ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -1098,7 +1098,7 @@ module Google
                               timestamp: (timestamp || read_timestamp),
                               staleness: (staleness || exact_staleness)
               Thread.current[:transaction_id] = snp_grpc.id
-              snp = Snapshot.from_grpc(snp_grpc, session)
+              snp = Snapshot.from_grpc snp_grpc, session
               yield snp if block_given?
             ensure
               Thread.current[:transaction_id] = nil
@@ -1284,7 +1284,7 @@ module Google
               project_id, instance_id, database_id
             ),
             labels: @session_labels
-          Session.from_grpc(grpc, @project.service)
+          Session.from_grpc grpc, @project.service
         end
 
         # @private
@@ -1393,7 +1393,7 @@ module Google
             return seconds + (nanos / 1000000000.0)
           end
           # No metadata? Try the inner error
-          delay_from_aborted(err.cause)
+          delay_from_aborted err.cause
         rescue StandardError
           # Any error indicates the backoff should be handled elsewhere
           nil

--- a/google-cloud-spanner/lib/google/cloud/spanner/commit.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/commit.rb
@@ -323,14 +323,14 @@ module Google
         protected
 
         def key_set keys
-          return Google::Spanner::V1::KeySet.new(all: true) if keys.nil?
+          return Google::Spanner::V1::KeySet.new all: true if keys.nil?
           keys = [keys] unless keys.is_a? Array
-          return Google::Spanner::V1::KeySet.new(all: true) if keys.empty?
+          return Google::Spanner::V1::KeySet.new all: true if keys.empty?
           if keys_are_ranges? keys
             key_ranges = keys.map do |r|
-              Convert.to_key_range(r)
+              Convert.to_key_range r
             end
-            return Google::Spanner::V1::KeySet.new(ranges: key_ranges)
+            return Google::Spanner::V1::KeySet.new ranges: key_ranges
           end
           key_list = keys.map do |key|
             key = [key] unless key.is_a? Array

--- a/google-cloud-spanner/lib/google/cloud/spanner/database/list.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database/list.rb
@@ -126,7 +126,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
@@ -113,7 +113,7 @@ module Google
 
           verify_sorted_types! sorted_types, types.count
 
-          @grpc_fields = Array.new(types.count) do |index|
+          @grpc_fields = Array.new types.count do |index|
             sorted_type = sorted_types.assoc index
             if sorted_type
               to_grpc_field sorted_type.last

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/config/list.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/config/list.rb
@@ -126,7 +126,7 @@ module Google
             def all request_limit: nil
               request_limit = request_limit.to_i if request_limit
               unless block_given?
-                return enum_for(:all, request_limit: request_limit)
+                return enum_for :all, request_limit: request_limit
               end
               results = self
               loop do

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/list.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/list.rb
@@ -123,7 +123,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-spanner/lib/google/cloud/spanner/partition.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/partition.rb
@@ -88,8 +88,8 @@ module Google
         #
         def to_h
           {}.tap do |h|
-            h[:execute] = Base64.strict_encode64(@execute.to_proto) if @execute
-            h[:read]    = Base64.strict_encode64(@read.to_proto)    if @read
+            h[:execute] = Base64.strict_encode64 @execute.to_proto if @execute
+            h[:read]    = Base64.strict_encode64 @read.to_proto    if @read
           end
         end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -271,7 +271,7 @@ module Google
         end
 
         def future
-          Concurrent::Future.new(executor: @thread_pool) do
+          Concurrent::Future.new executor: @thread_pool do
             yield
           end.execute
         end

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -243,7 +243,7 @@ module Google
 
         def create_session database_name, labels: nil
           opts = default_options_from_session database_name
-          session = Google::Spanner::V1::Session.new(labels: labels) if labels
+          session = Google::Spanner::V1::Session.new labels: labels if labels
           execute do
             service.create_session database_name, session: session,
                                                   options: opts

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -597,7 +597,7 @@ module Google
         # Creates a new transaction object every time.
         def create_transaction
           tx_grpc = service.begin_transaction path
-          Transaction.from_grpc(tx_grpc, self)
+          Transaction.from_grpc tx_grpc, self
         end
 
         ##

--- a/google-cloud-storage/.rubocop.yml
+++ b/google-cloud-storage/.rubocop.yml
@@ -12,6 +12,11 @@ Documentation:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true
+  AllowParenthesesInCamelCaseMethod: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Style/RescueModifier:

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -361,7 +361,7 @@ module Google
         # @param [Symbol, String] new_storage_class Storage class of the bucket.
         #
         def storage_class= new_storage_class
-          @gapi.storage_class = storage_class_for(new_storage_class)
+          @gapi.storage_class = storage_class_for new_storage_class
           patch_gapi! :storage_class
         end
 

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/list.rb
@@ -128,7 +128,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -443,7 +443,7 @@ module Google
         # @param [Symbol, String] storage_class Storage class of the file.
         #
         def storage_class= storage_class
-          @gapi.storage_class = storage_class_for(storage_class)
+          @gapi.storage_class = storage_class_for storage_class
           update_gapi! :storage_class
         end
 
@@ -940,7 +940,7 @@ module Google
                                   key: encryption_key, range: range,
                                   user_project: user_project
           # FIX: downloading with encryption key will return nil
-          file ||= ::File.new(path)
+          file ||= ::File.new path
           verify = :none if range
           verify_file! file, verify
           if !skip_decompress &&
@@ -1737,11 +1737,11 @@ module Google
         #   system or a StringIO instance.
         def gzip_decompress local_file
           if local_file.respond_to? :path
-            gz = ::File.open(Pathname(local_file).to_path, "rb") do |f|
-              Zlib::GzipReader.new(StringIO.new(f.read))
+            gz = ::File.open Pathname(local_file).to_path, "rb" do |f|
+              Zlib::GzipReader.new StringIO.new(f.read)
             end
             uncompressed_string = gz.read
-            ::File.open(Pathname(local_file).to_path, "w") do |f|
+            ::File.open Pathname(local_file).to_path, "w" do |f|
               f.write uncompressed_string
               f
             end

--- a/google-cloud-storage/lib/google/cloud/storage/file/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/list.rb
@@ -142,7 +142,7 @@ module Google
           def all request_limit: nil
             request_limit = request_limit.to_i if request_limit
             unless block_given?
-              return enum_for(:all, request_limit: request_limit)
+              return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer.rb
@@ -93,7 +93,7 @@ module Google
             raise SignedUrlUnavailable unless i && s
 
             policy_str = p.to_json
-            policy = Base64.strict_encode64(policy_str).delete("\n")
+            policy = Base64.strict_encode64(policy_str).delete "\n"
 
             signature = generate_signature s, policy
 
@@ -121,7 +121,7 @@ module Google
               signing_key = OpenSSL::PKey::RSA.new signing_key
             end
             signature = signing_key.sign OpenSSL::Digest::SHA256.new, secret
-            Base64.strict_encode64(signature).delete("\n")
+            Base64.strict_encode64(signature).delete "\n"
           end
 
           def generate_signed_url issuer, signed_string, expires, query

--- a/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
@@ -51,7 +51,7 @@ module Google
 
           def self.md5_for local_file
             if local_file.respond_to? :path
-              ::File.open(Pathname(local_file).to_path, "rb") do |f|
+              ::File.open Pathname(local_file).to_path, "rb" do |f|
                 ::Digest::MD5.file(f).base64digest
               end
             else # StringIO
@@ -64,7 +64,7 @@ module Google
 
           def self.crc32c_for local_file
             if local_file.respond_to? :path
-              ::File.open(Pathname(local_file).to_path, "rb") do |f|
+              ::File.open Pathname(local_file).to_path, "rb" do |f|
                 ::Digest::CRC32c.file(f).base64digest
               end
             else # StringIO

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -358,7 +358,7 @@ module Google
             name: bucket_name,
             location: location
           }.delete_if { |_, v| v.nil? })
-          storage_class = storage_class_for(storage_class)
+          storage_class = storage_class_for storage_class
           updater = Bucket::Updater.new(new_bucket).tap do |b|
             b.logging_bucket = logging_bucket unless logging_bucket.nil?
             b.logging_prefix = logging_prefix unless logging_prefix.nil?


### PR DESCRIPTION
This PR currently applies this change only to google-cloud-logging. If the style is acceptable, please approve and I will apply to all manual gems, then request a full review.


Enable Style/MethodCallWithArgsParentheses omit_parentheses

[closes #2716]