### PR TITLE
Firestore Numeric Transforms

### DIFF
--- a/google-cloud-firestore/lib/google/cloud/firestore/client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/client.rb
@@ -352,6 +352,122 @@ module Google
           FieldValue.array_delete(*values)
         end
 
+        ##
+        # Creates a sentinel value to indicate the addition the given value to
+        # the field's current value.
+        #
+        # If the field's current value is not an integer or a double value
+        # (Integer or Numeric), or if the field does not yet exist, the
+        # transformation will set the field to the given value. If either of the
+        # given value or the current field value are doubles, both values will
+        # be interpreted as doubles. Double arithmetic and representation of
+        # double values follow IEEE 754 semantics. If there is positive/negative
+        # integer overflow, the field is resolved to the largest magnitude
+        # positive/negative integer.
+        #
+        # @param [Integer, Numeric] value The value to add to the given value.
+        #   Required.
+        #
+        # @return [FieldValue] The increment field value object.
+        #
+        # @raise [ArgumentError] if the value is not an Integer or Numeric.
+        #
+        # @example
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #
+        #   # Get a document reference
+        #   nyc_ref = firestore.doc "cities/NYC"
+        #
+        #   # Set the population to increment by 1.
+        #   increment_value = firestore.field_increment 1
+        #
+        #   nyc_ref.update({ name: "New York City",
+        #                    population: increment_value })
+        #
+        def field_increment value
+          FieldValue.increment value
+        end
+
+        ##
+        # Creates a sentinel value to indicate the setting the field to the
+        # maximum of its current value and the given value.
+        #
+        # If the field is not an integer or double (Integer or Numeric), or if
+        # the field does not yet exist, the transformation will set the field to
+        # the given value. If a maximum operation is applied where the field and
+        # the input value are of mixed types (that is - one is an integer and
+        # one is a double) the field takes on the type of the larger operand. If
+        # the operands are equivalent (e.g. 3 and 3.0), the field does not
+        # change. 0, 0.0, and -0.0 are all zero. The maximum of a zero stored
+        # value and zero input value is always the stored value. The maximum of
+        # any numeric value x and NaN is NaN.
+        #
+        # @param [Integer, Numeric] value The value to compare against the given
+        #   value to calculate the maximum value to set. Required.
+        #
+        # @return [FieldValue] The maximum field value object.
+        #
+        # @raise [ArgumentError] if the value is not an Integer or Numeric.
+        #
+        # @example
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #
+        #   # Get a document reference
+        #   nyc_ref = firestore.doc "cities/NYC"
+        #
+        #   # Set the population to be at maximum 4,000,000.
+        #   maximum_value = firestore.field_maximum 4000000
+        #
+        #   nyc_ref.update({ name: "New York City",
+        #                    population: maximum_value })
+        #
+        def field_maximum value
+          FieldValue.maximum value
+        end
+
+        ##
+        # Creates a sentinel value to indicate the setting the field to the
+        # minimum of its current value and the given value.
+        #
+        # If the field is not an integer or double (Integer or Numeric), or if
+        # the field does not yet exist, the transformation will set the field to
+        # the input value. If a minimum operation is applied where the field and
+        # the input value are of mixed types (that is - one is an integer and
+        # one is a double) the field takes on the type of the smaller operand.
+        # If the operands are equivalent (e.g. 3 and 3.0), the field does not
+        # change. 0, 0.0, and -0.0 are all zero. The minimum of a zero stored
+        # value and zero input value is always the stored value. The minimum of
+        # any numeric value x and NaN is NaN.
+        #
+        # @param [Integer, Numeric] value The value to compare against the given
+        #   value to calculate the minimum value to set. Required.
+        #
+        # @return [FieldValue] The minimum field value object.
+        #
+        # @raise [ArgumentError] if the value is not an Integer or Numeric.
+        #
+        # @example
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #
+        #   # Get a document reference
+        #   nyc_ref = firestore.doc "cities/NYC"
+        #
+        #   # Set the population to be at minimum 1,000,000.
+        #   minimum_value = firestore.field_minimum 1000000
+        #
+        #   nyc_ref.update({ name: "New York City",
+        #                    population: minimum_value })
+        #
+        def field_minimum value
+          FieldValue.minimum value
+        end
+
         # @!endgroup
 
         # @!group Operations

--- a/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
@@ -601,12 +601,12 @@ module Google
             elsif field_value.type == :array_union
               Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
                 field_path: field_path.formatted_string,
-                append_missing_elements: raw_to_value(Array(field_value.values)).array_value
+                append_missing_elements: raw_to_value(Array(field_value.value)).array_value
               )
             elsif field_value.type == :array_delete
               Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
                 field_path: field_path.formatted_string,
-                remove_all_from_array: raw_to_value(Array(field_value.values)).array_value
+                remove_all_from_array: raw_to_value(Array(field_value.value)).array_value
               )
             else
               raise ArgumentError, "unknown field transform #{field_value.type}"

--- a/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
@@ -608,6 +608,21 @@ module Google
                 field_path: field_path.formatted_string,
                 remove_all_from_array: raw_to_value(Array(field_value.value)).array_value
               )
+            elsif field_value.type == :increment
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: field_path.formatted_string,
+                increment: raw_to_value(field_value.value)
+              )
+            elsif field_value.type == :maximum
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: field_path.formatted_string,
+                maximum: raw_to_value(field_value.value)
+              )
+            elsif field_value.type == :minimum
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: field_path.formatted_string,
+                minimum: raw_to_value(field_value.value)
+              )
             else
               raise ArgumentError, "unknown field transform #{field_value.type}"
             end

--- a/google-cloud-firestore/lib/google/cloud/firestore/field_value.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/field_value.rb
@@ -35,9 +35,9 @@ module Google
         ##
         # @private Creates a field value object representing changes made to
         # fields in document data.
-        def initialize type, values = nil
+        def initialize type, value = nil
           @type = type
-          @values = values
+          @value = value
         end
 
         ##
@@ -65,10 +65,10 @@ module Google
 
         ##
         # @private
-        # The values to change to an individual field in document data,
-        # depending on the type of change.
+        # The value to change to an individual field in document data, depending
+        # on the type of change.
         #
-        # @return [Array<Object>] The values.
+        # @return [Object] The value.
         #
         # @example
         #   require "google/cloud/firestore"
@@ -82,13 +82,13 @@ module Google
         #     1, 2, 3
         #   )
         #   array_union.type #=> :array_union
-        #   array_union.values #=> [1, 2, 3]
+        #   array_union.value #=> [1, 2, 3]
         #
         #   nyc_ref.update({ name: "New York City",
         #                    lucky_numbers: array_union })
         #
-        def values
-          @values
+        def value
+          @value
         end
 
         ##
@@ -138,7 +138,7 @@ module Google
         end
 
         ##
-        # Creates a sentinel value to indicate the union of the given values
+        # Creates a sentinel value to indicate the union of the given value
         # with an array.
         #
         # @param [Object] values The values to add to the array. Required.

--- a/google-cloud-firestore/lib/google/cloud/firestore/field_value.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/field_value.rb
@@ -202,6 +202,137 @@ module Google
 
           new :array_delete, values
         end
+
+        ##
+        # Creates a sentinel value to indicate the addition the given value to
+        # the field's current value.
+        #
+        # If the field's current value is not an integer or a double value
+        # (Integer or Numeric), or if the field does not yet exist, the
+        # transformation will set the field to the given value. If either of the
+        # given value or the current field value are doubles, both values will
+        # be interpreted as doubles. Double arithmetic and representation of
+        # double values follow IEEE 754 semantics. If there is positive/negative
+        # integer overflow, the field is resolved to the largest magnitude
+        # positive/negative integer.
+        #
+        # @param [Integer, Numeric] value The value to add to the given value.
+        #   Required.
+        #
+        # @return [FieldValue] The increment field value object.
+        #
+        # @raise [ArgumentError] if the value is not an Integer or Numeric.
+        #
+        # @example
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #
+        #   # Get a document reference
+        #   nyc_ref = firestore.doc "cities/NYC"
+        #
+        #   # Set the population to increment by 1.
+        #   increment_value = Google::Cloud::Firestore::FieldValue.increment 1
+        #
+        #   nyc_ref.update({ name: "New York City",
+        #                    population: increment_value })
+        #
+        def self.increment value
+          # verify the values are the correct types
+          unless [Integer, Numeric].include? value.class
+            raise ArgumentError, "value must be an Integer or Numeric"
+          end
+
+          new :increment, value
+        end
+
+        ##
+        # Creates a sentinel value to indicate the setting the field to the
+        # maximum of its current value and the given value.
+        #
+        # If the field is not an integer or double (Integer or Numeric), or if
+        # the field does not yet exist, the transformation will set the field to
+        # the given value. If a maximum operation is applied where the field and
+        # the input value are of mixed types (that is - one is an integer and
+        # one is a double) the field takes on the type of the larger operand. If
+        # the operands are equivalent (e.g. 3 and 3.0), the field does not
+        # change. 0, 0.0, and -0.0 are all zero. The maximum of a zero stored
+        # value and zero input value is always the stored value. The maximum of
+        # any numeric value x and NaN is NaN.
+        #
+        # @param [Integer, Numeric] value The value to compare against the given
+        #   value to calculate the maximum value to set. Required.
+        #
+        # @return [FieldValue] The maximum field value object.
+        #
+        # @raise [ArgumentError] if the value is not an Integer or Numeric.
+        #
+        # @example
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #
+        #   # Get a document reference
+        #   nyc_ref = firestore.doc "cities/NYC"
+        #
+        #   # Set the population to be at maximum 4,000,000.
+        #   maximum_value = Google::Cloud::Firestore::FieldValue.maximum 4000000
+        #
+        #   nyc_ref.update({ name: "New York City",
+        #                    population: maximum_value })
+        #
+        def self.maximum value
+          # verify the values are the correct types
+          unless [Integer, Numeric].include? value.class
+            raise ArgumentError, "value must be an Integer or Numeric"
+          end
+
+          new :maximum, value
+        end
+
+        ##
+        # Creates a sentinel value to indicate the setting the field to the
+        # minimum of its current value and the given value.
+        #
+        # If the field is not an integer or double (Integer or Numeric), or if
+        # the field does not yet exist, the transformation will set the field to
+        # the input value. If a minimum operation is applied where the field and
+        # the input value are of mixed types (that is - one is an integer and
+        # one is a double) the field takes on the type of the smaller operand.
+        # If the operands are equivalent (e.g. 3 and 3.0), the field does not
+        # change. 0, 0.0, and -0.0 are all zero. The minimum of a zero stored
+        # value and zero input value is always the stored value. The minimum of
+        # any numeric value x and NaN is NaN.
+        #
+        # @param [Integer, Numeric] value The value to compare against the given
+        #   value to calculate the minimum value to set. Required.
+        #
+        # @return [FieldValue] The minimum field value object.
+        #
+        # @raise [ArgumentError] if the value is not an Integer or Numeric.
+        #
+        # @example
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #
+        #   # Get a document reference
+        #   nyc_ref = firestore.doc "cities/NYC"
+        #
+        #   # Set the population to be at minimum 1,000,000.
+        #   minimum_value = Google::Cloud::Firestore::FieldValue.minimum 1000000
+        #
+        #   nyc_ref.update({ name: "New York City",
+        #                    population: minimum_value })
+        #
+        def self.minimum value
+          # verify the values are the correct types
+          unless [Integer, Numeric].include? value.class
+            raise ArgumentError, "value must be an Integer or Numeric"
+          end
+
+          new :minimum, value
+        end
       end
     end
   end

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/writes_for_create_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/writes_for_create_test.rb
@@ -635,4 +635,436 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
       error.message.must_equal "cannot nest array_delete under arrays"
     end
   end
+
+  describe :field_increment do
+    let(:field_increment) { Google::Cloud::Firestore::FieldValue.increment 1 }
+
+    it "INCREMENT alone" do
+      data = { a: field_increment }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "a",
+                increment: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: false)
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "INCREMENT with data" do
+      data = { a: 1, b: field_increment }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: document_path,
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(
+            exists: false)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b",
+                increment: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "multiple INCREMENT fields" do
+      data = { a: 1, b: field_increment, c: { d: field_increment } }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: document_path,
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: false)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b",
+                increment: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              ),
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "c.d",
+                increment: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "nested INCREMENT field" do
+      data = { a: 1, b: { c: field_increment } }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: document_path,
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(
+            exists: false)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b.c",
+                increment: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "INCREMENT cannot be anywhere inside an array value" do
+      data = { a: [1, { b: field_increment }] }
+
+      error = expect do
+        Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+      end.must_raise ArgumentError
+      error.message.must_equal "cannot nest increment under arrays"
+    end
+
+    it "INCREMENT cannot be in an array value" do
+      data = { a: [1, 2, field_increment] }
+
+      error = expect do
+        Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+      end.must_raise ArgumentError
+      error.message.must_equal "cannot nest increment under arrays"
+    end
+  end
+
+  describe :field_maximum do
+    let(:field_maximum) { Google::Cloud::Firestore::FieldValue.maximum 1 }
+
+    it "MAXIMUM alone" do
+      data = { a: field_maximum }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "a",
+                maximum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: false)
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "MAXIMUM with data" do
+      data = { a: 1, b: field_maximum }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: document_path,
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(
+            exists: false)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b",
+                maximum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "multiple MAXIMUM fields" do
+      data = { a: 1, b: field_maximum, c: { d: field_maximum } }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: document_path,
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: false)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b",
+                maximum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              ),
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "c.d",
+                maximum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "nested MAXIMUM field" do
+      data = { a: 1, b: { c: field_maximum } }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: document_path,
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(
+            exists: false)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b.c",
+                maximum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "MAXIMUM cannot be anywhere inside an array value" do
+      data = { a: [1, { b: field_maximum }] }
+
+      error = expect do
+        Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+      end.must_raise ArgumentError
+      error.message.must_equal "cannot nest maximum under arrays"
+    end
+
+    it "MAXIMUM cannot be in an array value" do
+      data = { a: [1, 2, field_maximum] }
+
+      error = expect do
+        Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+      end.must_raise ArgumentError
+      error.message.must_equal "cannot nest maximum under arrays"
+    end
+  end
+
+  describe :field_minimum do
+    let(:field_minimum) { Google::Cloud::Firestore::FieldValue.minimum 1 }
+
+    it "MINIMUM alone" do
+      data = { a: field_minimum }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "a",
+                minimum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: false)
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "MINIMUM with data" do
+      data = { a: 1, b: field_minimum }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: document_path,
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(
+            exists: false)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b",
+                minimum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "multiple MINIMUM fields" do
+      data = { a: 1, b: field_minimum, c: { d: field_minimum } }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: document_path,
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: false)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b",
+                minimum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              ),
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "c.d",
+                minimum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "nested MINIMUM field" do
+      data = { a: 1, b: { c: field_minimum } }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: document_path,
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(
+            exists: false)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b.c",
+                minimum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "MINIMUM cannot be anywhere inside an array value" do
+      data = { a: [1, { b: field_minimum }] }
+
+      error = expect do
+        Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+      end.must_raise ArgumentError
+      error.message.must_equal "cannot nest minimum under arrays"
+    end
+
+    it "MINIMUM cannot be in an array value" do
+      data = { a: [1, 2, field_minimum] }
+
+      error = expect do
+        Google::Cloud::Firestore::Convert.writes_for_create document_path, data
+      end.must_raise ArgumentError
+      error.message.must_equal "cannot nest minimum under arrays"
+    end
+  end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/writes_for_update_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/writes_for_update_test.rb
@@ -1032,4 +1032,508 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error.message.must_equal "cannot nest array_delete under arrays"
     end
   end
+
+  describe :field_increment do
+    let(:field_increment) { Google::Cloud::Firestore::FieldValue.increment 1 }
+
+    it "INCREMENT alone" do
+      data = { a: field_increment }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "a",
+                increment: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "INCREMENT with data" do
+      data = { a: 1, b: field_increment }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: "projects/projectID/databases/(default)/documents/C/d",
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          update_mask: Google::Firestore::V1beta1::DocumentMask.new(field_paths: ["a"]),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b",
+                increment: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "INCREMENT with dotted field" do
+      data = { "a.b.c" => field_increment }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "a.b.c",
+                increment: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "multiple INCREMENT fields" do
+      data = { a: 1, b: field_increment, c: { d: field_increment } }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: "projects/projectID/databases/(default)/documents/C/d",
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          update_mask: Google::Firestore::V1beta1::DocumentMask.new(field_paths: ["a", "c"]),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b",
+                increment: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              ),
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "c.d",
+                increment: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "nested INCREMENT field" do
+      data = { a: 1, b: { c: field_increment } }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: "projects/projectID/databases/(default)/documents/C/d",
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          update_mask: Google::Firestore::V1beta1::DocumentMask.new(field_paths: ["a", "b"]),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b.c",
+                increment: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "INCREMENT cannot be anywhere inside an array value" do
+      data = { a: [1, { b: field_increment }] }
+
+      error = expect do
+        Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+      end.must_raise ArgumentError
+      error.message.must_equal "cannot nest increment under arrays"
+    end
+
+    it "INCREMENT cannot be in an array value" do
+      data = { a: [1, 2, field_increment] }
+
+      error = expect do
+        Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+      end.must_raise ArgumentError
+      error.message.must_equal "cannot nest increment under arrays"
+    end
+  end
+
+  describe :field_maximum do
+    let(:field_maximum) { Google::Cloud::Firestore::FieldValue.maximum 1 }
+
+    it "MAXIMUM alone" do
+      data = { a: field_maximum }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "a",
+                maximum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "MAXIMUM with data" do
+      data = { a: 1, b: field_maximum }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: "projects/projectID/databases/(default)/documents/C/d",
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          update_mask: Google::Firestore::V1beta1::DocumentMask.new(field_paths: ["a"]),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b",
+                maximum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "MAXIMUM with dotted field" do
+      data = { "a.b.c" => field_maximum }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "a.b.c",
+                maximum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "multiple MAXIMUM fields" do
+      data = { a: 1, b: field_maximum, c: { d: field_maximum } }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: "projects/projectID/databases/(default)/documents/C/d",
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          update_mask: Google::Firestore::V1beta1::DocumentMask.new(field_paths: ["a", "c"]),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b",
+                maximum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              ),
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "c.d",
+                maximum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "nested MAXIMUM field" do
+      data = { a: 1, b: { c: field_maximum } }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: "projects/projectID/databases/(default)/documents/C/d",
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          update_mask: Google::Firestore::V1beta1::DocumentMask.new(field_paths: ["a", "b"]),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b.c",
+                maximum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "MAXIMUM cannot be anywhere inside an array value" do
+      data = { a: [1, { b: field_maximum }] }
+
+      error = expect do
+        Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+      end.must_raise ArgumentError
+      error.message.must_equal "cannot nest maximum under arrays"
+    end
+
+    it "MAXIMUM cannot be in an array value" do
+      data = { a: [1, 2, field_maximum] }
+
+      error = expect do
+        Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+      end.must_raise ArgumentError
+      error.message.must_equal "cannot nest maximum under arrays"
+    end
+  end
+
+  describe :field_minimum do
+    let(:field_minimum) { Google::Cloud::Firestore::FieldValue.minimum 1 }
+
+    it "MINIMUM alone" do
+      data = { a: field_minimum }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "a",
+                minimum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "MINIMUM with data" do
+      data = { a: 1, b: field_minimum }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: "projects/projectID/databases/(default)/documents/C/d",
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          update_mask: Google::Firestore::V1beta1::DocumentMask.new(field_paths: ["a"]),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b",
+                minimum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "MINIMUM with dotted field" do
+      data = { "a.b.c" => field_minimum }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "a.b.c",
+                minimum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          ),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "multiple MINIMUM fields" do
+      data = { a: 1, b: field_minimum, c: { d: field_minimum } }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: "projects/projectID/databases/(default)/documents/C/d",
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          update_mask: Google::Firestore::V1beta1::DocumentMask.new(field_paths: ["a", "c"]),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b",
+                minimum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              ),
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "c.d",
+                minimum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "nested MINIMUM field" do
+      data = { a: 1, b: { c: field_minimum } }
+
+      expected_writes = [
+        Google::Firestore::V1beta1::Write.new(
+          update: Google::Firestore::V1beta1::Document.new(
+            name: "projects/projectID/databases/(default)/documents/C/d",
+            fields: {
+              "a" => Google::Firestore::V1beta1::Value.new(integer_value: 1)
+            }
+          ),
+          update_mask: Google::Firestore::V1beta1::DocumentMask.new(field_paths: ["a", "b"]),
+          current_document: Google::Firestore::V1beta1::Precondition.new(exists: true)
+        ),
+        Google::Firestore::V1beta1::Write.new(
+          transform: Google::Firestore::V1beta1::DocumentTransform.new(
+            document: "projects/projectID/databases/(default)/documents/C/d",
+            field_transforms: [
+              Google::Firestore::V1beta1::DocumentTransform::FieldTransform.new(
+                field_path: "b.c",
+                minimum: Google::Firestore::V1beta1::Value.new(integer_value: 1)
+              )
+            ]
+          )
+        )
+      ]
+
+      actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+
+      actual_writes.must_equal expected_writes
+    end
+
+    it "MINIMUM cannot be anywhere inside an array value" do
+      data = { a: [1, { b: field_minimum }] }
+
+      error = expect do
+        Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+      end.must_raise ArgumentError
+      error.message.must_equal "cannot nest minimum under arrays"
+    end
+
+    it "MINIMUM cannot be in an array value" do
+      data = { a: [1, 2, field_minimum] }
+
+      error = expect do
+        Google::Cloud::Firestore::Convert.writes_for_update document_path, data
+      end.must_raise ArgumentError
+      error.message.must_equal "cannot nest minimum under arrays"
+    end
+  end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/field_value_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/field_value_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Firestore::FieldValue do
       field_union = Google::Cloud::Firestore::FieldValue.array_union 1, 2, 3
       field_union.must_be_kind_of Google::Cloud::Firestore::FieldValue
       field_union.type.must_equal :array_union
-      field_union.values.must_equal [1, 2, 3]
+      field_union.value.must_equal [1, 2, 3]
     end
 
     it "does not allow nested FieldValues" do
@@ -37,7 +37,7 @@ describe Google::Cloud::Firestore::FieldValue do
       field_delete = Google::Cloud::Firestore::FieldValue.array_delete 7, 8, 9
       field_delete.must_be_kind_of Google::Cloud::Firestore::FieldValue
       field_delete.type.must_equal :array_delete
-      field_delete.values.must_equal [7, 8, 9]
+      field_delete.value.must_equal [7, 8, 9]
     end
 
     it "does not allow nested FieldValues" do


### PR DESCRIPTION
This PR adds support for the numeric transforms `increment`, `maximum`, and `minimum`. These are added as class level methods to the `FieldValue` class, as well as helper methods added to `Client` objects.

```ruby
require "google/cloud/firestore"

firestore = Google::Cloud::Firestore.new

# Get a document reference
nyc_ref = firestore.doc "cities/NYC"

# Set the population to increment by 1.
increment_value = firestore.field_increment 1

nyc_ref.update({ name: "New York City",
                 population: increment_value })
```

[closes #2793]