### PR TITLE
Release google-cloud-debugger 0.33.0

### DIFF
--- a/google-cloud-debugger/CHANGELOG.md
+++ b/google-cloud-debugger/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Release History
 
+### 0.33.0 / 2019-02-01
+
+* Add Debugger on_error configuration.
+* Update Transmitter
+  * Add dependency on current-ruby.
+  * Add Transmitter#on_error method.
+  * Update Transmitter documentation.
+* Make use of Credentials#project_id
+  * Use Credentials#project_id
+    If a project_id is not provided, use the value on the Credentials object.
+    This value was added in googleauth 0.7.0.
+  * Loosen googleauth dependency
+    Allow for new releases up to 0.10.
+    The googleauth devs have committed to maintanining the current API
+    and will not make backwards compatible changes before 0.10.
+
 ### 0.32.6 / 2018-11-15
 
 * Update network configuration.

--- a/google-cloud-debugger/lib/google/cloud/debugger/version.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Debugger
-      VERSION = "0.32.6".freeze
+      VERSION = "0.33.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add Debugger on_error configuration.
* Update Transmitter
  * Add dependency on current-ruby.
  * Add Transmitter#on_error method.
  * Update Transmitter documentation.
* Make use of Credentials#project_id
  * Use Credentials#project_id
    If a project_id is not provided, use the value on the Credentials object.
    This value was added in googleauth 0.7.0.
  * Loosen googleauth dependency
    Allow for new releases up to 0.10.
    The googleauth devs have committed to maintanining the current API
    and will not make backwards compatible changes before 0.10.

This pull request was generated using releasetool.