### PR TITLE
Release google-cloud-core 1.3.0

### DIFF
--- a/google-cloud-core/CHANGELOG.md
+++ b/google-cloud-core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+### 1.3.0 / 2019-01-31
+
+* Add on_error configuration (#2735)
+* Upgrade Rubocop to 0.61 (#2743)
+* Update .rubocop.yml in all gems (#2721)
+* Upgrade Rubocop to 0.59.2 (#2525)
+* fix windows tests (#2598)
+
 ### 1.2.7 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-core/CHANGELOG.md
+++ b/google-cloud-core/CHANGELOG.md
@@ -2,11 +2,7 @@
 
 ### 1.3.0 / 2019-01-31
 
-* Add on_error configuration (#2735)
-* Upgrade Rubocop to 0.61 (#2743)
-* Update .rubocop.yml in all gems (#2721)
-* Upgrade Rubocop to 0.59.2 (#2525)
-* fix windows tests (#2598)
+* Add on_error configuration.
 
 ### 1.2.7 / 2018-09-20
 

--- a/google-cloud-core/lib/google/cloud/core/version.rb
+++ b/google-cloud-core/lib/google/cloud/core/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Core
-      VERSION = "1.2.7".freeze
+      VERSION = "1.3.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add on_error configuration (#2735)

This pull request was generated using releasetool.