### PR TITLE
Remove auto-load of minitest-reporters

### DIFF
--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -6,5 +6,5 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 
-gem "minitest-reporters", "~> 1.3.5"
+gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake", "~> 12.3"

--- a/google-cloud-bigtable/Gemfile
+++ b/google-cloud-bigtable/Gemfile
@@ -5,5 +5,5 @@ gemspec
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "minitest-reporters", "~> 1.3.5"
+gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake", "~> 12.3"

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -8,5 +8,5 @@ gem "google-cloud-error_reporting", path: "../google-cloud-error_reporting"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "minitest-reporters", "~> 1.3.5"
+gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake", "~> 12.3"

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -5,5 +5,5 @@ gemspec
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "minitest-reporters", "~> 1.3.5"
+gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake", "~> 12.3"

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -6,5 +6,5 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-pubsub", path: "../google-cloud-pubsub"
 
-gem "minitest-reporters", "~> 1.3.5"
+gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake", "~> 12.3"


### PR DESCRIPTION
This will allow `CTRL+T` to work as expected. Bundler's auto-loading was activating the reporters lib and stepping on Minitest's default handling of `CTRL+T`.