### PR TITLE
Release google-cloud-trace 0.34.1

### DIFF
--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.34.1 / 2019-02-13
+
+* Fix bug (typo) in retrieving default on_error proc.
+
 ### 0.34.0 / 2019-02-07
 
 * Add Trace `on_error` configuration.

--- a/google-cloud-trace/lib/google/cloud/trace/version.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Trace
-      VERSION = "0.34.0".freeze
+      VERSION = "0.34.1".freeze
     end
   end
 end


### PR DESCRIPTION
* Fix bug (typo) in retrieving default on_error proc.

This pull request was generated using releasetool.