### PR TITLE
Add default insert_id value for Entry

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry.rb
@@ -19,6 +19,7 @@ require "google/cloud/logging/entry/http_request"
 require "google/cloud/logging/entry/operation"
 require "google/cloud/logging/entry/source_location"
 require "google/cloud/logging/entry/list"
+require "securerandom"
 
 module Google
   module Cloud
@@ -82,6 +83,7 @@ module Google
           @operation = Operation.new
           @severity = :DEFAULT
           @source_location = SourceLocation.new
+          @insert_id = SecureRandom.uuid
         end
 
         ##
@@ -395,7 +397,6 @@ module Google
         def empty?
           log_name.nil? &&
             timestamp.nil? &&
-            insert_id.nil? &&
             (labels.nil? || labels.empty?) &&
             payload.nil? &&
             resource.empty? &&

--- a/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
@@ -32,6 +32,7 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
   def entries payload, labels = labels1
     Array(payload).map { |str|
       logging.entry(
+        insert_id: "insert_#{str}_id",
         log_name: log_name,
         resource: resource,
         severity: :INFO,
@@ -45,6 +46,7 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
     full_log_name = "projects/test/logs/#{log_name}"
     entries = Array(payload).map do |str|
       Google::Logging::V2::LogEntry.new(
+        insert_id: "insert_#{str}_id",
         text_payload: str,
         severity: :INFO,
         resource: resource.to_grpc,

--- a/google-cloud-logging/test/google/cloud/logging/entry/to_grpc_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/to_grpc_test.rb
@@ -15,10 +15,17 @@
 require "helper"
 
 describe Google::Cloud::Logging::Entry, :to_grpc, :mock_logging do
-  let(:entry) { Google::Cloud::Logging::Entry.new }
+  let(:default_insert_id) { "abc-123" }
+  let :entry do
+    SecureRandom.stub :uuid, default_insert_id do
+      Google::Cloud::Logging::Entry.new
+    end
+  end
 
   it "returns the correct data when empty" do
     entry.must_be :empty?
+    # empty even though insert_id has a value
+    entry.insert_id.must_equal default_insert_id
 
     grpc = entry.to_grpc
 
@@ -26,7 +33,7 @@ describe Google::Cloud::Logging::Entry, :to_grpc, :mock_logging do
     grpc.resource.must_be :nil?
     grpc.severity.must_equal :DEFAULT
     grpc.timestamp.must_be :nil?
-    grpc.insert_id.must_be :empty?
+    grpc.insert_id.must_equal default_insert_id
     Google::Cloud::Logging::Convert.map_to_hash(grpc.labels).must_be :empty?
     grpc.text_payload.must_be :empty?
     grpc.json_payload.must_be :nil?

--- a/google-cloud-logging/test/google/cloud/logging/logger/add_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/add_test.rb
@@ -25,6 +25,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     end
   end
   let(:labels) { { "env" => "production" } }
+  let(:insert_id) { "abc-123" }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:severity) { :DEBUG }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
@@ -34,10 +35,19 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
                                                      nanos: timestamp.nsec
 
-    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+    entries = [Google::Logging::V2::LogEntry.new(insert_id: insert_id,
+                                                 text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
     [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, partial_success: nil, options: default_options]
+  end
+
+  def apply_stubs
+    Time.stub :now, timestamp do
+      SecureRandom.stub :uuid, insert_id do
+        yield
+      end
+    end
   end
 
   before do
@@ -52,25 +62,25 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
 
   describe :debug do
     it "creates a log entry using :debug" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add :debug, "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using 'debug'" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add "debug", "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using Logger::DEBUG" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add ::Logger::DEBUG, "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using :debug with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add :debug do
           "Danger Will Robinson!"
         end
@@ -78,7 +88,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     end
 
     it "creates a log entry using 'debug' with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add "debug" do
           "Danger Will Robinson!"
         end
@@ -86,7 +96,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     end
 
     it "creates a log entry using Logger::DEBUG with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add ::Logger::DEBUG do
           "Danger Will Robinson!"
         end
@@ -98,25 +108,25 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     let(:severity) { :INFO }
 
     it "creates a log entry using :info" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add :info, "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using 'info'" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add "info", "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using Logger::INFO" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add ::Logger::INFO, "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using :info with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add :info do
           "Danger Will Robinson!"
         end
@@ -124,7 +134,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     end
 
     it "creates a log entry using 'info' with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add "info" do
           "Danger Will Robinson!"
         end
@@ -132,7 +142,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     end
 
     it "creates a log entry using Logger::INFO with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add ::Logger::INFO do
           "Danger Will Robinson!"
         end
@@ -144,25 +154,25 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     let(:severity) { :WARNING }
 
     it "creates a log entry using :warn" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add :warn, "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using 'warn'" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add "warn", "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using Logger::WARN" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add ::Logger::WARN, "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using :warn with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add :warn do
           "Danger Will Robinson!"
         end
@@ -170,7 +180,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     end
 
     it "creates a log entry using 'warn' with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add "warn" do
           "Danger Will Robinson!"
         end
@@ -178,7 +188,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     end
 
     it "creates a log entry using Logger::WARN with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add ::Logger::WARN do
           "Danger Will Robinson!"
         end
@@ -190,25 +200,25 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     let(:severity) { :ERROR }
 
     it "creates a log entry using :error" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add :error, "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using 'error'" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add "error", "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using Logger::ERROR" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add ::Logger::ERROR, "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using :error with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add :error do
           "Danger Will Robinson!"
         end
@@ -216,7 +226,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     end
 
     it "creates a log entry using 'error' with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add "error" do
           "Danger Will Robinson!"
         end
@@ -224,7 +234,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     end
 
     it "creates a log entry using Logger::ERROR with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add ::Logger::ERROR do
           "Danger Will Robinson!"
         end
@@ -236,25 +246,25 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     let(:severity) { :CRITICAL }
 
     it "creates a log entry using :fatal" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add :fatal, "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using 'fatal'" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add "fatal", "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using Logger::FATAL" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add ::Logger::FATAL, "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using :fatal with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add :fatal do
           "Danger Will Robinson!"
         end
@@ -262,7 +272,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     end
 
     it "creates a log entry using 'fatal' with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add "fatal" do
           "Danger Will Robinson!"
         end
@@ -270,7 +280,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     end
 
     it "creates a log entry using Logger::FATAL with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add ::Logger::FATAL do
           "Danger Will Robinson!"
         end
@@ -282,25 +292,25 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     let(:severity) { :DEFAULT }
 
     it "creates a log entry using :unknown" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add :unknown, "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using 'unknown'" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add "unknown", "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using Logger::UNKNOWN" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add ::Logger::UNKNOWN, "Danger Will Robinson!"
       end
     end
 
     it "creates a log entry using :unknown with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add :unknown do
           "Danger Will Robinson!"
         end
@@ -308,7 +318,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     end
 
     it "creates a log entry using 'unknown' with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add "unknown" do
           "Danger Will Robinson!"
         end
@@ -316,7 +326,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     end
 
     it "creates a log entry using Logger::UNKNOWN with a block" do
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.add ::Logger::UNKNOWN do
           "Danger Will Robinson!"
         end

--- a/google-cloud-logging/test/google/cloud/logging/logger/debug_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/debug_test.rb
@@ -25,6 +25,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     end
   end
   let(:labels) { { "env" => "production" } }
+  let(:insert_id) { "abc-123" }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
   let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
@@ -32,10 +33,19 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
   def write_req_args severity
     timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
                                                      nanos: timestamp.nsec
-    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+    entries = [Google::Logging::V2::LogEntry.new(insert_id: insert_id,
+                                                 text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
     [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, partial_success: nil, options: default_options]
+  end
+
+  def apply_stubs
+    Time.stub :now, timestamp do
+      SecureRandom.stub :uuid, insert_id do
+        yield
+      end
+    end
   end
 
   before do
@@ -55,7 +65,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEBUG)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.debug "Danger Will Robinson!"
 
       mock.verify
@@ -67,7 +77,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.info "Danger Will Robinson!"
 
       mock.verify
@@ -79,7 +89,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.warn "Danger Will Robinson!"
 
       mock.verify
@@ -91,7 +101,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.error "Danger Will Robinson!"
 
       mock.verify
@@ -103,7 +113,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.fatal "Danger Will Robinson!"
 
       mock.verify
@@ -115,7 +125,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.unknown "Danger Will Robinson!"
 
       mock.verify
@@ -127,7 +137,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEBUG)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.debug { "Danger Will Robinson!" }
 
       mock.verify
@@ -139,7 +149,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.info { "Danger Will Robinson!" }
 
       mock.verify
@@ -151,7 +161,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.warn { "Danger Will Robinson!" }
 
       mock.verify
@@ -163,7 +173,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.error { "Danger Will Robinson!" }
 
       mock.verify
@@ -175,7 +185,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.fatal { "Danger Will Robinson!" }
 
       mock.verify
@@ -187,7 +197,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.unknown { "Danger Will Robinson!" }
 
       mock.verify

--- a/google-cloud-logging/test/google/cloud/logging/logger/error_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/error_test.rb
@@ -25,6 +25,7 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
     end
   end
   let(:labels) { { "env" => "production" } }
+  let(:insert_id) { "abc-123" }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
   let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
@@ -32,10 +33,19 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
   def write_req_args severity
     timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
                                                      nanos: timestamp.nsec
-    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+    entries = [Google::Logging::V2::LogEntry.new(insert_id: insert_id,
+                                                 text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
     [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, partial_success: nil, options: default_options]
+  end
+
+  def apply_stubs
+    Time.stub :now, timestamp do
+      SecureRandom.stub :uuid, insert_id do
+        yield
+      end
+    end
   end
 
   before do
@@ -67,7 +77,7 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.error "Danger Will Robinson!"
 
       mock.verify
@@ -79,7 +89,7 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.fatal "Danger Will Robinson!"
 
       mock.verify
@@ -91,7 +101,7 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.unknown "Danger Will Robinson!"
 
       mock.verify
@@ -115,7 +125,7 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.error { "Danger Will Robinson!" }
 
       mock.verify
@@ -127,7 +137,7 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.fatal { "Danger Will Robinson!" }
 
       mock.verify
@@ -139,7 +149,7 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.unknown { "Danger Will Robinson!" }
 
       mock.verify

--- a/google-cloud-logging/test/google/cloud/logging/logger/fatal_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/fatal_test.rb
@@ -25,6 +25,7 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
     end
   end
   let(:labels) { { "env" => "production" } }
+  let(:insert_id) { "abc-123" }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
   let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
@@ -32,10 +33,19 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
   def write_req_args severity
     timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
                                                      nanos: timestamp.nsec
-    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+    entries = [Google::Logging::V2::LogEntry.new(insert_id: insert_id,
+                                                 text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
     [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, partial_success: nil, options: default_options]
+  end
+
+  def apply_stubs
+    Time.stub :now, timestamp do
+      SecureRandom.stub :uuid, insert_id do
+        yield
+      end
+    end
   end
 
   before do
@@ -71,7 +81,7 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.fatal "Danger Will Robinson!"
 
       mock.verify
@@ -83,7 +93,7 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.unknown "Danger Will Robinson!"
 
       mock.verify
@@ -111,7 +121,7 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.fatal { "Danger Will Robinson!" }
 
       mock.verify
@@ -123,7 +133,7 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.unknown { "Danger Will Robinson!" }
 
       mock.verify

--- a/google-cloud-logging/test/google/cloud/logging/logger/info_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/info_test.rb
@@ -25,6 +25,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     end
   end
   let(:labels) { { "env" => "production" } }
+  let(:insert_id) { "abc-123" }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
   let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
@@ -32,10 +33,19 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
   def write_req_args severity
     timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
                                                      nanos: timestamp.nsec
-    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+    entries = [Google::Logging::V2::LogEntry.new(insert_id: insert_id,
+                                                 text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
     [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, partial_success: nil, options: default_options]
+  end
+
+  def apply_stubs
+    Time.stub :now, timestamp do
+      SecureRandom.stub :uuid, insert_id do
+        yield
+      end
+    end
   end
 
   before do
@@ -59,7 +69,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.info "Danger Will Robinson!"
 
       mock.verify
@@ -71,7 +81,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.warn "Danger Will Robinson!"
 
       mock.verify
@@ -83,7 +93,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.error "Danger Will Robinson!"
 
       mock.verify
@@ -95,7 +105,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.fatal "Danger Will Robinson!"
 
       mock.verify
@@ -107,7 +117,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.unknown "Danger Will Robinson!"
 
       mock.verify
@@ -123,7 +133,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.info { "Danger Will Robinson!" }
 
       mock.verify
@@ -135,7 +145,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.warn { "Danger Will Robinson!" }
 
       mock.verify
@@ -147,7 +157,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.error { "Danger Will Robinson!" }
 
       mock.verify
@@ -159,7 +169,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.fatal { "Danger Will Robinson!" }
 
       mock.verify
@@ -171,7 +181,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.unknown { "Danger Will Robinson!" }
 
       mock.verify

--- a/google-cloud-logging/test/google/cloud/logging/logger/unknown_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/unknown_test.rb
@@ -25,6 +25,7 @@ describe Google::Cloud::Logging::Logger, :unknown, :mock_logging do
     end
   end
   let(:labels) { { "env" => "production" } }
+  let(:insert_id) { "abc-123" }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
   let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
@@ -32,10 +33,19 @@ describe Google::Cloud::Logging::Logger, :unknown, :mock_logging do
   def write_req_args severity
     timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
                                                      nanos: timestamp.nsec
-    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+    entries = [Google::Logging::V2::LogEntry.new(insert_id: insert_id,
+                                                 text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
     [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, partial_success: nil, options: default_options]
+  end
+
+  def apply_stubs
+    Time.stub :now, timestamp do
+      SecureRandom.stub :uuid, insert_id do
+        yield
+      end
+    end
   end
 
   before do
@@ -75,7 +85,7 @@ describe Google::Cloud::Logging::Logger, :unknown, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.unknown "Danger Will Robinson!"
 
       mock.verify
@@ -107,7 +117,7 @@ describe Google::Cloud::Logging::Logger, :unknown, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.unknown { "Danger Will Robinson!" }
 
       mock.verify

--- a/google-cloud-logging/test/google/cloud/logging/logger/warn_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/warn_test.rb
@@ -25,6 +25,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     end
   end
   let(:labels) { { "env" => "production" } }
+  let(:insert_id) { "abc-123" }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
   let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
@@ -32,10 +33,19 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
   def write_req_args severity
     timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
                                                      nanos: timestamp.nsec
-    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+    entries = [Google::Logging::V2::LogEntry.new(insert_id: insert_id,
+                                                 text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
     [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, partial_success: nil, options: default_options]
+  end
+
+  def apply_stubs
+    Time.stub :now, timestamp do
+      SecureRandom.stub :uuid, insert_id do
+        yield
+      end
+    end
   end
 
   before do
@@ -63,7 +73,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.warn "Danger Will Robinson!"
 
       mock.verify
@@ -75,7 +85,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.error "Danger Will Robinson!"
 
       mock.verify
@@ -87,7 +97,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.fatal "Danger Will Robinson!"
 
       mock.verify
@@ -99,7 +109,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.unknown "Danger Will Robinson!"
 
       mock.verify
@@ -119,7 +129,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.warn { "Danger Will Robinson!" }
 
       mock.verify
@@ -131,7 +141,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.error { "Danger Will Robinson!" }
 
       mock.verify
@@ -143,7 +153,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.fatal { "Danger Will Robinson!" }
 
       mock.verify
@@ -155,7 +165,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.unknown { "Danger Will Robinson!" }
 
       mock.verify

--- a/google-cloud-logging/test/google/cloud/logging/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger_test.rb
@@ -25,6 +25,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     end
   end
   let(:labels) { { "env" => "production" } }
+  let(:insert_id) { "abc-123" }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
   let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
@@ -33,7 +34,8 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
                      trace: nil, trace_sampled: nil
     timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
                                                      nanos: timestamp.nsec
-    entry = Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+    entry = Google::Logging::V2::LogEntry.new(insert_id: insert_id,
+                                              text_payload: "Danger Will Robinson!",
                                               severity: severity,
                                               timestamp: timestamp_grpc)
     entry.trace = trace if trace
@@ -48,6 +50,14 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     ]
   end
 
+  def apply_stubs
+    Time.stub :now, timestamp do
+      SecureRandom.stub :uuid, insert_id do
+        yield
+      end
+    end
+  end
+
   it "@labels instance variable is default to empty hash if not given" do
     logger = Google::Cloud::Logging::Logger.new logging, log_name, resource
     logger.labels.must_be_kind_of Hash
@@ -59,7 +69,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEBUG)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.debug "Danger Will Robinson!"
 
       mock.verify
@@ -71,7 +81,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.info "Danger Will Robinson!"
 
       mock.verify
@@ -83,7 +93,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.warn "Danger Will Robinson!"
 
       mock.verify
@@ -95,7 +105,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.error "Danger Will Robinson!"
 
       mock.verify
@@ -107,7 +117,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.fatal "Danger Will Robinson!"
 
       mock.verify
@@ -119,7 +129,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.unknown "Danger Will Robinson!"
 
       mock.verify
@@ -131,7 +141,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger << "Danger Will Robinson!"
 
       mock.verify
@@ -143,14 +153,14 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     logging.service.mocked_logging = mock
 
     # No mock expectation
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.close
       logger.error "Danger Will Robinson!"
       mock.verify
     end
 
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
-    Time.stub :now, timestamp do
+    apply_stubs do
       logger.reopen
       logger.error "Danger Will Robinson!"
       mock.verify
@@ -181,7 +191,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
       info = Google::Cloud::Logging::Logger::RequestInfo.new trace_id, log_name, nil, true
       logger.add_request_info info: info
 
-      Time.stub :now, timestamp do
+      apply_stubs do
         Google::Cloud.env.stub :app_engine?, false do
           logger.error "Danger Will Robinson!"
           mock.verify
@@ -209,7 +219,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
         logger.add_request_info env: env
 
-        Time.stub :now, timestamp do
+        apply_stubs do
           Google::Cloud.env.stub :app_engine?, false do
             logger.error "Danger Will Robinson!"
             mock.verify
@@ -237,7 +247,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
         logger.add_request_info env: env
 
-        Time.stub :now, timestamp do
+        apply_stubs do
           Google::Cloud.env.stub :app_engine?, false do
             logger.error "Danger Will Robinson!"
             mock.verify
@@ -260,7 +270,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
       info = Google::Cloud::Logging::Logger::RequestInfo.new trace_id, log_name
       logger.add_request_info info: info
 
-      Time.stub :now, timestamp do
+      apply_stubs do
         Google::Cloud.env.stub :app_engine?, true do
           logger.error "Danger Will Robinson!"
           mock.verify
@@ -300,7 +310,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
       logging.service.mocked_logging = mock
 
       logger.progname = "my_app_log"
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.error "Danger Will Robinson!"
         mock.verify
       end
@@ -322,7 +332,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
       # No expectation
       logging.service.mocked_logging = mock
 
-      Time.stub :now, timestamp do
+      apply_stubs do
         logger.debug "Danger Will Robinson!"
         mock.verify
       end

--- a/google-cloud-logging/test/google/cloud/logging/project_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project_test.rb
@@ -21,7 +21,10 @@ describe Google::Cloud::Logging::Project, :mock_logging do
   end
 
   it "creates an empty entry" do
-    entry = logging.entry
+    entry = nil
+    SecureRandom.stub :uuid, "abc-123" do
+      entry = logging.entry
+    end
     entry.must_be_kind_of Google::Cloud::Logging::Entry
     entry.resource.must_be_kind_of Google::Cloud::Logging::Resource
 
@@ -30,7 +33,7 @@ describe Google::Cloud::Logging::Project, :mock_logging do
     entry.resource.must_be :empty?
     entry.timestamp.must_be :nil?
     entry.severity.must_equal :DEFAULT
-    entry.insert_id.must_be :nil?
+    entry.insert_id.must_equal "abc-123"
     entry.labels.must_be :empty?
     entry.payload.must_be :nil?
   end


### PR DESCRIPTION
An Entry object is assigned an insert_id when created so that if the
Entry object gets persisted multiple times it would know its insert_id
value and not attempt to generate a new one for each persist attempt.
An Entry object will still be considered empty if the only value it has
is the insert_id.

[closes #2797]