### PR TITLE
Protobuf 3.7 redux

### DIFF
--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
@@ -17,9 +17,8 @@ require "helper"
 
 describe Google::Cloud::ErrorReporting::ErrorEvent, :mock_error_reporting do
   let(:error_event_hash) { random_error_event_hash }
-  let(:error_event_json) { error_event_hash.to_json }
   let(:error_event_grpc) {
-    Google::Devtools::Clouderrorreporting::V1beta1::ReportedErrorEvent.decode_json error_event_json
+    Google::Devtools::Clouderrorreporting::V1beta1::ReportedErrorEvent.new error_event_hash
   }
   let(:error_event) {
     Google::Cloud::ErrorReporting::ErrorEvent.from_grpc error_event_grpc

--- a/google-cloud-error_reporting/test/helper.rb
+++ b/google-cloud-error_reporting/test/helper.rb
@@ -35,45 +35,49 @@ class MockErrorReporting < Minitest::Spec
   end
 
   def random_error_event_hash
+    timestamp = Time.parse "2014-10-02T15:01:23.045123456Z"
     {
-      "event_time" => "2014-10-02T15:01:23.045123456Z",
-      "message" => "error message",
-      "service_context" => random_service_context_hash,
-      "context" => random_error_context_hash,
+      event_time: {
+        seconds: timestamp.to_i,
+        nanos: timestamp.nsec
+      },
+      message: "error message",
+      service_context: random_service_context_hash,
+      context: random_error_context_hash,
     }
   end
 
   def random_service_context_hash
     {
-      "service" => "default",
-      "version" => "v1"
+      service: "default",
+      version: "v1"
     }
   end
 
   def random_error_context_hash
     {
-      "user" => "testerson",
-      "http_request" => random_http_request_context_hash,
-      "report_location" => random_source_location_hash,
+      user: "testerson",
+      http_request: random_http_request_context_hash,
+      report_location: random_source_location_hash,
     }
   end
 
   def random_http_request_context_hash
     {
-      "method" => "GET",
-      "url" => "http://test.local/foo?bar=baz",
-      "user_agent" => "google-cloud/1.0.0",
-      "referrer" => "http://test/local/referrer",
-      "response_status_code" => 200,
-      "remote_ip" => "127.0.0.1",
+      method: "GET",
+      url: "http://test.local/foo?bar=baz",
+      user_agent: "google-cloud/1.0.0",
+      referrer: "http://test/local/referrer",
+      response_status_code: 200,
+      remote_ip: "127.0.0.1",
     }
   end
 
   def random_source_location_hash
     {
-      "file_path" => "/path/to/file.txt",
-      "line_number" => 5,
-      "function_name" => "testee"
+      file_path: "/path/to/file.txt",
+      line_number: 5,
+      function_name: "testee"
     }
   end
 end

--- a/google-cloud-firestore/Gemfile
+++ b/google-cloud-firestore/Gemfile
@@ -7,4 +7,4 @@ gem "google-cloud-env", path: "../google-cloud-env"
 
 gem "rake", "~> 12.3"
 
-gem "stackprof"
+gem "stackprof" unless Gem.win_platform?

--- a/google-cloud-firestore/test/google/cloud/firestore/commit_response_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/commit_response_test.rb
@@ -15,6 +15,10 @@
 require "helper"
 
 describe Google::Cloud::Firestore::CommitResponse, :mock_firestore do
+  let(:update_time) { Time.parse "2017-12-20T05:33:53.428000000Z" }
+  let(:update_timestamp) { Google::Cloud::Firestore::Convert.time_to_timestamp update_time }
+  let(:commit_time) { Time.parse "2017-12-20T05:35:21.295000000Z" }
+  let(:commit_timestamp) { Google::Cloud::Firestore::Convert.time_to_timestamp update_time }
 
   it "can represent no result" do
     grpc_response = nil
@@ -35,60 +39,91 @@ describe Google::Cloud::Firestore::CommitResponse, :mock_firestore do
   end
 
   it "can represent results with transforms" do
-    json = "{\"writeResults\":[{\"updateTime\":\"2017-12-20T05:33:53.441316000Z\",\"transformResults\":[{\"timestampValue\":\"2017-12-20T05:33:53.428000000Z\"},{\"timestampValue\":\"2017-12-20T05:33:53.428000000Z\"},{\"timestampValue\":\"2017-12-20T05:33:53.428000000Z\"}]}],\"commitTime\":\"2017-12-20T05:33:53.441316000Z\"}"
-    grpc_response = Google::Firestore::V1::CommitResponse.decode_json json
+    grpc_response = Google::Firestore::V1::CommitResponse.new(
+      write_results: [
+        {
+          update_time: update_timestamp,
+          transform_results: [
+            { timestamp_value: update_timestamp },
+            { timestamp_value: update_timestamp },
+            { timestamp_value: update_timestamp }
+          ]
+        }
+      ],
+      commit_time: commit_timestamp
+    )
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two]]
 
-    commit_response.commit_time.must_be_close_to Time.parse("2017-12-19 22:33:53 -0700"), 1
+    commit_response.commit_time.must_equal update_time
     commit_response.write_results.size.must_equal 1
     commit_response.write_results.first.tap do |write_result|
-      write_result.update_time.must_be_close_to Time.parse("2017-12-19 22:33:53 -0700"), 1
+      write_result.update_time.must_equal update_time
     end
   end
 
-  it "can represent results with and without updateTime" do
-    json = "{\"writeResults\":[{\"updateTime\":\"2017-12-20T05:34:53.441316000Z\"}, {}],\"commitTime\":\"2017-12-20T05:33:53.441316000Z\"}"
-    grpc_response = Google::Firestore::V1::CommitResponse.decode_json json
+  it "can represent results with and without update_time" do
+    grpc_response = Google::Firestore::V1::CommitResponse.new(
+      write_results: [
+        { update_time: update_timestamp },
+        {}
+      ],
+      commit_time: commit_timestamp
+    )
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two]]
 
-    commit_response.commit_time.must_be_close_to Time.parse("2017-12-19 22:33:53 -0700"), 1
+    commit_response.commit_time.must_equal update_time
     commit_response.write_results.size.must_equal 1
-    commit_response.write_results[0].update_time.must_be_close_to Time.parse("2017-12-19 22:34:53 -0700"), 1
+    commit_response.write_results[0].update_time.must_equal update_time
   end
 
-  it "can represent results without and with updateTime" do
-    json = "{\"writeResults\":[{}, {\"updateTime\":\"2017-12-20T05:34:53.441316000Z\"}],\"commitTime\":\"2017-12-20T05:33:53.441316000Z\"}"
-    grpc_response = Google::Firestore::V1::CommitResponse.decode_json json
+  it "can represent results without and with update_time" do
+    grpc_response = Google::Firestore::V1::CommitResponse.new(
+      write_results: [
+        {},
+        { update_time: update_timestamp }
+      ],
+      commit_time: commit_timestamp
+    )
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two]]
 
-    commit_response.commit_time.must_be_close_to Time.parse("2017-12-19 22:33:53 -0700"), 1
+    commit_response.commit_time.must_equal update_time
     commit_response.write_results.size.must_equal 1
-    commit_response.write_results[0].update_time.must_be_close_to Time.parse("2017-12-19 22:34:53 -0700"), 1
+    commit_response.write_results[0].update_time.must_equal update_time
   end
 
-  it "can represent results without updateTime" do
-    json = "{\"writeResults\":[{}, {}],\"commitTime\":\"2017-12-20T05:33:53.441316000Z\"}"
-    grpc_response = Google::Firestore::V1::CommitResponse.decode_json json
+  it "can represent results without update_time" do
+    grpc_response = Google::Firestore::V1::CommitResponse.new(
+      write_results: [
+        {},
+        {}
+      ],
+      commit_time: commit_timestamp
+    )
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two]]
 
-    commit_response.commit_time.must_be_close_to Time.parse("2017-12-19 22:33:53 -0700"), 1
+    commit_response.commit_time.must_equal update_time
     commit_response.write_results.size.must_equal 1
-    commit_response.write_results[0].update_time.must_be_close_to Time.parse("2017-12-19 22:33:53 -0700"), 1
+    commit_response.write_results[0].update_time.must_equal update_time
   end
 
   it "can represent results without mismatched writes" do
-    json = "{\"writeResults\":[{}, {}],\"commitTime\":\"2017-12-20T05:33:53.441316000Z\"}"
-    grpc_response = Google::Firestore::V1::CommitResponse.decode_json json
+    grpc_response = Google::Firestore::V1::CommitResponse.new(
+      write_results: [
+        {},
+        {}
+      ],
+      commit_time: commit_timestamp
+    )
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two], :three]
 
-    commit_response.commit_time.must_be_close_to Time.parse("2017-12-19 22:33:53 -0700"), 1
+    commit_response.commit_time.must_equal update_time
     commit_response.write_results.size.must_equal 2
-    commit_response.write_results[0].update_time.must_be_close_to Time.parse("2017-12-19 22:33:53 -0700"), 1
-    commit_response.write_results[1].update_time.must_be_close_to Time.parse("2017-12-19 22:33:53 -0700"), 1
+    commit_response.write_results[0].update_time.must_equal update_time
+    commit_response.write_results[1].update_time.must_equal update_time
   end
 end

--- a/google-cloud-logging/support/doctest_helper.rb
+++ b/google-cloud-logging/support/doctest_helper.rb
@@ -395,7 +395,7 @@ end
 def list_entries_res token = nil
   OpenStruct.new(
     page: OpenStruct.new(
-      response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, token))
+      response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, token))
     )
   )
 end
@@ -403,24 +403,24 @@ end
 def list_logs_res token = nil
   OpenStruct.new(
     page: OpenStruct.new(
-      response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, token))
+      response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(3, token))
     )
   )
 end
 
 def list_resource_descriptors_res
-  Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3))
+  Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3))
 end
 
 
 def get_sink_res
-  Google::Logging::V2::LogSink.decode_json(random_sink_hash.merge("name" => sink_name).to_json)
+  Google::Logging::V2::LogSink.new(random_sink_hash.merge(name:  sink_name).to_hash)
 end
 
 def list_sinks_res
   OpenStruct.new(
     page: OpenStruct.new(
-      response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3))
+      response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(3))
     )
   )
 end
@@ -428,78 +428,82 @@ end
 def list_metrics_res
   OpenStruct.new(
     page: OpenStruct.new(
-      response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3))
+      response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3))
     )
   )
 end
 
-def list_resource_descriptors_json count = 2, token = nil
+def list_resource_descriptors_hash count = 2, token = nil
   {
     resource_descriptors: count.times.map { random_resource_descriptor_hash },
     next_page_token: token
-  }.delete_if { |_, v| v.nil? }.to_json
+  }.delete_if { |_, v| v.nil? }
 end
 
-def list_metrics_json count = 2, token = nil
+def list_metrics_hash count = 2, token = nil
   {
     metrics: count.times.map { random_metric_hash },
     next_page_token: token
-  }.delete_if { |_, v| v.nil? }.to_json
+  }.delete_if { |_, v| v.nil? }
 end
 
-def list_entries_json count = 2, token = nil
+def list_entries_hash count = 2, token = nil
   {
     entries: count.times.map { random_entry_hash },
     next_page_token: token
-  }.delete_if { |_, v| v.nil? }.to_json
+  }.delete_if { |_, v| v.nil? }
 end
 
 def random_entry_hash
+  timestamp = Time.parse "2014-10-02T15:01:23.045123456Z"
   {
-    "log_name"  => "projects/my-projectid/logs/syslog",
-    "resource"  => random_resource_hash,
-    "timestamp" => "2014-10-02T15:01:23.045123456Z",
-    "severity"  => :DEFAULT,
-    "insert_id" => "abc123",
-    "labels" => {
-      "env" => "production",
-      "foo" => "bar"
+    log_name:   "projects/my-projectid/logs/syslog",
+    resource:   random_resource_hash,
+    timestamp:  {
+      seconds:  timestamp.to_i,
+      nanos:    timestamp.nsec
     },
-    "text_payload" => "payload",
-    "http_request" => random_http_request_hash,
-    "operation"    => random_operation_hash
+    severity:   :DEFAULT,
+    insert_id:  "abc123",
+    labels:  {
+      "env" =>  "production",
+      "foo" =>  "bar"
+    },
+    text_payload:  "payload",
+    http_request:  random_http_request_hash,
+    operation:     random_operation_hash
   }
 end
 
 def random_http_request_hash
   {
-    "request_method" => "GET",
-    "request_url" => "http://test.local/foo?bar=baz",
-    "request_size" => 123,
-    "status" => 200,
-    "response_size" => 456,
-    "user_agent" => "google-cloud/1.0.0",
-    "remote_ip" => "127.0.0.1",
-    "referer" => "http://test.local/referer",
-    "cache_hit" => false,
-    "cache_validated_with_origin_server" => false
+    request_method:  "GET",
+    request_url:  "http://test.local/foo?bar=baz",
+    request_size:  123,
+    status:  200,
+    response_size:  456,
+    user_agent:  "google-cloud/1.0.0",
+    remote_ip:  "127.0.0.1",
+    referer:  "http://test.local/referer",
+    cache_hit:  false,
+    cache_validated_with_origin_server:  false
   }
 end
 
 def random_operation_hash
   {
-    "id" => "xyz789",
-    "producer" => "MyApp.MyClass#my_method",
-    "first" => false,
-    "last" => false
+    id:  "xyz789",
+    producer:  "MyApp.MyClass#my_method",
+    first:  false,
+    last:  false
   }
 end
 
 def random_resource_hash
   {
-    "type" => "gae_app",
-    "labels" => {
-      "module_id" => "1",
+    type:  "gae_app",
+    labels:  {
+      "module_id"  => "1",
       "version_id" => "20150925t173233"
     }
   }
@@ -507,54 +511,58 @@ end
 
 def random_resource_descriptor_hash
   {
-    "type"         => "cloudsql_database",
-    "display_name" => "Cloud SQL Database",
-    "description"  => "This resource is a Cloud SQL Database",
-    "labels"       => [
+    type:          "cloudsql_database",
+    display_name:  "Cloud SQL Database",
+    description:   "This resource is a Cloud SQL Database",
+    labels:        [
       {
-       "key"          => "database_id",
-       "description"  => "The ID of the database."
+        key:           "database_id",
+        description:   "The ID of the database."
       },
       {
-       "key"          => "zone",
-       "value_type"   => :STRING,
-       "description"  => "The GCP zone in which the database is running."
+        key:           "zone",
+        value_type:    :STRING,
+        description:   "The GCP zone in which the database is running."
       }
     ]
   }
 end
 
 def random_sink_hash
+  timestamp = Time.parse "2014-10-02T15:01:23.045123456Z"
   {
-    "name"                  => "my-severe-errors-to-pubsub",
-    "destination"           => "storage.googleapis.com/a-bucket",
-    "filter"                => "logName:syslog AND severity>=ERROR",
-    "output_version_format" => :VERSION_FORMAT_UNSPECIFIED,
-    "writer_identity"       => "roles/owner",
-    "start_time"            => "2014-10-02T15:01:23.045123456Z"
+    name:                   "my-severe-errors-to-pubsub",
+    destination:            "storage.googleapis.com/a-bucket",
+    filter:                 "logName:syslog AND severity>=ERROR",
+    output_version_format:  :VERSION_FORMAT_UNSPECIFIED,
+    writer_identity:        "roles/owner",
+    start_time:             {
+                              seconds:  timestamp.to_i,
+                              nanos:    timestamp.nsec
+                            }
   }
 end
 
 def random_metric_hash
   {
-    "name"        => "severe_errors",
-    "description" => "The servere errors metric",
-    "filter"      => "logName:syslog AND severity>=ERROR"
+    name:         "severe_errors",
+    description:  "The servere errors metric",
+    filter:       "logName:syslog AND severity>=ERROR"
   }
 end
 
-def list_sinks_json count = 2, token = nil
+def list_sinks_hash count = 2, token = nil
   {
     sinks: count.times.map { random_sink_hash },
     next_page_token: token
-  }.delete_if { |_, v| v.nil? }.to_json
+  }.delete_if { |_, v| v.nil? }
 end
 
-def list_logs_json count = 2, token = nil
+def list_logs_hash count = 2, token = nil
   {
     log_names: count.times.map { "log-name" },
     next_page_token: token
-  }.delete_if { |_, v| v.nil? }.to_json
+  }.delete_if { |_, v| v.nil? }
 end
 
 # Storage helpers
@@ -565,39 +573,39 @@ def object_access_control_gapi
 end
 
 def bucket_gapi name = "my-bucket"
-  Google::Apis::StorageV1::Bucket.from_json random_bucket_hash(name).to_json
+  Google::Apis::StorageV1::Bucket.new random_bucket_hash(name)
 end
 
 def random_bucket_hash(name = "my-bucket",
   url_root="https://www.googleapis.com/storage/v1", location="US",
   storage_class="STANDARD", versioning=nil, logging_bucket=nil,
   logging_prefix=nil, website_main=nil, website_404=nil)
-  versioning_config = { "enabled" => versioning } if versioning
-  { "kind" => "storage#bucket",
-    "id" => name,
-    "selfLink" => "#{url_root}/b/#{name}",
-    "projectNumber" => "1234567890",
-    "name" => name,
-    "timeCreated" => Time.now,
-    "metageneration" => "1",
-    "owner" => { "entity" => "project-owners-1234567890" },
-    "location" => location,
-    "cors" => [{"origin"=>["http://example.org"], "method"=>["GET","POST","DELETE"], "responseHeader"=>["X-My-Custom-Header"], "maxAgeSeconds"=>3600},{"origin"=>["http://example.org"], "method"=>["GET","POST","DELETE"], "responseHeader"=>["X-My-Custom-Header"], "maxAgeSeconds"=>3600}],
-    "logging" => logging_hash(logging_bucket, logging_prefix),
-    "storageClass" => storage_class,
-    "versioning" => versioning_config,
-    "website" => website_hash(website_main, website_404),
-    "etag" => "CAE=" }.delete_if { |_, v| v.nil? }
+  versioning_config = { enabled:  versioning } if versioning
+  { kind:  "storage#bucket",
+    id:  name,
+    selfLink:  "#{url_root}/b/#{name}",
+    projectNumber:  "1234567890",
+    name:  name,
+    timeCreated:  Time.now,
+    metageneration:  "1",
+    owner:  { entity:  "project-owners-1234567890" },
+    location:  location,
+    cors:  [{origin: ["http://example.org"], method: ["GET","POST","DELETE"], response_header: ["X-My-Custom-Header"], max_age_seconds: 3600},{origin: ["http://example.org"], method: ["GET","POST","DELETE"], response_header: ["X-My-Custom-Header"], max_age_seconds: 3600}],
+    logging:  logging_hash(logging_bucket, logging_prefix),
+    storageClass:  storage_class,
+    versioning:  versioning_config,
+    website:  website_hash(website_main, website_404),
+    etag:  "CAE=" }.delete_if { |_, v| v.nil? }
 end
 
 def logging_hash(bucket, prefix)
-  { "logBucket"       => bucket,
-    "logObjectPrefix" => prefix,
+  { log_bucket:         bucket,
+    log_object_prefix:  prefix,
   }.delete_if { |_, v| v.nil? } if bucket || prefix
 end
 
 def website_hash(website_main, website_404)
-  { "mainPageSuffix" => website_main,
-    "notFoundPage"   => website_404,
+  { main_page_suffix:  website_main,
+    not_found_page:    website_404,
   }.delete_if { |_, v| v.nil? } if website_main || website_404
 end

--- a/google-cloud-logging/test/google/cloud/logging/entry/http_request_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/http_request_test.rb
@@ -15,8 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Logging::Entry::HttpRequest, :mock_logging do
-  let(:http_request_json) { random_http_request_hash.to_json }
-  let(:http_request_grpc) { Google::Logging::Type::HttpRequest.decode_json http_request_json }
+  let(:http_request_grpc) { Google::Logging::Type::HttpRequest.new random_http_request_hash }
   let(:http_request) { Google::Cloud::Logging::Entry::HttpRequest.from_grpc http_request_grpc }
 
   it "has attributes" do

--- a/google-cloud-logging/test/google/cloud/logging/entry/operation_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/operation_test.rb
@@ -15,8 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Logging::Entry::Operation, :mock_logging do
-  let(:operation_json) { random_operation_hash.to_json }
-  let(:operation_grpc) { Google::Logging::V2::LogEntryOperation.decode_json operation_json }
+  let(:operation_grpc) { Google::Logging::V2::LogEntryOperation.new random_operation_hash }
   let(:operation) { Google::Cloud::Logging::Entry::Operation.from_grpc operation_grpc }
 
   it "has attributes" do

--- a/google-cloud-logging/test/google/cloud/logging/entry/severity_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/severity_test.rb
@@ -15,8 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Logging::Entry, :severity, :mock_logging do
-  let(:entry_json) { random_entry_hash.to_json }
-  let(:entry_grpc) { Google::Logging::V2::LogEntry.decode_json entry_json }
+  let(:entry_grpc) { Google::Logging::V2::LogEntry.new random_entry_hash }
   let(:entry) { Google::Cloud::Logging::Entry.from_grpc entry_grpc }
 
   it "has the correct helpers for DEFAULT" do

--- a/google-cloud-logging/test/google/cloud/logging/entry_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry_test.rb
@@ -16,16 +16,15 @@ require "helper"
 
 describe Google::Cloud::Logging::Entry, :mock_logging do
   let(:entry_hash) { random_entry_hash }
-  let(:entry_json) { entry_hash.to_json }
-  let(:entry_grpc) { Google::Logging::V2::LogEntry.decode_json entry_json }
+  let(:entry_grpc) { Google::Logging::V2::LogEntry.new entry_hash }
   let(:entry) { Google::Cloud::Logging::Entry.from_grpc entry_grpc }
 
   it "knows its attributes" do
-    entry.log_name.must_equal             entry_hash["log_name"]
+    entry.log_name.must_equal             entry_hash[:log_name]
     entry.resource.must_be_kind_of        Google::Cloud::Logging::Resource
     entry.timestamp.to_i.must_equal       Time.parse("2014-10-02T15:01:23.045123456Z").to_i
-    entry.severity.must_equal             entry_hash["severity"]
-    entry.insert_id.must_equal            entry_hash["insert_id"]
+    entry.severity.must_equal             entry_hash[:severity]
+    entry.insert_id.must_equal            entry_hash[:insert_id]
     entry.labels.must_be_kind_of          Hash
     entry.labels["env"].must_equal        "production"
     entry.labels["foo"].must_equal        "bar"
@@ -47,7 +46,7 @@ describe Google::Cloud::Logging::Entry, :mock_logging do
   end
 
   it "timestamp returns nil when not present" do
-    entry_hash["timestamp"] = nil
+    entry_hash[:timestamp] = nil
     entry.timestamp.must_be :nil?
   end
 
@@ -57,7 +56,7 @@ describe Google::Cloud::Logging::Entry, :mock_logging do
   end
 
   it "labels will return a Hash even when missing from the Google API object" do
-    entry_hash["labels"] = nil
+    entry_hash[:labels] = nil
     entry.labels.must_be_kind_of Hash
     entry.labels.must_be :empty?
   end
@@ -81,13 +80,13 @@ describe Google::Cloud::Logging::Entry, :mock_logging do
   end
 
   it "has the correct resource attributes" do
-    entry.resource.type.must_equal entry_hash["resource"]["type"]
-    entry.resource.labels.keys.sort.must_equal   entry_hash["resource"]["labels"].keys.sort
-    entry.resource.labels.values.sort.must_equal entry_hash["resource"]["labels"].values.sort
+    entry.resource.type.must_equal entry_hash[:resource][:type]
+    entry.resource.labels.keys.sort.must_equal   entry_hash[:resource][:labels].keys.sort
+    entry.resource.labels.values.sort.must_equal entry_hash[:resource][:labels].values.sort
   end
 
   it "has a resource even if the Google API object doesn't have it" do
-    entry_hash.delete "resource"
+    entry_hash.delete :resource
 
     entry.resource.wont_be :nil?
     entry.resource.must_be_kind_of Google::Cloud::Logging::Resource
@@ -110,7 +109,7 @@ describe Google::Cloud::Logging::Entry, :mock_logging do
   end
 
   it "has an http_request even if the Google API object doesn't have it" do
-    entry_hash.delete "http_request"
+    entry_hash.delete :http_request
 
     entry.http_request.wont_be :nil?
     entry.http_request.must_be_kind_of Google::Cloud::Logging::Entry::HttpRequest
@@ -134,7 +133,7 @@ describe Google::Cloud::Logging::Entry, :mock_logging do
   end
 
   it "has an operation even if the Google API object doesn't have it" do
-    entry_hash.delete "operation"
+    entry_hash.delete :operation
 
     entry.operation.wont_be :nil?
     entry.operation.must_be_kind_of Google::Cloud::Logging::Entry::Operation
@@ -151,7 +150,7 @@ describe Google::Cloud::Logging::Entry, :mock_logging do
   end
 
   it "has a source location even if the Google API object doesn't have it" do
-    entry_hash.delete "source_location"
+    entry_hash.delete :source_location
 
     entry.source_location.wont_be :nil?
     entry.source_location.must_be_kind_of Google::Cloud::Logging::Entry::SourceLocation

--- a/google-cloud-logging/test/google/cloud/logging/metric_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/metric_test.rb
@@ -16,14 +16,13 @@ require "helper"
 
 describe Google::Cloud::Logging::Metric, :mock_logging do
   let(:metric_hash) { random_metric_hash }
-  let(:metric_json) { metric_hash.to_json }
-  let(:metric_grpc) { Google::Logging::V2::LogMetric.decode_json metric_json }
+  let(:metric_grpc) { Google::Logging::V2::LogMetric.new metric_hash }
   let(:metric) { Google::Cloud::Logging::Metric.from_grpc metric_grpc, logging.service }
 
   it "knows its attributes" do
-    metric.name.must_equal        metric_hash["name"]
-    metric.description.must_equal metric_hash["description"]
-    metric.filter.must_equal      metric_hash["filter"]
+    metric.name.must_equal        metric_hash[:name]
+    metric.description.must_equal metric_hash[:description]
+    metric.filter.must_equal      metric_hash[:filter]
   end
 
   it "can save itself" do

--- a/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
@@ -18,7 +18,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   it "lists entries" do
     num_entries = 3
 
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(num_entries))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(num_entries))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, list_res, [["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
@@ -35,7 +35,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   it "lists entries with find_entries alias" do
     num_entries = 3
 
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(num_entries))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(num_entries))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, list_res, [["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
@@ -50,8 +50,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, first_list_res, [["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
@@ -74,8 +74,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries with criteria" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, first_list_res, [["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: default_options]
@@ -117,8 +117,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries using next? and next" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, first_list_res, [["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
@@ -140,8 +140,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries with criteria using next? and next" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, first_list_res, [["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: default_options]
@@ -181,8 +181,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries using all" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, first_list_res, [["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
@@ -198,8 +198,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries with criteria using all" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, first_list_res, [["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: default_options]
@@ -217,8 +217,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries using all using Enumerator" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "second_page_token"))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, first_list_res, [["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
@@ -234,8 +234,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries using all with request_limit set" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "second_page_token"))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, first_list_res, [["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
@@ -251,7 +251,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries with one project" do
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, list_res, [["projects/project1"], filter: nil, order_by: nil, page_size: nil, options: default_options]
@@ -268,7 +268,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries with multiple projects" do
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, list_res, [["projects/project1", "projects/project2", "projects/project3"], filter: nil, order_by: nil, page_size: nil, options: default_options]
@@ -285,7 +285,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries with multiple resources" do
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, list_res, [["projects/project1", "projects/project2", "projects/project3"], filter: nil, order_by: nil, page_size: nil, options: default_options]
@@ -304,7 +304,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   it "paginates entries with a filter" do
     adv_logs_filter = 'resource.type:"gce_"'
 
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, list_res, [["projects/#{project}"], filter: adv_logs_filter, order_by: nil, page_size: nil, options: default_options]
@@ -322,7 +322,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries with order asc" do
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, list_res, [["projects/#{project}"], filter: nil, order_by: "timestamp", page_size: nil, options: default_options]
@@ -340,7 +340,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries with order desc" do
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, list_res, [["projects/#{project}"], filter: nil, order_by: "timestamp desc", page_size: nil, options: default_options]
@@ -358,7 +358,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries with max set" do
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, list_res, [["projects/#{project}"], filter: nil, order_by: nil, page_size: 3, options: default_options]
@@ -376,7 +376,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
   end
 
   it "paginates entries without max set" do
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_entries, list_res, [["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
@@ -393,10 +393,10 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     entries.token.must_equal "next_page_token"
   end
 
-  def list_entries_json count = 2, token = nil
+  def list_entries_hash count = 2, token = nil
     {
       entries: count.times.map { random_entry_hash },
       next_page_token: token
-    }.delete_if { |_, v| v.nil? }.to_json
+    }.delete_if { |_, v| v.nil? }
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/project/list_logs_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/list_logs_test.rb
@@ -18,7 +18,7 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
   it "lists logs" do
     num_logs = 3
 
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(num_logs))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(num_logs))))
 
     mock = Minitest::Mock.new
     mock.expect :list_logs, list_res, ["projects/#{project}", page_size: nil, options: default_options]
@@ -35,7 +35,7 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
   it "lists logs with find_logs alias" do
     num_logs = 3
 
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(num_logs))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(num_logs))))
 
     mock = Minitest::Mock.new
     mock.expect :list_logs, list_res, ["projects/#{project}", page_size: nil, options: default_options]
@@ -50,8 +50,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
   end
 
   it "paginates logs" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_logs, first_list_res, ["projects/#{project}", page_size: nil, options: default_options]
@@ -74,8 +74,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
   end
 
   it "paginates logs using next? and next" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_logs, first_list_res, ["projects/#{project}", page_size: nil, options: default_options]
@@ -97,8 +97,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
   end
 
   it "paginates logs using all" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_logs, first_list_res, ["projects/#{project}", page_size: nil, options: default_options]
@@ -114,8 +114,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
   end
 
   it "paginates logs using all using Enumerator" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "second_page_token"))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_logs, first_list_res, ["projects/#{project}", page_size: nil, options: default_options]
@@ -131,8 +131,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
   end
 
   it "paginates logs using all with request_limit set" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "second_page_token"))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_logs, first_list_res, ["projects/#{project}", page_size: nil, options: default_options]
@@ -148,7 +148,7 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
   end
 
   it "paginates logs with a resource" do
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_logs, list_res, ["projects/project1", page_size: nil, options: default_options]
@@ -165,8 +165,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
   end
 
   it "paginates logs with a resource" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(2, "second_page_token"))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(2, "second_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_logs, first_list_res, ["projects/project1", page_size: nil, options: default_options]
@@ -198,8 +198,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
   end
 
   it "paginates logs with a resource" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(2, "second_page_token"))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.new(list_logs_hash(2, "second_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_logs, first_list_res, ["projects/#{project}", page_size: 3, options: default_options]
@@ -230,10 +230,10 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
     second_logs.instance_variable_get(:@max).must_equal 3
   end
 
-  def list_logs_json count = 2, token = nil
+  def list_logs_hash count = 2, token = nil
     {
       log_names: count.times.map { "log-name" },
       next_page_token: token
-    }.delete_if { |_, v| v.nil? }.to_json
+    }.delete_if { |_, v| v.nil? }
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/project/metrics_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/metrics_test.rb
@@ -17,7 +17,7 @@ require "helper"
 describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
   it "lists metrics" do
     num_metrics = 3
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(num_metrics))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(num_metrics))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_metrics, list_res, [project_path, page_size: nil, options: default_options]
@@ -33,7 +33,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
   it "lists metrics with find_metrics alias" do
     num_metrics = 3
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(num_metrics))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(num_metrics))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_metrics, list_res, [project_path, page_size: nil, options: default_options]
@@ -48,8 +48,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
   end
 
   it "paginates metrics" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: default_options]
@@ -72,8 +72,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
   end
 
   it "paginates metrics with next? and next" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: default_options]
@@ -95,8 +95,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
   end
 
   it "paginates metrics with next? and next and max set" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2, "second_page_token"))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(2, "second_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_metrics, first_list_res, [project_path, page_size: 3, options: default_options]
@@ -126,8 +126,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
   end
 
   it "paginates metrics with all" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: default_options]
@@ -143,8 +143,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
   end
 
   it "paginates metrics with all and max set" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_metrics, first_list_res, [project_path, page_size: 3, options: default_options]
@@ -160,8 +160,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
   end
 
   it "iterates metrics with all using Enumerator" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "second_page_token"))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: default_options]
@@ -177,8 +177,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
   end
 
   it "iterates metrics with all request_limit set" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "second_page_token"))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: default_options]
@@ -194,7 +194,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
   end
 
   it "paginates metrics with max set" do
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_metrics, list_res, [project_path, page_size: 3, options: default_options]
@@ -211,7 +211,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
   end
 
   it "paginates metrics without max set" do
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_metrics, list_res, [project_path, page_size: nil, options: default_options]
@@ -234,8 +234,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
         name: new_metric_name,
         filter: new_metric_filter
       )
-    create_res = Google::Logging::V2::LogMetric.decode_json(empty_metric_hash.merge("name" => new_metric_name,
-                                                                                    "filter" => new_metric_filter).to_json)
+    create_res = Google::Logging::V2::LogMetric.new(empty_metric_hash.merge(name: new_metric_name,
+                                                                            filter: new_metric_filter))
 
     mock = Minitest::Mock.new
     mock.expect :create_log_metric, create_res, ["projects/test", new_metric, options: default_options]
@@ -261,9 +261,9 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
       description: new_metric_description,
       filter: new_metric_filter
     )
-    create_res = Google::Logging::V2::LogMetric.decode_json(empty_metric_hash.merge("name" => new_metric_name,
-                                                                                    "description" => new_metric_description,
-                                                                                    "filter" => new_metric_filter).to_json)
+    create_res = Google::Logging::V2::LogMetric.new(empty_metric_hash.merge(name: new_metric_name,
+                                                                            description: new_metric_description,
+                                                                            filter: new_metric_filter))
 
     mock = Minitest::Mock.new
     mock.expect :create_log_metric, create_res, ["projects/test", new_metric, options: default_options]
@@ -280,7 +280,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
   it "gets a metric" do
     metric_name = "existing-metric-#{Time.now.to_i}"
-    get_res = Google::Logging::V2::LogMetric.decode_json(random_metric_hash.merge("name" => metric_name).to_json)
+    get_res = Google::Logging::V2::LogMetric.new(random_metric_hash.merge(name: metric_name))
 
     mock = Minitest::Mock.new
     mock.expect :get_log_metric, get_res, ["projects/test/metrics/#{metric_name}", options: default_options]
@@ -309,18 +309,18 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     metric.must_be :nil?
   end
 
-  def list_metrics_json count = 2, token = nil
+  def list_metrics_hash count = 2, token = nil
     {
       metrics: count.times.map { random_metric_hash },
       next_page_token: token
-    }.delete_if { |_, v| v.nil? }.to_json
+    }.delete_if { |_, v| v.nil? }
   end
 
   def empty_metric_hash
     {
-      "name"                => "",
-      "description"         => "",
-      "filter"              => ""
+      name:        "",
+      description: "",
+      filter:      ""
     }
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/project/resource_descriptors_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/resource_descriptors_test.rb
@@ -17,7 +17,7 @@ require "helper"
 describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging do
   it "lists resource descriptors" do
     num_descriptors = 3
-    list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(num_descriptors))
+    list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(num_descriptors))
 
     mock = Minitest::Mock.new
     mock.expect :list_monitored_resource_descriptors, list_res, [page_size: nil, options: default_options]
@@ -33,7 +33,7 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
 
   it "lists resource descriptors with find_resource_descriptors alias" do
     num_descriptors = 3
-    list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(num_descriptors))
+    list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(num_descriptors))
 
     mock = Minitest::Mock.new
     mock.expect :list_monitored_resource_descriptors, list_res, [page_size: nil, options: default_options]
@@ -48,8 +48,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
   end
 
   it "paginates resource descriptors" do
-    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
-    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2))
+    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "next_page_token"))
+    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(2))
 
     mock = Minitest::Mock.new
     mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: default_options]
@@ -72,8 +72,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
   end
 
   it "paginates resource descriptors with next? and next" do
-    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
-    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2))
+    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "next_page_token"))
+    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(2))
 
     mock = Minitest::Mock.new
     mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: default_options]
@@ -96,8 +96,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
   end
 
   it "paginates resource descriptors with next? and next and max set" do
-    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
-    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2, "second_page_token"))
+    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "next_page_token"))
+    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(2, "second_page_token"))
 
     mock = Minitest::Mock.new
     mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: 3, options: default_options]
@@ -128,8 +128,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
   end
 
   it "paginates resource descriptors with all" do
-    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
-    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2))
+    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "next_page_token"))
+    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(2))
 
     mock = Minitest::Mock.new
     mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: default_options]
@@ -146,8 +146,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
   end
 
   it "paginates resource descriptors with all and max set" do
-    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
-    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2))
+    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "next_page_token"))
+    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(2))
 
     mock = Minitest::Mock.new
     mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: 3, options: default_options]
@@ -164,8 +164,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
   end
 
   it "paginates resource descriptors with all using Enumerator" do
-    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
-    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "second_page_token"))
+    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "next_page_token"))
+    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "second_page_token"))
 
     mock = Minitest::Mock.new
     mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: default_options]
@@ -182,8 +182,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
   end
 
   it "paginates resource descriptors with all and request_limit set" do
-    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
-    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "second_page_token"))
+    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "next_page_token"))
+    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "second_page_token"))
 
     mock = Minitest::Mock.new
     mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: default_options]
@@ -200,7 +200,7 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
   end
 
   it "paginates resource descriptors with max set" do
-    list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
+    list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "next_page_token"))
 
     mock = Minitest::Mock.new
     mock.expect :list_monitored_resource_descriptors, list_res, [page_size: 3, options: default_options]
@@ -217,7 +217,7 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
   end
 
   it "paginates resource descriptors without max set" do
-    list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
+    list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "next_page_token"))
 
     mock = Minitest::Mock.new
     mock.expect :list_monitored_resource_descriptors, list_res, [page_size: nil, options: default_options]
@@ -233,10 +233,10 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     resource_descriptors.token.must_equal "next_page_token"
   end
 
-  def list_resource_descriptors_json count = 2, token = nil
+  def list_resource_descriptors_hash count = 2, token = nil
     {
       resource_descriptors: count.times.map { random_resource_descriptor_hash },
       next_page_token: token
-    }.delete_if { |_, v| v.nil? }.to_json
+    }.delete_if { |_, v| v.nil? }
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/project/sinks_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/sinks_test.rb
@@ -17,7 +17,7 @@ require "helper"
 describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
   it "lists sinks" do
     num_sinks = 3
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(num_sinks))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(num_sinks))))
 
     mock = Minitest::Mock.new
     mock.expect :list_sinks, list_res, [project_path, page_size: nil, options: default_options]
@@ -33,7 +33,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
   it "lists sinks with find_sinks alias" do
     num_sinks = 3
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(num_sinks))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(num_sinks))))
 
     mock = Minitest::Mock.new
     mock.expect :list_sinks, list_res, [project_path, page_size: nil, options: default_options]
@@ -48,8 +48,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
   end
 
   it "paginates sinks" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: default_options]
@@ -72,8 +72,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
   end
 
   it "paginates sinks with next? and next" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: default_options]
@@ -95,8 +95,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
   end
 
   it "paginates sinks with next? and next and max set" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2, "second_page_token"))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(2, "second_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_sinks, first_list_res, [project_path, page_size: 3, options: default_options]
@@ -126,8 +126,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
   end
 
   it "paginates sinks with all" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: default_options]
@@ -143,8 +143,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
   end
 
   it "paginates sinks with all and max set" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(2))))
 
     mock = Minitest::Mock.new
     mock.expect :list_sinks, first_list_res, [project_path, page_size: 3, options: default_options]
@@ -160,8 +160,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
   end
 
   it "paginates sinks with all using Enumerator" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "second_page_token"))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: default_options]
@@ -177,8 +177,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
   end
 
   it "paginates sinks with all and request_limit set" do
-    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "second_page_token"))))
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: default_options]
@@ -195,7 +195,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
   it "paginates sinks with max set" do
     list_req = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksRequest.new(parent: project_path, page_size: 3)))
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_sinks, list_res, [project_path, page_size: 3, options: default_options]
@@ -213,7 +213,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
   it "paginates sinks without max set" do
     list_req = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksRequest.new(parent: project_path)))
-    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))))
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_sinks, list_res, [project_path, page_size: nil, options: default_options]
@@ -234,9 +234,9 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     new_sink_destination = "storage.googleapis.com/new-sinks"
     new_sink = Google::Logging::V2::LogSink.new name: new_sink_name, destination: new_sink_destination
 
-    create_res = Google::Logging::V2::LogSink.decode_json(empty_sink_hash.merge("name" => new_sink_name,
-                                                                                "destination" => new_sink_destination,
-                                                                                "writer_identity" => "roles/owner").to_json)
+    create_res = Google::Logging::V2::LogSink.new(empty_sink_hash.merge(name: new_sink_name,
+                                                                        destination: new_sink_destination,
+                                                                        writer_identity: "roles/owner"))
 
     mock = Minitest::Mock.new
     mock.expect :create_sink, create_res, ["projects/test", new_sink, unique_writer_identity: nil, options: default_options]
@@ -262,11 +262,11 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
       destination: new_sink_destination,
       filter: new_sink_filter
     )
-    create_res = Google::Logging::V2::LogSink.decode_json(empty_sink_hash.merge(
-                                                          "name" => new_sink_name,
-                                                          "destination" => new_sink_destination,
-                                                          "filter" => new_sink_filter,
-                                                          "writer_identity" => "roles/owner").to_json)
+    create_res = Google::Logging::V2::LogSink.new(empty_sink_hash.merge(
+                                                          name: new_sink_name,
+                                                          destination: new_sink_destination,
+                                                          filter: new_sink_filter,
+                                                          writer_identity: "roles/owner"))
 
     mock = Minitest::Mock.new
     mock.expect :create_sink, create_res, ["projects/test", new_sink, unique_writer_identity: nil, options: default_options]
@@ -290,9 +290,9 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     new_sink_destination = "storage.googleapis.com/new-sinks"
     new_sink = Google::Logging::V2::LogSink.new name: new_sink_name, destination: new_sink_destination
 
-    create_res = Google::Logging::V2::LogSink.decode_json(empty_sink_hash.merge("name" => new_sink_name,
-                                                                                "destination" => new_sink_destination,
-                                                                                "writer_identity" => "serviceAccount:cloud-logs@system.gserviceaccount.com").to_json)
+    create_res = Google::Logging::V2::LogSink.new(empty_sink_hash.merge(name: new_sink_name,
+                                                                        destination: new_sink_destination,
+                                                                        writer_identity: "serviceAccount:cloud-logs@system.gserviceaccount.com"))
 
     mock = Minitest::Mock.new
     mock.expect :create_sink, create_res, ["projects/test", new_sink, unique_writer_identity: true, options: default_options]
@@ -311,7 +311,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
   it "gets a sink" do
     sink_name = "existing-sink-#{Time.now.to_i}"
-    get_res = Google::Logging::V2::LogSink.decode_json(random_sink_hash.merge("name" => sink_name).to_json)
+    get_res = Google::Logging::V2::LogSink.new(random_sink_hash.merge(name: sink_name))
 
     mock = Minitest::Mock.new
     mock.expect :get_sink, get_res, ["projects/test/sinks/#{sink_name}", options: default_options]
@@ -326,19 +326,19 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     sink.writer_identity.must_equal "roles/owner"
   end
 
-  def list_sinks_json count = 2, token = nil
+  def list_sinks_hash count = 2, token = nil
     {
       sinks: count.times.map { random_sink_hash },
       next_page_token: token
-    }.delete_if { |_, v| v.nil? }.to_json
+    }.delete_if { |_, v| v.nil? }
   end
 
   def empty_sink_hash
     {
-      "name"                  => "",
-      "destination"           => "",
-      "filter"                => "",
-      "output_version_format" => "VERSION_FORMAT_UNSPECIFIED"
+      name:                  "",
+      destination:           "",
+      filter:                "",
+      output_version_format: :VERSION_FORMAT_UNSPECIFIED
     }
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/resource_descriptor_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/resource_descriptor_test.rb
@@ -16,8 +16,7 @@ require "helper"
 
 describe Google::Cloud::Logging::ResourceDescriptor, :mock_logging do
   let(:resource_descriptor_hash) { random_resource_descriptor_hash }
-  let(:resource_descriptor_json) { resource_descriptor_hash.to_json }
-  let(:resource_descriptor_grpc) { Google::Api::MonitoredResourceDescriptor.decode_json resource_descriptor_json }
+  let(:resource_descriptor_grpc) { Google::Api::MonitoredResourceDescriptor.new resource_descriptor_hash }
   let(:resource_descriptor) { Google::Cloud::Logging::ResourceDescriptor.from_grpc resource_descriptor_grpc }
 
   it "knows its attributes" do

--- a/google-cloud-logging/test/google/cloud/logging/resource_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/resource_test.rb
@@ -16,20 +16,19 @@ require "helper"
 
 describe Google::Cloud::Logging::Resource, :mock_logging do
   let(:resource_hash) { random_resource_hash }
-  let(:resource_json) { resource_hash.to_json }
-  let(:resource_grpc) { Google::Api::MonitoredResource.decode_json resource_json }
+  let(:resource_grpc) { Google::Api::MonitoredResource.new resource_hash }
   let(:resource) { Google::Cloud::Logging::Resource.from_grpc resource_grpc }
 
   it "knows its attributes" do
-    resource.type.must_equal resource_hash["type"]
-    resource.labels.keys.sort.must_equal   resource_hash["labels"].keys.sort
-    resource.labels.values.sort.must_equal resource_hash["labels"].values.sort
+    resource.type.must_equal resource_hash[:type]
+    resource.labels.keys.sort.must_equal   resource_hash[:labels].keys.sort
+    resource.labels.values.sort.must_equal resource_hash[:labels].values.sort
   end
 
   it "can export to a grpc object" do
     grpc = resource.to_grpc
-    grpc.type.must_equal resource_hash["type"]
-    grpc.labels.keys.sort.must_equal   resource_hash["labels"].keys.sort
-    grpc.labels.values.sort.must_equal resource_hash["labels"].values.sort
+    grpc.type.must_equal resource_hash[:type]
+    grpc.labels.keys.sort.must_equal   resource_hash[:labels].keys.sort
+    grpc.labels.values.sort.must_equal resource_hash[:labels].values.sort
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/sink_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/sink_test.rb
@@ -17,13 +17,12 @@ require "helper"
 describe Google::Cloud::Logging::Sink, :mock_logging do
   let(:sink) { Google::Cloud::Logging::Sink.from_grpc sink_grpc, logging.service }
   let(:sink_hash) { random_sink_hash }
-  let(:sink_json) { sink_hash.to_json }
-  let(:sink_grpc) { Google::Logging::V2::LogSink.decode_json sink_json }
+  let(:sink_grpc) { Google::Logging::V2::LogSink.new sink_hash }
 
   it "knows its attributes" do
-    sink.name.must_equal        sink_hash["name"]
-    sink.destination.must_equal sink_hash["destination"]
-    sink.filter.must_equal      sink_hash["filter"]
+    sink.name.must_equal        sink_hash[:name]
+    sink.destination.must_equal sink_hash[:destination]
+    sink.filter.must_equal      sink_hash[:filter]
     sink.writer_identity.must_equal  "roles/owner"
   end
 

--- a/google-cloud-logging/test/helper.rb
+++ b/google-cloud-logging/test/helper.rb
@@ -62,62 +62,66 @@ class MockLogging < Minitest::Spec
   end
 
   def random_entry_hash
+    timestamp = Time.parse "2014-10-02T15:01:23.045123456Z"
     {
-      "log_name"  => "projects/my-projectid/logs/syslog",
-      "resource"  => random_resource_hash,
-      "timestamp" => "2014-10-02T15:01:23.045123456Z",
-      "severity"  => :DEFAULT,
-      "insert_id" => "abc123",
-      "labels" => {
-        "env" => "production",
-        "foo" => "bar"
+      log_name:   "projects/my-projectid/logs/syslog",
+      resource:   random_resource_hash,
+      timestamp:  {
+        seconds:  timestamp.to_i,
+        nanos:    timestamp.nsec
       },
-      "text_payload"    => "payload",
-      "http_request"    => random_http_request_hash,
-      "operation"       => random_operation_hash,
-      "trace"           => "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824",
-      "source_location" => random_source_location_hash,
-      "trace_sampled"   => true
+      severity:   :DEFAULT,
+      insert_id:  "abc123",
+      labels:  {
+        "env" =>  "production",
+        "foo" =>  "bar"
+      },
+      text_payload:    "payload",
+      http_request:    random_http_request_hash,
+      operation:       random_operation_hash,
+      trace:           "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824",
+      source_location: random_source_location_hash,
+      trace_sampled:   true
     }
   end
 
   def random_http_request_hash
     {
-      "request_method" => "GET",
-      "request_url" => "http://test.local/foo?bar=baz",
-      "request_size" => 123,
-      "status" => 200,
-      "response_size" => 456,
-      "user_agent" => "google-cloud/1.0.0",
-      "remote_ip" => "127.0.0.1",
-      "referer" => "http://test.local/referer",
-      "cache_hit" => false,
-      "cache_validated_with_origin_server" => false
+      request_method:  "GET",
+      request_url:  "http://test.local/foo?bar=baz",
+      request_size:  123,
+      status:  200,
+      response_size:  456,
+      user_agent:  "google-cloud/1.0.0",
+      remote_ip:  "127.0.0.1",
+      referer:  "http://test.local/referer",
+      cache_hit:  false,
+      cache_validated_with_origin_server:  false
     }
   end
 
   def random_operation_hash
     {
-      "id" => "xyz789",
-      "producer" => "MyApp.MyClass#my_method",
-      "first" => false,
-      "last" => false
+      id:  "xyz789",
+      producer:  "MyApp.MyClass#my_method",
+      first:  false,
+      last:  false
     }
   end
 
   def random_source_location_hash
     {
-      "file" => "my_app/my_class.rb",
-      "line" => 321,
-      "function" => "#my_method"
+      file: "my_app/my_class.rb",
+      line: 321,
+      function: "#my_method"
     }
   end
 
   def random_resource_hash
     {
-      "type" => "gae_app",
-      "labels" => {
-        "module_id" => "1",
+      type:  "gae_app",
+      labels:  {
+        "module_id"  => "1",
         "version_id" => "20150925t173233"
       }
     }
@@ -125,49 +129,53 @@ class MockLogging < Minitest::Spec
 
   def random_resource_descriptor_hash
     {
-      "type"         => "cloudsql_database",
-      "display_name" => "Cloud SQL Database",
-      "description"  => "This resource is a Cloud SQL Database",
-      "labels"       => [
+      type:         "cloudsql_database",
+      display_name: "Cloud SQL Database",
+      description:  "This resource is a Cloud SQL Database",
+      labels:       [
         {
-         "key"          => "database_id",
-         "description"  => "The ID of the database."
+          key:          "database_id",
+          description:  "The ID of the database."
         },
         {
-         "key"          => "zone",
-         "value_type"   => :STRING,
-         "description"  => "The GCP zone in which the database is running."
+          key:          "zone",
+          value_type:   :STRING,
+          description:  "The GCP zone in which the database is running."
         },
         {
-         "key"          => "active",
-         "value_type"   => :BOOL,
-         "description"  => "Whether the database is active."
+          key:          "active",
+          value_type:   :BOOL,
+          description:  "Whether the database is active."
         },
         {
-         "key"          => "max_connections",
-         "value_type"   => :INT64,
-         "description"  => "The maximum number of connections it supports."
+          key:          "max_connections",
+          value_type:   :INT64,
+          description:  "The maximum number of connections it supports."
         }
       ]
     }
   end
 
   def random_sink_hash
+    timestamp = Time.parse "2014-10-02T15:01:23.045123456Z"
     {
-      "name"                  => "my-severe-errors-to-pubsub",
-      "destination"           => "storage.googleapis.com/a-bucket",
-      "filter"                => "logName:syslog AND severity>=ERROR",
-      "output_version_format" => :VERSION_FORMAT_UNSPECIFIED,
-      "writer_identity"       => "roles/owner",
-      "start_time"            => "2014-10-02T15:01:23.045123456Z"
+      name:                   "my-severe-errors-to-pubsub",
+      destination:            "storage.googleapis.com/a-bucket",
+      filter:                 "logName:syslog AND severity>=ERROR",
+      output_version_format:  :VERSION_FORMAT_UNSPECIFIED,
+      writer_identity:        "roles/owner",
+      start_time:             {
+                                seconds:  timestamp.to_i,
+                                nanos:    timestamp.nsec
+                              }
     }
   end
 
   def random_metric_hash
     {
-      "name"        => "severe_errors",
-      "description" => "The servere errors metric",
-      "filter"      => "logName:syslog AND severity>=ERROR"
+      name:         "severe_errors",
+      description:  "The servere errors metric",
+      filter:       "logName:syslog AND severity>=ERROR"
     }
   end
 

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -613,9 +613,14 @@ def snapshots_json topic_name, num_snapshots, token = nil
 end
 
 def snapshot_json topic_name, snapshot_name
+  time = Time.now
+  timestamp = {
+    "seconds" => time.to_i,
+    "nanos" => time.nsec
+  }
   { "name" => snapshot_path(snapshot_name),
     "topic" => topic_path(topic_name),
-    "expire_time" => Time.now.utc.strftime("%FT%T.%NZ")
+    "expire_time" => timestamp
   }.to_json
 end
 

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -562,85 +562,87 @@ def token_options token
                                page_token: token)
 end
 
-def topics_json num_topics, token = ""
+def topics_hash num_topics, token = ""
   topics = num_topics.times.map do
-    topic_resp "topic-#{rand 1000}"
+    topic_hash("topic-#{rand 1000}")
   end
-  data = { "topics" => topics }
-  data["next_page_token"] = token unless token.nil?
-  data.to_json
+  data = { topics: topics }
+  data[:next_page_token] = token unless token.nil?
+  data
 end
 
 def topic_resp topic_name = "my-topic"
   Google::Cloud::PubSub::V1::Topic.new name: topic_path(topic_name)
 end
 
-def topic_subscriptions_json num_subs, token = nil
+def topic_subscriptions_hash num_subs, token = nil
   subs = num_subs.times.map do
     subscription_path("sub-#{rand 1000}")
   end
-  data = { "subscriptions" => subs }
-  data["next_page_token"] = token unless token.nil?
-  data.to_json
+  data = { subscriptions: subs }
+  data[:next_page_token] = token unless token.nil?
+  data
 end
 
-def subscriptions_json topic_name, num_subs, token = nil
+def subscriptions_hash topic_name, num_subs, token = nil
   subs = num_subs.times.map do
-    JSON.parse(subscription_json(topic_name, "sub-#{rand 1000}"))
+    subscription_hash(topic_name, "sub-#{rand 1000}")
   end
-  data = { "subscriptions" => subs }
-  data["next_page_token"] = token unless token.nil?
-  data.to_json
+  data = { subscriptions: subs }
+  data[:next_page_token] = token unless token.nil?
+  data
 end
 
-def subscription_json topic_name, sub_name,
+def subscription_hash topic_name, sub_name,
                       deadline = 60,
-                      endpoint = "http://example.com/callback"
-  { "name" => subscription_path(sub_name),
-    "topic" => topic_path(topic_name),
-    "push_config" => { "push_endpoint" => endpoint },
-    "ack_deadline_seconds" => deadline,
-  }.to_json
+                      endpoint = "http://example.com/callback", labels: nil
+  { name: subscription_path(sub_name),
+    topic: topic_path(topic_name),
+    push_config: { "push_endpoint" => endpoint },
+    ack_deadline_seconds: deadline,
+    retain_acked_messages: true,
+    message_retention_duration: { seconds: 600, nanos: 900000000 }, # 600.9 seconds
+    labels: labels
+  }
 end
 
-def snapshots_json topic_name, num_snapshots, token = nil
+def snapshots_hash topic_name, num_snapshots, token = nil
   snapshots = num_snapshots.times.map do
-    JSON.parse(snapshot_json(topic_name, "snapshot-#{rand 1000}"))
+    snapshot_hash(topic_name, "snapshot-#{rand 1000}")
   end
-  data = { "snapshots" => snapshots }
-  data["next_page_token"] = token unless token.nil?
-  data.to_json
+  data = { snapshots: snapshots }
+  data[:next_page_token] = token unless token.nil?
+  data
 end
 
-def snapshot_json topic_name, snapshot_name
+def snapshot_hash topic_name, snapshot_name, labels: nil
   time = Time.now
   timestamp = {
-    "seconds" => time.to_i,
-    "nanos" => time.nsec
+    seconds: time.to_i,
+    nanos: time.nsec
   }
-  { "name" => snapshot_path(snapshot_name),
-    "topic" => topic_path(topic_name),
-    "expire_time" => timestamp
-  }.to_json
+  { name: snapshot_path(snapshot_name),
+    topic: topic_path(topic_name),
+    expire_time: timestamp,
+    labels: labels
+  }
 end
 
-def rec_message_json message, id = rand(1000000)
+def rec_message_hash message, id = rand(1000000)
   {
-    "ack_id" => "ack-id-#{id}",
-    "message" => {
-      "data" => Base64.strict_encode64(message),
-      "attributes" => {},
-      "message_id" => "msg-id-#{id}",
+    ack_id: "ack-id-#{id}",
+    message: {
+      data: Base64.strict_encode64(message),
+      attributes: {},
+      message_id: "msg-id-#{id}",
     }
-  }.to_json
+  }
 end
 
-def rec_messages_json message, id = nil
+def rec_messages_hash message, id = nil
   {
-    "received_messages" => [
-      JSON.parse(rec_message_json(message, id))
-    ]
-  }.to_json
+    received_messages: [rec_message_hash(message, id)]
+  }
 end
 
 def project_path
@@ -665,27 +667,27 @@ end
 
 
 def subscription_resp name = "my-sub"
-  Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json "my-topic", name
+  Google::Cloud::PubSub::V1::Subscription.new subscription_hash "my-topic", name
 end
 
 
 def list_subscriptions_resp token = "next_page_token"
-  response = Google::Cloud::PubSub::V1::ListSubscriptionsResponse.decode_json subscriptions_json("my-topic", 3, token)
+  response = Google::Cloud::PubSub::V1::ListSubscriptionsResponse.new subscriptions_hash("my-topic", 3, token)
   paged_enum_struct response
 end
 
 def list_topic_subscriptions_resp token = "next_page_token"
-  response = Google::Cloud::PubSub::V1::ListTopicSubscriptionsResponse.decode_json topic_subscriptions_json(3, token)
+  response = Google::Cloud::PubSub::V1::ListTopicSubscriptionsResponse.new topic_subscriptions_hash(3, token)
   paged_enum_struct response
 end
 
 def list_snapshots_resp token = "next_page_token"
-  response = Google::Cloud::PubSub::V1::ListSnapshotsResponse.decode_json snapshots_json("my-topic", 3, token)
+  response = Google::Cloud::PubSub::V1::ListSnapshotsResponse.new snapshots_hash("my-topic", 3, token)
   paged_enum_struct response
 end
 
 def snapshot_resp snapshot_name = "my-snapshot"
-  Google::Cloud::PubSub::V1::Snapshot.decode_json snapshot_json("my-topic", snapshot_name)
+  Google::Cloud::PubSub::V1::Snapshot.new snapshot_hash("my-topic", snapshot_name)
 end
 
 def policy_resp

--- a/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     messages = [
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded1)
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     pubsub.service.mocked_publisher = mock
@@ -60,7 +60,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     messages = [
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded1, attributes: {"format" => "text"})
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     pubsub.service.mocked_publisher = mock
@@ -90,7 +90,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     messages = [
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded1)
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     pubsub.service.mocked_publisher = mock
@@ -131,7 +131,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded2),
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded3, attributes: {"format" => "none"})
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1", "msg2", "msg3"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     pubsub.service.mocked_publisher = mock
@@ -165,7 +165,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded2),
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded3, attributes: {"format" => "none"})
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1", "msg2", "msg3"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     pubsub.service.mocked_publisher = mock
@@ -215,7 +215,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     message_ids = 10.times.map do |i|
       "msg#{i}"
     end
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: message_ids }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: message_ids })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
@@ -260,7 +260,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     message_ids = 10.times.map do |i|
       "msg#{i}"
     end
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: message_ids }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: message_ids })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
@@ -309,8 +309,8 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     big_message = Google::Cloud::PubSub::V1::PubsubMessage.new(data: big_msg_data)
     big_message_id = "msg999"
 
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: [message_id] }.to_json)
-    big_publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: [big_message_id] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: [message_id] })
+    big_publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: [big_message_id] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), [message], options: default_options]
     mock.expect :publish, big_publish_res, [topic_path(topic_name), [big_message], options: default_options]

--- a/google-cloud-pubsub/test/google/cloud/pubsub/message/attributes_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/message/attributes_test.rb
@@ -18,12 +18,11 @@ require "base64"
 describe Google::Cloud::PubSub::Message, :attributes do
   let(:message_hash) do
     {
-      "data" => Base64.strict_encode64("hello world"),
-      "attributes" => { "foo" => "FOO", "bar" => "BAR" }
+      data: "hello world",
+      attributes: { "foo" => "FOO", "bar" => "BAR" }
     }
   end
-  let(:message_json)  { message_hash.to_json }
-  let(:message_grpc)  { Google::Cloud::PubSub::V1::PubsubMessage.decode_json message_json }
+  let(:message_grpc)  { Google::Cloud::PubSub::V1::PubsubMessage.new message_hash }
   let(:message_obj)  { Google::Cloud::PubSub::Message.from_grpc message_grpc }
 
   it "has attributes as a Hash even when being a Google API object" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/message_test.rb
@@ -30,14 +30,14 @@ describe Google::Cloud::PubSub::Message, :mock_pubsub do
 
   describe "from gapi" do
     let(:topic_name) { "topic-name-goes-here" }
-    let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
+    let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
     let(:subscription_name) { "subscription-name-goes-here" }
-    let(:subscription_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(subscription_json(topic_name, subscription_name)) }
+    let(:subscription_grpc) { Google::Cloud::PubSub::V1::Subscription.new(subscription_hash(topic_name, subscription_name)) }
     let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc subscription_grpc, pubsub.service }
     let(:rec_message_name) { "rec_message-name-goes-here" }
     let(:rec_message_msg)  { "rec_message-msg-goes-here" }
-    let(:rec_message_data)  { JSON.parse(rec_message_json(rec_message_msg)) }
-    let(:rec_message_grpc)  { Google::Cloud::PubSub::V1::PubsubMessage.decode_json rec_message_data["message"].to_json }
+    let(:rec_message_data)  { rec_message_hash(rec_message_msg) }
+    let(:rec_message_grpc)  { Google::Cloud::PubSub::V1::PubsubMessage.new rec_message_data[:message] }
     let(:msg)     { Google::Cloud::PubSub::Message.from_grpc rec_message_grpc }
 
     it "knows its data" do
@@ -45,13 +45,13 @@ describe Google::Cloud::PubSub::Message, :mock_pubsub do
     end
 
     it "knows its attributes" do
-      msg.attributes.keys.sort.must_equal   rec_message_data["message"]["attributes"].keys.sort
-      msg.attributes.values.sort.must_equal rec_message_data["message"]["attributes"].values.sort
+      msg.attributes.keys.sort.must_equal   rec_message_data[:message][:attributes].keys.sort
+      msg.attributes.values.sort.must_equal rec_message_data[:message][:attributes].values.sort
     end
 
     it "knows its message_id" do
-      msg.msg_id.must_equal     rec_message_data["message"]["message_id"]
-      msg.message_id.must_equal rec_message_data["message"]["message_id"]
+      msg.msg_id.must_equal     rec_message_data[:message][:message_id]
+      msg.message_id.must_equal rec_message_data[:message][:message_id]
     end
 
     it "knows its published_at" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
@@ -16,39 +16,39 @@ require "helper"
 
 describe Google::Cloud::PubSub::Project, :mock_pubsub do
   let(:topics_with_token) do
-    response = Google::Cloud::PubSub::V1::ListTopicsResponse.decode_json topics_json(3, "next_page_token")
+    response = Google::Cloud::PubSub::V1::ListTopicsResponse.new topics_hash(3, "next_page_token")
     paged_enum_struct response
   end
   let(:topics_without_token) do
-    response = Google::Cloud::PubSub::V1::ListTopicsResponse.decode_json topics_json(2)
+    response = Google::Cloud::PubSub::V1::ListTopicsResponse.new topics_hash(2)
     paged_enum_struct response
   end
   let(:topics_with_token_2) do
-    response = Google::Cloud::PubSub::V1::ListTopicsResponse.decode_json topics_json(3, "second_page_token")
+    response = Google::Cloud::PubSub::V1::ListTopicsResponse.new topics_hash(3, "second_page_token")
     paged_enum_struct response
   end
   let(:subscriptions_with_token) do
-    response = Google::Cloud::PubSub::V1::ListSubscriptionsResponse.decode_json subscriptions_json("fake-topic", 3, "next_page_token")
+    response = Google::Cloud::PubSub::V1::ListSubscriptionsResponse.new subscriptions_hash("fake-topic", 3, "next_page_token")
     paged_enum_struct response
   end
   let(:subscriptions_without_token) do
-    response = Google::Cloud::PubSub::V1::ListSubscriptionsResponse.decode_json subscriptions_json("fake-topic", 2)
+    response = Google::Cloud::PubSub::V1::ListSubscriptionsResponse.new subscriptions_hash("fake-topic", 2)
     paged_enum_struct response
   end
   let(:subscriptions_with_token_2) do
-    response = Google::Cloud::PubSub::V1::ListSubscriptionsResponse.decode_json subscriptions_json("fake-topic", 3, "second_page_token")
+    response = Google::Cloud::PubSub::V1::ListSubscriptionsResponse.new subscriptions_hash("fake-topic", 3, "second_page_token")
     paged_enum_struct response
   end
   let(:snapshots_with_token) do
-    response = Google::Cloud::PubSub::V1::ListSnapshotsResponse.decode_json snapshots_json("fake-topic", 3, "next_page_token")
+    response = Google::Cloud::PubSub::V1::ListSnapshotsResponse.new snapshots_hash("fake-topic", 3, "next_page_token")
     paged_enum_struct response
   end
   let(:snapshots_without_token) do
-    response = Google::Cloud::PubSub::V1::ListSnapshotsResponse.decode_json snapshots_json("fake-topic", 2)
+    response = Google::Cloud::PubSub::V1::ListSnapshotsResponse.new snapshots_hash("fake-topic", 2)
     paged_enum_struct response
   end
   let(:snapshots_with_token_2) do
-    response = Google::Cloud::PubSub::V1::ListSnapshotsResponse.decode_json snapshots_json("fake-topic", 3, "second_page_token")
+    response = Google::Cloud::PubSub::V1::ListSnapshotsResponse.new snapshots_hash("fake-topic", 3, "second_page_token")
     paged_enum_struct response
   end
   let(:labels) { { "foo" => "bar" } }
@@ -60,7 +60,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
   it "creates a topic" do
     new_topic_name = "new-topic-#{Time.now.to_i}"
 
-    create_res = Google::Cloud::PubSub::V1::Topic.decode_json topic_json(new_topic_name)
+    create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name)
     mock = Minitest::Mock.new
     mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
@@ -75,7 +75,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
   it "creates a topic with new_topic_alias" do
     new_topic_name = "new-topic-#{Time.now.to_i}"
 
-    create_res = Google::Cloud::PubSub::V1::Topic.decode_json topic_json(new_topic_name)
+    create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name)
     mock = Minitest::Mock.new
     mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
@@ -90,7 +90,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
   it "creates a topic with labels" do
     new_topic_name = "new-topic-#{Time.now.to_i}"
 
-    create_res = Google::Cloud::PubSub::V1::Topic.decode_json topic_json(new_topic_name, labels: labels)
+    create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name, labels: labels)
     mock = Minitest::Mock.new
     mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: labels, options: default_options]
     pubsub.service.mocked_publisher = mock
@@ -107,7 +107,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
   it "gets a topic" do
     topic_name = "found-topic"
 
-    get_res = Google::Cloud::PubSub::V1::Topic.decode_json topic_json(topic_name)
+    get_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(topic_name)
     mock = Minitest::Mock.new
     mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
     pubsub.service.mocked_publisher = mock
@@ -124,7 +124,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
   it "gets a topic with get_topic alias" do
     topic_name = "found-topic"
 
-    get_res = Google::Cloud::PubSub::V1::Topic.decode_json topic_json(topic_name)
+    get_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(topic_name)
     mock = Minitest::Mock.new
     mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
     pubsub.service.mocked_publisher = mock
@@ -141,7 +141,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
   it "gets a topic with find_topic alias" do
     topic_name = "found-topic"
 
-    get_res = Google::Cloud::PubSub::V1::Topic.decode_json topic_json(topic_name)
+    get_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(topic_name)
     mock = Minitest::Mock.new
     mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
     pubsub.service.mocked_publisher = mock
@@ -374,7 +374,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
   it "gets a subscription" do
     sub_name = "found-sub-#{Time.now.to_i}"
 
-    get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json("random-topic", sub_name)
+    get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash("random-topic", sub_name)
     mock = Minitest::Mock.new
     mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
     pubsub.service.mocked_subscriber = mock
@@ -393,7 +393,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
   it "gets a subscription with get_subscription alias" do
     sub_name = "found-sub-#{Time.now.to_i}"
 
-    get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json("random-topic", sub_name)
+    get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash("random-topic", sub_name)
     mock = Minitest::Mock.new
     mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
     pubsub.service.mocked_subscriber = mock
@@ -412,7 +412,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
   it "gets a subscription with find_subscription alias" do
     sub_name = "found-sub-#{Time.now.to_i}"
 
-    get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json("random-topic", sub_name)
+    get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash("random-topic", sub_name)
     mock = Minitest::Mock.new
     mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
     pubsub.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
@@ -16,15 +16,14 @@ require "helper"
 
 describe Google::Cloud::PubSub::ReceivedMessage, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
+  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
   let(:subscription_name) { "subscription-name-goes-here" }
-  let(:subscription_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(subscription_json(topic_name, subscription_name)) }
+  let(:subscription_grpc) { Google::Cloud::PubSub::V1::Subscription.new(subscription_hash(topic_name, subscription_name)) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc subscription_grpc, pubsub.service }
   let(:rec_message_name) { "rec_message-name-goes-here" }
   let(:rec_message_msg)  { "rec_message-msg-goes-here" }
-  let(:rec_message_json_full)  { rec_message_json(rec_message_msg) }
-  let(:rec_message_data)  { JSON.parse rec_message_json_full }
-  let(:rec_message_grpc)  { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json rec_message_json_full }
+  let(:rec_message_data)  { rec_message_hash(rec_message_msg) }
+  let(:rec_message_grpc)  { Google::Cloud::PubSub::V1::ReceivedMessage.new rec_message_data }
   let(:rec_message) { Google::Cloud::PubSub::ReceivedMessage.from_grpc rec_message_grpc, subscription }
 
   it "knows its subscription" do
@@ -33,16 +32,16 @@ describe Google::Cloud::PubSub::ReceivedMessage, :mock_pubsub do
   end
 
   it "knows its ack_id" do
-    rec_message.ack_id.must_equal rec_message_data["ack_id"]
+    rec_message.ack_id.must_equal rec_message_data[:ack_id]
   end
 
   it "has a message" do
     rec_message.message.wont_be :nil?
     rec_message.message.data.must_equal rec_message_msg
-    rec_message.message.attributes.keys.sort.must_equal   rec_message_data["message"]["attributes"].keys.sort
-    rec_message.message.attributes.values.sort.must_equal rec_message_data["message"]["attributes"].values.sort
-    rec_message.message.msg_id.must_equal rec_message_data["message"]["message_id"]
-    rec_message.message.message_id.must_equal rec_message_data["message"]["message_id"]
+    rec_message.message.attributes.keys.sort.must_equal   rec_message_data[:message][:attributes].keys.sort
+    rec_message.message.attributes.values.sort.must_equal rec_message_data[:message][:attributes].values.sort
+    rec_message.message.msg_id.must_equal rec_message_data[:message][:message_id]
+    rec_message.message.message_id.must_equal rec_message_data[:message][:message_id]
   end
 
   it "knows the message's data" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/snapshot_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/snapshot_test.rb
@@ -18,7 +18,7 @@ describe Google::Cloud::PubSub::Snapshot, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:snapshot_name) { "snapshot-name-goes-here" }
   let(:labels) { { "foo" => "bar" } }
-  let(:snapshot_grpc) { Google::Cloud::PubSub::V1::Snapshot.decode_json(snapshot_json(topic_name, snapshot_name, labels: labels)) }
+  let(:snapshot_grpc) { Google::Cloud::PubSub::V1::Snapshot.new(snapshot_hash(topic_name, snapshot_name, labels: labels)) }
   let(:snapshot) { Google::Cloud::PubSub::Snapshot.from_grpc snapshot_grpc, pubsub.service }
   let(:new_labels) { { "baz" => "qux" } }
   let(:new_labels_map) do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
@@ -17,22 +17,21 @@ require "helper"
 describe Google::Cloud::PubSub::Subscriber, :acknowledge, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_hash) { JSON.parse sub_json }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:sub_path) { sub_grpc.name }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
-  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message1-msg-goes-here", 1111) }
-  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message2-msg-goes-here", 1112) }
-  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message3-msg-goes-here", 1113) }
+  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message1-msg-goes-here", 1111) }
+  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message2-msg-goes-here", 1112) }
+  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message3-msg-goes-here", 1113) }
 
   it "can acknowledge a single message" do
     rec_message_msg = "pulled-message"
     rec_message_ack_id = 123456789
-    pull_res = Google::Cloud::PubSub::V1::StreamingPullResponse.decode_json rec_messages_json(rec_message_msg, rec_message_ack_id)
+    pull_res = Google::Cloud::PubSub::V1::StreamingPullResponse.new rec_messages_hash(rec_message_msg, rec_message_ack_id)
     response_groups = [[pull_res]]
 
     stub = StreamingPullStub.new response_groups

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/error_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/error_test.rb
@@ -17,17 +17,16 @@ require "helper"
 describe Google::Cloud::PubSub::Subscriber, :error, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_hash) { JSON.parse sub_json }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:sub_path) { sub_grpc.name }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
-  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message1-msg-goes-here", 1111) }
-  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message2-msg-goes-here", 1112) }
-  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message3-msg-goes-here", 1113) }
+  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message1-msg-goes-here", 1111) }
+  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message2-msg-goes-here", 1112) }
+  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message3-msg-goes-here", 1113) }
 
   it "relays errors to the user" do
     pull_res1 = Google::Cloud::PubSub::V1::StreamingPullResponse.new received_messages: [rec_msg1_grpc]

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/modify_ack_deadline_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/modify_ack_deadline_test.rb
@@ -17,22 +17,21 @@ require "helper"
 describe Google::Cloud::PubSub::Subscriber, :modify_ack_deadline, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_hash) { JSON.parse sub_json }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:sub_path) { sub_grpc.name }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
-  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message1-msg-goes-here", 1111) }
-  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message2-msg-goes-here", 1112) }
-  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message3-msg-goes-here", 1113) }
+  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message1-msg-goes-here", 1111) }
+  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message2-msg-goes-here", 1112) }
+  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message3-msg-goes-here", 1113) }
 
   it "can modify_ack_deadline a single message" do
     rec_message_msg = "pulled-message"
     rec_message_ack_id = 123456789
-    pull_res = Google::Cloud::PubSub::V1::StreamingPullResponse.decode_json rec_messages_json(rec_message_msg, rec_message_ack_id)
+    pull_res = Google::Cloud::PubSub::V1::StreamingPullResponse.new rec_messages_hash(rec_message_msg, rec_message_ack_id)
     response_groups = [[pull_res]]
 
     stub = StreamingPullStub.new response_groups

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/nack_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/nack_test.rb
@@ -17,22 +17,21 @@ require "helper"
 describe Google::Cloud::PubSub::Subscriber, :nack, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_hash) { JSON.parse sub_json }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:sub_path) { sub_grpc.name }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
-  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message1-msg-goes-here", 1111) }
-  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message2-msg-goes-here", 1112) }
-  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message3-msg-goes-here", 1113) }
+  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message1-msg-goes-here", 1111) }
+  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message2-msg-goes-here", 1112) }
+  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message3-msg-goes-here", 1113) }
 
   it "can nack a single message" do
     rec_message_msg = "pulled-message"
     rec_message_ack_id = 123456789
-    pull_res = Google::Cloud::PubSub::V1::StreamingPullResponse.decode_json rec_messages_json(rec_message_msg, rec_message_ack_id)
+    pull_res = Google::Cloud::PubSub::V1::StreamingPullResponse.new rec_messages_hash(rec_message_msg, rec_message_ack_id)
     response_groups = [[pull_res]]
 
     stub = StreamingPullStub.new response_groups

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/restart_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/restart_test.rb
@@ -17,17 +17,16 @@ require "helper"
 describe Google::Cloud::PubSub::Subscriber, :error, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_hash) { JSON.parse sub_json }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:sub_path) { sub_grpc.name }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
-  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message1-msg-goes-here", 1111) }
-  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message2-msg-goes-here", 1112) }
-  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                          rec_message_json("rec_message3-msg-goes-here", 1113) }
+  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message1-msg-goes-here", 1111) }
+  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message2-msg-goes-here", 1112) }
+  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message3-msg-goes-here", 1113) }
 
   it "restarts on known errors" do
     pull_res1 = Google::Cloud::PubSub::V1::StreamingPullResponse.new received_messages: [rec_msg1_grpc]

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/acknowledge_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/acknowledge_test.rb
@@ -17,16 +17,15 @@ require "helper"
 describe Google::Cloud::PubSub::Subscription, :pull, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_hash) { JSON.parse sub_json }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
-  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                  rec_message_json("rec_message1-msg-goes-here") }
-  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                  rec_message_json("rec_message2-msg-goes-here") }
-  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json \
-                  rec_message_json("rec_message3-msg-goes-here") }
+  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                  rec_message_hash("rec_message1-msg-goes-here") }
+  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                  rec_message_hash("rec_message2-msg-goes-here") }
+  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                  rec_message_hash("rec_message3-msg-goes-here") }
   let(:rec_message1) { Google::Cloud::PubSub::ReceivedMessage.from_grpc rec_msg1_grpc, subscription }
   let(:rec_message2) { Google::Cloud::PubSub::ReceivedMessage.from_grpc rec_msg2_grpc, subscription }
   let(:rec_message3) { Google::Cloud::PubSub::ReceivedMessage.from_grpc rec_msg3_grpc, subscription }

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
@@ -17,11 +17,10 @@ require "helper"
 describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_hash) { JSON.parse sub_json }
-  let(:sub_deadline) { sub_hash["ack_deadline_seconds"] }
-  let(:sub_endpoint) { sub_hash["push_config"]["push_endpoint"] }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_deadline) { sub_hash[:ack_deadline_seconds] }
+  let(:sub_endpoint) { sub_hash[:push_config][:push_endpoint] }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
 
   it "gets topic from the Google API object" do
@@ -68,7 +67,7 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
     end
 
     it "makes an HTTP API call to retrieve topic" do
-      get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
+      get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, sub_name)
       mock = Minitest::Mock.new
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
@@ -83,7 +82,7 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
     end
 
     it "makes an HTTP API call to retrieve deadline" do
-      get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
+      get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, sub_name)
       mock = Minitest::Mock.new
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
@@ -94,7 +93,7 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
     end
 
     it "makes an HTTP API call to retrieve retain_acked" do
-      get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
+      get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, sub_name)
       mock = Minitest::Mock.new
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
@@ -105,7 +104,7 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
     end
 
     it "makes an HTTP API call to retrieve endpoint" do
-      get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
+      get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, sub_name)
       mock = Minitest::Mock.new
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delete_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delete_test.rb
@@ -17,9 +17,8 @@ require "helper"
 describe Google::Cloud::PubSub::Subscription, :delete, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_hash) { JSON.parse sub_json }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
 
   it "can delete itself" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/exists_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/exists_test.rb
@@ -17,8 +17,8 @@ require "helper"
 describe Google::Cloud::PubSub::Subscription, :exists, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json(topic_name, sub_name) }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash(topic_name, sub_name) }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
 
   it "knows if it exists when created with an HTTP method" do
@@ -36,7 +36,7 @@ describe Google::Cloud::PubSub::Subscription, :exists, :mock_pubsub do
     end
 
     it "checks if the subscription exists by making an HTTP call" do
-      get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
+      get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, sub_name)
       mock = Minitest::Mock.new
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/lazy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/lazy_test.rb
@@ -18,8 +18,8 @@ describe Google::Cloud::PubSub::Subscription, :name, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
   let(:sub_path) { subscription_path sub_name }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
 
   it "is not reference when created with an HTTP method" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
@@ -17,9 +17,8 @@ require "helper"
 describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_hash) { JSON.parse sub_json }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
 
   it "will create a Subscriber" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/modify_ack_deadline_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/modify_ack_deadline_test.rb
@@ -17,13 +17,12 @@ require "helper"
 describe Google::Cloud::PubSub::Subscription, :modify_ack_deadline, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_hash) { JSON.parse sub_json }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
-  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json rec_message_json("rec_message1-msg-goes-here") }
-  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json rec_message_json("rec_message2-msg-goes-here") }
-  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.decode_json rec_message_json("rec_message3-msg-goes-here") }
+  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new rec_message_hash("rec_message1-msg-goes-here") }
+  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new rec_message_hash("rec_message2-msg-goes-here") }
+  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new rec_message_hash("rec_message3-msg-goes-here") }
   let(:rec_message1) { Google::Cloud::PubSub::ReceivedMessage.from_grpc rec_msg1_grpc, subscription }
   let(:rec_message2) { Google::Cloud::PubSub::ReceivedMessage.from_grpc rec_msg2_grpc, subscription }
   let(:rec_message3) { Google::Cloud::PubSub::ReceivedMessage.from_grpc rec_msg3_grpc, subscription }

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/name_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/name_test.rb
@@ -18,8 +18,8 @@ describe Google::Cloud::PubSub::Subscription, :name, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
   let(:sub_path) { subscription_path sub_name }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
 
   it "gives the name returned from the HTTP method" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/policy_test.rb
@@ -17,13 +17,12 @@ require "helper"
 describe Google::Cloud::PubSub::Subscription, :policy, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_hash) { JSON.parse sub_json }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
 
   it "gets the IAM Policy" do
-    policy_json = {
+    policy_hash = {
       "etag"=>"CAE=",
       "bindings" => [{
         "role" => "roles/viewer",
@@ -32,8 +31,8 @@ describe Google::Cloud::PubSub::Subscription, :policy, :mock_pubsub do
           "serviceAccount:1234567890@developer.gserviceaccount.com"
         ]
       }]
-    }.to_json
-    get_res = Google::Iam::V1::Policy.decode_json policy_json
+    }
+    get_res = Google::Iam::V1::Policy.decode_json policy_hash.to_json
     mock = Minitest::Mock.new
     mock.expect :get_iam_policy, get_res, [subscription_path(sub_name), options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -53,7 +52,7 @@ describe Google::Cloud::PubSub::Subscription, :policy, :mock_pubsub do
   end
 
   it "sets the IAM Policy" do
-    policy_json = {
+    policy_hash = {
       "etag"=>"CAE=",
       "bindings" => [{
         "role" => "roles/owner",
@@ -62,8 +61,8 @@ describe Google::Cloud::PubSub::Subscription, :policy, :mock_pubsub do
           "serviceAccount:0987654321@developer.gserviceaccount.com"
         ]
       }]
-    }.to_json
-    get_res = Google::Iam::V1::Policy.decode_json policy_json
+    }
+    get_res = Google::Iam::V1::Policy.decode_json policy_hash.to_json
     mock = Minitest::Mock.new
     mock.expect :get_iam_policy, get_res, [subscription_path(sub_name), options: default_options]
 
@@ -88,7 +87,7 @@ describe Google::Cloud::PubSub::Subscription, :policy, :mock_pubsub do
       }]
     }
 
-    set_req = Google::Iam::V1::Policy.decode_json(JSON.dump(updated_policy))
+    set_req = Google::Iam::V1::Policy.decode_json JSON.dump(updated_policy)
     set_res = Google::Iam::V1::Policy.decode_json JSON.dump(new_policy)
     mock.expect :set_iam_policy, set_res, [subscription_path(sub_name), set_req, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -114,7 +113,7 @@ describe Google::Cloud::PubSub::Subscription, :policy, :mock_pubsub do
   end
 
   it "sets the IAM Policy in a block" do
-    policy_json = {
+    policy_hash = {
       "etag"=>"CAE=",
       "bindings" => [{
         "role" => "roles/owner",
@@ -123,8 +122,8 @@ describe Google::Cloud::PubSub::Subscription, :policy, :mock_pubsub do
           "serviceAccount:0987654321@developer.gserviceaccount.com"
         ]
       }]
-    }.to_json
-    get_res = Google::Iam::V1::Policy.decode_json policy_json
+    }
+    get_res = Google::Iam::V1::Policy.decode_json policy_hash.to_json
     mock = Minitest::Mock.new
     mock.expect :get_iam_policy, get_res, [subscription_path(sub_name), options: default_options]
 
@@ -148,7 +147,7 @@ describe Google::Cloud::PubSub::Subscription, :policy, :mock_pubsub do
         ]
       }]
     }
-    set_req = Google::Iam::V1::Policy.decode_json(JSON.dump(updated_policy))
+    set_req = Google::Iam::V1::Policy.decode_json JSON.dump(updated_policy)
     set_res = Google::Iam::V1::Policy.decode_json JSON.dump(new_policy)
     mock.expect :set_iam_policy, set_res, [subscription_path(sub_name), set_req, options: default_options]
     subscription.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_test.rb
@@ -17,14 +17,13 @@ require "helper"
 describe Google::Cloud::PubSub::Subscription, :pull, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_hash) { JSON.parse sub_json }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
 
   it "can pull messages" do
     rec_message_msg = "pulled-message"
-    pull_res = Google::Cloud::PubSub::V1::PullResponse.decode_json rec_messages_json(rec_message_msg)
+    pull_res = Google::Cloud::PubSub::V1::PullResponse.new rec_messages_hash(rec_message_msg)
     mock = Minitest::Mock.new
     mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: true, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -45,7 +44,7 @@ describe Google::Cloud::PubSub::Subscription, :pull, :mock_pubsub do
 
     it "can pull messages" do
       rec_message_msg = "pulled-message"
-      pull_res = Google::Cloud::PubSub::V1::PullResponse.decode_json rec_messages_json(rec_message_msg)
+      pull_res = Google::Cloud::PubSub::V1::PullResponse.new rec_messages_hash(rec_message_msg)
       mock = Minitest::Mock.new
       mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: true, options: default_options]
       subscription.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_wait_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_wait_test.rb
@@ -17,14 +17,13 @@ require "helper"
 describe Google::Cloud::PubSub::Subscription, :pull, :wait, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_hash) { JSON.parse sub_json }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
 
   it "can pull messages without returning immediately" do
     rec_message_msg = "pulled-message"
-    pull_res = Google::Cloud::PubSub::V1::PullResponse.decode_json rec_messages_json(rec_message_msg)
+    pull_res = Google::Cloud::PubSub::V1::PullResponse.new rec_messages_hash(rec_message_msg)
     mock = Minitest::Mock.new
     mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: false, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -39,7 +38,7 @@ describe Google::Cloud::PubSub::Subscription, :pull, :wait, :mock_pubsub do
 
   it "can pull messages by calling wait_for_messages" do
     rec_message_msg = "pulled-message"
-    pull_res = Google::Cloud::PubSub::V1::PullResponse.decode_json rec_messages_json(rec_message_msg)
+    pull_res = Google::Cloud::PubSub::V1::PullResponse.new rec_messages_hash(rec_message_msg)
     mock = Minitest::Mock.new
     mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: false, options: default_options]
     subscription.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/seek_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/seek_test.rb
@@ -17,11 +17,11 @@ require "helper"
 describe Google::Cloud::PubSub::Subscription, :seek, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_json) { subscription_json topic_name, sub_name }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
   let(:snapshot_name) { "my-snapshot" }
-  let(:snapshot_grpc) { Google::Cloud::PubSub::V1::Snapshot.decode_json(snapshot_json(topic_name, snapshot_name)) }
+  let(:snapshot_grpc) { Google::Cloud::PubSub::V1::Snapshot.new(snapshot_hash(topic_name, snapshot_name)) }
   let(:snapshot) { Google::Cloud::PubSub::Snapshot.from_grpc snapshot_grpc, pubsub.service }
 
   it "can seek using a time" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -25,11 +25,10 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     new_labels.each { |k, v| labels_map[String(k)] = String(v) }
     labels_map
   end
-  let(:sub_json) { subscription_json topic_name, sub_name, labels: labels }
-  let(:sub_hash) { JSON.parse sub_json }
+  let(:sub_hash) { subscription_hash topic_name, sub_name, labels: labels }
   let(:sub_deadline) { sub_hash["ack_deadline_seconds"] }
   let(:sub_endpoint) { sub_hash["push_config"]["push_endpoint"] }
-  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
 
   it "updates deadline" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription_test.rb
@@ -17,7 +17,7 @@ require "helper"
 describe Google::Cloud::PubSub::Subscription, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:subscription_name) { "subscription-name-goes-here" }
-  let(:subscription_grpc) { Google::Cloud::PubSub::V1::Subscription.decode_json(subscription_json(topic_name, subscription_name)) }
+  let(:subscription_grpc) { Google::Cloud::PubSub::V1::Subscription.new(subscription_hash(topic_name, subscription_name)) }
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc subscription_grpc, pubsub.service }
   let(:labels) { { "foo" => "bar" } }
 
@@ -74,7 +74,7 @@ describe Google::Cloud::PubSub::Subscription, :mock_pubsub do
 
   it "can pull a message" do
     rec_message_msg = "pulled-message"
-    pull_res = Google::Cloud::PubSub::V1::PullResponse.decode_json rec_messages_json(rec_message_msg)
+    pull_res = Google::Cloud::PubSub::V1::PullResponse.new rec_messages_hash(rec_message_msg)
     mock = Minitest::Mock.new
     mock.expect :pull, pull_res, [subscription_path(subscription_name), 100, return_immediately: true, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -122,7 +122,7 @@ describe Google::Cloud::PubSub::Subscription, :mock_pubsub do
 
   it "creates a snapshot" do
     new_snapshot_name = "new-snapshot-#{Time.now.to_i}"
-    create_res = Google::Cloud::PubSub::V1::Snapshot.decode_json snapshot_json(subscription_name, new_snapshot_name)
+    create_res = Google::Cloud::PubSub::V1::Snapshot.new snapshot_hash(subscription_name, new_snapshot_name)
     mock = Minitest::Mock.new
     mock.expect :create_snapshot, create_res, [snapshot_path(new_snapshot_name), subscription_path(subscription_name), labels: nil, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -137,7 +137,7 @@ describe Google::Cloud::PubSub::Subscription, :mock_pubsub do
 
   it "creates a snapshot with new_snapshot alias" do
     new_snapshot_name = "new-snapshot-#{Time.now.to_i}"
-    create_res = Google::Cloud::PubSub::V1::Snapshot.decode_json snapshot_json(subscription_name, new_snapshot_name)
+    create_res = Google::Cloud::PubSub::V1::Snapshot.new snapshot_hash(subscription_name, new_snapshot_name)
     mock = Minitest::Mock.new
     mock.expect :create_snapshot, create_res, [snapshot_path(new_snapshot_name), subscription_path(subscription_name), labels: nil, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -152,7 +152,7 @@ describe Google::Cloud::PubSub::Subscription, :mock_pubsub do
 
   it "creates a snapshot with labels" do
     new_snapshot_name = "new-snapshot-#{Time.now.to_i}"
-    create_res = Google::Cloud::PubSub::V1::Snapshot.decode_json snapshot_json(subscription_name, new_snapshot_name, labels: labels)
+    create_res = Google::Cloud::PubSub::V1::Snapshot.new snapshot_hash(subscription_name, new_snapshot_name, labels: labels)
     mock = Minitest::Mock.new
     mock.expect :create_snapshot, create_res, [snapshot_path(new_snapshot_name), subscription_path(subscription_name), labels: labels, options: default_options]
     subscription.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/autocreate_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/autocreate_test.rb
@@ -16,7 +16,7 @@ require "helper"
 
 describe Google::Cloud::PubSub::Topic, :reference, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
+  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
 
   it "will not be reference when created with an HTTP method" do
     topic.wont_be :reference?

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/exists_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/exists_test.rb
@@ -16,7 +16,7 @@ require "helper"
 
 describe Google::Cloud::PubSub::Topic, :exists, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
+  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
 
   it "knows if it exists when created with an HTTP method" do
     # The absense of a mock means this test will fail
@@ -30,7 +30,7 @@ describe Google::Cloud::PubSub::Topic, :exists, :mock_pubsub do
     let(:topic) { Google::Cloud::PubSub::Topic.from_name topic_name, pubsub.service }
 
     it "checks if the topic exists by making an HTTP call" do
-      get_res = Google::Cloud::PubSub::V1::Topic.decode_json topic_json(topic_name)
+      get_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(topic_name)
       mock = Minitest::Mock.new
       mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
       topic.service.mocked_publisher = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/lazy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/lazy_test.rb
@@ -16,7 +16,7 @@ require "helper"
 
 describe Google::Cloud::PubSub::Topic, :reference, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
+  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
 
   it "is not reference when created with an HTTP method" do
     topic.wont_be :reference?

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/name_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/name_test.rb
@@ -16,7 +16,7 @@ require "helper"
 
 describe Google::Cloud::PubSub::Topic, :name, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
+  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
 
   it "gives the name returned from the HTTP method" do
     topic.name.must_equal "projects/#{project}/topics/#{topic_name}"

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
@@ -16,10 +16,10 @@ require "helper"
 
 describe Google::Cloud::PubSub::Topic, :policy, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
+  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
 
   it "gets the IAM Policy" do
-    policy_json = {
+    policy_hash = {
       "etag"=>"CAE=",
       "bindings"=>[{
         "role"=>"roles/viewer",
@@ -28,8 +28,8 @@ describe Google::Cloud::PubSub::Topic, :policy, :mock_pubsub do
           "serviceAccount:1234567890@developer.gserviceaccount.com"
          ]
       }]
-    }.to_json
-    get_res = Google::Iam::V1::Policy.decode_json policy_json
+    }
+    get_res = Google::Iam::V1::Policy.decode_json policy_hash.to_json
     mock = Minitest::Mock.new
     mock.expect :get_iam_policy, get_res, [topic_path(topic_name), options: default_options]
     topic.service.mocked_publisher = mock
@@ -49,7 +49,7 @@ describe Google::Cloud::PubSub::Topic, :policy, :mock_pubsub do
   end
 
   it "sets the IAM Policy" do
-    policy_json = {
+    policy_hash = {
       "etag"=>"CAE=",
       "bindings" => [{
         "role" => "roles/owner",
@@ -58,8 +58,8 @@ describe Google::Cloud::PubSub::Topic, :policy, :mock_pubsub do
           "serviceAccount:0987654321@developer.gserviceaccount.com"
         ]
       }]
-    }.to_json
-    get_res = Google::Iam::V1::Policy.decode_json policy_json
+    }
+    get_res = Google::Iam::V1::Policy.decode_json policy_hash.to_json
     mock = Minitest::Mock.new
     mock.expect :get_iam_policy, get_res, [topic_path(topic_name), options: default_options]
 
@@ -84,7 +84,7 @@ describe Google::Cloud::PubSub::Topic, :policy, :mock_pubsub do
       }]
     }
 
-    set_req = Google::Iam::V1::Policy.decode_json(JSON.dump(updated_policy))
+    set_req = Google::Iam::V1::Policy.decode_json JSON.dump(updated_policy)
     set_res = Google::Iam::V1::Policy.decode_json JSON.dump(new_policy)
     mock.expect :set_iam_policy, set_res, [topic_path(topic_name), set_req, options: default_options]
     topic.service.mocked_publisher = mock
@@ -110,7 +110,7 @@ describe Google::Cloud::PubSub::Topic, :policy, :mock_pubsub do
   end
 
   it "sets the IAM Policy in a block" do
-    policy_json = {
+    policy_hash = {
       "etag"=>"CAE=",
       "bindings" => [{
         "role" => "roles/owner",
@@ -119,8 +119,8 @@ describe Google::Cloud::PubSub::Topic, :policy, :mock_pubsub do
           "serviceAccount:0987654321@developer.gserviceaccount.com"
         ]
       }]
-    }.to_json
-    get_res = Google::Iam::V1::Policy.decode_json policy_json
+    }
+    get_res = Google::Iam::V1::Policy.decode_json policy_hash.to_json
     mock = Minitest::Mock.new
     mock.expect :get_iam_policy, get_res, [topic_path(topic_name), options: default_options]
 
@@ -145,7 +145,7 @@ describe Google::Cloud::PubSub::Topic, :policy, :mock_pubsub do
       }]
     }
 
-    set_req = Google::Iam::V1::Policy.decode_json(JSON.dump(updated_policy))
+    set_req = Google::Iam::V1::Policy.decode_json JSON.dump(updated_policy)
     set_res = Google::Iam::V1::Policy.decode_json JSON.dump(new_policy)
     mock.expect :set_iam_policy, set_res, [topic_path(topic_name), set_req, options: default_options]
     topic.service.mocked_publisher = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
@@ -16,13 +16,13 @@ require "helper"
 
 describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
+  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
 
   it "publishes a message" do
     messages = [
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: "async-message".encode(Encoding::ASCII_8BIT))
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
@@ -55,7 +55,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
     messages = [
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: "async-message".encode(Encoding::ASCII_8BIT))
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
@@ -98,7 +98,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
     messages = [
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT))
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
@@ -142,7 +142,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
     messages = [
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT))
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
@@ -192,7 +192,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
     messages = [
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: "async-message".encode(Encoding::ASCII_8BIT), attributes: {"format" => "text"})
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
@@ -242,7 +242,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
       messages = [
         Google::Cloud::PubSub::V1::PubsubMessage.new(data: "async-message".encode(Encoding::ASCII_8BIT))
       ]
-      publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+      publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
       mock = Minitest::Mock.new
       mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
       topic.service.mocked_publisher = mock
@@ -275,7 +275,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
       messages = [
         Google::Cloud::PubSub::V1::PubsubMessage.new(data: "async-message".encode(Encoding::ASCII_8BIT), attributes: { "format" => "text" })
       ]
-      publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+      publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
       mock = Minitest::Mock.new
       mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
       topic.service.mocked_publisher = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
@@ -16,7 +16,7 @@ require "helper"
 
 describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
+  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
   let(:message1) { "new-message-here" }
   let(:message2) { "second-new-message" }
   let(:message3) { "third-new-message" }
@@ -28,7 +28,7 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
    messages = [
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded1)
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
@@ -45,7 +45,7 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
    messages = [
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT))
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
@@ -63,7 +63,7 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
    messages = [
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT))
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
@@ -87,7 +87,7 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
    messages = [
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded1, attributes: {"format" => "text"})
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
@@ -107,7 +107,7 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded2),
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded3, attributes: {"format" => "none"})
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1", "msg2", "msg3"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
@@ -134,7 +134,7 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
      messages = [
         Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded1)
       ]
-      publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+      publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
       mock = Minitest::Mock.new
       mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
       topic.service.mocked_publisher = mock
@@ -151,7 +151,7 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
      messages = [
         Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded1, attributes: { "format" => "text" })
       ]
-      publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+      publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
       mock = Minitest::Mock.new
       mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
       topic.service.mocked_publisher = mock
@@ -171,7 +171,7 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
         Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded2),
         Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded3, attributes: {"format" => "none"})
       ]
-      publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)
+      publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1", "msg2", "msg3"] })
       mock = Minitest::Mock.new
       mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
       topic.service.mocked_publisher = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
@@ -16,12 +16,12 @@ require "helper"
 
 describe Google::Cloud::PubSub::Topic, :subscribe, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
+  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
   let(:new_sub_name) { "new-sub-#{Time.now.to_i}" }
   let(:labels) { { "foo" => "bar" } }
 
   it "creates a subscription when calling subscribe" do
-    create_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
+    create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
     mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, options: default_options]
     topic.service.mocked_subscriber = mock
@@ -35,7 +35,7 @@ describe Google::Cloud::PubSub::Topic, :subscribe, :mock_pubsub do
   end
 
   it "creates a subscription with labels" do
-    create_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name, labels: labels)
+    create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name, labels: labels)
     mock = Minitest::Mock.new
     mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: labels, options: default_options]
     topic.service.mocked_subscriber = mock
@@ -54,7 +54,7 @@ describe Google::Cloud::PubSub::Topic, :subscribe, :mock_pubsub do
     let(:topic) { Google::Cloud::PubSub::Topic.from_name topic_name, pubsub.service }
 
     it "creates a subscription when calling subscribe" do
-      create_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
+      create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
       mock = Minitest::Mock.new
       mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, options: default_options]
       topic.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscription_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscription_test.rb
@@ -16,12 +16,12 @@ require "helper"
 
 describe Google::Cloud::PubSub::Topic, :subscription, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
+  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
   let(:found_sub_name) { "found-sub-#{Time.now.to_i}" }
   let(:not_found_sub_name) { "found-sub-#{Time.now.to_i}" }
 
   it "gets an existing subscription" do
-    get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, found_sub_name)
+    get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, found_sub_name)
     mock = Minitest::Mock.new
     mock.expect :get_subscription, get_res, [subscription_path(found_sub_name), options: default_options]
     topic.service.mocked_subscriber = mock
@@ -36,7 +36,7 @@ describe Google::Cloud::PubSub::Topic, :subscription, :mock_pubsub do
   end
 
   it "gets an existing subscription with get_subscription alias" do
-    get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, found_sub_name)
+    get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, found_sub_name)
     mock = Minitest::Mock.new
     mock.expect :get_subscription, get_res, [subscription_path(found_sub_name), options: default_options]
     topic.service.mocked_subscriber = mock
@@ -51,7 +51,7 @@ describe Google::Cloud::PubSub::Topic, :subscription, :mock_pubsub do
   end
 
   it "gets an existing subscription with find_subscription alias" do
-    get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, found_sub_name)
+    get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, found_sub_name)
     mock = Minitest::Mock.new
     mock.expect :get_subscription, get_res, [subscription_path(found_sub_name), options: default_options]
     topic.service.mocked_subscriber = mock
@@ -91,7 +91,7 @@ describe Google::Cloud::PubSub::Topic, :subscription, :mock_pubsub do
     let(:topic) { Google::Cloud::PubSub::Topic.from_name topic_name, pubsub.service }
 
     it "gets an existing subscription" do
-      get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, found_sub_name)
+      get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, found_sub_name)
       mock = Minitest::Mock.new
       mock.expect :get_subscription, get_res, [subscription_path(found_sub_name), options: default_options]
       topic.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
@@ -16,9 +16,9 @@ require "helper"
 
 describe Google::Cloud::PubSub::Topic, :subscriptions, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.decode_json(topic_json(topic_name)), pubsub.service }
+  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
   let(:subscriptions_with_token) do
-    response = Google::Cloud::PubSub::V1::ListTopicSubscriptionsResponse.decode_json topic_subscriptions_json(3, "next_page_token")
+    response = Google::Cloud::PubSub::V1::ListTopicSubscriptionsResponse.new topic_subscriptions_hash(3, "next_page_token")
     paged_enum_struct response
   end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/update_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::PubSub::Topic, :update, :mock_pubsub do
     new_labels.each { |k, v| labels_map[String(k)] = String(v) }
     labels_map
   end
-  let(:topic_grpc) { Google::Cloud::PubSub::V1::Topic.decode_json topic_json(topic_name, labels: labels) }
+  let(:topic_grpc) { Google::Cloud::PubSub::V1::Topic.new topic_hash(topic_name, labels: labels) }
   let(:topic) { Google::Cloud::PubSub::Topic.from_grpc topic_grpc, pubsub.service }
 
   it "updates labels" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -17,17 +17,17 @@ require "helper"
 describe Google::Cloud::PubSub::Topic, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:labels) { { "foo" => "bar" } }
-  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.decode_json(topic_json(topic_name, labels: labels)), pubsub.service }
+  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name, labels: labels)), pubsub.service }
   let(:subscriptions_with_token) do
-    response = Google::Cloud::PubSub::V1::ListTopicSubscriptionsResponse.decode_json topic_subscriptions_json(3, "next_page_token")
+    response = Google::Cloud::PubSub::V1::ListTopicSubscriptionsResponse.new topic_subscriptions_hash(3, "next_page_token")
     paged_enum_struct response
   end
   let(:subscriptions_without_token) do
-    response = Google::Cloud::PubSub::V1::ListTopicSubscriptionsResponse.decode_json topic_subscriptions_json(2)
+    response = Google::Cloud::PubSub::V1::ListTopicSubscriptionsResponse.new topic_subscriptions_hash(2)
     paged_enum_struct response
   end
   let(:subscriptions_with_token_2) do
-    response = Google::Cloud::PubSub::V1::ListTopicSubscriptionsResponse.decode_json topic_subscriptions_json(3, "next_page_token")
+    response = Google::Cloud::PubSub::V1::ListTopicSubscriptionsResponse.new topic_subscriptions_hash(3, "next_page_token")
     paged_enum_struct response
   end
 
@@ -53,7 +53,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
   it "creates a subscription" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
-    create_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
+    create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
     mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, options: default_options]
     topic.service.mocked_subscriber = mock
@@ -68,7 +68,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
   it "creates a subscription with create_subscription alias" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
-    create_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
+    create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
     mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, options: default_options]
     topic.service.mocked_subscriber = mock
@@ -83,7 +83,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
   it "creates a subscription with new_subscription alias" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
-    create_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
+    create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
     mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, options: default_options]
     topic.service.mocked_subscriber = mock
@@ -99,7 +99,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
   it "creates a subscription with a deadline" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     deadline = 42
-    create_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
+    create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
     mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: 42, retain_acked_messages: false, message_retention_duration: nil, labels: nil, options: default_options]
     topic.service.mocked_subscriber = mock
@@ -114,7 +114,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
   it "creates a subscription with retain_acked and retention" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
-    create_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
+    create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
 
     duration = Google::Protobuf::Duration.new seconds: 600, nanos: 0
     mock = Minitest::Mock.new
@@ -133,7 +133,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     endpoint = "http://foo.bar/baz"
     push_config = Google::Cloud::PubSub::V1::PushConfig.new(push_endpoint: endpoint)
-    create_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
+    create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
     mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: push_config, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, options: default_options]
     topic.service.mocked_subscriber = mock
@@ -148,7 +148,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
   it "creates a subscription with labels" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
-    create_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name, labels: labels)
+    create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name, labels: labels)
     mock = Minitest::Mock.new
     mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: labels, options: default_options]
     topic.service.mocked_subscriber = mock
@@ -199,7 +199,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
   it "gets a subscription" do
     sub_name = "found-sub-#{Time.now.to_i}"
 
-    get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
+    get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, sub_name)
     mock = Minitest::Mock.new
     mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
     topic.service.mocked_subscriber = mock
@@ -217,7 +217,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
   it "gets a subscription with get_subscription alias" do
     sub_name = "found-sub-#{Time.now.to_i}"
 
-    get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
+    get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, sub_name)
     mock = Minitest::Mock.new
     mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
     topic.service.mocked_subscriber = mock
@@ -235,7 +235,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
   it "gets a subscription with find_subscription alias" do
     sub_name = "found-sub-#{Time.now.to_i}"
 
-    get_res = Google::Cloud::PubSub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
+    get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, sub_name)
     mock = Minitest::Mock.new
     mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
     topic.service.mocked_subscriber = mock
@@ -490,7 +490,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     messages = [
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: encoded_msg)
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
@@ -509,7 +509,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     messages = [
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: encoded_msg, attributes: { "format" => "text" })
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
@@ -532,7 +532,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: encoded_msg1),
       Google::Cloud::PubSub::V1::PubsubMessage.new(data: encoded_msg2, attributes: { "format" => "none" })
     ]
-    publish_res = Google::Cloud::PubSub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2"] }.to_json)
+    publish_res = Google::Cloud::PubSub::V1::PublishResponse.new({ message_ids: ["msg1", "msg2"] })
     mock = Minitest::Mock.new
     mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -111,89 +111,87 @@ class MockPubsub < Minitest::Spec
                                  page_token: token)
   end
 
-  def topics_json num_topics, token = ""
+  def topics_hash num_topics, token = ""
     topics = num_topics.times.map do
-      JSON.parse(topic_json("topic-#{rand 1000}"))
+      topic_hash("topic-#{rand 1000}")
     end
-    data = { "topics" => topics }
-    data["next_page_token"] = token unless token.nil?
-    data.to_json
+    data = { topics: topics }
+    data[:next_page_token] = token unless token.nil?
+    data
   end
 
-  def topic_json topic_name, labels: nil
-    { "name" => topic_path(topic_name), labels: labels }.to_json
+  def topic_hash topic_name, labels: nil
+    { name: topic_path(topic_name), labels: labels }
   end
 
-  def topic_subscriptions_json num_subs, token = nil
+  def topic_subscriptions_hash num_subs, token = nil
     subs = num_subs.times.map do
       subscription_path("sub-#{rand 1000}")
     end
-    data = { "subscriptions" => subs }
-    data["next_page_token"] = token unless token.nil?
-    data.to_json
+    data = { subscriptions: subs }
+    data[:next_page_token] = token unless token.nil?
+    data
   end
 
-  def subscriptions_json topic_name, num_subs, token = nil
+  def subscriptions_hash topic_name, num_subs, token = nil
     subs = num_subs.times.map do
-      JSON.parse(subscription_json(topic_name, "sub-#{rand 1000}"))
+      subscription_hash(topic_name, "sub-#{rand 1000}")
     end
-    data = { "subscriptions" => subs }
-    data["next_page_token"] = token unless token.nil?
-    data.to_json
+    data = { subscriptions: subs }
+    data[:next_page_token] = token unless token.nil?
+    data
   end
 
-  def subscription_json topic_name, sub_name,
+  def subscription_hash topic_name, sub_name,
                         deadline = 60,
                         endpoint = "http://example.com/callback", labels: nil
-    { "name" => subscription_path(sub_name),
-      "topic" => topic_path(topic_name),
-      "push_config" => { "push_endpoint" => endpoint },
-      "ack_deadline_seconds" => deadline,
-      "retain_acked_messages" => true,
-      "message_retention_duration" => {"seconds" => 600, "nanos" => 900000000}, # 600.9 seconds
-      "labels" => labels
-    }.to_json
+    { name: subscription_path(sub_name),
+      topic: topic_path(topic_name),
+      push_config: { push_endpoint: endpoint },
+      ack_deadline_seconds: deadline,
+      retain_acked_messages: true,
+      message_retention_duration: { seconds: 600, nanos: 900000000 }, # 600.9 seconds
+      labels: labels
+    }
   end
 
-  def snapshots_json topic_name, num_snapshots, token = nil
+  def snapshots_hash topic_name, num_snapshots, token = nil
     snapshots = num_snapshots.times.map do
-      JSON.parse(snapshot_json(topic_name, "snapshot-#{rand 1000}"))
+      snapshot_hash(topic_name, "snapshot-#{rand 1000}")
     end
-    data = { "snapshots" => snapshots }
-    data["next_page_token"] = token unless token.nil?
-    data.to_json
+    data = { snapshots: snapshots }
+    data[:next_page_token] = token unless token.nil?
+    data
   end
 
-  def snapshot_json topic_name, snapshot_name, labels: nil
+  def snapshot_hash topic_name, snapshot_name, labels: nil
     time = Time.now
     timestamp = {
-      "seconds" => time.to_i,
-      "nanos" => time.nsec
+      seconds: time.to_i,
+      nanos: time.nsec
     }
-    { "name" => snapshot_path(snapshot_name),
-      "topic" => topic_path(topic_name),
-      "expire_time" => timestamp,
-      "labels" => labels
-    }.to_json
+    { name: snapshot_path(snapshot_name),
+      topic: topic_path(topic_name),
+      expire_time: timestamp,
+      labels: labels
+    }
   end
 
-  def rec_message_json message, id = rand(1000000)
+  def rec_message_hash message, id = rand(1000000)
     {
-      "ack_id" => "ack-id-#{id}",
-      "message" => {
-        "data" => Base64.strict_encode64(message),
-        "attributes" => {},
-        "message_id" => "msg-id-#{id}",
+      ack_id: "ack-id-#{id}",
+      message: {
+        data: message,
+        attributes: {},
+        message_id: "msg-id-#{id}",
       }
-    }.to_json
+    }
   end
 
-  def rec_messages_json message, id = nil
+  def rec_messages_hash message, id = nil
     {
-      "received_messages" => [
-        JSON.parse(rec_message_json(message, id))
-      ]
-    }.to_json
+      received_messages: [rec_message_hash(message, id)]
+    }
   end
 
   def project_path

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -150,7 +150,7 @@ class MockPubsub < Minitest::Spec
       "push_config" => { "push_endpoint" => endpoint },
       "ack_deadline_seconds" => deadline,
       "retain_acked_messages" => true,
-      "message_retention_duration" => "600.900000000s", # 600.9 seconds
+      "message_retention_duration" => {"seconds" => 600, "nanos" => 900000000}, # 600.9 seconds
       "labels" => labels
     }.to_json
   end
@@ -165,9 +165,14 @@ class MockPubsub < Minitest::Spec
   end
 
   def snapshot_json topic_name, snapshot_name, labels: nil
+    time = Time.now
+    timestamp = {
+      "seconds" => time.to_i,
+      "nanos" => time.nsec
+    }
     { "name" => snapshot_path(snapshot_name),
       "topic" => topic_path(topic_name),
-      "expire_time" => Time.now.utc.strftime("%FT%T.%NZ"),
+      "expire_time" => timestamp,
       "labels" => labels
     }.to_json
   end


### PR DESCRIPTION
Avoid parsing JSON in test fixtures that use `Google::Protobuf::Timestamp` values. Windows is unable to parse the JSON formatted timestamp, and raises a ParseError.

[fixes #2982]