### PR TITLE
Release google-cloud-datastore 1.5.1

### DIFF
--- a/google-cloud-datastore/CHANGELOG.md
+++ b/google-cloud-datastore/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 1.5.1 / 2019-02-13
+
+* Add `ReadOnlyTransaction` convenience methods:
+  * Add `ReadOnlyTransaction#query`
+  * Add `ReadOnlyTransaction#gql`
+  * Add `ReadOnlyTransaction#key`
+
 ### 1.5.0 / 2019-02-01
 
 * Make use of Credentials#project_id

--- a/google-cloud-datastore/lib/google/cloud/datastore/version.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Datastore
-      VERSION = "1.5.0".freeze
+      VERSION = "1.5.1".freeze
     end
   end
 end


### PR DESCRIPTION
* Add `ReadOnlyTransaction` convenience methods:
  * Add `ReadOnlyTransaction#query`
  * Add `ReadOnlyTransaction#gql`
  * Add `ReadOnlyTransaction#key`

This pull request was generated using releasetool.