### PR TITLE
Remove resource_pb require

### DIFF
--- a/google-cloud-redis/lib/google/cloud/redis/v1/cloud_redis_pb.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1/cloud_redis_pb.rb
@@ -5,7 +5,6 @@
 require 'google/protobuf'
 
 require 'google/api/annotations_pb'
-require 'google/api/resource_pb'
 require 'google/longrunning/operations_pb'
 require 'google/protobuf/field_mask_pb'
 require 'google/protobuf/timestamp_pb'


### PR DESCRIPTION
This was added recently by Autosynth, but this file is not included in the current google-protobuf gem.

Removing the require so the build can succeed.