### PR TITLE
Release google-cloud-error_reporting 0.31.2

### DIFF
--- a/google-cloud-error_reporting/CHANGELOG.md
+++ b/google-cloud-error_reporting/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.31.2 / 2019-02-09
+
+* Fix conversion code for ErrorEvent and Debugee.
+  * Prepare for changes in JSON serialization coming in
+    google-protobuf 3.7.
+
 ### 0.31.1 / 2019-02-07
 
 * Update concurrent-ruby dependency

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module ErrorReporting
-      VERSION = "0.31.1".freeze
+      VERSION = "0.31.2".freeze
     end
   end
 end


### PR DESCRIPTION
* Fix conversion code for ErrorEvent and Debugee.
  * Prepare for changes in JSON serialization coming in
    google-protobuf 3.7.

This pull request was generated using releasetool.