### PR TITLE
Release google-cloud-asset 0.1.2

### DIFF
--- a/google-cloud-asset/CHANGELOG.md
+++ b/google-cloud-asset/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.1.2 / 2019-02-01
+
+* Update documentation.
+
 ### 0.1.1 / 2018-11-19
 
 * Update rubygems homepage link

--- a/google-cloud-asset/google-cloud-asset.gemspec
+++ b/google-cloud-asset/google-cloud-asset.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-asset"
-  gem.version       = "0.1.1"
+  gem.version       = "0.1.2"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Update documentation.

This pull request was generated using releasetool.