### PR TITLE
Release google-cloud-dataproc 0.3.0

### DIFF
--- a/google-cloud-dataproc/CHANGELOG.md
+++ b/google-cloud-dataproc/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Release History
 
+### 0.3.0 / 2019-02-01
+
+* Correct documentation to be Alpha quality level.
+* Add WorkflowTemplateService module and factory method.
+* Add arguments to the following ClusterControllerClient methods:
+  * Add request_id argument to #create_cluster method.
+  * Add graceful_decommission_timeout argument to #update_cluster method.
+  * Add request_id argument to #update_cluster method.
+  * Add cluster_uuid argument to #delete_cluster method.
+  * Add request_id argument to #delete_cluster method.
+* Add EncryptionConfig class and ClusterConfig#encryption_config attribute.
+* Add DiskConfig#boot_disk_type attribute.
+* Add v1beta2 API version.
+* Update documentation.
+
 ### 0.2.2 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-dataproc/google-cloud-dataproc.gemspec
+++ b/google-cloud-dataproc/google-cloud-dataproc.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dataproc"
-  gem.version       = "0.2.2"
+  gem.version       = "0.3.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Correct documentation to be Alpha quality level.
* Add WorkflowTemplateService module and factory method.
* Add arguments to the following ClusterControllerClient methods:
  * Add request_id argument to #create_cluster method.
  * Add graceful_decommission_timeout argument to #update_cluster method.
  * Add request_id argument to #update_cluster method.
  * Add cluster_uuid argument to #delete_cluster method.
  * Add request_id argument to #delete_cluster method.
* Add EncryptionConfig class and ClusterConfig#encryption_config attribute.
* Add DiskConfig#boot_disk_type attribute.
* Add v1beta2 API version.
* Update documentation.

This pull request was generated using releasetool.