### PR TITLE
Fetch credentials for magic github proxy

### DIFF
--- a/.kokoro/release/common.cfg
+++ b/.kokoro/release/common.cfg
@@ -17,6 +17,26 @@ before_action {
   }
 }
 
+# Fetch magictoken to use with Magic Github Proxy 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "releasetool-magictoken"
+    }
+  }
+}
+
+# Fetch api key to use with Magic Github Proxy 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "magic-github-proxy-api-key"
+    }
+  }
+}
+
 # Download resources for system tests (service account key, etc.)
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-ruby"
 


### PR DESCRIPTION
These credentials will be used by the releasetool reporter.