### PR TITLE
Release google-cloud-vision 0.58.0

### DIFF
--- a/google-cloud-vision/CHANGELOG.md
+++ b/google-cloud-vision/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.58.0 / 2019-01-15
+
+- sort methods prior to generating helper methods (#2776)
+- Re-generated google-cloud-vision (no significant changes)
+- Upgrade Rubocop to 0.61 (#2743)
+
 ### 0.32.2 / 2018-12-14
 
 * Add image_context as optional parameter to ImageAnnotatorClient.*_detection helpers

--- a/google-cloud-vision/google-cloud-vision.gemspec
+++ b/google-cloud-vision/google-cloud-vision.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-vision"
-  gem.version       = "0.32.2"
+  gem.version       = 0.58.0
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
- sort methods prior to generating helper methods (#2776)
- Re-generated google-cloud-vision (no significant changes)
- Upgrade Rubocop to 0.61 (#2743)

This pull request was generated using releasetool.