### PR TITLE
Convert Debugger Transmitter to concurrent-ruby

### DIFF
--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-logging", "~> 1.0"
   gem.add_dependency "google-gax", "~> 1.0"
   gem.add_dependency "stackdriver-core", "~> 1.3"
+  gem.add_dependency "concurrent-ruby", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-debugger/lib/google-cloud-debugger.rb
+++ b/google-cloud-debugger/lib/google-cloud-debugger.rb
@@ -178,4 +178,5 @@ Google::Cloud.configure.add_config! :debugger do |config|
   config.add_field! :client_config, nil, match: Hash
   config.add_field! :allow_mutating_methods, false
   config.add_field! :evaluation_time_limit, 0.05, match: Numeric
+  config.add_field! :on_error, nil, match: Proc
 end

--- a/google-cloud-debugger/lib/google/cloud/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb
@@ -147,6 +147,9 @@ module Google
       #   state. Defaults to false.
       # * `evaluation_time_limit` - (Numeric) Time limit in seconds for
       #   expression evaluation. Defaults to 0.05.
+      # * `on_error` - (Proc) A Proc to be run when an error is encountered
+      #   on a background thread. The Proc must take the error object as the
+      #   single argument.
       #
       # See the [Configuration
       # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint.rb
@@ -347,7 +347,7 @@ module Google
             is_final_state: is_final_state,
             create_time: timestamp_to_grpc(create_time),
             final_time: timestamp_to_grpc(final_time),
-            user_email: user_email,
+            user_email: user_email.to_s,
             stack_frames: stack_frames_to_grpc,
             evaluated_expressions: evaluated_expressions_to_grpc,
             status: status_to_grpc,

--- a/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
@@ -88,9 +88,10 @@ module Google
         end
 
         ##
-        # Enqueue an evaluated breakpoints to be submitted by the transmitter.
-        # This will raise if there are no resources available to make the API
-        # call.
+        # Enqueue an evaluated breakpoint to be submitted by the transmitter.
+        #
+        # @raise [TransmitterError] if there are no resources available to make
+        #   queue the API call on the thread pool.
         def submit breakpoint
           Concurrent::Promises.future_on(@thread_pool, breakpoint) do |bp|
             submit_sync bp

--- a/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
@@ -84,7 +84,7 @@ module Google
           @error_callbacks = []
 
           # Make sure all queued calls are completed when process exits.
-          # at_exit { stop }
+          at_exit { stop }
         end
 
         ##

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint_manager_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint_manager_test.rb
@@ -81,7 +81,7 @@ describe Google::Cloud::Debugger::BreakpointManager, :mock_debugger do
       breakpoint_manager.service.stub :list_active_breakpoints, mocked_response do
         Google::Cloud::Debugger::Breakpoint.stub :from_grpc, breakpoint1 do
           app_root = "my/app/path"
-          breakpoint_manager.agent.app_root =app_root
+          breakpoint_manager.agent.app_root = app_root
           breakpoint_manager.sync_active_breakpoints(nil).must_equal true
 
           breakpoint1.full_path.must_match app_root


### PR DESCRIPTION
This PR changes Debugger's Transmitter to use a threar pool instead of AsyncActor.

[refs #2084]