### PR TITLE
Release google-cloud-resource_manager 0.31.0

### DIFF
--- a/google-cloud-resource_manager/CHANGELOG.md
+++ b/google-cloud-resource_manager/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+### 0.31.0 / 2019-02-12
+
+* Add parent resoure to `Project`:
+  * Add `Project#parent`.
+  * Add `project` optional named argument to `Manager#create_project`.
+  * Add `Resource` class.
+  * Add `Manager#resource` convenience method.
+
 ### 0.30.3 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-resource_manager/CHANGELOG.md
+++ b/google-cloud-resource_manager/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Add parent resoure to `Project`:
   * Add `Project#parent`.
-  * Add `project` optional named argument to `Manager#create_project`.
+  * Add `parent` optional named argument to `Manager#create_project`.
   * Add `Resource` class.
   * Add `Manager#resource` convenience method.
 

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/version.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module ResourceManager
-      VERSION = "0.30.3".freeze
+      VERSION = "0.31.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add parent resoure to `Project`:
  * Add `Project#parent`.
  * Add `project` optional named argument to `Manager#create_project`.
  * Add `Resource` class.
  * Add `Manager#resource` convenience method.

This pull request was generated using releasetool.