### PR TITLE
Update google-cloud-storage.gemspec

### DIFF
--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-api-client", "~> 0.23"
+  gem.add_dependency "google-api-client", "~> 0.26"
   gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
   gem.add_dependency "digest-crc", "~> 0.4"
 


### PR DESCRIPTION
Upgrade `google-api-client` dependency to `~> 0.26` to provide `Bucket::IamConfiguration`.

I visually inspected and ran automated tests against the `google-api-client` versions `0.25.0` and `0.26.0` to confirm the need for this change.