### PR TITLE
Release google-cloud-monitoring 0.29.3

### DIFF
--- a/google-cloud-monitoring/CHANGELOG.md
+++ b/google-cloud-monitoring/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.29.3 / 2019-02-01
+
+* Update network configuration.
+* Update documentation.
+
 ### 0.29.2 / 2018-09-20
 
 * Update Monitoring generated files.

--- a/google-cloud-monitoring/google-cloud-monitoring.gemspec
+++ b/google-cloud-monitoring/google-cloud-monitoring.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-monitoring"
-  gem.version       = "0.29.2"
+  gem.version       = "0.29.3"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Update network configuration.
* Update documentation.

This pull request was generated using releasetool.