### PR TITLE
Release google-cloud-debugger 0.33.2

### DIFF
--- a/google-cloud-debugger/CHANGELOG.md
+++ b/google-cloud-debugger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.33.2 / 2019-02-08
+
+* Fix conversion code for ErrorEvent and Debugee.
+  * Prepare for changes in JSON serialization coming in
+    google-protobuf 3.7.
+
 ### 0.33.1 / 2019-02-07
 
 * Update concurrent-ruby dependency

--- a/google-cloud-debugger/lib/google/cloud/debugger/version.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Debugger
-      VERSION = "0.33.1".freeze
+      VERSION = "0.33.2".freeze
     end
   end
 end


### PR DESCRIPTION
* Fix conversion code for ErrorEvent and Debugee.
  * Prepare for changes in JSON serialization coming in
    google-protobuf 3.7.

This pull request was generated using releasetool.