### PR TITLE
Release google-cloud-tasks 0.4.0

### DIFF
--- a/google-cloud-tasks/CHANGELOG.md
+++ b/google-cloud-tasks/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 0.4.0 / 2019-03-12
+
+* Add HTTP Request to V2beta3
+  * Add Task#http_request
+  * Add HttpMethod
+* Update documentation
+
 ### 0.3.0 / 2019-02-01
 
 * Add Task#dispatch_deadline attribute.

--- a/google-cloud-tasks/google-cloud-tasks.gemspec
+++ b/google-cloud-tasks/google-cloud-tasks.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-tasks"
-  gem.version       = "0.3.0"
+  gem.version       = "0.4.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Add HTTP Request to V2beta3
  * Add Task#http_request
  * Add HttpMethod
* Update documentation

This pull request was generated using releasetool.