### PR TITLE
Release google-cloud-storage 1.17.0

### DIFF
--- a/google-cloud-storage/CHANGELOG.md
+++ b/google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.17.0 / 2019-02-07
+
+* Add Bucket#policy_only? and #policy_only=
+
 ### 1.16.0 / 2019-02-01
 
 * Make use of Credentials#project_id

--- a/google-cloud-storage/CHANGELOG.md
+++ b/google-cloud-storage/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 1.17.0 / 2019-02-07
 
 * Add support for Bucket Policy Only with `Bucket#policy_only?`,
-  `Bucket#policy_only` and `Bucket#policy_only_locked_at`.
+  `Bucket#policy_only=` and `Bucket#policy_only_locked_at`.
   Read more at https://cloud.google.com/storage/docs/bucket-policy-only
 
 ### 1.16.0 / 2019-02-01

--- a/google-cloud-storage/CHANGELOG.md
+++ b/google-cloud-storage/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### 1.17.0 / 2019-02-07
 
-* Add Bucket#policy_only? and #policy_only=
+* Add support for Bucket Policy Only with `Bucket#policy_only?`,
+  `Bucket#policy_only` and `Bucket#policy_only_locked_at`.
+  Read more at https://cloud.google.com/storage/docs/bucket-policy-only
 
 ### 1.16.0 / 2019-02-01
 

--- a/google-cloud-storage/lib/google/cloud/storage/version.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Storage
-      VERSION = "1.16.0".freeze
+      VERSION = "1.17.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add Bucket#policy_only? and #policy_only=

This pull request was generated using releasetool.