### PR TITLE
Release google-cloud-pubsub 0.34.1

### DIFF
--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.34.1 / 2019-02-13
+
+* Fix bug (typo) in retrieving default on_error proc.
+* Update network configuration.
+
 ### 0.34.0 / 2019-02-01
 
 * Switch to use Google::Cloud::PubSub namespace.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module PubSub
-      VERSION = "0.34.0".freeze
+      VERSION = "0.34.1".freeze
     end
 
     Pubsub = PubSub unless const_defined? :Pubsub


### PR DESCRIPTION
* Fix bug (typo) in retrieving default on_error proc.
* Update network configuration.

This pull request was generated using releasetool.