### PR TITLE
Release google-cloud-trace 0.34.0

### DIFF
--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Release History
 
+### 0.34.0 / 2019-02-07
+
+* Update AsyncReporter to buffer traces and batch API calls.
+  * Back pressure is applied by limiting the number of queued API calls.
+  * Errors will now be raised when there are not enough resources.
+  * Errors are reported using the AsyncReporter#on_error callback.
+  * Pending traces are sent before the process closes using at_exit.
+* Improve middleware error handling
+  * Add the `on_error` Proc to the Trace configuration that is called
+    when an error is encountered in the middleware. This allows users
+    to handle the errors proactively, instead of scanning logs.
+* Make use of Credentials#project_id
+  * Use Credentials#project_id
+    If a project_id is not provided, use the value on the Credentials object.
+    This value was added in googleauth 0.7.0.
+  * Loosen googleauth dependency
+    Allow for new releases up to 0.10.
+    The googleauth devs have committed to maintanining the current API
+    and will not make backwards compatible changes before 0.10.
+
 ### 0.33.6 / 2018-11-15
 
 * Update network configuration.

--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -16,6 +16,8 @@
     Allow for new releases up to 0.10.
     The googleauth devs have committed to maintaining the current API
     and will not make backwards compatible changes before 0.10.
+* Update Trace documentation
+  * Correct the C-code's comments.
 
 ### 0.33.6 / 2018-11-15
 

--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -2,15 +2,12 @@
 
 ### 0.34.0 / 2019-02-07
 
-* Update `AsyncReporter` to buffer traces and batch API calls.
+* Add Trace `on_error` configuration.
+* Middleware improvements:
+  * Buffer traces and make batch API calls.
   * Back pressure is applied by limiting the number of queued API calls.
   * Errors will now be raised when there are not enough resources.
-  * Errors are reported using the `AsyncReporter#on_error` callback.
-  * Pending traces are sent before the process closes using `at_exit`.
-* Improve middleware error handling
-  * Add the `on_error` Proc to the Trace configuration that is called
-    when an error is encountered in the middleware. This allows users
-    to handle the errors proactively, instead of scanning logs.
+  * Errors are reported by calling the `on_error` callback.
 * Make use of `Credentials#project_id`
   * Use `Credentials#project_id`
     If a `project_id` is not provided, use the value on the Credentials object.

--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -2,22 +2,22 @@
 
 ### 0.34.0 / 2019-02-07
 
-* Update AsyncReporter to buffer traces and batch API calls.
+* Update `AsyncReporter` to buffer traces and batch API calls.
   * Back pressure is applied by limiting the number of queued API calls.
   * Errors will now be raised when there are not enough resources.
-  * Errors are reported using the AsyncReporter#on_error callback.
-  * Pending traces are sent before the process closes using at_exit.
+  * Errors are reported using the `AsyncReporter#on_error` callback.
+  * Pending traces are sent before the process closes using `at_exit`.
 * Improve middleware error handling
   * Add the `on_error` Proc to the Trace configuration that is called
     when an error is encountered in the middleware. This allows users
     to handle the errors proactively, instead of scanning logs.
-* Make use of Credentials#project_id
-  * Use Credentials#project_id
-    If a project_id is not provided, use the value on the Credentials object.
+* Make use of `Credentials#project_id`
+  * Use `Credentials#project_id`
+    If a `project_id` is not provided, use the value on the Credentials object.
     This value was added in googleauth 0.7.0.
   * Loosen googleauth dependency
     Allow for new releases up to 0.10.
-    The googleauth devs have committed to maintanining the current API
+    The googleauth devs have committed to maintaining the current API
     and will not make backwards compatible changes before 0.10.
 
 ### 0.33.6 / 2018-11-15

--- a/google-cloud-trace/lib/google/cloud/trace/version.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Trace
-      VERSION = "0.33.6".freeze
+      VERSION = "0.34.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Update AsyncReporter to buffer traces and batch API calls.
  * Back pressure is applied by limiting the number of queued API calls.
  * Errors will now be raised when there are not enough resources.
  * Errors are reported using the AsyncReporter#on_error callback.
  * Pending traces are sent before the process closes using at_exit.
* Improve middleware error handling
  * Add the `on_error` Proc to the Trace configuration that is called
    when an error is encountered in the middleware. This allows users
    to handle the errors proactively, instead of scanning logs.
* Make use of Credentials#project_id
  * Use Credentials#project_id
    If a project_id is not provided, use the value on the Credentials object.
    This value was added in googleauth 0.7.0.
  * Loosen googleauth dependency
    Allow for new releases up to 0.10.
    The googleauth devs have committed to maintanining the current API
    and will not make backwards compatible changes before 0.10.

This pull request was generated using releasetool.