### PR TITLE
Release google-cloud-translate 1.3.0

### DIFF
--- a/google-cloud-translate/CHANGELOG.md
+++ b/google-cloud-translate/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+### 1.3.0 / 2019-02-01
+
+* Make use of Credentials#project_id
+  * Use Credentials#project_id
+    If a project_id is not provided, use the value on the Credentials object.
+    This value was added in googleauth 0.7.0.
+  * Loosen googleauth dependency
+    Allow for new releases up to 0.10.
+    The googleauth devs have committed to maintanining the current API
+    and will not make backwards compatible changes before 0.10.
+
 ### 1.2.4 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-translate/lib/google/cloud/translate/version.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Translate
-      VERSION = "1.2.4".freeze
+      VERSION = "1.3.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Make use of Credentials#project_id
  * Use Credentials#project_id
    If a project_id is not provided, use the value on the Credentials object.
    This value was added in googleauth 0.7.0.
  * Loosen googleauth dependency
    Allow for new releases up to 0.10.
    The googleauth devs have committed to maintanining the current API
    and will not make backwards compatible changes before 0.10.

This pull request was generated using releasetool.