### PR TITLE
Update rubocop to 0.64.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "minitest-focus", "~> 1.1"
 gem "minitest-rg", "~> 5.2"
 gem "autotest-suffix", "~> 1.1"
 gem "redcarpet", "~> 3.0"
-gem "rubocop", "~> 0.61.0"
+gem "rubocop", "~> 0.64.0"
 gem "simplecov", "~> 0.16"
 gem "codecov", "~> 0.1", require: false
 gem "yard", "~> 0.9"

--- a/gcloud/gcloud.gemspec
+++ b/gcloud/gcloud.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-asset/google-cloud-asset.gemspec
+++ b/google-cloud-asset/google-cloud-asset.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -105,5 +105,5 @@ s.replace(
 s.replace(
     'google-cloud-asset.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )

--- a/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec
+++ b/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -104,5 +104,5 @@ s.replace(
 s.replace(
     'google-cloud-bigquery-data_transfer.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )

--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-bigtable/google-cloud-bigtable.gemspec
+++ b/google-cloud-bigtable/google-cloud-bigtable.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-container/google-cloud-container.gemspec
+++ b/google-cloud-container/google-cloud-container.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -82,5 +82,5 @@ s.replace(
 s.replace(
     'google-cloud-container.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )

--- a/google-cloud-core/google-cloud-core.gemspec
+++ b/google-cloud-core/google-cloud-core.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-dataproc/google-cloud-dataproc.gemspec
+++ b/google-cloud-dataproc/google-cloud-dataproc.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -93,7 +93,7 @@ s.replace(
 s.replace(
     'google-cloud-dataproc.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 s.replace(

--- a/google-cloud-datastore/google-cloud-datastore.gemspec
+++ b/google-cloud-datastore/google-cloud-datastore.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.8"

--- a/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
+++ b/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -81,5 +81,5 @@ s.replace(
 s.replace(
     'google-cloud-dialogflow.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )

--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -83,5 +83,5 @@ s.replace(
 s.replace(
     'google-cloud-dlp.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )

--- a/google-cloud-dns/google-cloud-dns.gemspec
+++ b/google-cloud-dns/google-cloud-dns.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-env/google-cloud-env.gemspec
+++ b/google-cloud-env/google-cloud-env.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
+++ b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "railties", "~> 4.0"
   gem.add_development_dependency "rack", ">= 0.1"
   gem.add_development_dependency "simplecov", "~> 0.9"

--- a/google-cloud-firestore/google-cloud-firestore.gemspec
+++ b/google-cloud-firestore/google-cloud-firestore.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-irm/.rubocop.yml
+++ b/google-cloud-irm/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-irm/google-cloud-irm.gemspec
+++ b/google-cloud-irm/google-cloud-irm.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-irm/synth.py
+++ b/google-cloud-irm/synth.py
@@ -73,7 +73,7 @@ s.replace(
 s.replace(
     'google-cloud-irm.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 # Require the helpers file

--- a/google-cloud-kms/google-cloud-kms.gemspec
+++ b/google-cloud-kms/google-cloud-kms.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -94,7 +94,7 @@ s.replace(
 s.replace(
     'google-cloud-kms.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 # Require the helpers file

--- a/google-cloud-language/google-cloud-language.gemspec
+++ b/google-cloud-language/google-cloud-language.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -95,5 +95,5 @@ s.replace(
 s.replace(
     'google-cloud-language.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )

--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-monitoring/google-cloud-monitoring.gemspec
+++ b/google-cloud-monitoring/google-cloud-monitoring.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -92,5 +92,5 @@ s.replace(
 s.replace(
     'google-cloud-monitoring.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )

--- a/google-cloud-os_login/google-cloud-os_login.gemspec
+++ b/google-cloud-os_login/google-cloud-os_login.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -120,5 +120,5 @@ s.replace(
 s.replace(
     'google-cloud-os_login.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )

--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-redis/google-cloud-redis.gemspec
+++ b/google-cloud-redis/google-cloud-redis.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -114,5 +114,5 @@ s.replace(
 s.replace(
     'google-cloud-redis.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )

--- a/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
+++ b/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-scheduler/google-cloud-scheduler.gemspec
+++ b/google-cloud-scheduler/google-cloud-scheduler.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-scheduler/synth.py
+++ b/google-cloud-scheduler/synth.py
@@ -45,7 +45,7 @@ s.copy(v1beta1_library / 'google-cloud-scheduler.gemspec', merge=ruby.merge_gems
 s.replace(
     'google-cloud-scheduler.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 # https://github.com/googleapis/gapic-generator/issues/2279

--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -170,5 +170,5 @@ s.replace(
 s.replace(
     'google-cloud-speech.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )

--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-talent/.rubocop.yml
+++ b/google-cloud-talent/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false

--- a/google-cloud-talent/google-cloud-talent.gemspec
+++ b/google-cloud-talent/google-cloud-talent.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-talent/synth.py
+++ b/google-cloud-talent/synth.py
@@ -75,7 +75,7 @@ s.replace(
 s.replace(
     'google-cloud-talent.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 services = ['Company', 'Job', 'Profile']

--- a/google-cloud-tasks/google-cloud-tasks.gemspec
+++ b/google-cloud-tasks/google-cloud-tasks.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -100,5 +100,5 @@ s.replace(
 s.replace(
     'google-cloud-tasks.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )

--- a/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
+++ b/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -71,5 +71,5 @@ s.replace(
 s.replace(
     'google-cloud-text_to_speech.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )

--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "faraday", "~> 0.8"
   gem.add_development_dependency "railties", "~> 4.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest" #, "~> 0.1.6"

--- a/google-cloud-translate/google-cloud-translate.gemspec
+++ b/google-cloud-translate/google-cloud-translate.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
+++ b/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -138,5 +138,5 @@ s.replace(
 s.replace(
     'google-cloud-video_intelligence.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )

--- a/google-cloud-vision/google-cloud-vision.gemspec
+++ b/google-cloud-vision/google-cloud-vision.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -136,7 +136,7 @@ s.replace(
 s.replace(
     'google-cloud-vision.gemspec',
     'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.61.0"'
+    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 # Adds LICENSE to .yardopts
 s.replace(

--- a/google-cloud/google-cloud.gemspec
+++ b/google-cloud/google-cloud.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/stackdriver-core/stackdriver-core.gemspec
+++ b/stackdriver-core/stackdriver-core.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"

--- a/stackdriver/stackdriver.gemspec
+++ b/stackdriver/stackdriver.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.61.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.6"


### PR DESCRIPTION
Update rubocop in all gemspecs.
Update rubocop in synth.py.
Set `TargetRubyVersion: 2.2` in `google-cloud-irm/.rubocop.yml` and
`google-cloud-talent/.rubocop.yml`.