### PR TITLE
Resource Manager: Project Parent Resource

### DIFF
--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/manager.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/manager.rb
@@ -17,6 +17,7 @@ require "google/cloud/errors"
 require "google/cloud/resource_manager/credentials"
 require "google/cloud/resource_manager/service"
 require "google/cloud/resource_manager/project"
+require "google/cloud/resource_manager/resource"
 
 module Google
   module Cloud
@@ -166,6 +167,15 @@ module Google
         #   <code>([a-z]([-a-z0-9]*[a-z0-9])?)?</code>.
         #
         #   No more than 256 labels can be associated with a given resource.
+        # @param [Resource] parent A parent Resource. Optional.
+        #
+        #   Supported parent types include "organization" and "folder". Once
+        #   set, the parent can be updated but cannot be cleared.
+        #
+        #   The end user must have the `resourcemanager.projects.create`
+        #   permission on the parent.
+        #
+        #   (See {#resource} and {Resource}.)
         #
         # @return [Google::Cloud::ResourceManager::Project]
         #
@@ -182,8 +192,16 @@ module Google
         #   project = resource_manager.create_project "tokyo-rain-123",
         #     name: "Todos Development", labels: {env: :development}
         #
-        def create_project project_id, name: nil, labels: nil
-          gapi = service.create_project project_id, name, labels
+        # @example A project can also be created with a `name` and `parent`:
+        #   require "google/cloud/resource_manager"
+        #
+        #   resource_manager = Google::Cloud::ResourceManager.new
+        #   folder = resource_manager.resource "folder", "1234"
+        #   project = resource_manager.create_project "tokyo-rain-123",
+        #     name: "Todos Development", parent: folder
+        #
+        def create_project project_id, name: nil, labels: nil, parent: nil
+          gapi = service.create_project project_id, name, labels, parent
           Project.from_gapi gapi, service
         end
 
@@ -239,6 +257,27 @@ module Google
         def undelete project_id
           service.undelete_project project_id
           true
+        end
+
+        ##
+        # Create a Resource object. (See {Resource}.)
+        #
+        # @param [String] type The resource type this id is for. At present, the
+        #   valid types are: "organization" and "folder".
+        # @param [String] id The type-specific id. This should correspond to the
+        #   id used in the type-specific API's.
+        # @return [resource]
+        #
+        # @example
+        #   require "google/cloud/resource_manager"
+        #
+        #   resource_manager = Google::Cloud::ResourceManager.new
+        #   project = resource_manager.project "tokyo-rain-123"
+        #   folder = resource_manager.resource "folder", "1234"
+        #   project.parent = folder
+        #
+        def resource type, id
+          Resource.new type, id
         end
 
         protected

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/updater.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/updater.rb
@@ -118,6 +118,32 @@ module Google
           end
 
           ##
+          # Updates the reference to a parent with a new Resource.
+          #
+          # Supported parent types include "organization" and "folder". Once
+          # set, the parent can be updated but cannot be cleared.
+          #
+          # The end user must have the `resourcemanager.projects.create`
+          # permission on the parent.
+          #
+          # (See {Resource} and {Manager#resource}.)
+          #
+          # @param [Resource] new_parent A new parent Resource.
+          #
+          # @example
+          #   require "google/cloud/resource_manager"
+          #
+          #   resource_manager = Google::Cloud::ResourceManager.new
+          #   project = resource_manager.project "tokyo-rain-123"
+          #   folder = resource_manager.resource "folder", "1234"
+          #   project.parent = folder
+          #
+          def parent= new_parent
+            raise ArgumentError, "new_parent is required" if new_parent.nil?
+            gapi.parent = new_parent.to_gapi
+          end
+
+          ##
           # @private Create an Updater object.
           def self.from_project project
             dupe_gapi = project.gapi.class.new project.gapi.to_h

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/resource.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/resource.rb
@@ -1,0 +1,119 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module ResourceManager
+      ##
+      # # Resource
+      #
+      # A container to reference an id for any resource type. A `resource` in
+      # Google Cloud Platform is a generic term for something a developer may
+      # want to interact with through an API. Some examples are an App Engine
+      # app, a Compute Engine instance, a Cloud SQL database, and so on. (See
+      # {Manager#resource}.)
+      #
+      # @example
+      #   require "google/cloud/resource_manager"
+      #
+      #   resource_manager = Google::Cloud::ResourceManager.new
+      #   project = resource_manager.project "tokyo-rain-123"
+      #   folder = Google::Cloud::ResourceManager::Resource.new "folder", "1234"
+      #   project.parent = folder
+      #
+      class Resource
+        ##
+        # Create a Resource object.
+        #
+        # @param [String] type The resource type this id is for. At present, the
+        #   valid types are: "organization" and "folder".
+        # @param [String] id The type-specific id. This should correspond to the
+        #   id used in the type-specific API's.
+        def initialize type, id
+          raise ArgumentError, "type is required" if type.nil?
+          raise ArgumentError, "id is required"   if id.nil?
+
+          @type = type
+          @id   = id
+        end
+
+        ##
+        # Required field representing the resource type this id is for. At
+        # present, the valid types are: "organization" and "folder".
+        # @return [String]
+        attr_accessor :type
+
+        ##
+        # Required field for the type-specific id. This should correspond to the
+        # id used in the type-specific API's.
+        # @return [String]
+        attr_accessor :id
+
+        ##
+        # Checks if the type is `folder`.
+        # @return [Boolean]
+        def folder?
+          return false if type.nil?
+          "folder".casecmp(type).zero?
+        end
+
+        ##
+        # Checks if the type is `organization`.
+        # @return [Boolean]
+        def organization?
+          return false if type.nil?
+          "organization".casecmp(type).zero?
+        end
+
+        ##
+        # Create a Resource object with type `folder`.
+        #
+        # @param [String] id The type-specific id. This should correspond to the
+        #   id used in the type-specific API's.
+        # @return [Resource]
+        def self.folder id
+          new "folder", id
+        end
+
+        ##
+        # Create a Resource object with type `organization`.
+        #
+        # @param [String] id The type-specific id. This should correspond to the
+        #   id used in the type-specific API's.
+        # @return [Resource]
+        def self.organization id
+          new "organization", id
+        end
+
+        ##
+        # @private Convert the Resource to a Google API Client ResourceId
+        # object.
+        def to_gapi
+          Google::Apis::CloudresourcemanagerV1::ResourceId.new(
+            type: type,
+            id: id
+          )
+        end
+
+        ##
+        # @private Create new Resource from a Google API Client ResourceId
+        # object.
+        def self.from_gapi gapi
+          new gapi.type, gapi.id
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/service.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/service.rb
@@ -74,9 +74,11 @@ module Google
 
         ##
         # Returns API::Project
-        def create_project project_id, name, labels
-          project_attrs = { project_id: project_id, name: name,
-                            labels: labels }.delete_if { |_, v| v.nil? }
+        def create_project project_id, name, labels, parent
+          parent = parent.to_gapi unless parent.nil?
+          project_attrs = {
+            project_id: project_id, name: name, labels: labels, parent: parent
+          }.delete_if { |_, v| v.nil? }
           execute { service.create_project API::Project.new(project_attrs) }
         end
 

--- a/google-cloud-resource_manager/support/doctest_helper.rb
+++ b/google-cloud-resource_manager/support/doctest_helper.rb
@@ -92,13 +92,19 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::ResourceManager::Manager#create_project" do
     mock_translate do |mock|
-      mock.expect :create_project, project_gapi, ["tokyo-rain-123", nil, nil]
+      mock.expect :create_project, project_gapi, ["tokyo-rain-123", nil, nil, nil]
     end
   end
 
   doctest.before "Google::Cloud::ResourceManager::Manager#create_project@A project can also be created with a `name` and `labels`:" do
     mock_translate do |mock|
-      mock.expect :create_project, project_gapi, ["tokyo-rain-123", "Todos Development", {:env=>:development}]
+      mock.expect :create_project, project_gapi, ["tokyo-rain-123", "Todos Development", {:env=>:development}, nil]
+    end
+  end
+
+  doctest.before "Google::Cloud::ResourceManager::Manager#create_project@A project can also be created with a `name` and `parent`:" do
+    mock_translate do |mock|
+      mock.expect :create_project, project_gapi, ["tokyo-rain-123", "Todos Development", nil, Google::Cloud::ResourceManager::Resource]
     end
   end
 
@@ -111,6 +117,13 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::ResourceManager::Manager#undelete" do
     mock_translate do |mock|
       mock.expect :undelete_project, project_gapi, ["tokyo-rain-123"]
+    end
+  end
+
+  doctest.before "Google::Cloud::ResourceManager::Manager#resource" do
+    mock_translate do |mock|
+      mock.expect :get_project, project_gapi, ["tokyo-rain-123"]
+      mock.expect :update_project, project_gapi(labels: {"env"=>"production"}), [Google::Apis::CloudresourcemanagerV1::Project]
     end
   end
 
@@ -178,6 +191,13 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_project, project_gapi, ["tokyo-rain-123"]
       mock.expect :get_policy, policy_gapi, ["tokyo-rain-123"]
       mock.expect :set_policy, policy_gapi, ["tokyo-rain-123", Google::Apis::CloudresourcemanagerV1::Policy]
+    end
+  end
+
+  doctest.before "Google::Cloud::ResourceManager::Resource" do
+    mock_translate do |mock|
+      mock.expect :get_project, project_gapi, ["tokyo-rain-123"]
+      mock.expect :update_project, project_gapi(labels: {"env"=>"production"}), [Google::Apis::CloudresourcemanagerV1::Project]
     end
   end
 end

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/project_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/project_test.rb
@@ -25,6 +25,11 @@ describe Google::Cloud::ResourceManager::Project, :mock_res_man do
     project.project_number.must_equal "123456789123"
     project.name.must_equal "Example Project 123"
     project.labels["env"].must_equal "production"
+    project.parent.must_be_kind_of Google::Cloud::ResourceManager::Resource
+    project.parent.type.must_equal "folder"
+    project.parent.id.must_equal "123"
+    project.parent.must_be :folder?
+    project.parent.wont_be :organization?
     project.created_at.must_equal Time.new(2015, 9, 1, 12, 0, 0, 0)
   end
 
@@ -92,6 +97,28 @@ describe Google::Cloud::ResourceManager::Project, :mock_res_man do
     mock.verify
 
     project.labels["env"].must_equal "production"
+  end
+
+  it "updates the parent" do
+    mock = Minitest::Mock.new
+    updated_project = random_project_gapi seed, nil, nil, "798"
+    mock.expect :update_project, updated_project, [updated_project.project_id, updated_project]
+
+    project.parent.must_be_kind_of Google::Cloud::ResourceManager::Resource
+    project.parent.type.must_equal "folder"
+    project.parent.id.must_equal "123"
+    project.parent.must_be :folder?
+    project.parent.wont_be :organization?
+
+    resource_manager.service.mocked_service = mock
+    project.parent = resource_manager.resource "folder", "798"
+    mock.verify
+
+    project.parent.must_be_kind_of Google::Cloud::ResourceManager::Resource
+    project.parent.type.must_equal "folder"
+    project.parent.id.must_equal "798"
+    project.parent.must_be :folder?
+    project.parent.wont_be :organization?
   end
 
   it "can update name and labels in a single API call" do

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/resource_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/resource_test.rb
@@ -1,0 +1,63 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::ResourceManager::Resource do
+  it "creates a resource" do
+    folder = Google::Cloud::ResourceManager::Resource.new "folder", "1234"
+    folder.must_be_kind_of Google::Cloud::ResourceManager::Resource
+    folder.type.must_equal "folder"
+    folder.id.must_equal "1234"
+    folder.must_be :folder?
+    folder.wont_be :organization?
+
+    organization = Google::Cloud::ResourceManager::Resource.new "organization", "7890"
+    organization.must_be_kind_of Google::Cloud::ResourceManager::Resource
+    organization.type.must_equal "organization"
+    organization.id.must_equal "7890"
+    organization.wont_be :folder?
+    organization.must_be :organization?
+  end
+
+  it "creating a resource without type or id raises" do
+    error = expect do
+      Google::Cloud::ResourceManager::Resource.new "folder", nil
+    end.must_raise ArgumentError
+    error.message.must_equal "id is required"
+
+    error = expect do
+      Google::Cloud::ResourceManager::Resource.new nil, "1234"
+    end.must_raise ArgumentError
+    error.message.must_equal "type is required"
+  end
+
+  it "creates a folder" do
+    folder = Google::Cloud::ResourceManager::Resource.folder "1234"
+    folder.must_be_kind_of Google::Cloud::ResourceManager::Resource
+    folder.type.must_equal "folder"
+    folder.id.must_equal "1234"
+    folder.must_be :folder?
+    folder.wont_be :organization?
+  end
+
+  it "creates an organization" do
+    organization = Google::Cloud::ResourceManager::Resource.organization "7890"
+    organization.must_be_kind_of Google::Cloud::ResourceManager::Resource
+    organization.type.must_equal "organization"
+    organization.id.must_equal "7890"
+    organization.wont_be :folder?
+    organization.must_be :organization?
+  end
+end

--- a/google-cloud-resource_manager/test/helper.rb
+++ b/google-cloud-resource_manager/test/helper.rb
@@ -44,15 +44,20 @@ class MockResourceManager < Minitest::Spec
     addl.include? :mock_res_man
   end
 
-  def random_project_gapi seed = nil, name = nil, labels = nil
+  def random_project_gapi seed = nil, name = nil, labels = nil, parent_id = nil
     seed ||= rand(9999)
     name ||= "Example Project #{seed}"
     labels = { "env" => "production" } if labels.nil?
+    parent = Google::Apis::CloudresourcemanagerV1::ResourceId.new(
+      type: "folder",
+      id: (parent_id || seed.to_s)
+    )
     Google::Apis::CloudresourcemanagerV1::Project.new(
       project_number: "123456789#{seed}",
       project_id:     "example-project-#{seed}",
       name:           name,
       labels:         labels,
+      parent:         parent,
       create_time:    "2015-09-01T12:00:00.00Z",
       lifecycle_state: "ACTIVE")
   end


### PR DESCRIPTION
The PR adds the parent resource to Project. This was added to the Project API a while ago, but never exposed in the Ruby gem. The parent resource to be set on a project's creation, as well an a project's update.

* Add `Project#parent`
* Add `project` optional named argument to `Manager#create_project`
* Add `Resource` class
* Add `Manager#resource` convenience method

This PR is a partial implementation for #2885, but it only affects the aspects of the API already covered by the gem. The other API features such as Folders and Organizations are still not supported by the Ruby gem.

[refs #2885]