### PR TITLE
Make use of Credentials#project_id

### DIFF
--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "google-api-client", "~> 0.23"
-  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.8.0"
+  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -66,18 +66,21 @@ module Google
       #
       def self.new project_id: nil, credentials: nil, scope: nil, retries: nil,
                    timeout: nil, project: nil, keyfile: nil
-        project_id ||= (project || default_project_id)
-        project_id = project_id.to_s # Always cast to a string
-        raise ArgumentError, "project_id is missing" if project_id.empty?
-
-        scope ||= configure.scope
-        retries ||= configure.retries
-        timeout ||= configure.timeout
-
+        project_id  ||= (project || default_project_id)
+        scope       ||= configure.scope
+        retries     ||= configure.retries
+        timeout     ||= configure.timeout
         credentials ||= (keyfile || default_credentials(scope: scope))
+
         unless credentials.is_a? Google::Auth::Credentials
           credentials = Bigquery::Credentials.new credentials, scope: scope
         end
+
+        if credentials.respond_to? :project_id
+          project_id ||= credentials.project_id
+        end
+        project_id = project_id.to_s # Always cast to a string
+        raise ArgumentError, "project_id is missing" if project_id.empty?
 
         Bigquery::Project.new(
           Bigquery::Service.new(

--- a/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
@@ -209,6 +209,38 @@ describe Google::Cloud do
         end
       end
     end
+
+    it "gets project_id from credentials" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        OpenStruct.new project_id: "project-id"
+      }
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+        project.must_equal "project-id"
+        credentials.must_be_kind_of OpenStruct
+        credentials.project_id.must_equal "project-id"
+        retries.must_be :nil?
+        timeout.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
+                bigquery = Google::Cloud::Bigquery.new credentials: "path/to/keyfile.json"
+                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
+                bigquery.project.must_equal "project-id"
+                bigquery.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
   describe "Bigquery.configure" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
@@ -224,17 +224,20 @@ describe Google::Cloud do
         timeout.must_be :nil?
         OpenStruct.new project: project
       }
+      empty_env = OpenStruct.new
 
       # Clear all environment variables
       ENV.stub :[], nil do
-        File.stub :file?, true, ["path/to/keyfile.json"] do
-          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
-            Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
-              Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
-                bigquery = Google::Cloud::Bigquery.new credentials: "path/to/keyfile.json"
-                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
-                bigquery.project.must_equal "project-id"
-                bigquery.service.must_be_kind_of OpenStruct
+        Google::Cloud.stub :env, empty_env do
+          File.stub :file?, true, ["path/to/keyfile.json"] do
+            File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+              Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
+                Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
+                  bigquery = Google::Cloud::Bigquery.new credentials: "path/to/keyfile.json"
+                  bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
+                  bigquery.project.must_equal "project-id"
+                  bigquery.service.must_be_kind_of OpenStruct
+                end
               end
             end
           end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable.rb
@@ -75,14 +75,16 @@ module Google
           scope: nil,
           client_config: nil,
           timeout: nil
-        project_id = (project_id || default_project_id).to_s
-        raise ArgumentError, "project_id is required" if project_id.empty?
-
-        scope ||= configure.scope
-        timeout ||= configure.timeout
+        project_id    ||= default_project_id
+        scope         ||= configure.scope
+        timeout       ||= configure.timeout
         client_config ||= configure.client_config
         emulator_host ||= configure.emulator_host
+
         if emulator_host
+          project_id = project_id.to_s # Always cast to a string
+          raise ArgumentError, "project_id is missing" if project_id.empty?
+
           return Bigtable::Project.new(
             Bigtable::Service.new(
               project_id, :this_channel_is_insecure,
@@ -96,6 +98,12 @@ module Google
         unless credentials.is_a? Google::Auth::Credentials
           credentials = Bigtable::Credentials.new credentials, scope: scope
         end
+
+        if credentials.respond_to? :project_id
+          project_id ||= credentials.project_id
+        end
+        project_id = project_id.to_s # Always cast to a string
+        raise ArgumentError, "project_id is missing" if project_id.empty?
 
         service = Bigtable::Service.new(
           project_id,

--- a/google-cloud-bigtable/test/google/cloud/bigtable_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable_test.rb
@@ -268,17 +268,20 @@ describe Google::Cloud do
         client_config.must_be :nil?
         OpenStruct.new project_id: project_id
       }
+      empty_env = OpenStruct.new
 
       # Clear all environment variables
       ENV.stub :[], nil do
-        File.stub :file?, true, ["path/to/keyfile.json"] do
-          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
-            Google::Cloud::Bigtable::Credentials.stub :new, stubbed_credentials do
-              Google::Cloud::Bigtable::Service.stub :new, stubbed_service do
-                bigtable = Google::Cloud::Bigtable.new credentials: "path/to/keyfile.json"
-                bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-                bigtable.project_id.must_equal "project-id"
-                bigtable.service.must_be_kind_of OpenStruct
+        Google::Cloud.stub :env, empty_env do
+          File.stub :file?, true, ["path/to/keyfile.json"] do
+            File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+              Google::Cloud::Bigtable::Credentials.stub :new, stubbed_credentials do
+                Google::Cloud::Bigtable::Service.stub :new, stubbed_service do
+                  bigtable = Google::Cloud::Bigtable.new credentials: "path/to/keyfile.json"
+                  bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
+                  bigtable.project_id.must_equal "project-id"
+                  bigtable.service.must_be_kind_of OpenStruct
+                end
               end
             end
           end

--- a/google-cloud-datastore/lib/google/cloud/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore.rb
@@ -46,6 +46,7 @@ module Google
     #   datastore.save task
     #
     module Datastore
+      # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/MethodLength
 
       ##
@@ -99,15 +100,16 @@ module Google
       def self.new project_id: nil, credentials: nil, scope: nil, timeout: nil,
                    client_config: nil, emulator_host: nil, project: nil,
                    keyfile: nil
-        project_id ||= (project || default_project_id)
-        project_id = project_id.to_s # Always cast to a string
-        raise ArgumentError, "project_id is missing" if project_id.empty?
-
-        scope ||= configure.scope
-        timeout ||= configure.timeout
+        project_id    ||= (project || default_project_id)
+        scope         ||= configure.scope
+        timeout       ||= configure.timeout
         client_config ||= configure.client_config
         emulator_host ||= configure.emulator_host
+
         if emulator_host
+          project_id = project_id.to_s # Always cast to a string
+          raise ArgumentError, "project_id is missing" if project_id.empty?
+
           return Datastore::Dataset.new(
             Datastore::Service.new(
               project_id, :this_channel_is_insecure,
@@ -122,6 +124,12 @@ module Google
           credentials = Datastore::Credentials.new credentials, scope: scope
         end
 
+        if credentials.respond_to? :project_id
+          project_id ||= credentials.project_id
+        end
+        project_id = project_id.to_s # Always cast to a string
+        raise ArgumentError, "project_id is missing" if project_id.empty?
+
         Datastore::Dataset.new(
           Datastore::Service.new(
             project_id, credentials,
@@ -130,6 +138,7 @@ module Google
         )
       end
 
+      # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/MethodLength
 
       ##

--- a/google-cloud-datastore/test/google/cloud/datastore_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore_test.rb
@@ -248,6 +248,38 @@ describe Google::Cloud do
         end
       end
     end
+
+    it "gets project_id from credentials" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        OpenStruct.new project_id: "project-id"
+      }
+      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_be_kind_of OpenStruct
+        credentials.project_id.must_equal "project-id"
+        timeout.must_be :nil?
+        client_config.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Datastore::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Datastore::Service.stub :new, stubbed_service do
+                datastore = Google::Cloud::Datastore.new credentials: "path/to/keyfile.json"
+                datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
+                datastore.project.must_equal "project-id"
+                datastore.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
   describe "Datastore.configure" do

--- a/google-cloud-datastore/test/google/cloud/datastore_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore_test.rb
@@ -263,17 +263,20 @@ describe Google::Cloud do
         client_config.must_be :nil?
         OpenStruct.new project: project
       }
+      empty_env = OpenStruct.new
 
       # Clear all environment variables
       ENV.stub :[], nil do
-        File.stub :file?, true, ["path/to/keyfile.json"] do
-          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
-            Google::Cloud::Datastore::Credentials.stub :new, stubbed_credentials do
-              Google::Cloud::Datastore::Service.stub :new, stubbed_service do
-                datastore = Google::Cloud::Datastore.new credentials: "path/to/keyfile.json"
-                datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-                datastore.project.must_equal "project-id"
-                datastore.service.must_be_kind_of OpenStruct
+        Google::Cloud.stub :env, empty_env do
+          File.stub :file?, true, ["path/to/keyfile.json"] do
+            File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+              Google::Cloud::Datastore::Credentials.stub :new, stubbed_credentials do
+                Google::Cloud::Datastore::Service.stub :new, stubbed_service do
+                  datastore = Google::Cloud::Datastore.new credentials: "path/to/keyfile.json"
+                  datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
+                  datastore.project.must_equal "project-id"
+                  datastore.service.must_be_kind_of OpenStruct
+                end
               end
             end
           end

--- a/google-cloud-debugger/lib/google/cloud/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb
@@ -85,29 +85,31 @@ module Google
       def self.new project_id: nil, credentials: nil, service_name: nil,
                    service_version: nil, scope: nil, timeout: nil,
                    client_config: nil, project: nil, keyfile: nil
-        project_id ||= (project || default_project_id)
-        project_id = project_id.to_s # Always cast to a string
-
-        service_name ||= default_service_name
-        service_name = service_name.to_s
-
+        project_id      ||= (project || default_project_id)
+        service_name    ||= default_service_name
         service_version ||= default_service_version
-        service_version = service_version.to_s
+        scope           ||= configure.scope
+        timeout         ||= configure.timeout
+        client_config   ||= configure.client_config
 
-        raise ArgumentError, "project_id is missing" if project_id.empty?
+        service_name = service_name.to_s
         raise ArgumentError, "service_name is missing" if service_name.empty?
+
+        service_version = service_version.to_s
         if service_version.nil?
           raise ArgumentError, "service_version is missing"
         end
-
-        scope ||= configure.scope
-        timeout ||= configure.timeout
-        client_config ||= configure.client_config
 
         credentials ||= (keyfile || default_credentials(scope: scope))
         unless credentials.is_a? Google::Auth::Credentials
           credentials = Debugger::Credentials.new credentials, scope: scope
         end
+
+        if credentials.respond_to? :project_id
+          project_id ||= credentials.project_id
+        end
+        project_id = project_id.to_s # Always cast to a string
+        raise ArgumentError, "project_id is missing" if project_id.empty?
 
         Debugger::Project.new(
           Debugger::Service.new(project_id, credentials,

--- a/google-cloud-debugger/test/google/cloud/debugger_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger_test.rb
@@ -272,16 +272,18 @@ describe Google::Cloud do
         client_config.must_be_nil
         OpenStruct.new project: project
       }
-
+      empty_env = OpenStruct.new
       ENV.stub :[], nil do
-        File.stub :file?, true, ["path/to/keyfile.json"] do
-          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
-            Google::Cloud::Debugger::Credentials.stub :new, stubbed_credentials do
-              Google::Cloud::Debugger::Service.stub :new, stubbed_service do
-                debugger = Google::Cloud::Debugger.new credentials: "path/to/keyfile.json"
-                debugger.must_be_kind_of Google::Cloud::Debugger::Project
-                debugger.project.must_equal "project-id"
-                debugger.service.must_be_kind_of OpenStruct
+        Google::Cloud.stub :env, empty_env do
+          File.stub :file?, true, ["path/to/keyfile.json"] do
+            File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+              Google::Cloud::Debugger::Credentials.stub :new, stubbed_credentials do
+                Google::Cloud::Debugger::Service.stub :new, stubbed_service do
+                  debugger = Google::Cloud::Debugger.new credentials: "path/to/keyfile.json"
+                  debugger.must_be_kind_of Google::Cloud::Debugger::Project
+                  debugger.project.must_equal "project-id"
+                  debugger.service.must_be_kind_of OpenStruct
+                end
               end
             end
           end

--- a/google-cloud-debugger/test/google/cloud/debugger_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger_test.rb
@@ -255,6 +255,39 @@ describe Google::Cloud do
         end
       end
     end
+
+    it "gets project_id from credentials" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be_nil
+        OpenStruct.new project_id: "project-id"
+      }
+      stubbed_service_name = "utest-service"
+      stubbed_service_version = "vUTest"
+      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_be_kind_of OpenStruct
+        credentials.project_id.must_equal "project-id"
+        timeout.must_be_nil
+        client_config.must_be_nil
+        OpenStruct.new project: project
+      }
+
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Debugger::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Debugger::Service.stub :new, stubbed_service do
+                debugger = Google::Cloud::Debugger.new credentials: "path/to/keyfile.json"
+                debugger.must_be_kind_of Google::Cloud::Debugger::Project
+                debugger.project.must_equal "project-id"
+                debugger.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
   describe "Debugger.configure" do

--- a/google-cloud-dns/google-cloud-dns.gemspec
+++ b/google-cloud-dns/google-cloud-dns.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "google-api-client", "~> 0.23"
-  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.8.0"
+  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
   gem.add_dependency "zonefile", "~> 1.04"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-dns/lib/google/cloud/dns.rb
+++ b/google-cloud-dns/lib/google/cloud/dns.rb
@@ -74,18 +74,21 @@ module Google
       #
       def self.new project_id: nil, credentials: nil, scope: nil, retries: nil,
                    timeout: nil, project: nil, keyfile: nil
-        project_id ||= (project || default_project_id)
-        project_id = project_id.to_s # Always cast to a string
-        raise ArgumentError, "project_id is missing" if project_id.empty?
-
-        scope ||= configure.scope
-        retries ||= configure.retries
-        timeout ||= configure.timeout
-
+        project_id  ||= (project || default_project_id)
+        scope       ||= configure.scope
+        retries     ||= configure.retries
+        timeout     ||= configure.timeout
         credentials ||= (keyfile || default_credentials(scope: scope))
+
         unless credentials.is_a? Google::Auth::Credentials
           credentials = Dns::Credentials.new credentials, scope: scope
         end
+
+        if credentials.respond_to? :project_id
+          project_id ||= credentials.project_id
+        end
+        project_id = project_id.to_s # Always cast to a string
+        raise ArgumentError, "project_id is missing" if project_id.empty?
 
         Dns::Project.new(
           Dns::Service.new(

--- a/google-cloud-dns/test/google/cloud/dns_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns_test.rb
@@ -224,17 +224,20 @@ describe Google::Cloud do
         timeout.must_be :nil?
         OpenStruct.new project: project
       }
+      empty_env = OpenStruct.new
 
       # Clear all environment variables
       ENV.stub :[], nil do
-        File.stub :file?, true, ["path/to/keyfile.json"] do
-          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
-            Google::Cloud::Dns::Credentials.stub :new, stubbed_credentials do
-              Google::Cloud::Dns::Service.stub :new, stubbed_service do
-                dns = Google::Cloud::Dns.new credentials: "path/to/keyfile.json"
-                dns.must_be_kind_of Google::Cloud::Dns::Project
-                dns.project.must_equal "project-id"
-                dns.service.must_be_kind_of OpenStruct
+        Google::Cloud.stub :env, empty_env do
+          File.stub :file?, true, ["path/to/keyfile.json"] do
+            File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+              Google::Cloud::Dns::Credentials.stub :new, stubbed_credentials do
+                Google::Cloud::Dns::Service.stub :new, stubbed_service do
+                  dns = Google::Cloud::Dns.new credentials: "path/to/keyfile.json"
+                  dns.must_be_kind_of Google::Cloud::Dns::Project
+                  dns.project.must_equal "project-id"
+                  dns.service.must_be_kind_of OpenStruct
+                end
               end
             end
           end

--- a/google-cloud-dns/test/google/cloud/dns_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns_test.rb
@@ -209,6 +209,38 @@ describe Google::Cloud do
         end
       end
     end
+
+    it "gets project_id from credentials" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        OpenStruct.new project_id: "project-id"
+      }
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+        project.must_equal "project-id"
+        credentials.must_be_kind_of OpenStruct
+        credentials.project_id.must_equal "project-id"
+        retries.must_be :nil?
+        timeout.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Dns::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Dns::Service.stub :new, stubbed_service do
+                dns = Google::Cloud::Dns.new credentials: "path/to/keyfile.json"
+                dns.must_be_kind_of Google::Cloud::Dns::Project
+                dns.project.must_equal "project-id"
+                dns.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
   describe "Dns.configure" do

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
@@ -76,19 +76,23 @@ module Google
       #
       def self.new project_id: nil, credentials: nil, scope: nil, timeout: nil,
                    client_config: nil, project: nil, keyfile: nil
-        project_id ||= (project || ErrorReporting::Project.default_project_id)
-        project_id = project_id.to_s
-        raise ArgumentError, "project_id is missing" if project_id.empty?
-
-        scope ||= configure.scope
-        timeout ||= configure.timeout
+        project_id    ||= project
+        project_id    ||= ErrorReporting::Project.default_project_id
+        scope         ||= configure.scope
+        timeout       ||= configure.timeout
         client_config ||= configure.client_config
+        credentials   ||= (keyfile || default_credentials(scope: scope))
 
-        credentials ||= (keyfile || default_credentials(scope: scope))
         unless credentials.is_a? Google::Auth::Credentials
           credentials = ErrorReporting::Credentials.new credentials,
                                                         scope: scope
         end
+
+        if credentials.respond_to? :project_id
+          project_id ||= credentials.project_id
+        end
+        project_id = project_id.to_s
+        raise ArgumentError, "project_id is missing" if project_id.empty?
 
         ErrorReporting::Project.new(
           ErrorReporting::Service.new(

--- a/google-cloud-firestore/lib/google/cloud/firestore.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore.rb
@@ -32,6 +32,9 @@ module Google
     # See {file:OVERVIEW.md Firestore Overview}.
     #
     module Firestore
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
+
       ##
       # Creates a new object for connecting to the Firestore service.
       # Each call creates a new connection.
@@ -71,14 +74,16 @@ module Google
       def self.new project_id: nil, credentials: nil, scope: nil, timeout: nil,
                    client_config: nil, emulator_host: nil, project: nil,
                    keyfile: nil
-        project_id = (project_id || project || default_project_id).to_s
-        raise ArgumentError, "project_id is missing" if project_id.empty?
-
-        scope ||= configure.scope
-        timeout ||= configure.timeout
+        project_id    ||= (project || default_project_id)
+        scope         ||= configure.scope
+        timeout       ||= configure.timeout
         client_config ||= configure.client_config
         emulator_host ||= configure.emulator_host
+
         if emulator_host
+          project_id = project_id.to_s
+          raise ArgumentError, "project_id is missing" if project_id.empty?
+
           return Firestore::Client.new(
             Firestore::Service.new(
               project_id, :this_channel_is_insecure,
@@ -93,6 +98,12 @@ module Google
           credentials = Firestore::Credentials.new credentials, scope: scope
         end
 
+        if credentials.respond_to? :project_id
+          project_id ||= credentials.project_id
+        end
+        project_id = project_id.to_s
+        raise ArgumentError, "project_id is missing" if project_id.empty?
+
         Firestore::Client.new(
           Firestore::Service.new(
             project_id, credentials, timeout:       timeout,
@@ -100,6 +111,9 @@ module Google
           )
         )
       end
+
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
 
       ##
       # Configure the Google Cloud Firestore library.

--- a/google-cloud-firestore/test/google/cloud/firestore_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore_test.rb
@@ -263,18 +263,21 @@ describe Google::Cloud do
         client_config.must_be :nil?
         OpenStruct.new project: project
       }
+      empty_env = OpenStruct.new
 
       # Clear all environment variables
       ENV.stub :[], nil do
-        File.stub :file?, true, ["path/to/keyfile.json"] do
-          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
-            Google::Cloud::Firestore::Credentials.stub :new, stubbed_credentials do
-              Google::Cloud::Firestore::Service.stub :new, stubbed_service do
-                firestore = Google::Cloud::Firestore.new credentials: "path/to/keyfile.json"
-                firestore.must_be_kind_of Google::Cloud::Firestore::Client
-                firestore.project_id.must_equal "project-id"
-                firestore.database_id.must_equal "(default)"
-                firestore.service.must_be_kind_of OpenStruct
+        Google::Cloud.stub :env, empty_env do
+          File.stub :file?, true, ["path/to/keyfile.json"] do
+            File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+              Google::Cloud::Firestore::Credentials.stub :new, stubbed_credentials do
+                Google::Cloud::Firestore::Service.stub :new, stubbed_service do
+                  firestore = Google::Cloud::Firestore.new credentials: "path/to/keyfile.json"
+                  firestore.must_be_kind_of Google::Cloud::Firestore::Client
+                  firestore.project_id.must_equal "project-id"
+                  firestore.database_id.must_equal "(default)"
+                  firestore.service.must_be_kind_of OpenStruct
+                end
               end
             end
           end

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -83,18 +83,21 @@ module Google
       #
       def self.new project_id: nil, credentials: nil, scope: nil, timeout: nil,
                    client_config: nil, project: nil, keyfile: nil
-        project_id ||= (project || default_project_id)
-        project_id = project_id.to_s # Always cast to a string
-        raise ArgumentError, "project_id is missing" if project_id.empty?
-
-        scope ||= configure.scope
-        timeout ||= configure.timeout
+        project_id    ||= (project || default_project_id)
+        scope         ||= configure.scope
+        timeout       ||= configure.timeout
         client_config ||= configure.client_config
+        credentials   ||= (keyfile || default_credentials(scope: scope))
 
-        credentials ||= (keyfile || default_credentials(scope: scope))
         unless credentials.is_a? Google::Auth::Credentials
           credentials = Logging::Credentials.new credentials, scope: scope
         end
+
+        if credentials.respond_to? :project_id
+          project_id ||= credentials.project_id
+        end
+        project_id = project_id.to_s # Always cast to a string
+        raise ArgumentError, "project_id is missing" if project_id.empty?
 
         Logging::Project.new(
           Logging::Service.new(

--- a/google-cloud-logging/test/google/cloud/logging_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging_test.rb
@@ -223,17 +223,20 @@ describe Google::Cloud do
         client_config.must_be_nil
         OpenStruct.new project: project
       }
+      empty_env = OpenStruct.new
 
       # Clear all environment variables
       ENV.stub :[], nil do
-        File.stub :file?, true, ["path/to/keyfile.json"] do
-          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
-            Google::Cloud::Logging::Credentials.stub :new, stubbed_credentials do
-              Google::Cloud::Logging::Service.stub :new, stubbed_service do
-                logging = Google::Cloud::Logging.new credentials: "path/to/keyfile.json"
-                logging.must_be_kind_of Google::Cloud::Logging::Project
-                logging.project.must_equal "project-id"
-                logging.service.must_be_kind_of OpenStruct
+        Google::Cloud.stub :env, empty_env do
+          File.stub :file?, true, ["path/to/keyfile.json"] do
+            File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+              Google::Cloud::Logging::Credentials.stub :new, stubbed_credentials do
+                Google::Cloud::Logging::Service.stub :new, stubbed_service do
+                  logging = Google::Cloud::Logging.new credentials: "path/to/keyfile.json"
+                  logging.must_be_kind_of Google::Cloud::Logging::Project
+                  logging.project.must_equal "project-id"
+                  logging.service.must_be_kind_of OpenStruct
+                end
               end
             end
           end

--- a/google-cloud-logging/test/google/cloud/logging_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging_test.rb
@@ -208,6 +208,38 @@ describe Google::Cloud do
         end
       end
     end
+
+    it "gets project_id from credentials" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be_nil
+        OpenStruct.new project_id: "project-id"
+      }
+      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_be_kind_of OpenStruct
+        credentials.project_id.must_equal "project-id"
+        timeout.must_be_nil
+        client_config.must_be_nil
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Logging::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Logging::Service.stub :new, stubbed_service do
+                logging = Google::Cloud::Logging.new credentials: "path/to/keyfile.json"
+                logging.must_be_kind_of Google::Cloud::Logging::Project
+                logging.project.must_equal "project-id"
+                logging.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
   describe "Logging.configure" do

--- a/google-cloud-pubsub/lib/google/cloud/pubsub.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub.rb
@@ -33,6 +33,8 @@ module Google
     # See {file:OVERVIEW.md Google Cloud Pub/Sub Overview}.
     #
     module Pubsub
+      # rubocop:disable Metrics/AbcSize
+
       ##
       # Creates a new object for connecting to the Pub/Sub service.
       # Each call creates a new connection.
@@ -76,15 +78,16 @@ module Google
       def self.new project_id: nil, credentials: nil, scope: nil, timeout: nil,
                    client_config: nil, emulator_host: nil, project: nil,
                    keyfile: nil
-        project_id ||= (project || default_project_id)
-        project_id = project_id.to_s # Always cast to a string
-        raise ArgumentError, "project_id is missing" if project_id.empty?
-
-        scope ||= configure.scope
-        timeout ||= configure.timeout
+        project_id    ||= (project || default_project_id)
+        scope         ||= configure.scope
+        timeout       ||= configure.timeout
         client_config ||= configure.client_config
         emulator_host ||= configure.emulator_host
+
         if emulator_host
+          project_id = project_id.to_s # Always cast to a string
+          raise ArgumentError, "project_id is missing" if project_id.empty?
+
           return Pubsub::Project.new(
             Pubsub::Service.new(
               project_id, :this_channel_is_insecure,
@@ -99,6 +102,12 @@ module Google
           credentials = Pubsub::Credentials.new credentials, scope: scope
         end
 
+        if credentials.respond_to? :project_id
+          project_id ||= credentials.project_id
+        end
+        project_id = project_id.to_s # Always cast to a string
+        raise ArgumentError, "project_id is missing" if project_id.empty?
+
         Pubsub::Project.new(
           Pubsub::Service.new(
             project_id, credentials, timeout:       timeout,
@@ -106,6 +115,8 @@ module Google
           )
         )
       end
+
+      # rubocop:enable Metrics/AbcSize
 
       ##
       # Configure the Google Cloud Pubsub library.

--- a/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
@@ -248,6 +248,38 @@ describe Google::Cloud do
         end
       end
     end
+
+    it "gets project_id from credentials" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        OpenStruct.new project_id: "project-id"
+      }
+      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_be_kind_of OpenStruct
+        credentials.project_id.must_equal "project-id"
+        timeout.must_be :nil?
+        client_config.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Pubsub::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Pubsub::Service.stub :new, stubbed_service do
+                pubsub = Google::Cloud::Pubsub.new credentials: "path/to/keyfile.json"
+                pubsub.must_be_kind_of Google::Cloud::Pubsub::Project
+                pubsub.project.must_equal "project-id"
+                pubsub.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
   describe "Pubsub.configure" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
@@ -263,17 +263,20 @@ describe Google::Cloud do
         client_config.must_be :nil?
         OpenStruct.new project: project
       }
+      empty_env = OpenStruct.new
 
       # Clear all environment variables
       ENV.stub :[], nil do
-        File.stub :file?, true, ["path/to/keyfile.json"] do
-          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
-            Google::Cloud::Pubsub::Credentials.stub :new, stubbed_credentials do
-              Google::Cloud::Pubsub::Service.stub :new, stubbed_service do
-                pubsub = Google::Cloud::Pubsub.new credentials: "path/to/keyfile.json"
-                pubsub.must_be_kind_of Google::Cloud::Pubsub::Project
-                pubsub.project.must_equal "project-id"
-                pubsub.service.must_be_kind_of OpenStruct
+        Google::Cloud.stub :env, empty_env do
+          File.stub :file?, true, ["path/to/keyfile.json"] do
+            File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+              Google::Cloud::Pubsub::Credentials.stub :new, stubbed_credentials do
+                Google::Cloud::Pubsub::Service.stub :new, stubbed_service do
+                  pubsub = Google::Cloud::Pubsub.new credentials: "path/to/keyfile.json"
+                  pubsub.must_be_kind_of Google::Cloud::Pubsub::Project
+                  pubsub.project.must_equal "project-id"
+                  pubsub.service.must_be_kind_of OpenStruct
+                end
               end
             end
           end

--- a/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
+++ b/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "google-api-client", "~> 0.23"
-  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.8.0"
+  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-spanner/lib/google/cloud/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner.rb
@@ -72,17 +72,21 @@ module Google
       #
       def self.new project_id: nil, credentials: nil, scope: nil, timeout: nil,
                    client_config: nil, project: nil, keyfile: nil
-        project_id ||= (project || default_project_id)
-        project_id = project_id.to_s # Always cast to a string
-        raise ArgumentError, "project_id is missing" if project_id.empty?
-
-        scope ||= configure.scope
-        timeout ||= configure.timeout
+        project_id    ||= (project || default_project_id)
+        scope         ||= configure.scope
+        timeout       ||= configure.timeout
         client_config ||= configure.client_config
-        credentials ||= (keyfile || default_credentials(scope: scope))
+        credentials   ||= (keyfile || default_credentials(scope: scope))
+
         unless credentials.is_a? Google::Auth::Credentials
           credentials = Spanner::Credentials.new credentials, scope: scope
         end
+
+        if credentials.respond_to? :project_id
+          project_id ||= credentials.project_id
+        end
+        project_id = project_id.to_s # Always cast to a string
+        raise ArgumentError, "project_id is missing" if project_id.empty?
 
         Spanner::Project.new(
           Spanner::Service.new(

--- a/google-cloud-spanner/test/google/cloud/spanner_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner_test.rb
@@ -208,6 +208,38 @@ describe Google::Cloud do
         end
       end
     end
+
+    it "gets project_id from credentials" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        OpenStruct.new project_id: "project-id"
+      }
+      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_be_kind_of OpenStruct
+        credentials.project_id.must_equal "project-id"
+        timeout.must_be :nil?
+        client_config.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Spanner::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Spanner::Service.stub :new, stubbed_service do
+                spanner = Google::Cloud::Spanner.new credentials: "path/to/keyfile.json"
+                spanner.must_be_kind_of Google::Cloud::Spanner::Project
+                spanner.project.must_equal "project-id"
+                spanner.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
   describe "Spanner.configure" do

--- a/google-cloud-spanner/test/google/cloud/spanner_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner_test.rb
@@ -223,17 +223,20 @@ describe Google::Cloud do
         client_config.must_be :nil?
         OpenStruct.new project: project
       }
+      empty_env = OpenStruct.new
 
       # Clear all environment variables
       ENV.stub :[], nil do
-        File.stub :file?, true, ["path/to/keyfile.json"] do
-          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
-            Google::Cloud::Spanner::Credentials.stub :new, stubbed_credentials do
-              Google::Cloud::Spanner::Service.stub :new, stubbed_service do
-                spanner = Google::Cloud::Spanner.new credentials: "path/to/keyfile.json"
-                spanner.must_be_kind_of Google::Cloud::Spanner::Project
-                spanner.project.must_equal "project-id"
-                spanner.service.must_be_kind_of OpenStruct
+        Google::Cloud.stub :env, empty_env do
+          File.stub :file?, true, ["path/to/keyfile.json"] do
+            File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+              Google::Cloud::Spanner::Credentials.stub :new, stubbed_credentials do
+                Google::Cloud::Spanner::Service.stub :new, stubbed_service do
+                  spanner = Google::Cloud::Spanner.new credentials: "path/to/keyfile.json"
+                  spanner.must_be_kind_of Google::Cloud::Spanner::Project
+                  spanner.project.must_equal "project-id"
+                  spanner.service.must_be_kind_of OpenStruct
+                end
               end
             end
           end

--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "google-api-client", "~> 0.23"
-  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.8.0"
+  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
   gem.add_dependency "digest-crc", "~> 0.4"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-storage/lib/google/cloud/storage.rb
+++ b/google-cloud-storage/lib/google/cloud/storage.rb
@@ -75,17 +75,21 @@ module Google
       #
       def self.new project_id: nil, credentials: nil, scope: nil, retries: nil,
                    timeout: nil, project: nil, keyfile: nil
-        project_id ||= (project || default_project_id)
-        project_id = project_id.to_s # Always cast to a string
-        raise ArgumentError, "project_id is missing" if project_id.empty?
-
-        scope ||= configure.scope
-        retries ||= configure.retries
-        timeout ||= configure.timeout
+        project_id  ||= (project || default_project_id)
+        scope       ||= configure.scope
+        retries     ||= configure.retries
+        timeout     ||= configure.timeout
         credentials ||= (keyfile || default_credentials(scope: scope))
+
         unless credentials.is_a? Google::Auth::Credentials
           credentials = Storage::Credentials.new credentials, scope: scope
         end
+
+        if credentials.respond_to? :project_id
+          project_id ||= credentials.project_id
+        end
+        project_id = project_id.to_s # Always cast to a string
+        raise ArgumentError, "project_id is missing" if project_id.empty?
 
         Storage::Project.new(
           Storage::Service.new(

--- a/google-cloud-storage/test/google/cloud/storage_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage_test.rb
@@ -209,6 +209,38 @@ describe Google::Cloud do
         end
       end
     end
+
+    it "gets project_id from credentials" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        OpenStruct.new project_id: "project-id"
+      }
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+        project.must_equal "project-id"
+        credentials.must_be_kind_of OpenStruct
+        credentials.project_id.must_equal "project-id"
+        retries.must_be :nil?
+        timeout.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Storage::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Storage::Service.stub :new, stubbed_service do
+                storage = Google::Cloud::Storage.new credentials: "path/to/keyfile.json"
+                storage.must_be_kind_of Google::Cloud::Storage::Project
+                storage.project.must_equal "project-id"
+                storage.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
   describe "Storage.configure" do

--- a/google-cloud-storage/test/google/cloud/storage_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage_test.rb
@@ -224,17 +224,20 @@ describe Google::Cloud do
         timeout.must_be :nil?
         OpenStruct.new project: project
       }
+      empty_env = OpenStruct.new
 
       # Clear all environment variables
       ENV.stub :[], nil do
-        File.stub :file?, true, ["path/to/keyfile.json"] do
-          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
-            Google::Cloud::Storage::Credentials.stub :new, stubbed_credentials do
-              Google::Cloud::Storage::Service.stub :new, stubbed_service do
-                storage = Google::Cloud::Storage.new credentials: "path/to/keyfile.json"
-                storage.must_be_kind_of Google::Cloud::Storage::Project
-                storage.project.must_equal "project-id"
-                storage.service.must_be_kind_of OpenStruct
+        Google::Cloud.stub :env, empty_env do
+          File.stub :file?, true, ["path/to/keyfile.json"] do
+            File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+              Google::Cloud::Storage::Credentials.stub :new, stubbed_credentials do
+                Google::Cloud::Storage::Service.stub :new, stubbed_service do
+                  storage = Google::Cloud::Storage.new credentials: "path/to/keyfile.json"
+                  storage.must_be_kind_of Google::Cloud::Storage::Project
+                  storage.project.must_equal "project-id"
+                  storage.service.must_be_kind_of OpenStruct
+                end
               end
             end
           end

--- a/google-cloud-trace/lib/google/cloud/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace.rb
@@ -86,18 +86,21 @@ module Google
       #
       def self.new project_id: nil, credentials: nil, scope: nil, timeout: nil,
                    client_config: nil, project: nil, keyfile: nil
-        project_id ||= (project || default_project_id)
-        project_id = project_id.to_s # Always cast to a string
-        raise ArgumentError, "project_id is missing" if project_id.empty?
-
-        scope ||= configure.scope
-        timeout ||= configure.timeout
+        project_id    ||= (project || default_project_id)
+        scope         ||= configure.scope
+        timeout       ||= configure.timeout
         client_config ||= configure.client_config
+        credentials   ||= (keyfile || default_credentials(scope: scope))
 
-        credentials ||= (keyfile || default_credentials(scope: scope))
         unless credentials.is_a? Google::Auth::Credentials
           credentials = Trace::Credentials.new credentials, scope: scope
         end
+
+        if credentials.respond_to? :project_id
+          project_id ||= credentials.project_id
+        end
+        project_id = project_id.to_s # Always cast to a string
+        raise ArgumentError, "project_id is missing" if project_id.empty?
 
         Trace::Project.new(
           Trace::Service.new(

--- a/google-cloud-translate/google-cloud-translate.gemspec
+++ b/google-cloud-translate/google-cloud-translate.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "faraday", "~> 0.13"
-  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.8.0"
+  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-translate/lib/google/cloud/translate.rb
+++ b/google-cloud-translate/lib/google/cloud/translate.rb
@@ -39,6 +39,8 @@ module Google
     # See {file:OVERVIEW.md Translation Overview}.
     #
     module Translate
+      # rubocop:disable Metrics/AbcSize
+
       ##
       # Creates a new object for connecting to Cloud Translation API. Each call
       # creates a new connection.
@@ -108,26 +110,30 @@ module Google
       def self.new project_id: nil, credentials: nil, key: nil, scope: nil,
                    retries: nil, timeout: nil, project: nil, keyfile: nil
         project_id ||= (project || default_project_id)
-        project_id = project_id.to_s # Always cast to a string
+        key        ||= configure.key
 
-        key ||= configure.key
         if key
           return Google::Cloud::Translate::Api.new(
             Google::Cloud::Translate::Service.new(
-              project_id, nil, retries: retries, timeout: timeout, key: key
+              project_id.to_s, nil, retries: retries, timeout: timeout, key: key
             )
           )
         end
 
-        raise ArgumentError, "project_id is missing" if project_id.empty?
-
-        scope ||= configure.scope
-        retries ||= configure.retries
-        timeout ||= configure.timeout
+        scope       ||= configure.scope
+        retries     ||= configure.retries
+        timeout     ||= configure.timeout
         credentials ||= keyfile || default_credentials(scope: scope)
+
         unless credentials.is_a? Google::Auth::Credentials
           credentials = Translate::Credentials.new credentials, scope: scope
         end
+
+        if credentials.respond_to? :project_id
+          project_id ||= credentials.project_id
+        end
+        project_id = project_id.to_s # Always cast to a string
+        raise ArgumentError, "project_id is missing" if project_id.empty?
 
         Translate::Api.new(
           Translate::Service.new(
@@ -135,6 +141,8 @@ module Google
           )
         )
       end
+
+      # rubocop:enable Metrics/AbcSize
 
       ##
       # Configure the Google Cloud Translate library.

--- a/google-cloud-translate/test/google/cloud/translate_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate_test.rb
@@ -379,17 +379,20 @@ describe Google::Cloud do
         timeout.must_be :nil?
         OpenStruct.new project: project
       }
+      empty_env = OpenStruct.new
 
       # Clear all environment variables
       ENV.stub :[], nil do
-        File.stub :file?, true, ["path/to/keyfile.json"] do
-          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
-            Google::Cloud::Translate::Credentials.stub :new, stubbed_credentials do
-              Google::Cloud::Translate::Service.stub :new, stubbed_service do
-                translate = Google::Cloud::Translate.new credentials: "path/to/keyfile.json"
-                translate.must_be_kind_of Google::Cloud::Translate::Api
-                translate.project_id.must_equal "project-id"
-                translate.service.must_be_kind_of OpenStruct
+        Google::Cloud.stub :env, empty_env do
+          File.stub :file?, true, ["path/to/keyfile.json"] do
+            File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+              Google::Cloud::Translate::Credentials.stub :new, stubbed_credentials do
+                Google::Cloud::Translate::Service.stub :new, stubbed_service do
+                  translate = Google::Cloud::Translate.new credentials: "path/to/keyfile.json"
+                  translate.must_be_kind_of Google::Cloud::Translate::Api
+                  translate.project_id.must_equal "project-id"
+                  translate.service.must_be_kind_of OpenStruct
+                end
               end
             end
           end


### PR DESCRIPTION
If a `project_id` value is not provided, use the value on the Credentials object. This value was added in googleauth 0.7.0.

Loosen the dependency on googleauth to allow for future releases up until 0.10.0. The googleauth developers have committed to not changing the public API before that version.

[closes #2537]