### PR TITLE
Protobuf 3.7

### DIFF
--- a/google-cloud-debugger/acceptance/debugger_helper.rb
+++ b/google-cloud-debugger/acceptance/debugger_helper.rb
@@ -62,7 +62,7 @@ module Acceptance
     end
 
     ##
-    # Create a test gRPC Snappoing
+    # Create a test gRPC snappoint
     def sample_snappoint
       file_path = "acceptance/debugger_helper.rb"
       line = method(:trigger_breakpoint).source_location.last + 2
@@ -72,10 +72,7 @@ module Acceptance
           "path" => file_path,
           "line" => line
         },
-        "create_time" => {
-          "seconds" => Time.now.to_i,
-          "nanos"   => Time.now.nsec
-        },
+        "create_time" => Time.now.utc.strftime("%FT%T.%NZ"),
         "expressions" => ["local_var"]
       }
 
@@ -95,10 +92,7 @@ module Acceptance
           "path" => file_path,
           "line" => line
         },
-        "create_time" => {
-          "seconds" => Time.now.to_i,
-          "nanos"   => Time.now.nsec
-        },
+        "create_time" => Time.now.utc.strftime("%FT%T.%NZ"),
         "log_message_format" => "local_var is $0. #{token}",
         "expressions" => ["local_var"]
       }

--- a/google-cloud-debugger/integration/debugger_helper.rb
+++ b/google-cloud-debugger/integration/debugger_helper.rb
@@ -44,10 +44,7 @@ module Integration
           "path" => file_path,
           "line" => line
         },
-        "create_time" => {
-          "seconds" => Time.now.to_i,
-          "nanos"   => Time.now.nsec
-        },
+        "create_time" => Time.now.utc.strftime("%FT%T.%NZ"),
         "expressions" => ["local_var"]
       }
 
@@ -64,10 +61,7 @@ module Integration
           "path" => file_path,
           "line" => line
         },
-        "create_time" => {
-          "seconds" => Time.now.to_i,
-          "nanos"   => Time.now.nsec
-        },
+        "create_time" => Time.now.utc.strftime("%FT%T.%NZ"),
         "log_message_format" => "local_var is $0. #{token}",
         "expressions" => ["local_var"]
       }

--- a/google-cloud-debugger/test/helper.rb
+++ b/google-cloud-debugger/test/helper.rb
@@ -107,19 +107,12 @@ class MockDebugger < Minitest::Spec
   end
 
   def random_breakpoint_hash
-    timestamp = Time.parse "2014-10-02T15:01:23.045123456Z"
     {
       "id" => "abc123",
       "action" => :CAPTURE,
       "location" => random_source_location_hash,
-      "create_time" => {
-        "seconds" => timestamp.to_i,
-        "nanos"   => timestamp.nsec
-      },
-      "final_time" => {
-        "seconds" => timestamp.to_i,
-        "nanos"   => timestamp.nsec
-      },
+      "create_time" => "2014-10-02T15:01:23.045123456Z",
+      "final_time" => "2014-10-02T15:01:23.045123456Z",
       "stack_frames" => [random_stack_frame_hash],
       "condition" => "i == 2",
       "expressions" => ["[3]"],

--- a/google-cloud-error_reporting/test/helper.rb
+++ b/google-cloud-error_reporting/test/helper.rb
@@ -35,12 +35,8 @@ class MockErrorReporting < Minitest::Spec
   end
 
   def random_error_event_hash
-    timestamp = Time.parse "2014-10-02T15:01:23.045123456Z"
     {
-      "event_time" => {
-        "seconds" => timestamp.to_i,
-        "nanos" => timestamp.nsec
-      },
+      "event_time" => "2014-10-02T15:01:23.045123456Z",
       "message" => "error message",
       "service_context" => random_service_context_hash,
       "context" => random_error_context_hash,

--- a/google-cloud-firestore/test/google/cloud/firestore/commit_response_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/commit_response_test.rb
@@ -35,7 +35,7 @@ describe Google::Cloud::Firestore::CommitResponse, :mock_firestore do
   end
 
   it "can represent results with transforms" do
-    json = "{\"writeResults\":[{\"updateTime\":{\"seconds\":1513748033,\"nanos\":441316000},\"transformResults\":[{\"timestampValue\":{\"seconds\":1513748033,\"nanos\":428000000}},{\"timestampValue\":{\"seconds\":1513748033,\"nanos\":428000000}},{\"timestampValue\":{\"seconds\":1513748033,\"nanos\":428000000}}]}],\"commitTime\":{\"seconds\":1513748033,\"nanos\":441316000}}"
+    json = "{\"writeResults\":[{\"updateTime\":\"2017-12-20T05:33:53.441316000Z\",\"transformResults\":[{\"timestampValue\":\"2017-12-20T05:33:53.428000000Z\"},{\"timestampValue\":\"2017-12-20T05:33:53.428000000Z\"},{\"timestampValue\":\"2017-12-20T05:33:53.428000000Z\"}]}],\"commitTime\":\"2017-12-20T05:33:53.441316000Z\"}"
     grpc_response = Google::Firestore::V1::CommitResponse.decode_json json
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two]]
@@ -48,7 +48,7 @@ describe Google::Cloud::Firestore::CommitResponse, :mock_firestore do
   end
 
   it "can represent results with and without updateTime" do
-    json = "{\"writeResults\":[{\"updateTime\":{\"seconds\":1513748093,\"nanos\":441316000}}, {}],\"commitTime\":{\"seconds\":1513748033,\"nanos\":441316000}}"
+    json = "{\"writeResults\":[{\"updateTime\":\"2017-12-20T05:34:53.441316000Z\"}, {}],\"commitTime\":\"2017-12-20T05:33:53.441316000Z\"}"
     grpc_response = Google::Firestore::V1::CommitResponse.decode_json json
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two]]
@@ -59,7 +59,7 @@ describe Google::Cloud::Firestore::CommitResponse, :mock_firestore do
   end
 
   it "can represent results without and with updateTime" do
-    json = "{\"writeResults\":[{}, {\"updateTime\":{\"seconds\":1513748093,\"nanos\":441316000}}],\"commitTime\":{\"seconds\":1513748033,\"nanos\":441316000}}"
+    json = "{\"writeResults\":[{}, {\"updateTime\":\"2017-12-20T05:34:53.441316000Z\"}],\"commitTime\":\"2017-12-20T05:33:53.441316000Z\"}"
     grpc_response = Google::Firestore::V1::CommitResponse.decode_json json
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two]]
@@ -70,7 +70,7 @@ describe Google::Cloud::Firestore::CommitResponse, :mock_firestore do
   end
 
   it "can represent results without updateTime" do
-    json = "{\"writeResults\":[{}, {}],\"commitTime\":{\"seconds\":1513748033,\"nanos\":441316000}}"
+    json = "{\"writeResults\":[{}, {}],\"commitTime\":\"2017-12-20T05:33:53.441316000Z\"}"
     grpc_response = Google::Firestore::V1::CommitResponse.decode_json json
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two]]
@@ -81,7 +81,7 @@ describe Google::Cloud::Firestore::CommitResponse, :mock_firestore do
   end
 
   it "can represent results without mismatched writes" do
-    json = "{\"writeResults\":[{}, {}],\"commitTime\":{\"seconds\":1513748033,\"nanos\":441316000}}"
+    json = "{\"writeResults\":[{}, {}],\"commitTime\":\"2017-12-20T05:33:53.441316000Z\"}"
     grpc_response = Google::Firestore::V1::CommitResponse.decode_json json
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two], :three]

--- a/google-cloud-logging/support/doctest_helper.rb
+++ b/google-cloud-logging/support/doctest_helper.rb
@@ -455,14 +455,10 @@ def list_entries_json count = 2, token = nil
 end
 
 def random_entry_hash
-  timestamp = Time.parse "2014-10-02T15:01:23.045123456Z"
   {
     "log_name"  => "projects/my-projectid/logs/syslog",
     "resource"  => random_resource_hash,
-    "timestamp" => {
-      "seconds" => timestamp.to_i,
-      "nanos"   => timestamp.nsec
-    },
+    "timestamp" => "2014-10-02T15:01:23.045123456Z",
     "severity"  => :DEFAULT,
     "insert_id" => "abc123",
     "labels" => {
@@ -535,7 +531,7 @@ def random_sink_hash
     "filter"                => "logName:syslog AND severity>=ERROR",
     "output_version_format" => :VERSION_FORMAT_UNSPECIFIED,
     "writer_identity"       => "roles/owner",
-    "start_time"            => { "seconds" => 1479920135, "nanos" => 711253000 }
+    "start_time"            => "2014-10-02T15:01:23.045123456Z"
   }
 end
 

--- a/google-cloud-logging/test/helper.rb
+++ b/google-cloud-logging/test/helper.rb
@@ -62,14 +62,10 @@ class MockLogging < Minitest::Spec
   end
 
   def random_entry_hash
-    timestamp = Time.parse "2014-10-02T15:01:23.045123456Z"
     {
       "log_name"  => "projects/my-projectid/logs/syslog",
       "resource"  => random_resource_hash,
-      "timestamp" => {
-        "seconds" => timestamp.to_i,
-        "nanos"   => timestamp.nsec
-      },
+      "timestamp" => "2014-10-02T15:01:23.045123456Z",
       "severity"  => :DEFAULT,
       "insert_id" => "abc123",
       "labels" => {
@@ -163,7 +159,7 @@ class MockLogging < Minitest::Spec
       "filter"                => "logName:syslog AND severity>=ERROR",
       "output_version_format" => :VERSION_FORMAT_UNSPECIFIED,
       "writer_identity"       => "roles/owner",
-      "start_time"            => { "seconds" => 1479920135, "nanos" => 711253000 }
+      "start_time"            => "2014-10-02T15:01:23.045123456Z"
     }
   end
 

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -613,14 +613,9 @@ def snapshots_json topic_name, num_snapshots, token = nil
 end
 
 def snapshot_json topic_name, snapshot_name
-  time = Time.now
-  timestamp = {
-    "seconds" => time.to_i,
-    "nanos" => time.nsec
-  }
   { "name" => snapshot_path(snapshot_name),
     "topic" => topic_path(topic_name),
-    "expire_time" => timestamp
+    "expire_time" => Time.now.utc.strftime("%FT%T.%NZ")
   }.to_json
 end
 

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -150,7 +150,7 @@ class MockPubsub < Minitest::Spec
       "push_config" => { "push_endpoint" => endpoint },
       "ack_deadline_seconds" => deadline,
       "retain_acked_messages" => true,
-      "message_retention_duration" => {"seconds" => 600, "nanos" => 900000000}, # 600.9 seconds
+      "message_retention_duration" => "600.900000000s", # 600.9 seconds
       "labels" => labels
     }.to_json
   end
@@ -165,14 +165,9 @@ class MockPubsub < Minitest::Spec
   end
 
   def snapshot_json topic_name, snapshot_name, labels: nil
-    time = Time.now
-    timestamp = {
-      "seconds" => time.to_i,
-      "nanos" => time.nsec
-    }
     { "name" => snapshot_path(snapshot_name),
       "topic" => topic_path(topic_name),
-      "expire_time" => timestamp,
+      "expire_time" => Time.now.utc.strftime("%FT%T.%NZ"),
       "labels" => labels
     }.to_json
   end

--- a/google-cloud-spanner/support/doctest_helper.rb
+++ b/google-cloud-spanner/support/doctest_helper.rb
@@ -870,19 +870,21 @@ def instance_hash name: "my-instance", nodes: 1, state: "READY", labels: {}
   {
     name: "projects/#{project}/instances/#{name}",
     config: "projects/#{project}/instanceConfigs/regional-us-central1",
-    displayName: name.split("-").map(&:capitalize).join(" "),
+    display_name: name.split("-").map(&:capitalize).join(" "),
     nodeCount: nodes,
     state: state,
     labels: labels
   }
 end
 
-def job_json
-  "{\"name\":\"1234567890\",\"metadata\":{\"typeUrl\":\"google.spanner.admin.database.v1.CreateDatabaseMetadata\",\"value\":\"\"}}"
-end
-
 def job_grpc
-  Google::Longrunning::Operation.decode_json job_json
+  Google::Longrunning::Operation.new(
+    name: "1234567890",
+    metadata: {
+      type_url: "google.spanner.admin.database.v1.UpdateDatabaseDdlRequest",
+      value: ""
+    }
+  )
 end
 
 def create_instance_resp client: nil
@@ -896,29 +898,29 @@ end
 
 def instance_configs_hash
   {
-    instanceConfigs: [
+    instance_configs: [
       { name: "projects/#{project}/instanceConfigs/regional-europe-west1",
-        displayName: "EU West 1"},
+        display_name: "EU West 1"},
       { name: "projects/#{project}/instanceConfigs/regional-us-west1",
-        displayName: "US West 1"},
+        display_name: "US West 1"},
       { name: "projects/#{project}/instanceConfigs/regional-us-central1",
-        displayName: "US Central 1"}
+        display_name: "US Central 1"}
     ]
   }
 end
 
 def instance_config_hash
-  instance_configs_hash[:instanceConfigs].last
+  instance_configs_hash[:instance_configs].last
 end
 
 def instance_config_resp
-  Google::Spanner::Admin::Instance::V1::InstanceConfig.decode_json instance_config_hash.to_json
+  Google::Spanner::Admin::Instance::V1::InstanceConfig.new instance_config_hash
 end
 
 def instance_configs_resp token: nil
   h = instance_configs_hash
-  h[:nextPageToken] = token if token
-  response = Google::Spanner::Admin::Instance::V1::ListInstanceConfigsResponse.decode_json h.to_json
+  h[:next_page_token] = token if token
+  response = Google::Spanner::Admin::Instance::V1::ListInstanceConfigsResponse.new h
   paged_enum_struct response
 end
 
@@ -930,8 +932,8 @@ def instance_hash name: "my-instance", nodes: 1, state: "READY", labels: {}
   {
     name: "projects/#{project}/instances/#{name}",
     config: "projects/#{project}/instanceConfigs/regional-us-central1",
-    displayName: name.split("-").map(&:capitalize).join(" "),
-    nodeCount: nodes,
+    display_name: name.split("-").map(&:capitalize).join(" "),
+    node_count: nodes,
     state: state,
     labels: labels
   }
@@ -939,8 +941,8 @@ end
 
 def instances_resp token: nil
   h = instances_hash
-  h[:nextPageToken] = token if token
-  response = Google::Spanner::Admin::Instance::V1::ListInstancesResponse.decode_json h.to_json
+  h[:next_page_token] = token if token
+  response = Google::Spanner::Admin::Instance::V1::ListInstancesResponse.new h
   paged_enum_struct response
 end
 
@@ -965,13 +967,13 @@ def database_hash instance_id: "my-instance", database_id: "my-database", state:
 end
 
 def database_resp instance_id: "my-instance", database_id: "my-database"
-  Google::Spanner::Admin::Database::V1::Database.decode_json database_hash(instance_id: instance_id, database_id: database_id).to_json
+  Google::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id)
 end
 
 def databases_resp token: nil
   h = databases_hash
-  h[:nextPageToken] = token if token
-  response = Google::Spanner::Admin::Database::V1::ListDatabasesResponse.decode_json h.to_json
+  h[:next_page_token] = token if token
+  response = Google::Spanner::Admin::Database::V1::ListDatabasesResponse.new h
   paged_enum_struct response
 end
 
@@ -985,9 +987,9 @@ def session_grpc
   Google::Spanner::V1::Session.new(name: "session-name")
 end
 
-def policy_json
+def policy_hash
   {
-    etag: "CAE=",
+    etag: "\b\x01",
     bindings: [{
       role: "roles/viewer",
       members: [
@@ -995,11 +997,11 @@ def policy_json
         "serviceAccount:1234567890@developer.gserviceaccount.com"
        ]
     }]
-  }.to_json
+  }
 end
 
 def policy_resp
-  Google::Iam::V1::Policy.decode_json policy_json
+  Google::Iam::V1::Policy.new policy_hash
 end
 
 def test_permissions_res permissions: ["spanner.instances.get"]
@@ -1020,18 +1022,18 @@ end
 def results_hash1
   {
     metadata: {
-      rowType: {
+      row_type: {
         fields: [
-          { name: "id",          type: { code: "INT64" } },
-          { name: "name",        type: { code: "STRING" } },
-          { name: "active",      type: { code: "BOOL" } },
-          { name: "age",         type: { code: "INT64" } },
-          { name: "score",       type: { code: "FLOAT64" } },
-          { name: "updated_at",  type: { code: "TIMESTAMP" } },
-          { name: "birthday",    type: { code: "DATE"} },
-          { name: "avatar",      type: { code: "BYTES" } },
-          { name: "project_ids", type: { code: "ARRAY",
-                                         arrayElementType: { code: "INT64" } } }
+          { name: "id",          type: { code: :INT64 } },
+          { name: "name",        type: { code: :STRING } },
+          { name: "active",      type: { code: :BOOL } },
+          { name: "age",         type: { code: :INT64 } },
+          { name: "score",       type: { code: :FLOAT64 } },
+          { name: "updated_at",  type: { code: :TIMESTAMP } },
+          { name: "birthday",    type: { code: :DATE} },
+          { name: "avatar",      type: { code: :BYTES } },
+          { name: "project_ids", type: { code: :ARRAY,
+                                         array_element_type: { code: :INT64 } } }
         ]
       }
     },
@@ -1044,9 +1046,9 @@ end
 def results_hash_marketing
   {
     metadata: {
-      rowType: {
+      row_type: {
         fields: [
-          { name: "marketing_budget",          type: { code: "INT64" } }
+          { name: "marketing_budget", type: { code: :INT64 } }
         ]
       }
     }
@@ -1056,19 +1058,19 @@ end
 def results_hash_marketing_2
   {
     values: [
-      { stringValue: "400000" }
+      { string_value: "400000" }
     ]
   }
 end
 
 def results_enum
-  [Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json)].to_enum
+  [Google::Spanner::V1::PartialResultSet.new(results_hash1)].to_enum
 end
 
 def results_enum_marketing
   [
-    Google::Spanner::V1::PartialResultSet.decode_json(results_hash_marketing.to_json),
-    Google::Spanner::V1::PartialResultSet.decode_json(results_hash_marketing_2.to_json)
+    Google::Spanner::V1::PartialResultSet.new(results_hash_marketing),
+    Google::Spanner::V1::PartialResultSet.new(results_hash_marketing_2)
   ].to_enum
 end
 

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_client_test.rb
@@ -25,7 +25,6 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
   let(:timestamp_time) { Google::Cloud::Spanner::Convert.timestamp_to_time timestamp }
   let(:transaction_grpc) { Google::Spanner::V1::Transaction.new id: transaction_id, read_timestamp: timestamp }
   let(:batch_tx_hash) { { session: Base64.strict_encode64(session_grpc.to_proto), transaction: Base64.strict_encode64(transaction_grpc.to_proto) } }
-  let(:batch_tx_json) { batch_tx_hash.to_json }
   let(:snp_opts) { Google::Spanner::V1::TransactionOptions::ReadOnly.new return_read_timestamp: true }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new read_only: snp_opts }
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
@@ -47,7 +46,7 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
   end
 
   it "retrieves the instance" do
-    get_res = Google::Spanner::Admin::Instance::V1::Instance.decode_json instance_hash(name: instance_id).to_json
+    get_res = Google::Spanner::Admin::Instance::V1::Instance.new instance_hash(name: instance_id)
     mock = Minitest::Mock.new
     mock.expect :get_instance, get_res, [instance_path(instance_id)]
     spanner.service.mocked_instances = mock
@@ -66,7 +65,7 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
   end
 
   it "retrieves the database" do
-    get_res = Google::Spanner::Admin::Database::V1::Database.decode_json database_hash(instance_id: instance_id, database_id: database_id).to_json
+    get_res = Google::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id)
     mock = Minitest::Mock.new
     mock.expect :get_database, get_res, [database_path(instance_id, database_id)]
     spanner.service.mocked_databases = mock
@@ -244,7 +243,7 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
   end
 
   it "loads a batch_snapshot (json)" do
-    batch_snapshot = batch_client.load_batch_snapshot batch_tx_json
+    batch_snapshot = batch_client.load_batch_snapshot batch_tx_hash
 
     batch_snapshot.transaction_id.must_equal transaction_id
     batch_snapshot.timestamp.must_equal timestamp_time

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
@@ -31,38 +31,37 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       },
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
 
   it "can execute a simple query" do

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_query_test.rb
@@ -28,38 +28,37 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       },
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
 
   it "can execute a simple query" do

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/read_test.rb
@@ -28,18 +28,18 @@ describe Google::Cloud::Spanner::BatchSnapshot, :read, :mock_spanner do
   let :results_hash1 do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       }
@@ -48,30 +48,30 @@ describe Google::Cloud::Spanner::BatchSnapshot, :read, :mock_spanner do
   let :results_hash2 do
     {
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" }
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" }
       ]
     }
   end
   let :results_hash3 do
     {
       values: [
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_hash1),
+     Google::Spanner::V1::PartialResultSet.new(results_hash2),
+     Google::Spanner::V1::PartialResultSet.new(results_hash3)].to_enum
   end
 
   it "can read all rows" do

--- a/google-cloud-spanner/test/google/cloud/spanner/client/admin_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/admin_test.rb
@@ -40,7 +40,7 @@ describe Google::Cloud::Spanner::Client, :admin, :mock_spanner do
   end
 
   it "retrieves the instance" do
-    get_res = Google::Spanner::Admin::Instance::V1::Instance.decode_json instance_hash(name: instance_id).to_json
+    get_res = Google::Spanner::Admin::Instance::V1::Instance.new instance_hash(name: instance_id)
     mock = Minitest::Mock.new
     mock.expect :get_instance, get_res, [instance_path(instance_id)]
     spanner.service.mocked_instances = mock
@@ -59,7 +59,7 @@ describe Google::Cloud::Spanner::Client, :admin, :mock_spanner do
   end
 
   it "retrieves the database" do
-    get_res = Google::Spanner::Admin::Database::V1::Database.decode_json database_hash(instance_id: instance_id, database_id: database_id).to_json
+    get_res = Google::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id)
     mock = Minitest::Mock.new
     mock.expect :get_database, get_res, [database_path(instance_id, database_id)]
     spanner.service.mocked_databases = mock

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_resume_test.rb
@@ -23,18 +23,18 @@ describe Google::Cloud::Spanner::Client, :execute_query, :resume, :mock_spanner 
   let :results_hash1 do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       }
@@ -43,62 +43,62 @@ describe Google::Cloud::Spanner::Client, :execute_query, :resume, :mock_spanner 
   let :results_hash2 do
     {
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" }
+        { string_value: "1" },
+        { string_value: "Charlie" }
       ],
-      resumeToken: Base64.strict_encode64("xyz890")
+      resume_token: "xyz890"
     }
   end
   let :results_hash3 do
     {
       values: [
-        { boolValue: true},
-        { stringValue: "29" }
+        { bool_value: true},
+        { string_value: "29" }
       ]
     }
   end
   let :results_hash4 do
     {
       values: [
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" }
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" }
       ],
-      resumeToken: Base64.strict_encode64("abc123")
+      resume_token: "abc123"
     }
   end
   let :results_hash5 do
     {
       values: [
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
       ]
     }
   end
   let :results_hash6 do
     {
       values: [
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
   let(:results_enum1) do
     [
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
+      Google::Spanner::V1::PartialResultSet.new(results_hash1),
+      Google::Spanner::V1::PartialResultSet.new(results_hash2),
+      Google::Spanner::V1::PartialResultSet.new(results_hash3),
+      Google::Spanner::V1::PartialResultSet.new(results_hash4),
+      Google::Spanner::V1::PartialResultSet.new(results_hash5),
       GRPC::Unavailable,
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash6.to_json)
+      Google::Spanner::V1::PartialResultSet.new(results_hash6)
     ].to_enum
   end
   let(:results_enum2) do
     [
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash6.to_json)
+      Google::Spanner::V1::PartialResultSet.new(results_hash1),
+      Google::Spanner::V1::PartialResultSet.new(results_hash5),
+      Google::Spanner::V1::PartialResultSet.new(results_hash6)
     ].to_enum
   end
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_single_use_test.rb
@@ -23,38 +23,37 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       },
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
   let(:time_obj) { Time.parse "2014-10-02T15:01:23.045123456Z" }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_test.rb
@@ -23,38 +23,37 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       },
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
@@ -23,25 +23,24 @@ describe Google::Cloud::Spanner::Client, :fields_for, :mock_spanner do
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       }
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_error_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_error_test.rb
@@ -23,18 +23,18 @@ describe Google::Cloud::Spanner::Client, :read, :error, :mock_spanner do
   let :results_hash1 do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       }
@@ -43,55 +43,55 @@ describe Google::Cloud::Spanner::Client, :read, :error, :mock_spanner do
   let :results_hash2 do
     {
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" }
+        { string_value: "1" },
+        { string_value: "Charlie" }
       ],
-      resumeToken: Base64.strict_encode64("xyz890")
+      resume_token: Base64.strict_encode64("xyz890")
     }
   end
   let :results_hash3 do
     {
       values: [
-        { boolValue: true},
-        { stringValue: "29" }
+        { bool_value: true},
+        { string_value: "29" }
       ]
     }
   end
   let :results_hash4 do
     {
       values: [
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" }
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" }
       ],
-      resumeToken: Base64.strict_encode64("abc123")
+      resume_token: Base64.strict_encode64("abc123")
     }
   end
   let :results_hash5 do
     {
       values: [
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
       ]
     }
   end
   let :results_hash6 do
     {
       values: [
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
   let(:results_enum1) do
     [
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
+      Google::Spanner::V1::PartialResultSet.new(results_hash1),
+      Google::Spanner::V1::PartialResultSet.new(results_hash2),
+      Google::Spanner::V1::PartialResultSet.new(results_hash3),
+      Google::Spanner::V1::PartialResultSet.new(results_hash4),
+      Google::Spanner::V1::PartialResultSet.new(results_hash5),
       GRPC::InvalidArgument,
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash6.to_json)
+      Google::Spanner::V1::PartialResultSet.new(results_hash6)
     ].to_enum
   end
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
@@ -23,18 +23,18 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
   let :results_header do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       }
@@ -43,41 +43,41 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
   let :results_hash1 do
     {
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" }
+        { string_value: "1" },
+        { string_value: "Charlie" }
       ]
     }
   end
   let :results_hash2 do
     {
       values: [
-        { boolValue: true},
-        { stringValue: "29" }
+        { bool_value: true},
+        { string_value: "29" }
       ]
     }
   end
   let :results_hash3 do
     {
       values: [
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" }
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" }
       ]
     }
   end
   let :results_hash4 do
     {
       values: [
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
       ]
     }
   end
   let :results_hash5 do
     {
       values: [
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
@@ -86,22 +86,22 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
 
   it "returns all rows even when there is no resume_token" do
     no_tokens_enum = [
-      Google::Spanner::V1::PartialResultSet.decode_json(results_header.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json)
+      Google::Spanner::V1::PartialResultSet.new(results_header),
+      Google::Spanner::V1::PartialResultSet.new(results_hash1),
+      Google::Spanner::V1::PartialResultSet.new(results_hash2),
+      Google::Spanner::V1::PartialResultSet.new(results_hash3),
+      Google::Spanner::V1::PartialResultSet.new(results_hash4),
+      Google::Spanner::V1::PartialResultSet.new(results_hash5),
+      Google::Spanner::V1::PartialResultSet.new(results_hash1),
+      Google::Spanner::V1::PartialResultSet.new(results_hash2),
+      Google::Spanner::V1::PartialResultSet.new(results_hash3),
+      Google::Spanner::V1::PartialResultSet.new(results_hash4),
+      Google::Spanner::V1::PartialResultSet.new(results_hash5),
+      Google::Spanner::V1::PartialResultSet.new(results_hash1),
+      Google::Spanner::V1::PartialResultSet.new(results_hash2),
+      Google::Spanner::V1::PartialResultSet.new(results_hash3),
+      Google::Spanner::V1::PartialResultSet.new(results_hash4),
+      Google::Spanner::V1::PartialResultSet.new(results_hash5)
     ].to_enum
 
     mock = Minitest::Mock.new
@@ -123,22 +123,22 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
 
   it "returns all rows even when all requests have resume_token" do
     all_tokens_enum = [
-      Google::Spanner::V1::PartialResultSet.decode_json(results_header.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.merge(resumeToken: Base64.strict_encode64("xyz123")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.merge(resumeToken: Base64.strict_encode64("xyz124")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.merge(resumeToken: Base64.strict_encode64("xyz125")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.merge(resumeToken: Base64.strict_encode64("xyz126")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.merge(resumeToken: Base64.strict_encode64("xyz127")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.merge(resumeToken: Base64.strict_encode64("xyz128")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.merge(resumeToken: Base64.strict_encode64("xyz129")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.merge(resumeToken: Base64.strict_encode64("xyz130")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.merge(resumeToken: Base64.strict_encode64("xyz131")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.merge(resumeToken: Base64.strict_encode64("xyz132")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.merge(resumeToken: Base64.strict_encode64("xyz133")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.merge(resumeToken: Base64.strict_encode64("xyz134")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.merge(resumeToken: Base64.strict_encode64("xyz135")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.merge(resumeToken: Base64.strict_encode64("xyz137")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.merge(resumeToken: Base64.strict_encode64("xyz128")).to_json)
+      Google::Spanner::V1::PartialResultSet.new(results_header),
+      Google::Spanner::V1::PartialResultSet.new(results_hash1.merge(resume_token: Base64.strict_encode64("xyz123"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash2.merge(resume_token: Base64.strict_encode64("xyz124"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash3.merge(resume_token: Base64.strict_encode64("xyz125"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash4.merge(resume_token: Base64.strict_encode64("xyz126"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash5.merge(resume_token: Base64.strict_encode64("xyz127"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash1.merge(resume_token: Base64.strict_encode64("xyz128"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash2.merge(resume_token: Base64.strict_encode64("xyz129"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash3.merge(resume_token: Base64.strict_encode64("xyz130"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash4.merge(resume_token: Base64.strict_encode64("xyz131"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash5.merge(resume_token: Base64.strict_encode64("xyz132"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash1.merge(resume_token: Base64.strict_encode64("xyz133"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash2.merge(resume_token: Base64.strict_encode64("xyz134"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash3.merge(resume_token: Base64.strict_encode64("xyz135"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash4.merge(resume_token: Base64.strict_encode64("xyz137"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash5.merge(resume_token: Base64.strict_encode64("xyz128")))
     ].to_enum
 
     mock = Minitest::Mock.new
@@ -160,23 +160,23 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
 
   it "returns buffered responses once it hits the buffer bounds, but will re-raise if there is no resume_token" do
     bounds_with_abort_enum = [
-      Google::Spanner::V1::PartialResultSet.decode_json(results_header.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.merge(resumeToken: Base64.strict_encode64("xyz123")).to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
+      Google::Spanner::V1::PartialResultSet.new(results_header),
+      Google::Spanner::V1::PartialResultSet.new(results_hash1.merge(resume_token: Base64.strict_encode64("xyz123"))),
+      Google::Spanner::V1::PartialResultSet.new(results_hash2),
+      Google::Spanner::V1::PartialResultSet.new(results_hash3),
+      Google::Spanner::V1::PartialResultSet.new(results_hash4),
+      Google::Spanner::V1::PartialResultSet.new(results_hash5),
+      Google::Spanner::V1::PartialResultSet.new(results_hash1),
+      Google::Spanner::V1::PartialResultSet.new(results_hash2),
+      Google::Spanner::V1::PartialResultSet.new(results_hash3),
+      Google::Spanner::V1::PartialResultSet.new(results_hash4),
+      Google::Spanner::V1::PartialResultSet.new(results_hash5),
+      Google::Spanner::V1::PartialResultSet.new(results_hash1),
+      Google::Spanner::V1::PartialResultSet.new(results_hash2),
+      Google::Spanner::V1::PartialResultSet.new(results_hash3),
       GRPC::Unavailable,
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json)
+      Google::Spanner::V1::PartialResultSet.new(results_hash4),
+      Google::Spanner::V1::PartialResultSet.new(results_hash5)
     ].to_enum
 
     mock = Minitest::Mock.new

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
@@ -23,18 +23,18 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :mock_spanner do
   let :results_hash1 do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       }
@@ -43,62 +43,62 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :mock_spanner do
   let :results_hash2 do
     {
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" }
+        { string_value: "1" },
+        { string_value: "Charlie" }
       ],
-      resumeToken: Base64.strict_encode64("xyz890")
+      resume_token: Base64.strict_encode64("xyz890")
     }
   end
   let :results_hash3 do
     {
       values: [
-        { boolValue: true},
-        { stringValue: "29" }
+        { bool_value: true},
+        { string_value: "29" }
       ]
     }
   end
   let :results_hash4 do
     {
       values: [
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" }
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" }
       ],
-      resumeToken: Base64.strict_encode64("abc123")
+      resume_token: "abc123"
     }
   end
   let :results_hash5 do
     {
       values: [
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
       ]
     }
   end
   let :results_hash6 do
     {
       values: [
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
   let(:results_enum1) do
     [
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
+      Google::Spanner::V1::PartialResultSet.new(results_hash1),
+      Google::Spanner::V1::PartialResultSet.new(results_hash2),
+      Google::Spanner::V1::PartialResultSet.new(results_hash3),
+      Google::Spanner::V1::PartialResultSet.new(results_hash4),
+      Google::Spanner::V1::PartialResultSet.new(results_hash5),
       GRPC::Unavailable,
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash6.to_json)
+      Google::Spanner::V1::PartialResultSet.new(results_hash6)
     ].to_enum
   end
   let(:results_enum2) do
     [
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
-      Google::Spanner::V1::PartialResultSet.decode_json(results_hash6.to_json)
+      Google::Spanner::V1::PartialResultSet.new(results_hash1),
+      Google::Spanner::V1::PartialResultSet.new(results_hash5),
+      Google::Spanner::V1::PartialResultSet.new(results_hash6)
     ].to_enum
   end
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
@@ -23,38 +23,38 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       },
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_hash.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_hash)].to_enum
   end
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
   let(:columns) { [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids] }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -23,18 +23,18 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   let :results_hash1 do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       }
@@ -43,30 +43,30 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   let :results_hash2 do
     {
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" }
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" }
       ]
     }
   end
   let :results_hash3 do
     {
       values: [
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_hash1),
+     Google::Spanner::V1::PartialResultSet.new(results_hash2),
+     Google::Spanner::V1::PartialResultSet.new(results_hash3)].to_enum
   end
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
@@ -75,7 +75,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
 
   it "can read all rows" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-
+# puts Google::Spanner::V1::PartialResultSet.new(results_hash2).inspect
+# puts Google::Spanner::V1::PartialResultSet.new(Google::Spanner::V1::PartialResultSet.new(results_hash2)).inspect
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -28,38 +28,37 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       },
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
   let(:snp_opts) { Google::Spanner::V1::TransactionOptions::ReadOnly.new return_read_timestamp: true }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -28,38 +28,37 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       },
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
@@ -28,38 +28,37 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       },
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -28,38 +28,37 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       },
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }

--- a/google-cloud-spanner/test/google/cloud/spanner/database/ddl_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/ddl_test.rb
@@ -17,8 +17,7 @@ require "helper"
 describe Google::Cloud::Spanner::Database, :ddl, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
-  let(:database_json) { database_hash(instance_id: instance_id, database_id: database_id).to_json }
-  let(:database_grpc) { Google::Spanner::Admin::Database::V1::Database.decode_json database_json }
+  let(:database_grpc) { Google::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id) }
   let(:database) { Google::Cloud::Spanner::Database.from_grpc database_grpc, spanner.service }
   let(:statements) { ["CREATE TABLE table1", "CREATE TABLE table2", "CREATE TABLE table3"] }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/database/drop_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/drop_test.rb
@@ -17,8 +17,7 @@ require "helper"
 describe Google::Cloud::Spanner::Database, :drop, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
-  let(:database_json) { database_hash(instance_id: instance_id, database_id: database_id).to_json }
-  let(:database_grpc) { Google::Spanner::Admin::Database::V1::Database.decode_json database_json }
+  let(:database_grpc) { Google::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id) }
   let(:database) { Google::Cloud::Spanner::Database.from_grpc database_grpc, spanner.service }
 
   it "can delete itself" do

--- a/google-cloud-spanner/test/google/cloud/spanner/database/iam_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/iam_test.rb
@@ -17,12 +17,11 @@ require "helper"
 describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
-  let(:database_json) { database_hash(instance_id: instance_id, database_id: database_id).to_json }
-  let(:database_grpc) { Google::Spanner::Admin::Database::V1::Database.decode_json database_json }
+  let(:database_grpc) { Google::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id) }
   let(:database) { Google::Cloud::Spanner::Database.from_grpc database_grpc, spanner.service }
-  let(:viewer_policy_json) do
+  let(:viewer_policy_hash) do
     {
-      etag: "CAE=",
+      etag: "\b\x01",
       bindings: [{
         role: "roles/viewer",
         members: [
@@ -30,11 +29,11 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
           "serviceAccount:1234567890@developer.gserviceaccount.com"
          ]
       }]
-    }.to_json
+    }
   end
-  let(:owner_policy_json) do
+  let(:owner_policy_hash) do
     {
-      etag: "CAE=",
+      etag: "\b\x01",
       bindings: [{
         role: "roles/owner",
         members: [
@@ -42,11 +41,11 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
           "serviceAccount:0987654321@developer.gserviceaccount.com"
          ]
       }]
-    }.to_json
+    }
   end
 
   it "gets the IAM Policy" do
-    get_res = Google::Iam::V1::Policy.decode_json viewer_policy_json
+    get_res = Google::Iam::V1::Policy.new viewer_policy_hash
     mock = Minitest::Mock.new
     mock.expect :get_iam_policy, get_res, [database.path]
     database.service.mocked_databases = mock
@@ -66,16 +65,16 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
   end
 
   it "sets the IAM Policy" do
-    get_res = Google::Iam::V1::Policy.decode_json owner_policy_json
+    get_res = Google::Iam::V1::Policy.new owner_policy_hash
     mock = Minitest::Mock.new
     mock.expect :get_iam_policy, get_res, [database.path]
 
-    updated_policy_hash = JSON.parse owner_policy_json
-    updated_policy_hash["bindings"].first["members"].shift
-    updated_policy_hash["bindings"].first["members"] << "user:newowner@example.com"
+    updated_policy_hash = owner_policy_hash.dup
+    updated_policy_hash[:bindings].first[:members].shift
+    updated_policy_hash[:bindings].first[:members] << "user:newowner@example.com"
 
-    set_req = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
-    set_res = Google::Iam::V1::Policy.decode_json updated_policy_hash.merge(etag: "CBD=").to_json
+    set_req = Google::Iam::V1::Policy.new updated_policy_hash
+    set_res = Google::Iam::V1::Policy.new updated_policy_hash.merge(etag: "\b\x10")
     mock.expect :set_iam_policy, set_res, [database.path, set_req]
     database.service.mocked_databases = mock
 
@@ -101,16 +100,16 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
 
   it "sets the IAM Policy in a block" do
 
-    get_res = Google::Iam::V1::Policy.decode_json owner_policy_json
+    get_res = Google::Iam::V1::Policy.new owner_policy_hash
     mock = Minitest::Mock.new
     mock.expect :get_iam_policy, get_res, [database.path]
 
-    updated_policy_hash = JSON.parse owner_policy_json
-    updated_policy_hash["bindings"].first["members"].shift
-    updated_policy_hash["bindings"].first["members"] << "user:newowner@example.com"
+    updated_policy_hash = owner_policy_hash.dup
+    updated_policy_hash[:bindings].first[:members].shift
+    updated_policy_hash[:bindings].first[:members] << "user:newowner@example.com"
 
-    set_req = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
-    set_res = Google::Iam::V1::Policy.decode_json updated_policy_hash.merge(etag: "CBD=").to_json
+    set_req = Google::Iam::V1::Policy.new updated_policy_hash
+    set_res = Google::Iam::V1::Policy.new updated_policy_hash.merge(etag: "\b\x10")
     mock.expect :set_iam_policy, set_res, [database.path, set_req]
     database.service.mocked_databases = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/database/update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/update_test.rb
@@ -17,11 +17,17 @@ require "helper"
 describe Google::Cloud::Spanner::Database, :update, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
-  let(:database_json) { database_hash(instance_id: instance_id, database_id: database_id).to_json }
-  let(:database_grpc) { Google::Spanner::Admin::Database::V1::Database.decode_json database_json }
+  let(:database_grpc) { Google::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id) }
   let(:database) { Google::Cloud::Spanner::Database.from_grpc database_grpc, spanner.service }
-  let(:job_json) { "{\"name\":\"1234567890\",\"metadata\":{\"typeUrl\":\"google.spanner.admin.database.v1.UpdateDatabaseDdlRequest\",\"value\":\"\"}}" }
-  let(:job_grpc) { Google::Longrunning::Operation.decode_json job_json }
+  let(:job_grpc) do
+    Google::Longrunning::Operation.new(
+      name: "1234567890",
+      metadata: {
+        type_url: "google.spanner.admin.database.v1.UpdateDatabaseDdlRequest",
+        value: ""
+      }
+    )
+  end
 
   it "updates with single statement" do
     update_res = Google::Gax::Operation.new(

--- a/google-cloud-spanner/test/google/cloud/spanner/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database_test.rb
@@ -17,8 +17,7 @@ require "helper"
 describe Google::Cloud::Spanner::Instance, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
-  let(:database_json) { database_hash(instance_id: instance_id, database_id: database_id).to_json }
-  let(:database_grpc) { Google::Spanner::Admin::Database::V1::Database.decode_json database_json }
+  let(:database_grpc) { Google::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id) }
   let(:database) { Google::Cloud::Spanner::Database.from_grpc database_grpc, spanner.service }
 
   it "knows the identifiers" do

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/config_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/config_test.rb
@@ -16,13 +16,11 @@ require "helper"
 
 describe Google::Cloud::Spanner::Instance, :config, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
-  let(:instance_json) { instance_hash(name: instance_id).to_json }
-  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.decode_json instance_json }
+  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.new instance_hash(name: instance_id) }
   let(:instance) { Google::Cloud::Spanner::Instance.from_grpc instance_grpc, spanner.service }
-  let(:instance_config_json) { instance_config_hash.to_json }
 
   it "gets an instance config object" do
-    get_res = Google::Spanner::Admin::Instance::V1::InstanceConfig.decode_json instance_config_json
+    get_res = Google::Spanner::Admin::Instance::V1::InstanceConfig.new instance_config_hash
     mock = Minitest::Mock.new
     mock.expect :get_instance_config, get_res, [instance_grpc.config]
     spanner.service.mocked_instances = mock
@@ -35,7 +33,7 @@ describe Google::Cloud::Spanner::Instance, :config, :mock_spanner do
     config.project_id.must_equal project
     config.instance_config_id.must_equal instance_config_hash[:name].split("/").last
     config.path.must_equal instance_config_hash[:name]
-    config.name.must_equal instance_config_hash[:displayName]
-    config.display_name.must_equal instance_config_hash[:displayName]
+    config.name.must_equal instance_config_hash[:display_name]
+    config.display_name.must_equal instance_config_hash[:display_name]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/create_database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/create_database_test.rb
@@ -16,12 +16,18 @@ require "helper"
 
 describe Google::Cloud::Spanner::Instance, :create_database, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
-  let(:instance_json) { instance_hash(name: instance_id).to_json }
-  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.decode_json instance_json }
+  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.new instance_hash(name: instance_id) }
   let(:instance) { Google::Cloud::Spanner::Instance.from_grpc instance_grpc, spanner.service }
 
-  let(:job_json) { "{\"name\":\"1234567890\",\"metadata\":{\"typeUrl\":\"google.spanner.admin.database.v1.CreateDatabaseMetadata\",\"value\":\"\"}}" }
-  let(:job_grpc) { Google::Longrunning::Operation.decode_json job_json }
+  let(:job_grpc) do
+    Google::Longrunning::Operation.new(
+      name: "1234567890",
+      metadata: {
+        type_url: "google.spanner.admin.database.v1.UpdateDatabaseDdlRequest",
+        value: ""
+      }
+    )
+  end
   let(:database_grpc) do
     Google::Spanner::Admin::Database::V1::Database.new \
       name: "projects/bustling-kayak-91516/instances/my-new-instance",

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/database_test.rb
@@ -16,14 +16,13 @@ require "helper"
 
 describe Google::Cloud::Spanner::Instance, :database, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
-  let(:instance_json) { instance_hash(name: instance_id).to_json }
-  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.decode_json instance_json }
+  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.new instance_hash(name: instance_id) }
   let(:instance) { Google::Cloud::Spanner::Instance.from_grpc instance_grpc, spanner.service }
 
   it "gets an database" do
     database_id = "found-database"
 
-    get_res = Google::Spanner::Admin::Database::V1::Database.decode_json database_hash(instance_id: instance_id, database_id: database_id).to_json
+    get_res = Google::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id)
     mock = Minitest::Mock.new
     mock.expect :get_database, get_res, [database_path(instance_id, database_id)]
     instance.service.mocked_databases = mock

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/databases_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/databases_test.rb
@@ -16,26 +16,25 @@ require "helper"
 
 describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
-  let(:instance_json) { instance_hash(name: instance_id).to_json }
-  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.decode_json instance_json }
+  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.new instance_hash(name: instance_id) }
   let(:instance) { Google::Cloud::Spanner::Instance.from_grpc instance_grpc, spanner.service }
   let(:first_page) do
     h = databases_hash instance_id: instance_id
-    h[:nextPageToken] = "next_page_token"
-    response = Google::Spanner::Admin::Database::V1::ListDatabasesResponse.decode_json h.to_json
+    h[:next_page_token] = "next_page_token"
+    response = Google::Spanner::Admin::Database::V1::ListDatabasesResponse.new h
     paged_enum_struct response
 
   end
   let(:second_page) do
     h = databases_hash instance_id: instance_id
-    h[:nextPageToken] = "second_page_token"
-    response = Google::Spanner::Admin::Database::V1::ListDatabasesResponse.decode_json h.to_json
+    h[:next_page_token] = "second_page_token"
+    response = Google::Spanner::Admin::Database::V1::ListDatabasesResponse.new h
     paged_enum_struct response
   end
   let(:last_page) do
     h = databases_hash instance_id: instance_id
     h[:databases].pop
-    response = Google::Spanner::Admin::Database::V1::ListDatabasesResponse.decode_json h.to_json
+    response = Google::Spanner::Admin::Database::V1::ListDatabasesResponse.new h
     paged_enum_struct response
   end
   let(:next_page_options) { Google::Gax::CallOptions.new page_token: "next_page_token" }

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/delete_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/delete_test.rb
@@ -16,8 +16,7 @@ require "helper"
 
 describe Google::Cloud::Spanner::Instance, :delete, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
-  let(:instance_json) { instance_hash(name: instance_id).to_json }
-  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.decode_json instance_json }
+  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.new instance_hash(name: instance_id) }
   let(:instance) { Google::Cloud::Spanner::Instance.from_grpc instance_grpc, spanner.service }
 
   it "can delete itself" do

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/iam_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/iam_test.rb
@@ -16,12 +16,11 @@ require "helper"
 
 describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
-  let(:instance_json) { instance_hash(name: instance_id).to_json }
-  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.decode_json instance_json }
+  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.new instance_hash(name: instance_id) }
   let(:instance) { Google::Cloud::Spanner::Instance.from_grpc instance_grpc, spanner.service }
-  let(:viewer_policy_json) do
+  let(:viewer_policy_hash) do
     {
-      etag: "CAE=",
+      etag: "\b\x01",
       bindings: [{
         role: "roles/viewer",
         members: [
@@ -29,11 +28,11 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
           "serviceAccount:1234567890@developer.gserviceaccount.com"
          ]
       }]
-    }.to_json
+    }
   end
-  let(:owner_policy_json) do
+  let(:owner_policy_hash) do
     {
-      etag: "CAE=",
+      etag: "\b\x01",
       bindings: [{
         role: "roles/owner",
         members: [
@@ -41,11 +40,11 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
           "serviceAccount:0987654321@developer.gserviceaccount.com"
          ]
       }]
-    }.to_json
+    }
   end
 
   it "gets the IAM Policy" do
-    get_res = Google::Iam::V1::Policy.decode_json viewer_policy_json
+    get_res = Google::Iam::V1::Policy.new viewer_policy_hash
     mock = Minitest::Mock.new
     mock.expect :get_iam_policy, get_res, [instance.path]
     instance.service.mocked_instances = mock
@@ -65,16 +64,16 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
   end
 
   it "sets the IAM Policy" do
-    get_res = Google::Iam::V1::Policy.decode_json owner_policy_json
+    get_res = Google::Iam::V1::Policy.new owner_policy_hash
     mock = Minitest::Mock.new
     mock.expect :get_iam_policy, get_res, [instance.path]
 
-    updated_policy_hash = JSON.parse owner_policy_json
-    updated_policy_hash["bindings"].first["members"].shift
-    updated_policy_hash["bindings"].first["members"] << "user:newowner@example.com"
+    updated_policy_hash = owner_policy_hash.dup
+    updated_policy_hash[:bindings].first[:members].shift
+    updated_policy_hash[:bindings].first[:members] << "user:newowner@example.com"
 
-    set_req = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
-    set_res = Google::Iam::V1::Policy.decode_json updated_policy_hash.merge(etag: "CBD=").to_json
+    set_req = Google::Iam::V1::Policy.new updated_policy_hash
+    set_res = Google::Iam::V1::Policy.new updated_policy_hash.merge(etag: "\b\x10")
     mock.expect :set_iam_policy, set_res, [instance.path, set_req]
     instance.service.mocked_instances = mock
 
@@ -100,16 +99,16 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
 
   it "sets the IAM Policy in a block" do
 
-    get_res = Google::Iam::V1::Policy.decode_json owner_policy_json
+    get_res = Google::Iam::V1::Policy.new owner_policy_hash
     mock = Minitest::Mock.new
     mock.expect :get_iam_policy, get_res, [instance.path]
 
-    updated_policy_hash = JSON.parse owner_policy_json
-    updated_policy_hash["bindings"].first["members"].shift
-    updated_policy_hash["bindings"].first["members"] << "user:newowner@example.com"
+    updated_policy_hash = owner_policy_hash.dup
+    updated_policy_hash[:bindings].first[:members].shift
+    updated_policy_hash[:bindings].first[:members] << "user:newowner@example.com"
 
-    set_req = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
-    set_res = Google::Iam::V1::Policy.decode_json updated_policy_hash.merge(etag: "CBD=").to_json
+    set_req = Google::Iam::V1::Policy.new updated_policy_hash
+    set_res = Google::Iam::V1::Policy.new updated_policy_hash.merge(etag: "\b\x10")
     mock.expect :set_iam_policy, set_res, [instance.path, set_req]
     instance.service.mocked_instances = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/save_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/save_test.rb
@@ -16,11 +16,17 @@ require "helper"
 
 describe Google::Cloud::Spanner::Instance, :save, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
-  let(:instance_json) { instance_hash(name: instance_id).to_json }
-  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.decode_json instance_json }
+  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.new instance_hash(name: instance_id) }
   let(:instance) { Google::Cloud::Spanner::Instance.from_grpc instance_grpc, spanner.service }
-  let(:job_json) { "{\"name\":\"1234567890\",\"metadata\":{\"typeUrl\":\"google.spanner.admin.instance.v1.CreateInstanceMetadata\",\"value\":\"\"}}" }
-  let(:job_grpc) { Google::Longrunning::Operation.decode_json job_json }
+  let(:job_grpc) do
+    Google::Longrunning::Operation.new(
+      name: "1234567890",
+      metadata: {
+        type_url: "google.spanner.admin.database.v1.UpdateDatabaseDdlRequest",
+        value: ""
+      }
+    )
+  end
 
   it "updates and saves itself" do
     instance.display_name = "Updated display name"

--- a/google-cloud-spanner/test/google/cloud/spanner/instance_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance_test.rb
@@ -16,8 +16,7 @@ require "helper"
 
 describe Google::Cloud::Spanner::Instance, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
-  let(:instance_json) { instance_hash(name: instance_id).to_json }
-  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.decode_json instance_json }
+  let(:instance_grpc) { Google::Spanner::Admin::Instance::V1::Instance.new instance_hash(name: instance_id) }
   let(:instance) { Google::Cloud::Spanner::Instance.from_grpc instance_grpc, spanner.service }
 
   it "knows the identifiers" do

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
@@ -30,19 +30,16 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { type: { code: "INT64" } }
+            { type: { code: :INT64 } }
           ]
         }
       },
-      values: [
-        { stringValue: "1" }
-      ]
+      values: [ { string_value: "1" }]
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
 
   before do

--- a/google-cloud-spanner/test/google/cloud/spanner/project/create_database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/create_database_test.rb
@@ -17,8 +17,15 @@ require "helper"
 describe Google::Cloud::Spanner::Project, :create_database, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
 
-  let(:job_json) { "{\"name\":\"1234567890\",\"metadata\":{\"typeUrl\":\"google.spanner.admin.database.v1.CreateDatabaseMetadata\",\"value\":\"\"}}" }
-  let(:job_grpc) { Google::Longrunning::Operation.decode_json job_json }
+  let(:job_grpc) do
+    Google::Longrunning::Operation.new(
+      name: "1234567890",
+      metadata: {
+        type_url: "google.spanner.admin.database.v1.UpdateDatabaseDdlRequest",
+        value: ""
+      }
+    )
+  end
 
   it "creates an empty database" do
     instance_id = "my-instance-id"

--- a/google-cloud-spanner/test/google/cloud/spanner/project/create_instance_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/create_instance_test.rb
@@ -15,8 +15,15 @@
 require "helper"
 
 describe Google::Cloud::Spanner::Project, :create_instance, :mock_spanner do
-  let(:job_json) { "{\"name\":\"1234567890\",\"metadata\":{\"typeUrl\":\"google.spanner.admin.instance.v1.CreateInstanceMetadata\",\"value\":\"\"}}" }
-  let(:job_grpc) { Google::Longrunning::Operation.decode_json job_json }
+  let(:job_grpc) do
+    Google::Longrunning::Operation.new(
+      name: "1234567890",
+      metadata: {
+        type_url: "google.spanner.admin.database.v1.UpdateDatabaseDdlRequest",
+        value: ""
+      }
+    )
+  end
   let(:config) { instance_config_hash[:name] }
   let(:instance_grpc) do
     Google::Spanner::Admin::Instance::V1::Instance.new \

--- a/google-cloud-spanner/test/google/cloud/spanner/project/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/database_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Spanner::Project, :database, :mock_spanner do
   it "gets an database" do
     database_id = "found-database"
 
-    get_res = Google::Spanner::Admin::Database::V1::Database.decode_json database_hash(instance_id: instance_id, database_id: database_id).to_json
+    get_res = Google::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id)
     mock = Minitest::Mock.new
     mock.expect :get_database, get_res, [database_path(instance_id, database_id)]
     spanner.service.mocked_databases = mock

--- a/google-cloud-spanner/test/google/cloud/spanner/project/databases_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/databases_test.rb
@@ -18,21 +18,21 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:first_page) do
     h = databases_hash instance_id: instance_id
-    h[:nextPageToken] = "next_page_token"
-    response = Google::Spanner::Admin::Database::V1::ListDatabasesResponse.decode_json h.to_json
+    h[:next_page_token] = "next_page_token"
+    response = Google::Spanner::Admin::Database::V1::ListDatabasesResponse.new h
     paged_enum_struct response
 
   end
   let(:second_page) do
     h = databases_hash instance_id: instance_id
-    h[:nextPageToken] = "second_page_token"
-    response = Google::Spanner::Admin::Database::V1::ListDatabasesResponse.decode_json h.to_json
+    h[:next_page_token] = "second_page_token"
+    response = Google::Spanner::Admin::Database::V1::ListDatabasesResponse.new h
     paged_enum_struct response
   end
   let(:last_page) do
     h = databases_hash instance_id: instance_id
     h[:databases].pop
-    response = Google::Spanner::Admin::Database::V1::ListDatabasesResponse.decode_json h.to_json
+    response = Google::Spanner::Admin::Database::V1::ListDatabasesResponse.new h
     paged_enum_struct response
   end
   let(:next_page_options) { Google::Gax::CallOptions.new page_token: "next_page_token" }

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_config_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_config_test.rb
@@ -15,13 +15,11 @@
 require "helper"
 
 describe Google::Cloud::Spanner::Project, :instance_config, :mock_spanner do
-  let(:instance_config_json) { instance_config_hash.to_json }
-
   it "gets an instance config" do
     config_name = "found-config"
 
 
-    get_res = Google::Spanner::Admin::Instance::V1::InstanceConfig.decode_json instance_config_json
+    get_res = Google::Spanner::Admin::Instance::V1::InstanceConfig.new instance_config_hash
     mock = Minitest::Mock.new
     mock.expect :get_instance_config, get_res, [instance_config_path(config_name)]
     spanner.service.mocked_instances = mock
@@ -33,8 +31,8 @@ describe Google::Cloud::Spanner::Project, :instance_config, :mock_spanner do
     config.project_id.must_equal project
     config.instance_config_id.must_equal instance_config_hash[:name].split("/").last
     config.path.must_equal instance_config_hash[:name]
-    config.name.must_equal instance_config_hash[:displayName]
-    config.display_name.must_equal instance_config_hash[:displayName]
+    config.name.must_equal instance_config_hash[:display_name]
+    config.display_name.must_equal instance_config_hash[:display_name]
   end
 
   it "returns nil when getting an non-existent instance config" do

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_configs_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_configs_test.rb
@@ -17,21 +17,21 @@ require "helper"
 describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
   let(:first_page) do
     h = instance_configs_hash
-    h[:nextPageToken] = "next_page_token"
-    response = Google::Spanner::Admin::Instance::V1::ListInstanceConfigsResponse.decode_json h.to_json
+    h[:next_page_token] = "next_page_token"
+    response = Google::Spanner::Admin::Instance::V1::ListInstanceConfigsResponse.new h
     paged_enum_struct response
 
   end
   let(:second_page) do
     h = instance_configs_hash
-    h[:nextPageToken] = "second_page_token"
-    response = Google::Spanner::Admin::Instance::V1::ListInstanceConfigsResponse.decode_json h.to_json
+    h[:next_page_token] = "second_page_token"
+    response = Google::Spanner::Admin::Instance::V1::ListInstanceConfigsResponse.new h
     paged_enum_struct response
   end
   let(:last_page) do
     h = instance_configs_hash
-    h[:instanceConfigs].pop
-    response = Google::Spanner::Admin::Instance::V1::ListInstanceConfigsResponse.decode_json h.to_json
+    h[:instance_configs].pop
+    response = Google::Spanner::Admin::Instance::V1::ListInstanceConfigsResponse.new h
     paged_enum_struct response
   end
   let(:next_page_options) { Google::Gax::CallOptions.new page_token: "next_page_token" }

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_test.rb
@@ -18,7 +18,7 @@ describe Google::Cloud::Spanner::Project, :instance, :mock_spanner do
   it "gets an instance" do
     instance_id = "found-instance"
 
-    get_res = Google::Spanner::Admin::Instance::V1::Instance.decode_json instance_hash(name: instance_id).to_json
+    get_res = Google::Spanner::Admin::Instance::V1::Instance.new instance_hash(name: instance_id)
     mock = Minitest::Mock.new
     mock.expect :get_instance, get_res, [instance_path(instance_id)]
     spanner.service.mocked_instances = mock

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instances_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instances_test.rb
@@ -17,21 +17,21 @@ require "helper"
 describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
   let(:first_page) do
     h = instances_hash
-    h[:nextPageToken] = "next_page_token"
-    response = Google::Spanner::Admin::Instance::V1::ListInstancesResponse.decode_json h.to_json
+    h[:next_page_token] = "next_page_token"
+    response = Google::Spanner::Admin::Instance::V1::ListInstancesResponse.new h
     paged_enum_struct response
 
   end
   let(:second_page) do
     h = instances_hash
-    h[:nextPageToken] = "second_page_token"
-    response = Google::Spanner::Admin::Instance::V1::ListInstancesResponse.decode_json h.to_json
+    h[:next_page_token] = "second_page_token"
+    response = Google::Spanner::Admin::Instance::V1::ListInstancesResponse.new h
     paged_enum_struct response
   end
   let(:last_page) do
     h = instances_hash
     h[:instances].pop
-    response = Google::Spanner::Admin::Instance::V1::ListInstancesResponse.decode_json h.to_json
+    response = Google::Spanner::Admin::Instance::V1::ListInstancesResponse.new h
     paged_enum_struct response
   end
   let(:next_page_options) { Google::Gax::CallOptions.new page_token: "next_page_token" }

--- a/google-cloud-spanner/test/google/cloud/spanner/results/anonymous_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/anonymous_struct_test.rb
@@ -16,25 +16,25 @@ require "helper"
 
 describe Google::Cloud::Spanner::Results, :anonymous_struct, :mock_spanner do
   let :results_hash do
-    {"metadata"=>
-      {"rowType"=>
-        {"fields"=>
-          [{"type"=>
-             {"code"=>"ARRAY",
-              "arrayElementType"=>
-               {"code"=>"STRUCT",
-                "structType"=>
-                 {"fields"=>
-                   [{"type"=>{"code"=>"INT64"}},
-                    {"type"=>{"code"=>"INT64"}}]}}}}]}},
-     "values"=>
-      [{"listValue"=>
-         {"values"=>
-           [{"listValue"=>
-              {"values"=>[{"stringValue"=>"1"}, {"stringValue"=>"2"}]}}]}}]}
+    {metadata:
+      {row_type:
+        {fields:
+          [{type:
+             {code: :ARRAY,
+              array_element_type:
+               {code: :STRUCT,
+                struct_type:
+                 {fields:
+                   [{type:{code: :INT64}},
+                    {type:{code: :INT64}}]}}}}]}},
+     values:
+      [{list_value:
+         {values:
+           [{list_value:
+              {values:[{string_value: "1"}, {string_value: "2"}]}}]}}]}
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_hash.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_hash)].to_enum
   end
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/results/deeply_nested_list_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/deeply_nested_list_test.rb
@@ -17,163 +17,163 @@ require "helper"
 describe Google::Cloud::Spanner::Results, :deeply_nested_list, :mock_spanner do
   let :results_metadata do
     { metadata:
-      { rowType:
+      { row_type:
         { fields:
           [{ type:
              { code: :ARRAY,
-               arrayElementType:
+               array_element_type:
                { code: :STRUCT,
-                 structType:
+                 struct_type:
                  { fields:
-                   [{ name: "name", type: { code: "STRING"}},
-                    { name: "numbers", type: { code: :ARRAY, arrayElementType: { code: :INT64 }}},
-                    { name: "strings", type: { code: :ARRAY, arrayElementType: { code: :STRING }}}] }}}}] }},
+                   [{ name: "name", type: { code: :STRING}},
+                    { name: "numbers", type: { code: :ARRAY, array_element_type: { code: :INT64 }}},
+                    { name: "strings", type: { code: :ARRAY, array_element_type: { code: :STRING }}}] }}}}] }},
     }
   end
   let :results_values1 do
     { values:
-      [{ listValue:
+      [{ list_value:
          { values:
-           [{ listValue:
+           [{ list_value:
               { values:
-                [{ stringValue: "foo"},
-                 { listValue:
+                [{ string_value: "foo"},
+                 { list_value:
                    { values:
-                     [{ stringValue: "111"},
-                      { stringValue: "222"}] }}] }}
+                     [{ string_value: "111"},
+                      { string_value: "222"}] }}] }}
       ] }}],
-    chunkedValue: true }
+    chunked_value: true }
   end
   let :results_values2 do
     { values:
-      [{ listValue:
+      [{ list_value:
          { values:
-           [{ listValue:
+           [{ list_value:
               { values:
-                [{ listValue:
+                [{ list_value:
                    { values:
-                     [{ stringValue: "333"}] }},
-                 { listValue:
+                     [{ string_value: "333"}] }},
+                 { list_value:
                    { values:
-                     [{ stringValue: "foo"},
-                      { stringValue: "bar"}] }}] }}
+                     [{ string_value: "foo"},
+                      { string_value: "bar"}] }}] }}
       ] }}],
-    chunkedValue: true }
+    chunked_value: true }
   end
   let :results_values3 do
     { values:
-      [{ listValue:
+      [{ list_value:
          { values:
-           [{ listValue:
+           [{ list_value:
               { values:
-                [{ listValue:
+                [{ list_value:
                    { values:
-                     [{ stringValue: "baz"}] }}] }},
-            { listValue:
+                     [{ string_value: "baz"}] }}] }},
+            { list_value:
               { values:
-                [{ stringValue: "bar"},
-                 { listValue:
+                [{ string_value: "bar"},
+                 { list_value:
                    { values:
-                     [{ stringValue: "444"}] }}] }}
+                     [{ string_value: "444"}] }}] }}
       ] }}],
-    chunkedValue: true }
+    chunked_value: true }
   end
   let :results_values4 do
     { values:
-      [{ listValue:
+      [{ list_value:
          { values:
-           [{ listValue:
+           [{ list_value:
               { values:
-                 [{ listValue:
+                 [{ list_value:
                     { values:
-                      [{ stringValue: "555"},
-                       { stringValue: "666"}] }},
-                  { listValue:
+                      [{ string_value: "555"},
+                       { string_value: "666"}] }},
+                  { list_value:
                     { values:
-                      [{ stringValue: "foo"}] }}] }}
+                      [{ string_value: "foo"}] }}] }}
       ] }}],
-    chunkedValue: true }
+    chunked_value: true }
   end
   let :results_values5 do
     { values:
-      [{ listValue:
+      [{ list_value:
          { values:
-           [{ listValue:
+           [{ list_value:
               { values:
-                [{ listValue:
+                [{ list_value:
                    { values:
-                     [{ stringValue: "bar"},
-                      { stringValue: "baz"}] }}] }},
-            { listValue:
+                     [{ string_value: "bar"},
+                      { string_value: "baz"}] }}] }},
+            { list_value:
               { values:
-                [{ stringValue: "baz"},
-                 { listValue:
+                [{ string_value: "baz"},
+                 { list_value:
                    { values:
-                     [{ stringValue: "777"}] }}] }}
+                     [{ string_value: "777"}] }}] }}
       ] }}],
-    chunkedValue: true }
+    chunked_value: true }
   end
   let :results_values6 do
     { values:
-      [{ listValue:
+      [{ list_value:
          { values:
-           [{ listValue:
+           [{ list_value:
               { values:
-                [{ listValue:
+                [{ list_value:
                    { values:
-                     [{ stringValue: "888"}] }}] }}
+                     [{ string_value: "888"}] }}] }}
       ] }}],
-    chunkedValue: true }
+    chunked_value: true }
   end
   let :results_values7 do
     { values:
-      [{ listValue:
+      [{ list_value:
          { values:
-           [{ listValue:
+           [{ list_value:
               { values:
-                [{ listValue:
+                [{ list_value:
                    { values:
-                     [{ stringValue: "999"}] }},
-                 { listValue:
+                     [{ string_value: "999"}] }},
+                 { list_value:
                    { values:
-                     [{ stringValue: "foo"}] }}] }}
+                     [{ string_value: "foo"}] }}] }}
       ] }}],
-    chunkedValue: true }
+    chunked_value: true }
   end
   let :results_values8 do
     { values:
-      [{ listValue:
+      [{ list_value:
          { values:
-           [{ listValue:
+           [{ list_value:
               { values:
-                [{ listValue:
+                [{ list_value:
                    { values:
-                     [{ stringValue: "bar"}] }}] }}
+                     [{ string_value: "bar"}] }}] }}
       ] }}],
-    chunkedValue: true }
+    chunked_value: true }
   end
   let :results_values9 do
     { values:
-      [{ listValue:
+      [{ list_value:
          { values:
-           [{ listValue:
+           [{ list_value:
               { values:
-                [{ listValue:
+                [{ list_value:
                    { values:
-                     [{ stringValue: "baz"}] }}] }}
+                     [{ string_value: "baz"}] }}] }}
       ] }}] }
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_metadata.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_values1.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_values2.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_values3.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_values4.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_values5.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_values6.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_values7.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_values8.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_values9.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_metadata),
+     Google::Spanner::V1::PartialResultSet.new(results_values1),
+     Google::Spanner::V1::PartialResultSet.new(results_values2),
+     Google::Spanner::V1::PartialResultSet.new(results_values3),
+     Google::Spanner::V1::PartialResultSet.new(results_values4),
+     Google::Spanner::V1::PartialResultSet.new(results_values5),
+     Google::Spanner::V1::PartialResultSet.new(results_values6),
+     Google::Spanner::V1::PartialResultSet.new(results_values7),
+     Google::Spanner::V1::PartialResultSet.new(results_values8),
+     Google::Spanner::V1::PartialResultSet.new(results_values9)].to_enum
   end
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_struct_test.rb
@@ -16,25 +16,25 @@ require "helper"
 
 describe Google::Cloud::Spanner::Results, :duplicate_struct, :mock_spanner do
   let :results_hash do
-    {"metadata"=>
-      {"rowType"=>
-        {"fields"=>
-          [{"type"=>
-             {"code"=>"ARRAY",
-              "arrayElementType"=>
-               {"code"=>"STRUCT",
-                "structType"=>
-                 {"fields"=>
-                   [{"name"=>"num", "type"=>{"code"=>"INT64"}},
-                    {"name"=>"num", "type"=>{"code"=>"INT64"}}]}}}}]}},
-     "values"=>
-      [{"listValue"=>
-         {"values"=>
-           [{"listValue"=>
-              {"values"=>[{"stringValue"=>"1"}, {"stringValue"=>"2"}]}}]}}]}
+    {metadata:
+      {row_type:
+        {fields:
+          [{type:
+             {code: :ARRAY,
+              array_element_type:
+               {code: :STRUCT,
+                struct_type:
+                 {fields:
+                   [{name: "num", type:{code: :INT64}},
+                    {name: "num", type:{code: :INT64}}]}}}}]}},
+     values:
+      [{list_value:
+         {values:
+           [{list_value:
+              {values:[{string_value: "1"}, {string_value: "2"}]}}]}}]}
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_hash.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_hash)].to_enum
   end
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_test.rb
@@ -18,12 +18,12 @@ describe Google::Cloud::Spanner::Results, :duplicate, :mock_spanner do
   let :results_types do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "num", type: { code: "INT64" } },
-            { name: "str", type: { code: "INT64" } },
-            { name: "num", type: { code: "STRING" } },
-            { name: "str", type: { code: "STRING" } }
+            { name: "num", type: { code: :INT64 } },
+            { name: "str", type: { code: :INT64 } },
+            { name: "num", type: { code: :STRING } },
+            { name: "str", type: { code: :STRING } }
           ]
         }
       }
@@ -32,20 +32,20 @@ describe Google::Cloud::Spanner::Results, :duplicate, :mock_spanner do
   let :results_values do
     {
       values: [
-        { stringValue: "1" },
-        { stringValue: "2" },
-        { stringValue: "hello" },
-        { stringValue: "world" },
-        { stringValue: "3" },
-        { stringValue: "4" },
-        { stringValue: "hola" },
-        { stringValue: "mundo" }
+        { string_value: "1" },
+        { string_value: "2" },
+        { string_value: "hello" },
+        { string_value: "world" },
+        { string_value: "3" },
+        { string_value: "4" },
+        { string_value: "hola" },
+        { string_value: "mundo" }
       ]
     }
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_types.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_values.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_types),
+     Google::Spanner::V1::PartialResultSet.new(results_values)].to_enum
   end
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/results/empty_field_names_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/empty_field_names_test.rb
@@ -18,12 +18,12 @@ describe Google::Cloud::Spanner::Results, :empty_field_names, :mock_spanner do
   let :results_types do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { type: { code: "INT64" } },
-            { type: { code: "INT64" } },
-            { type: { code: "INT64" } },
-            { type: { code: "INT64" } }
+            { type: { code: :INT64 } },
+            { type: { code: :INT64 } },
+            { type: { code: :INT64 } },
+            { type: { code: :INT64 } }
           ]
         }
       }
@@ -32,20 +32,20 @@ describe Google::Cloud::Spanner::Results, :empty_field_names, :mock_spanner do
   let :results_values do
     {
       values: [
-        { stringValue: "1" },
-        { stringValue: "2" },
-        { stringValue: "3" },
-        { stringValue: "4" },
-        { stringValue: "5" },
-        { stringValue: "6" },
-        { stringValue: "7" },
-        { stringValue: "8" }
+        { string_value: "1" },
+        { string_value: "2" },
+        { string_value: "3" },
+        { string_value: "4" },
+        { string_value: "5" },
+        { string_value: "6" },
+        { string_value: "7" },
+        { string_value: "8" }
       ]
     }
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_types.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_values.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_types),
+     Google::Spanner::V1::PartialResultSet.new(results_values)].to_enum
   end
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/results/empty_fields_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/empty_fields_test.rb
@@ -18,7 +18,7 @@ describe Google::Cloud::Spanner::Results, :empty_fields, :mock_spanner do
   let :results_types do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: []
         }
       }
@@ -30,7 +30,7 @@ describe Google::Cloud::Spanner::Results, :empty_fields, :mock_spanner do
     }
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_types.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_types)].to_enum
   end
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/results/empty_rows_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/empty_rows_test.rb
@@ -18,12 +18,12 @@ describe Google::Cloud::Spanner::Results, :empty_rows, :mock_spanner do
   let :results_types do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { type: { code: "INT64" } },
-            { type: { code: "INT64" } },
-            { type: { code: "INT64" } },
-            { type: { code: "INT64" } }
+            { type: { code: :INT64 } },
+            { type: { code: :INT64 } },
+            { type: { code: :INT64 } },
+            { type: { code: :INT64 } }
           ]
         }
       }
@@ -35,7 +35,7 @@ describe Google::Cloud::Spanner::Results, :empty_rows, :mock_spanner do
     }
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_types.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_types)].to_enum
   end
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_single_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_single_test.rb
@@ -18,38 +18,38 @@ describe Google::Cloud::Spanner::Results, :from_enum, :single_response, :mock_sp
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       },
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_hash.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_hash)].to_enum
   end
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_test.rb
@@ -18,18 +18,18 @@ describe Google::Cloud::Spanner::Results, :from_enum, :mock_spanner do
   let :results_hash1 do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       }
@@ -38,30 +38,30 @@ describe Google::Cloud::Spanner::Results, :from_enum, :mock_spanner do
   let :results_hash2 do
     {
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" }
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" }
       ]
     }
   end
   let :results_hash3 do
     {
       values: [
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_hash1),
+     Google::Spanner::V1::PartialResultSet.new(results_hash2),
+     Google::Spanner::V1::PartialResultSet.new(results_hash3)].to_enum
   end
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/results/merge_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/merge_test.rb
@@ -17,14 +17,14 @@ require "helper"
 describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
   it "merges Strings" do
     results_hashes = [
-      { metadata: { rowType: { fields: [{ name: "f1", type: { code: "STRING" } }] } },
-        values: [{ stringValue: "abc" }],
-        chunkedValue: true },
-      { values: [{ stringValue: "def" }],
-        chunkedValue: true },
-      { values: [{ stringValue: "ghi" }] }
+      { metadata: { row_type: { fields: [{ name: "f1", type: { code: :STRING } }] } },
+        values: [{ string_value: "abc" }],
+        chunked_value: true },
+      { values: [{ string_value: "def" }],
+        chunked_value: true },
+      { values: [{ string_value: "ghi" }] }
     ]
-    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
+    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
@@ -43,14 +43,14 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
 
   it "merges String Arrays" do
     results_hashes = [
-      { metadata: { rowType: { fields: [{ name: "f1", type: { code: "ARRAY", arrayElementType: { code: "STRING" }}}] }},
-        values: [{ listValue: { values: [{ stringValue: "abc" }, { stringValue: "d" }] }}],
-        chunkedValue: true },
-      { values: [{ listValue: { values: [{ stringValue: "ef" }, { stringValue: "gh" }] }}],
-        chunkedValue: true },
-      { values: [{ listValue: { values: [{ stringValue: "i" }, { stringValue: "jkl" }] }}]}
+      { metadata: { row_type: { fields: [{ name: "f1", type: { code: :ARRAY, array_element_type: { code: :STRING }}}] }},
+        values: [{ list_value: { values: [{ string_value: "abc" }, { string_value: "d" }] }}],
+        chunked_value: true },
+      { values: [{ list_value: { values: [{ string_value: "ef" }, { string_value: "gh" }] }}],
+        chunked_value: true },
+      { values: [{ list_value: { values: [{ string_value: "i" }, { string_value: "jkl" }] }}]}
     ]
-    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
+    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
@@ -69,14 +69,14 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
 
   it "merges String Arrays With Nulls" do
     results_hashes = [
-      { metadata: { rowType: { fields: [{ name: "f1", type: { code: "ARRAY", arrayElementType: { code: "STRING" }}}] }},
-        values: [{ listValue: { values: [{ stringValue: "abc" }, { stringValue: "def" }] }}],
-        chunkedValue: true },
-      { values: [{ listValue: { values: [{ nullValue: "NULL_VALUE" }, { stringValue: "ghi" }] }}],
-        chunkedValue: true },
-      { values: [{ listValue: { values: [{ nullValue: "NULL_VALUE" }, { stringValue: "jkl" }] }}]}
+      { metadata: { row_type: { fields: [{ name: "f1", type: { code: :ARRAY, array_element_type: { code: :STRING }}}] }},
+        values: [{ list_value: { values: [{ string_value: "abc" }, { string_value: "def" }] }}],
+        chunked_value: true },
+      { values: [{ list_value: { values: [{ null_value: "NULL_VALUE" }, { string_value: "ghi" }] }}],
+        chunked_value: true },
+      { values: [{ list_value: { values: [{ null_value: "NULL_VALUE" }, { string_value: "jkl" }] }}]}
     ]
-    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
+    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
@@ -95,14 +95,14 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
 
   it "merges String Arrays With Empty Strings" do
     results_hashes = [
-      { metadata: { rowType: { fields: [{ name: "f1", type: { code: "ARRAY", arrayElementType: { code: "STRING" }}}] }},
-        values: [{ listValue: { values: [{ stringValue: "abc" }, { stringValue: "def" }] }}],
-        chunkedValue: true },
-      { values: [{ listValue: { values: [{ stringValue: "" }, { stringValue: "ghi" }] }}],
-        chunkedValue: true },
-      { values: [{ listValue: { values: [{ stringValue: "" }, { stringValue: "jkl" }] }}]}
+      { metadata: { row_type: { fields: [{ name: "f1", type: { code: :ARRAY, array_element_type: { code: :STRING }}}] }},
+        values: [{ list_value: { values: [{ string_value: "abc" }, { string_value: "def" }] }}],
+        chunked_value: true },
+      { values: [{ list_value: { values: [{ string_value: "" }, { string_value: "ghi" }] }}],
+        chunked_value: true },
+      { values: [{ list_value: { values: [{ string_value: "" }, { string_value: "jkl" }] }}]}
     ]
-    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
+    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
@@ -121,14 +121,14 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
 
   it "merges String Arrays With One Large String" do
     results_hashes = [
-      { metadata: { rowType: { fields: [{ name: "f1", type: { code: "ARRAY", arrayElementType: { code: "STRING" }}}] }},
-        values: [{ listValue: { values: [{ stringValue: "abc" }] }}],
-        chunkedValue: true },
-      { values: [{ listValue: { values: [{ stringValue: "def" }] }}],
-        chunkedValue: true },
-      { values: [{ listValue: { values: [{ stringValue: "ghi" }] }}]}
+      { metadata: { row_type: { fields: [{ name: "f1", type: { code: :ARRAY, array_element_type: { code: :STRING }}}] }},
+        values: [{ list_value: { values: [{ string_value: "abc" }] }}],
+        chunked_value: true },
+      { values: [{ list_value: { values: [{ string_value: "def" }] }}],
+        chunked_value: true },
+      { values: [{ list_value: { values: [{ string_value: "ghi" }] }}]}
     ]
-    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
+    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
@@ -147,14 +147,14 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
 
   it "merges INT64 Arrays" do
     results_hashes = [
-      { metadata: { rowType: { fields: [{ name: "f1", type: { code: "ARRAY", arrayElementType: { code: "INT64" }}}] }},
-        values: [{ listValue: { values: [{ stringValue: "1" }, { stringValue: "2" }] }}],
-        chunkedValue: true },
-      { values: [{ listValue: { values: [{ stringValue: "3" }, { stringValue: "4" }] }}],
-        chunkedValue: true },
-      { values: [{ listValue: { values: [{ nullValue: "NULL_VALUE" }, { stringValue: "5" }] }}]}
+      { metadata: { row_type: { fields: [{ name: "f1", type: { code: :ARRAY, array_element_type: { code: :INT64 }}}] }},
+        values: [{ list_value: { values: [{ string_value: "1" }, { string_value: "2" }] }}],
+        chunked_value: true },
+      { values: [{ list_value: { values: [{ string_value: "3" }, { string_value: "4" }] }}],
+        chunked_value: true },
+      { values: [{ list_value: { values: [{ null_value: "NULL_VALUE" }, { string_value: "5" }] }}]}
     ]
-    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
+    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
@@ -173,14 +173,14 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
 
   it "merges FLOAT64 Arrays" do
     results_hashes = [
-      { metadata: { rowType: { fields: [{ name: "f1", type: { code: "ARRAY", arrayElementType: { code: "FLOAT64" }}}] }},
-        values: [{ listValue: { values: [{ numberValue: 1.0 }, { numberValue: 2.0 }] }}],
-        chunkedValue: true },
-      { values: [{ listValue: { values: [{ stringValue: "Infinity" }, { stringValue: "-Infinity" }, { stringValue: "NaN" }] }}],
-        chunkedValue: true },
-      { values: [{ listValue: { values: [{ nullValue: "NULL_VALUE" }, { numberValue: 3.0 }] }}]}
+      { metadata: { row_type: { fields: [{ name: "f1", type: { code: :ARRAY, array_element_type: { code: :FLOAT64 }}}] }},
+        values: [{ list_value: { values: [{ number_value: 1.0 }, { number_value: 2.0 }] }}],
+        chunked_value: true },
+      { values: [{ list_value: { values: [{ string_value: "Infinity" }, { string_value: "-Infinity" }, { string_value: "NaN" }] }}],
+        chunked_value: true },
+      { values: [{ list_value: { values: [{ null_value: "NULL_VALUE" }, { number_value: 3.0 }] }}]}
     ]
-    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
+    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
@@ -199,15 +199,15 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
 
   it "merges Multiple Row Chunks/Non Chunks Interleaved" do
     results_hashes = [
-      { metadata: { rowType: { fields: [{ name: "f1", type: { code: "STRING" } }] } },
-        values: [{ stringValue: "a" }],
-        chunkedValue: true },
-      { values: [{ stringValue: "b" }, { stringValue: "c" }] },
-      { values: [{ stringValue: "d" }, { stringValue: "e" }],
-        chunkedValue: true },
-      { values: [{ stringValue: "f" }] }
+      { metadata: { row_type: { fields: [{ name: "f1", type: { code: :STRING } }] } },
+        values: [{ string_value: "a" }],
+        chunked_value: true },
+      { values: [{ string_value: "b" }, { string_value: "c" }] },
+      { values: [{ string_value: "d" }, { string_value: "e" }],
+        chunked_value: true },
+      { values: [{ string_value: "f" }] }
     ]
-    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
+    results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results

--- a/google-cloud-spanner/test/google/cloud/spanner/results/nested_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/nested_struct_test.rb
@@ -16,27 +16,27 @@ require "helper"
 
 describe Google::Cloud::Spanner::Results, :nested_struct, :mock_spanner do
   let :results_hash do
-    {"metadata"=>
-      {"rowType"=>
-        {"fields"=>
-          [{"type"=>
-             {"code"=>"ARRAY",
-              "arrayElementType"=>
-               {"code"=>"STRUCT",
-                "structType"=>
-                 {"fields"=>
-                   [{"name"=>"C1", "type"=>{"code"=>"STRING"}},
-                    {"name"=>"C2", "type"=>{"code"=>"INT64"}}]}}}}]}},
-     "values"=>
-      [{"listValue"=>
-         {"values"=>
-           [{"listValue"=>
-              {"values"=>[{"stringValue"=>"a"}, {"stringValue"=>"1"}]}},
-            {"listValue"=>
-              {"values"=>[{"stringValue"=>"b"}, {"stringValue"=>"2"}]}}]}}]}
+    {metadata:
+      {row_type:
+        {fields:
+          [{type:
+             {code: :ARRAY,
+              array_element_type:
+               {code: :STRUCT,
+                struct_type:
+                 {fields:
+                   [{name: "C1", type:{code: :STRING}},
+                    {name: "C2", type:{code: :INT64}}]}}}}]}},
+     values:
+      [{list_value:
+         {values:
+           [{list_value:
+              {values:[{string_value: "a"}, {string_value: "1"}]}},
+            {list_value:
+              {values:[{string_value: "b"}, {string_value: "2"}]}}]}}]}
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_hash.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_hash)].to_enum
   end
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/results/timestamp_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/timestamp_test.rb
@@ -20,22 +20,22 @@ describe Google::Cloud::Spanner::Results, :timestamp, :mock_spanner do
   let :results_types do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { type: { code: "INT64" } },
-            { type: { code: "INT64" } },
-            { type: { code: "INT64" } },
-            { type: { code: "INT64" } }
+            { type: { code: :INT64 } },
+            { type: { code: :INT64 } },
+            { type: { code: :INT64 } },
+            { type: { code: :INT64 } }
           ]
         },
         transaction: {
-          read_timestamp: JSON.parse(timestamp.to_json)
+          read_timestamp: timestamp
         }
       }
     }
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_types.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_types)].to_enum
   end
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/session/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/execute_query_test.rb
@@ -24,38 +24,37 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       },
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
 
   it "can execute a simple query" do

--- a/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
@@ -24,19 +24,18 @@ describe Google::Cloud::Spanner::Session, :keepalive, :mock_spanner do
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { type: { code: "INT64" } }
+            { type: { code: :INT64 } }
           ]
         }
       },
       values: [
-        { stringValue: "1" }
+        { string_value: "1" }
       ]
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
 
   let(:labels) { { "env" => "production" } }

--- a/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
@@ -25,18 +25,18 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
   let :results_hash1 do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       }
@@ -45,30 +45,30 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
   let :results_hash2 do
     {
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" }
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" }
       ]
     }
   end
   let :results_hash3 do
     {
       values: [
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_hash1),
+     Google::Spanner::V1::PartialResultSet.new(results_hash2),
+     Google::Spanner::V1::PartialResultSet.new(results_hash3)].to_enum
   end
 
   it "can read all rows" do

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_query_test.rb
@@ -28,38 +28,37 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       },
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
 
   it "can execute a simple query" do

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
@@ -28,18 +28,18 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
   let :results_hash1 do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       }
@@ -48,30 +48,30 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
   let :results_hash2 do
     {
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" }
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" }
       ]
     }
   end
   let :results_hash3 do
     {
       values: [
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_hash1),
+     Google::Spanner::V1::PartialResultSet.new(results_hash2),
+     Google::Spanner::V1::PartialResultSet.new(results_hash3)].to_enum
   end
 
   it "can read all rows" do

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_query_test.rb
@@ -28,38 +28,37 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       },
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" },
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" },
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
 
   it "can execute a simple query" do

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/fields_for_test.rb
@@ -28,25 +28,24 @@ describe Google::Cloud::Spanner::Transaction, :fields_for, :mock_spanner do
   let :results_hash do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       }
     }
   end
-  let(:results_json) { results_hash.to_json }
-  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
 
   it "can get a table's fields" do

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
@@ -28,18 +28,18 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
   let :results_hash1 do
     {
       metadata: {
-        rowType: {
+        row_type: {
           fields: [
-            { name: "id",          type: { code: "INT64" } },
-            { name: "name",        type: { code: "STRING" } },
-            { name: "active",      type: { code: "BOOL" } },
-            { name: "age",         type: { code: "INT64" } },
-            { name: "score",       type: { code: "FLOAT64" } },
-            { name: "updated_at",  type: { code: "TIMESTAMP" } },
-            { name: "birthday",    type: { code: "DATE"} },
-            { name: "avatar",      type: { code: "BYTES" } },
-            { name: "project_ids", type: { code: "ARRAY",
-                                           arrayElementType: { code: "INT64" } } }
+            { name: "id",          type: { code: :INT64 } },
+            { name: "name",        type: { code: :STRING } },
+            { name: "active",      type: { code: :BOOL } },
+            { name: "age",         type: { code: :INT64 } },
+            { name: "score",       type: { code: :FLOAT64 } },
+            { name: "updated_at",  type: { code: :TIMESTAMP } },
+            { name: "birthday",    type: { code: :DATE} },
+            { name: "avatar",      type: { code: :BYTES } },
+            { name: "project_ids", type: { code: :ARRAY,
+                                           array_element_type: { code: :INT64 } } }
           ]
         }
       }
@@ -48,30 +48,30 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
   let :results_hash2 do
     {
       values: [
-        { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" }
+        { string_value: "1" },
+        { string_value: "Charlie" },
+        { bool_value: true},
+        { string_value: "29" },
+        { number_value: 0.9 },
+        { string_value: "2017-01-02T03:04:05.060000000Z" },
+        { string_value: "1950-01-01" },
+        { string_value: "aW1hZ2U=" }
       ]
     }
   end
   let :results_hash3 do
     {
       values: [
-        { listValue: { values: [ { stringValue: "1"},
-                                 { stringValue: "2"},
-                                 { stringValue: "3"} ]}}
+        { list_value: { values: [ { string_value: "1"},
+                                 { string_value: "2"},
+                                 { string_value: "3"} ]}}
       ]
     }
   end
   let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json)].to_enum
+    [Google::Spanner::V1::PartialResultSet.new(results_hash1),
+     Google::Spanner::V1::PartialResultSet.new(results_hash2),
+     Google::Spanner::V1::PartialResultSet.new(results_hash3)].to_enum
   end
 
   it "can read all rows" do

--- a/google-cloud-spanner/test/helper.rb
+++ b/google-cloud-spanner/test/helper.rb
@@ -77,19 +77,19 @@ class MockSpanner < Minitest::Spec
 
   def instance_configs_hash
     {
-      instanceConfigs: [
+      instance_configs: [
         { name: "projects/#{project}/instanceConfigs/regional-europe-west1",
-          displayName: "EU West 1"},
+          display_name: "EU West 1"},
         { name: "projects/#{project}/instanceConfigs/regional-us-west1",
-          displayName: "US West 1"},
+          display_name: "US West 1"},
         { name: "projects/#{project}/instanceConfigs/regional-us-central1",
-          displayName: "US Central 1"}
+          display_name: "US Central 1"}
       ]
     }
   end
 
   def instance_config_hash
-    instance_configs_hash[:instanceConfigs].last
+    instance_configs_hash[:instance_configs].last
   end
 
   def instances_hash
@@ -100,8 +100,8 @@ class MockSpanner < Minitest::Spec
     {
       name: "projects/#{project}/instances/#{name}",
       config: "projects/#{project}/instanceConfigs/regional-us-central1",
-      displayName: name.split("-").map(&:capitalize).join(" "),
-      nodeCount: nodes,
+      display_name: name.split("-").map(&:capitalize).join(" "),
+      node_count: nodes,
       state: state,
       labels: labels
     }


### PR DESCRIPTION
The google-protobuf 3.7.0 release over the weekend fixes many issues, but it also changes the JSON structure used in our tests. This PR updates the tests to use the new JSON structure for `Timestamp` and `Google::Protobuf::Duration`, and moves Spanner tests off of JSON due to the numerous changes for JSON serialization and deserialization of `Google::Protobuf::Type`.