### PR TITLE
Release google-cloud-bigtable 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This client supports the following Google Cloud Platform services at a
 
 * [Cloud Asset](#cloud-asset-beta) (Beta)
 * [BigQuery Data Transfer](#bigquery-data-transfer-api-beta) (Beta)
+* [Cloud Bigtable](#cloud-bigtable-beta) (Beta)
 * [Stackdriver Debugger](#stackdriver-debugger-beta) (Beta)
 * [Stackdriver Error Reporting](#stackdriver-error-reporting-beta) (Beta)
 * [Cloud Firestore](#cloud-firestore-beta) (Beta)
@@ -37,7 +38,6 @@ This client supports the following Google Cloud Platform services at a
 This client supports the following Google Cloud Platform services at an
 [Alpha](#versioning) quality level:
 
-* [Cloud Bigtable](#cloud-bigtable-alpha) (Alpha)
 * [Container Engine](#container-engine-alpha) (Alpha)
 * [Cloud Dataproc](#cloud-dataproc-alpha) (Alpha)
 * [Data Loss Prevention](#data-loss-prevention-alpha) (Alpha)
@@ -183,7 +183,7 @@ data_transfer_service_client.list_data_sources(formatted_parent).each_page do |p
 end
 ```
 
-### Cloud Bigtable (Alpha)
+### Cloud Bigtable (Beta)
 
 - [google-cloud-bigtable README](google-cloud-bigtable/README.md)
 - [google-cloud-bigtable API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigtable/latest)

--- a/google-cloud-bigtable/CHANGELOG.md
+++ b/google-cloud-bigtable/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+### 0.3.0 / 2019-02-01
+
+* Move library to Beta.
+* Make use of Credentials#project_id
+  * Use Credentials#project_id
+    If a project_id is not provided, use the value on the Credentials object.
+    This value was added in googleauth 0.7.0.
+  * Loosen googleauth dependency
+    Allow for new releases up to 0.10.
+    The googleauth devs have committed to maintanining the current API
+    and will not make backwards compatible changes before 0.10.
+
 ### 0.2.0 / 2018-11-15
 
 * Update network configuration.

--- a/google-cloud-bigtable/OVERVIEW.md
+++ b/google-cloud-bigtable/OVERVIEW.md
@@ -1,6 +1,6 @@
 # Cloud Bigtable
 
-Ruby Client for Cloud Bigtable API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+Ruby Client for Cloud Bigtable API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
 
 [Cloud Bigtable API][Product Documentation]:
 API for reading and writing the contents of Bigtables associated with a

--- a/google-cloud-bigtable/README.md
+++ b/google-cloud-bigtable/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud Bigtable API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud Bigtable API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
 
 [Cloud Bigtable API][Product Documentation]:
 API for reading and writing the contents of Bigtables associated with a

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/version.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigtable
-      VERSION = "0.2.0".freeze
+      VERSION = "0.3.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Move library to Beta.
* Make use of Credentials#project_id
  * Use Credentials#project_id
    If a project_id is not provided, use the value on the Credentials object.
    This value was added in googleauth 0.7.0.
  * Loosen googleauth dependency
    Allow for new releases up to 0.10.
    The googleauth devs have committed to maintanining the current API
    and will not make backwards compatible changes before 0.10.

This pull request was generated using releasetool.