### PR TITLE
Release google-cloud-logging 1.6.2

### DIFF
--- a/google-cloud-logging/CHANGELOG.md
+++ b/google-cloud-logging/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.6.2 / 2019-02-13
+
+* Fix bug (typo) in retrieving default on_error proc.
+
 ### 1.6.1 / 2019-02-07
 
 * Update concurrent-ruby dependency

--- a/google-cloud-logging/lib/google/cloud/logging/version.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Logging
-      VERSION = "1.6.1".freeze
+      VERSION = "1.6.2".freeze
     end
   end
 end


### PR DESCRIPTION
* Fix bug (typo) in retrieving default on_error proc.

This pull request was generated using releasetool.