### PR TITLE
Fix big query code sample in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ bigquery = Google::Cloud::Bigquery.new
 dataset = bigquery.create_dataset "my_dataset"
 
 table = dataset.create_table "my_table" do |t|
-  t.name = "My Table",
+  t.name = "My Table"
   t.description = "A description of my table."
   t.schema do |s|
     s.string "first_name", mode: :required

--- a/google-cloud-bigquery/README.md
+++ b/google-cloud-bigquery/README.md
@@ -27,7 +27,7 @@ bigquery = Google::Cloud::Bigquery.new
 dataset = bigquery.create_dataset "my_dataset"
 
 table = dataset.create_table "my_table" do |t|
-  t.name = "My Table",
+  t.name = "My Table"
   t.description = "A description of my table."
   t.schema do |s|
     s.string "first_name", mode: :required

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -480,7 +480,7 @@ module Google
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   table = dataset.create_table "my_table" do |t|
-        #     t.name = "My Table",
+        #     t.name = "My Table"
         #     t.description = "A description of my table."
         #     t.schema do |s|
         #       s.string "first_name", mode: :required

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -2590,7 +2590,7 @@ module Google
           #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |t|
-          #     t.name = "My Table",
+          #     t.name = "My Table"
           #     t.description = "A description of my table."
           #     t.schema do |s|
           #       s.string "first_name", mode: :required
@@ -2607,7 +2607,7 @@ module Google
           #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |t|
-          #     t.name = "My Table",
+          #     t.name = "My Table"
           #     t.description = "A description of my table."
           #     t.schema do |s|
           #       s.load File.open("schema.json")


### PR DESCRIPTION
The big query example code in the readme has an unnecessary comma which causes the code to fail. This change removes the comma.