### PR TITLE
Release google-cloud-container 0.4.0

### DIFF
--- a/google-cloud-container/CHANGELOG.md
+++ b/google-cloud-container/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.4.0 / 2019-03-11
+
+* Add v1beta1 API version
+
 ### 0.3.0 / 2018-12-10
 
 * Add support for Regional Clusters.

--- a/google-cloud-container/google-cloud-container.gemspec
+++ b/google-cloud-container/google-cloud-container.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-container"
-  gem.version       = "0.3.0"
+  gem.version       = "0.4.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Add v1beta1 API version

This pull request was generated using releasetool.