### PR TITLE
Update concurrent-ruby dependency

### DIFF
--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-logging", "~> 1.0"
   gem.add_dependency "google-gax", "~> 1.0"
   gem.add_dependency "stackdriver-core", "~> 1.3"
-  gem.add_dependency "concurrent-ruby", "~> 1.0"
+  gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
+++ b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "google-gax", "~> 1.0"
-  gem.add_dependency "concurrent-ruby", "~> 1.0"
+  gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "google-gax", "~> 1.3"
   gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"
-  gem.add_dependency "concurrent-ruby", "~> 1.0"
+  gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "google-gax", "~> 1.3"
-  gem.add_dependency "concurrent-ruby", "~> 1.0"
+  gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"


### PR DESCRIPTION
Update dependency to reflect the features used in the gem.

[fixes #2890]