### PR TITLE
Debugger/fix acceptance checks

### DIFF
--- a/google-cloud-debugger/acceptance/debugger/debugger_test.rb
+++ b/google-cloud-debugger/acceptance/debugger/debugger_test.rb
@@ -30,6 +30,8 @@ describe Google::Cloud::Debugger, :debugger do
       breakpoint.is_final_state
     end
 
+    breakpoint.must_be :is_final_state
+
     stack_frame = breakpoint.stack_frames[0]
     stack_frame.function.must_equal "trigger_breakpoint"
     stack_frame.locals.size.must_equal 1
@@ -61,6 +63,8 @@ describe Google::Cloud::Debugger, :debugger do
       entries = logging.entries filter: filter
       !entries.empty?
     end
+
+    entries.wont_be :empty?
 
     entries.first.payload.must_match "LOGPOINT"
     entries.first.payload.must_match "local_var is 42"

--- a/google-cloud-debugger/acceptance/debugger_helper.rb
+++ b/google-cloud-debugger/acceptance/debugger_helper.rb
@@ -28,7 +28,7 @@ require "grpc"
 module Acceptance
   class DebuggerTest < Minitest::Test
     MIN_DELAY = 2
-    MAX_DELAY = 11
+    MAX_DELAY = 15
 
     attr_accessor :debugger
 


### PR DESCRIPTION
* Add post-`wait_until` assertions
  * The `wait_until` block will delay until MAX_DELAY is met.
    But, if the criteria is not met then the test will fail.
    Add additonal assertions that match the wait_until criteria.
* Extend Debugger `wait_until` delay
  * Give the acceptance tests more time to complete successfully.