### PR TITLE
Release google-cloud-datastore 1.5.0

### DIFF
--- a/google-cloud-datastore/CHANGELOG.md
+++ b/google-cloud-datastore/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+### 1.5.0 / 2019-02-01
+
+* Make use of Credentials#project_id
+  * Use Credentials#project_id
+    If a project_id is not provided, use the value on the Credentials object.
+    This value was added in googleauth 0.7.0.
+  * Loosen googleauth dependency
+    Allow for new releases up to 0.10.
+    The googleauth devs have committed to maintanining the current API
+    and will not make backwards compatible changes before 0.10.
+
 ### 1.4.4 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-datastore/lib/google/cloud/datastore/version.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Datastore
-      VERSION = "1.4.4".freeze
+      VERSION = "1.5.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Make use of Credentials#project_id
  * Use Credentials#project_id
    If a project_id is not provided, use the value on the Credentials object.
    This value was added in googleauth 0.7.0.
  * Loosen googleauth dependency
    Allow for new releases up to 0.10.
    The googleauth devs have committed to maintanining the current API
    and will not make backwards compatible changes before 0.10.

This pull request was generated using releasetool.