### PR TITLE
Switch to Ruby 2.5.4

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -20,7 +20,7 @@ ruby --version
 # https://github.com/bundler/bundler/issues/6154
 export BUNDLE_GEMFILE=
 
-RUBY_VERSIONS=("2.3.8" "2.4.5" "2.5.3")
+RUBY_VERSIONS=("2.3.8" "2.4.5" "2.5.4")
 
 # Capture failures
 EXIT_STATUS=0 # everything passed

--- a/.kokoro/docker/ruby-multi/Dockerfile
+++ b/.kokoro/docker/ruby-multi/Dockerfile
@@ -32,6 +32,6 @@ ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
 RUN rbenv install 2.3.8 && rbenv global 2.3.8 && gem install bundler --version 1.17.3
 RUN rbenv install 2.4.5 && rbenv global 2.4.5 && gem install bundler --version 1.17.3
-RUN rbenv install 2.5.3 && rbenv global 2.5.3 && gem install bundler --version 1.17.3
+RUN rbenv install 2.5.4 && rbenv global 2.5.4 && gem install bundler --version 1.17.3
 
 RUN apt-get -y autoremove && apt-get -y autoclean

--- a/.kokoro/docker/ruby-release/Dockerfile
+++ b/.kokoro/docker/ruby-release/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get -y autoclean
 # Install Ruby
 RUN mkdir $HOME/.ruby
 RUN git clone https://github.com/rbenv/ruby-build.git $HOME/.ruby-build
-RUN $HOME/.ruby-build/bin/ruby-build 2.5.3 $HOME/.ruby
+RUN $HOME/.ruby-build/bin/ruby-build 2.5.4 $HOME/.ruby
 ENV PATH /root/.ruby/bin:$PATH
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc


### PR DESCRIPTION
Switch Kokoro to use the recently released Ruby 2.5.4, which includes a fix for #1979.