### PR TITLE
Pub/Sub: Remove delay alias

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -160,7 +160,6 @@ module Google
           ensure_subscription!
           subscription.modify_ack_deadline new_deadline, ack_id
         end
-        alias delay! modify_ack_deadline!
 
         ##
         # Resets the acknowledge deadline for the message without acknowledging
@@ -188,7 +187,7 @@ module Google
         #   subscriber.stop.wait!
         #
         def reject!
-          delay! 0
+          modify_ack_deadline! 0
         end
         alias nack! reject!
         alias ignore! reject!

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -419,9 +419,9 @@ module Google
         #     * `:callback` (Integer) The number of threads used to handle the
         #       received messages. Default is 8.
         #     * `:push` (Integer) The number of threads to handle
-        #       acknowledgement ({ReceivedMessage#ack!}) and delay messages
-        #       ({ReceivedMessage#nack!}, {ReceivedMessage#delay!}). Default is
-        #       4.
+        #       acknowledgement ({ReceivedMessage#ack!}) and modify ack deadline
+        #       messages ({ReceivedMessage#nack!},
+        #       {ReceivedMessage#modify_ack_deadline!}). Default is 4.
         #
         # @yield [received_message] a block for processing new messages
         # @yieldparam [ReceivedMessage] received_message the newly received
@@ -511,7 +511,7 @@ module Google
         # make the messages available for redelivery if the processing was
         # interrupted.
         #
-        # See also {ReceivedMessage#delay!}.
+        # See also {ReceivedMessage#modify_ack_deadline!}.
         #
         # @param [Integer] new_deadline The new ack deadline in seconds from the
         #   time this request is sent to the Pub/Sub system. Must be >= 0. For
@@ -536,7 +536,6 @@ module Google
           service.modify_ack_deadline name, ack_ids, new_deadline
           true
         end
-        alias delay modify_ack_deadline
 
         ##
         # Creates a new {Snapshot} from the subscription. The created snapshot

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -227,16 +227,6 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Pubsub::ReceivedMessage#delay!" do
-    mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_subscriber.expect :get_subscription, subscription_resp, ["projects/my-project/subscriptions/my-topic-sub", Hash]
-      mock_subscriber.expect :streaming_pull, [OpenStruct.new(received_messages: [Google::Pubsub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)])].to_enum, [Enumerator, Hash]
-      mock_subscriber.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
-      mock_subscriber.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
-      mock_subscriber.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
-      mock_subscriber.expect :modify_ack_deadline, nil, ["projects/my-project/subscriptions/my-sub", ["2"], 120, Hash]
-    end
-  end
   doctest.before "Google::Cloud::Pubsub::ReceivedMessage#modify_ack_deadline!" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp, ["projects/my-project/subscriptions/my-topic-sub", Hash]
@@ -323,13 +313,6 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Pubsub::Subscription#delay" do
-    mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub"), ["projects/my-project/subscriptions/my-topic-sub", Hash]
-      mock_subscriber.expect :pull, OpenStruct.new(received_messages: [Google::Pubsub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]), ["projects/my-project/subscriptions/my-topic-sub", 100, Hash]
-      mock_subscriber.expect :modify_ack_deadline, nil, ["projects/my-project/subscriptions/my-topic-sub", ["2"], 120, Hash]
-    end
-  end
   doctest.before "Google::Cloud::Pubsub::Subscription#modify_ack_deadline" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub"), ["projects/my-project/subscriptions/my-topic-sub", Hash]

--- a/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
@@ -91,14 +91,14 @@ describe Google::Cloud::Pubsub::ReceivedMessage, :mock_pubsub do
     mock.verify
   end
 
-  it "can delay" do
+  it "can modify_ack_deadline" do
     new_deadline = 42
     mad_res = nil
     mock = Minitest::Mock.new
     mock.expect :modify_ack_deadline, mad_res, [subscription_path(subscription_name), [rec_message.ack_id], new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
 
-    rec_message.delay! new_deadline
+    rec_message.modify_ack_deadline! new_deadline
 
     mock.verify
   end


### PR DESCRIPTION
* Remove the `modify_ack_deadline` alias `delay`.
* Users should use the `modify_ack_deadline` and `modify_ack_deadline!` methods directly instead.

[fixes #2785]