### PR TITLE
Patch debugger unit tests for Ruby 2.6

### DIFF
--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
@@ -111,9 +111,14 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     it "doesn't allow return operation in expression" do
       expression = "return"
       result = evaluator.readonly_eval_expression binding, expression
-      if RUBY_VERSION.to_f >= 2.4
+      if RUBY_VERSION.to_f >= 2.6
+        # Ruby 2.6 raises LocalJumpError
+        result.message.must_match "unexpected return"
+      elsif RUBY_VERSION.to_f >= 2.4
+        # Ruby 2.4 and 2.5 treat this as a mutation
         result.message.must_match evaluator::PROHIBITED_OPERATION_MSG
       else
+        # Ruby 2.3 fails compilation
         result.message.must_match evaluator::COMPILATION_FAIL_MSG
       end
     end

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
@@ -33,25 +33,25 @@ end
 describe Google::Cloud::Debugger::Tracer, :mock_debugger do
   let(:breakpoint_path) { File.expand_path("../tracer_test_helper.rb", __FILE__) }
   let(:breakpoint1) {
-    Google::Cloud::Debugger::Breakpoint.new "1", breakpoint_path, 21 }
+    Google::Cloud::Debugger::Breakpoint.new "1", breakpoint_path, 22 }
   let(:breakpoint2) {
-    Google::Cloud::Debugger::Breakpoint.new "2", breakpoint_path, 34 }
+    Google::Cloud::Debugger::Breakpoint.new "2", breakpoint_path, 35 }
   let(:breakpoint3) {
-    Google::Cloud::Debugger::Breakpoint.new "3", breakpoint_path, 47 }
+    Google::Cloud::Debugger::Breakpoint.new "3", breakpoint_path, 49 }
   let(:breakpoint4) {
-    Google::Cloud::Debugger::Breakpoint.new "4", breakpoint_path, 54 }
+    Google::Cloud::Debugger::Breakpoint.new "4", breakpoint_path, 56 }
   let(:breakpoint5) {
-    Google::Cloud::Debugger::Breakpoint.new "5", breakpoint_path, 62 }
+    Google::Cloud::Debugger::Breakpoint.new "5", breakpoint_path, 64 }
   let(:breakpoint6) {
-    Google::Cloud::Debugger::Breakpoint.new "6", breakpoint_path, 70 }
+    Google::Cloud::Debugger::Breakpoint.new "6", breakpoint_path, 72 }
   let(:breakpoint7) {
-    Google::Cloud::Debugger::Breakpoint.new "7", breakpoint_path, 72 }
+    Google::Cloud::Debugger::Breakpoint.new "7", breakpoint_path, 74 }
   let(:breakpoint8) {
-    Google::Cloud::Debugger::Breakpoint.new "8", breakpoint_path, 82 }
+    Google::Cloud::Debugger::Breakpoint.new "8", breakpoint_path, 84 }
   let(:breakpoint9) {
-    Google::Cloud::Debugger::Breakpoint.new "9", breakpoint_path, 89 }
+    Google::Cloud::Debugger::Breakpoint.new "9", breakpoint_path, 91 }
   let(:breakpoint10) {
-    Google::Cloud::Debugger::Breakpoint.new "10", breakpoint_path, 97 }
+    Google::Cloud::Debugger::Breakpoint.new "10", breakpoint_path, 99 }
 
   it "catches breakpoint from function call" do
     hit = false

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_test_helper.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_test_helper.rb
@@ -18,7 +18,8 @@ require "google/cloud/debugger/tracer/tracer_scenarios_test"
 ##
 # Helper method to test tracer
 def tracer_test_func
-  true
+  s = true
+  s
 end
 
 ##
@@ -44,7 +45,8 @@ end
 ##
 # Helper method to test tracer
 def tracer_test_func5
-  true
+  s = true
+  s
 end
 
 ##


### PR DESCRIPTION
Patch that should get debugger unit tests to run on Ruby 2.6. This sidesteps the underlying issue which is a change in the behavior of tracepoint. Will continue to track those in #3022