### PR TITLE
Release google-cloud-speech 0.32.1

### DIFF
--- a/google-cloud-speech/CHANGELOG.md
+++ b/google-cloud-speech/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+### 0.32.1 / 2019-01-22
+
+- Re-generate google-cloud-speech files (#2819)
+- Re-generate google-cloud-speech files
+- Re-generated google-cloud-speech (no significant changes)
+- Upgrade Rubocop to 0.61 (#2743)
+- Update .rubocop.yml in all gems (#2721)
+- Update google-cloud-speech generated files (#2654)
+- Update google-cloud-speech generated files (#2630)
+
 ### 0.32.0 / 2018-11-15
 
 * Add StreamingRecognitionResult#result_end_time value.

--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-speech"
-  gem.version       = "0.32.0"
+  gem.version       = "0.32.1"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
- Re-generate google-cloud-speech files (#2819)
- Re-generate google-cloud-speech files
- Re-generated google-cloud-speech (no significant changes)
- Upgrade Rubocop to 0.61 (#2743)
- Update .rubocop.yml in all gems (#2721)
- Update google-cloud-speech generated files (#2654)
- Update google-cloud-speech generated files (#2630)

This pull request was generated using releasetool.