### PR TITLE
Add field_mask argument to get_all method

### DIFF
--- a/google-cloud-firestore/acceptance/firestore/firestore_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/firestore_test.rb
@@ -56,4 +56,17 @@ describe "Firestore", :firestore_acceptance do
     docs = firestore.get_all doc1, doc2
     docs.to_a.count.must_equal 2
   end
+
+  it "has get_all method with field_mask argument" do
+    get_all_col = firestore.col "#{root_path}/get_all/#{SecureRandom.hex(4)}"
+
+    doc1 = get_all_col.doc "doc1"
+    doc2 = get_all_col.doc "doc2"
+
+    doc1.create foo: :a
+    doc2.create foo: :b
+
+    docs = firestore.get_all doc1, doc2, field_mask: :foo
+    docs.to_a.count.must_equal 2
+  end
 end

--- a/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
@@ -84,6 +84,17 @@ module Google
         # @param [String, DocumentReference, Array<String|DocumentReference>]
         #   docs One or more strings representing the path of the document, or
         #   document reference objects.
+        # @param [Array<String|FieldPath>] field_mask One or more field path
+        #   values, representing the fields of the document to be returned. If a
+        #   document has a field that is not present in this mask, that field
+        #   will not be returned in the response. All fields are returned when
+        #   the mask is not set.
+        #
+        #   A field path can either be a {FieldPath} object, or a dotted string
+        #   representing the nested fields. In other words the string represents
+        #   individual fields joined by ".". Fields containing `~`, `*`, `/`,
+        #   `[`, `]`, and `.` cannot be in a dotted string, and should provided
+        #   using a {FieldPath} object instead. See {Client#field_path}.)
         #
         # @yield [documents] The block for accessing the document snapshots.
         # @yieldparam [DocumentSnapshot] document A document snapshot.
@@ -102,18 +113,41 @@ module Google
         #     end
         #   end
         #
-        def get_all *docs
+        # @example Get docs using a field mask:
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #
+        #   firestore.transaction do |tx|
+        #     # Get and print city documents
+        #     cities = ["cities/NYC", "cities/SF", "cities/LA"]
+        #     tx.get_all(*cities, field_mask: :population).each do |city|
+        #       puts "#{city.document_id} has #{city[:population]} residents."
+        #     end
+        #   end
+        #
+        def get_all *docs, field_mask: nil
           ensure_not_closed!
           ensure_service!
 
-          return enum_for(:get_all, docs) unless block_given?
+          unless block_given?
+            return enum_for(:get_all, docs, field_mask: field_mask)
+          end
 
           doc_paths = Array(docs).flatten.map do |doc_path|
             coalesce_doc_path_argument doc_path
           end
+          mask = Array(field_mask).map do |field_path|
+            if field_path.is_a? FieldPath
+              field_path.formatted_string
+            else
+              FieldPath.parse(field_path).formatted_string
+            end
+          end
+          mask = nil if mask.empty?
 
           results = service.get_documents \
-            doc_paths, transaction: transaction_or_create
+            doc_paths, mask: mask, transaction: transaction_or_create
           results.each do |result|
             extract_transaction_from_result! result
             next if result.result.nil?

--- a/google-cloud-firestore/test/google/cloud/firestore/client/get_all_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/client/get_all_test.rb
@@ -125,6 +125,90 @@ describe Google::Cloud::Firestore::Client, :get_all, :mock_firestore do
     docs.first.read_at.must_equal read_time
   end
 
+  describe :field_mask do
+    let(:field_mask) { Google::Firestore::V1beta1::DocumentMask.new(field_paths: ["name"]) }
+
+    it "gets multiple docs using splat (string)" do
+      firestore_mock.expect :batch_get_documents, batch_docs_enum, [database_path, full_doc_paths, mask: field_mask, options: default_options]
+
+      docs_enum = firestore.get_all "users/mike", "users/tad", "users/chris", field_mask: [:name]
+
+      assert_docs_enum docs_enum
+    end
+
+    it "gets multiple docs using array (string)" do
+      firestore_mock.expect :batch_get_documents, batch_docs_enum, [database_path, full_doc_paths, mask: field_mask, options: default_options]
+
+      docs_enum = firestore.get_all ["users/mike", "users/tad", "users/chris"], field_mask: :name
+
+      assert_docs_enum docs_enum
+    end
+
+    it "gets multiple docs using splat (doc ref)" do
+      firestore_mock.expect :batch_get_documents, batch_docs_enum, [database_path, full_doc_paths, mask: field_mask, options: default_options]
+
+      docs_enum = firestore.get_all firestore.doc("users/mike"), firestore.doc("users/tad"), firestore.doc("users/chris"), field_mask: ["name"]
+
+      assert_docs_enum docs_enum
+    end
+
+    it "gets multiple docs using array (doc ref)" do
+      firestore_mock.expect :batch_get_documents, batch_docs_enum, [database_path, full_doc_paths, mask: field_mask, options: default_options]
+
+      docs_enum = firestore.get_all [firestore.doc("users/mike"), firestore.doc("users/tad"), firestore.doc("users/chris")], field_mask: "name"
+
+      assert_docs_enum docs_enum
+    end
+
+    it "gets a single doc (string)" do
+      firestore_mock.expect :batch_get_documents, [batch_docs_enum.to_a.first].to_enum, [database_path, [full_doc_paths.first], mask: field_mask, options: default_options]
+
+      docs_enum = firestore.get_all "users/mike", field_mask: firestore.field_path(:name)
+
+      docs_enum.must_be_kind_of Enumerator
+
+      docs = docs_enum.to_a
+      docs.count.must_equal 1
+
+      docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+
+      docs.first.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      docs.first.parent.collection_id.must_equal "users"
+      docs.first.parent.collection_path.must_equal "users"
+      docs.first.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+
+      docs.first.data.must_be_kind_of Hash
+      docs.first.data.must_equal({ name: "Mike" })
+      docs.first.created_at.must_equal read_time
+      docs.first.updated_at.must_equal read_time
+      docs.first.read_at.must_equal read_time
+    end
+
+    it "gets a single doc (doc ref)" do
+      firestore_mock.expect :batch_get_documents, [batch_docs_enum.to_a.first].to_enum, [database_path, [full_doc_paths.first], mask: field_mask, options: default_options]
+
+      docs_enum = firestore.get_all firestore.doc("users/mike"), field_mask: [firestore.field_path(:name)]
+
+      docs_enum.must_be_kind_of Enumerator
+
+      docs = docs_enum.to_a
+      docs.count.must_equal 1
+
+      docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+
+      docs.first.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      docs.first.parent.collection_id.must_equal "users"
+      docs.first.parent.collection_path.must_equal "users"
+      docs.first.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+
+      docs.first.data.must_be_kind_of Hash
+      docs.first.data.must_equal({ name: "Mike" })
+      docs.first.created_at.must_equal read_time
+      docs.first.updated_at.must_equal read_time
+      docs.first.read_at.must_equal read_time
+    end
+  end
+
   def assert_docs_enum enum
     enum.must_be_kind_of Enumerator
 


### PR DESCRIPTION
Allows specific portions of the document data to be returned.

[closes #2794]