### PR TITLE
Release google-cloud-speech 0.33.0

### DIFF
--- a/google-cloud-speech/CHANGELOG.md
+++ b/google-cloud-speech/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+### 0.33.0 / 2019-01-24
+
+* Add the following attributes to the Google::Cloud::Speech::V1 namespace:
+  * RecognitionConfig#enable_separate_recognition_per_channel
+  * StreamingRecognitionResult#channel_tag
+  * SpeechRecognitionResult#channel_tag
+* Update documentation.
+
 ### 0.32.0 / 2018-11-15
 
 * Add StreamingRecognitionResult#result_end_time value.

--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-speech"
-  gem.version       = "0.32.0"
+  gem.version       = "0.33.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Add the following attributes to the Google::Cloud::Speech::V1 namespace:
  * RecognitionConfig#enable_separate_recognition_per_channel
  * StreamingRecognitionResult#channel_tag
  * SpeechRecognitionResult#channel_tag
* Update documentation.

This pull request was generated using releasetool.