### PR TITLE
Release google-cloud-error_reporting 0.31.3

### DIFF
--- a/google-cloud-error_reporting/CHANGELOG.md
+++ b/google-cloud-error_reporting/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.31.3 / 2019-02-13
+
+* Fix bug (typo) in retrieving default on_error proc.
+
 ### 0.31.2 / 2019-02-09
 
 * Fix conversion code for ErrorEvent and Debugee.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module ErrorReporting
-      VERSION = "0.31.2".freeze
+      VERSION = "0.31.3".freeze
     end
   end
 end


### PR DESCRIPTION
* Fix bug (typo) in retrieving default on_error proc.

This pull request was generated using releasetool.