### PR TITLE
Release google-cloud-tasks 0.3.0

### DIFF
--- a/google-cloud-tasks/CHANGELOG.md
+++ b/google-cloud-tasks/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.3.0 / 2019-02-01
+
+* Add Task#dispatch_deadline attribute.
+* Add HttpMethod::PATCH and HttpMethod::OPTIONS enumerated values.
+* Update documentation.
+
 ### 0.2.6 / 2018-11-15
 
 * Update network configuration.

--- a/google-cloud-tasks/google-cloud-tasks.gemspec
+++ b/google-cloud-tasks/google-cloud-tasks.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-tasks"
-  gem.version       = "0.2.6"
+  gem.version       = "0.3.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Add Task#dispatch_deadline attribute.
* Add HttpMethod::PATCH and HttpMethod::OPTIONS enumerated values.
* Update documentation.

This pull request was generated using releasetool.