### PR TITLE
Release google-cloud-error_reporting 0.31.1

### DIFF
--- a/google-cloud-error_reporting/CHANGELOG.md
+++ b/google-cloud-error_reporting/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.31.1 / 2019-02-07
+
+* Update concurrent-ruby dependency
+
 ### 0.31.0 / 2019-02-01
 
 * Add ErrorReporting on_error configuration.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module ErrorReporting
-      VERSION = "0.31.0".freeze
+      VERSION = "0.31.1".freeze
     end
   end
 end


### PR DESCRIPTION
* Update concurrent-ruby dependency

This pull request was generated using releasetool.