### PR TITLE
Add list_collections alias

### DIFF
--- a/google-cloud-firestore/lib/google/cloud/firestore/client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/client.rb
@@ -108,6 +108,7 @@ module Google
           collection_ids.each { |collection_id| yield col(collection_id) }
         end
         alias collections cols
+        alias list_collections cols
 
         ##
         # Retrieves a collection.

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
@@ -97,6 +97,7 @@ module Google
           collection_ids.each { |collection_id| yield col(collection_id) }
         end
         alias collections cols
+        alias list_collections cols
 
         ##
         # Retrieves a collection nested under the document snapshot.

--- a/google-cloud-firestore/support/doctest_helper.rb
+++ b/google-cloud-firestore/support/doctest_helper.rb
@@ -131,6 +131,7 @@ YARD::Doctest.configure do |doctest|
   end
   # Skip aliased methods
   doctest.skip "Google::Cloud::Firestore::Client#collections"
+  doctest.skip "Google::Cloud::Firestore::Client#list_collections"
 
   doctest.before "Google::Cloud::Firestore::Client#docs" do
     mock_firestore do |mock|
@@ -320,6 +321,7 @@ YARD::Doctest.configure do |doctest|
   end
   # Skip aliased methods
   doctest.skip "Google::Cloud::Firestore::DocumentReference#collections"
+  doctest.skip "Google::Cloud::Firestore::DocumentReference#list_collections"
 
   doctest.before "Google::Cloud::Firestore::DocumentReference#get" do
     mock_firestore do |mock|


### PR DESCRIPTION
The Firestore design document recently renamed `getCollections` to `listCollections`. In Ruby, we have named this method `cols`, and were aliased as `collections`. This PR adds the additional alias `list_collections` for symmetry with the other language implementations.