### PR TITLE
Release google-cloud-debugger 0.33.3

### DIFF
--- a/google-cloud-debugger/CHANGELOG.md
+++ b/google-cloud-debugger/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.33.3 / 2019-02-13
+
+* Fix bug (typo) in retrieving default on_error proc.
+
 ### 0.33.2 / 2019-02-08
 
 * Fix conversion code for ErrorEvent and Debugee.

--- a/google-cloud-debugger/lib/google/cloud/debugger/version.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Debugger
-      VERSION = "0.33.2".freeze
+      VERSION = "0.33.3".freeze
     end
   end
 end


### PR DESCRIPTION
* Fix bug (typo) in retrieving default on_error proc.

This pull request was generated using releasetool.