### PR TITLE
Add __pycache__ to gitignore to prevent local synth from adding it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ jsondoc/*
 # directories left by gh-pages
 _site/*
 .DS_STORE
+
+# Ignore stuff left by synth
+__pycache__


### PR DESCRIPTION
If I run synth locally, it tends to leave a `__pycache__` directory with cached python bytecode (pyc) files. Hide those from git to prevent them from getting added to the repo by mistake.