### PR TITLE
Release google-cloud-scheduler 0.2.0

### DIFF
--- a/google-cloud-scheduler/CHANGELOG.md
+++ b/google-cloud-scheduler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.0 / 2019-03-12
+
+* Add v1 api version
+
 ### 0.1.0 / 2018-12-13
 
 * Initial release

--- a/google-cloud-scheduler/google-cloud-scheduler.gemspec
+++ b/google-cloud-scheduler/google-cloud-scheduler.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-scheduler"
-  gem.version       = "0.1.0"
+  gem.version       = "0.2.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Add v1 api version

This pull request was generated using releasetool.