### PR TITLE
Release google-cloud-spanner 1.8.0

### DIFF
--- a/google-cloud-spanner/CHANGELOG.md
+++ b/google-cloud-spanner/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Release History
 
+### 1.8.0 / 2019-02-01
+
+* Make use of Credentials#project_id
+  * Use Credentials#project_id
+    If a project_id is not provided, use the value on the Credentials object.
+    This value was added in googleauth 0.7.0.
+  * Loosen googleauth dependency
+    Allow for new releases up to 0.10.
+    The googleauth devs have committed to maintanining the current API
+    and will not make backwards compatible changes before 0.10.
+* Performance improvements for Data#to_h
+  * Add Data skip_dup_check optional arg
+    * This enhancement allows users to skip the dupplicate name check
+      when serializing Data to a Ruby Hash or Array.
+      This speeds up the serialization, but data may be lost.
+* Update network configuration
+* Update Client#close to block on session release
+
 ### 1.7.2 / 2018-11-15
 
 * Allow Spanner streams to recover from more errors.

--- a/google-cloud-spanner/lib/google/cloud/spanner/version.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Spanner
-      VERSION = "1.7.2".freeze
+      VERSION = "1.8.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Make use of Credentials#project_id
  * Use Credentials#project_id
    If a project_id is not provided, use the value on the Credentials object.
    This value was added in googleauth 0.7.0.
  * Loosen googleauth dependency
    Allow for new releases up to 0.10.
    The googleauth devs have committed to maintanining the current API
    and will not make backwards compatible changes before 0.10.
* Performance improvements for Data#to_h
  * Add Data skip_dup_check optional arg
    * This enhancement allows users to skip the dupplicate name check
      when serializing Data to a Ruby Hash or Array.
      This speeds up the serialization, but data may be lost.
* Update network configuration
* Update Client#close to block on session release

This pull request was generated using releasetool.