### PR TITLE
add instance aliases for class methods

### DIFF
--- a/google-cloud-tasks/Rakefile
+++ b/google-cloud-tasks/Rakefile
@@ -92,6 +92,30 @@ namespace :ci do
   end
 end
 
+task :generate_partials do
+  require "google/cloud/tasks"
+  Google::Cloud::Tasks::AVAILABLE_VERSIONS.each do |version|
+    require "google/cloud/tasks/#{version}/cloud_tasks_client"
+    class_methods = Google::Cloud::Tasks.const_get(version.capitalize)::CloudTasksClient.methods false
+    class_methods.sort!
+    file_path = "./lib/google/cloud/tasks/#{version}/helpers.rb"
+    params = Hash[class_methods.collect { |method_name| [method_name, ""] }]
+    params.each do |method_name, _|
+      args = Google::Cloud::Tasks.const_get(version.capitalize)::CloudTasksClient.method(method_name).parameters
+      params[method_name] = args.map(&:last)
+    end
+    File.open file_path, "w" do |f|
+      config = ERB.new File.read("./synth/helpers.rb.erb")
+      f.write config.result(binding)
+    end
+    file_path = "./test/google/cloud/tasks/#{version}/helpers_test.rb"
+    File.open file_path, "w" do |f|
+      config = ERB.new File.read("./synth/helpers_test.rb.erb")
+      f.write config.result(binding)
+    end
+  end
+end
+
 task :default => :test
 
 def header str, token = "#"

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2.rb
@@ -14,6 +14,7 @@
 
 
 require "google/cloud/tasks/v2beta2/cloud_tasks_client"
+require "google/cloud/tasks/v2beta2/helpers"
 
 module Google
   module Cloud

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/helpers.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/helpers.rb
@@ -1,0 +1,56 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# # limitations under the License.
+ module Google
+  module Cloud
+    module Tasks
+      module V2beta2
+        class CloudTasksClient
+          # Alias for Google::Cloud::Tasks::V2beta2::CloudTasksClient.location_path.
+          # @param project [String]
+          # @param location [String]
+          # @return [String]
+          def location_path project, location
+            self.class.location_path project, location
+          end
+          
+          # Alias for Google::Cloud::Tasks::V2beta2::CloudTasksClient.project_path.
+          # @param project [String]
+          # @return [String]
+          def project_path project
+            self.class.project_path project
+          end
+          
+          # Alias for Google::Cloud::Tasks::V2beta2::CloudTasksClient.queue_path.
+          # @param project [String]
+          # @param location [String]
+          # @param queue [String]
+          # @return [String]
+          def queue_path project, location, queue
+            self.class.queue_path project, location, queue
+          end
+          
+          # Alias for Google::Cloud::Tasks::V2beta2::CloudTasksClient.task_path.
+          # @param project [String]
+          # @param location [String]
+          # @param queue [String]
+          # @param task [String]
+          # @return [String]
+          def task_path project, location, queue, task
+            self.class.task_path project, location, queue, task
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta3.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta3.rb
@@ -14,6 +14,7 @@
 
 
 require "google/cloud/tasks/v2beta3/cloud_tasks_client"
+require "google/cloud/tasks/v2beta3/helpers"
 
 module Google
   module Cloud

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta3/helpers.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta3/helpers.rb
@@ -1,0 +1,56 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# # limitations under the License.
+ module Google
+  module Cloud
+    module Tasks
+      module V2beta3
+        class CloudTasksClient
+          # Alias for Google::Cloud::Tasks::V2beta3::CloudTasksClient.location_path.
+          # @param project [String]
+          # @param location [String]
+          # @return [String]
+          def location_path project, location
+            self.class.location_path project, location
+          end
+          
+          # Alias for Google::Cloud::Tasks::V2beta3::CloudTasksClient.project_path.
+          # @param project [String]
+          # @return [String]
+          def project_path project
+            self.class.project_path project
+          end
+          
+          # Alias for Google::Cloud::Tasks::V2beta3::CloudTasksClient.queue_path.
+          # @param project [String]
+          # @param location [String]
+          # @param queue [String]
+          # @return [String]
+          def queue_path project, location, queue
+            self.class.queue_path project, location, queue
+          end
+          
+          # Alias for Google::Cloud::Tasks::V2beta3::CloudTasksClient.task_path.
+          # @param project [String]
+          # @param location [String]
+          # @param queue [String]
+          # @param task [String]
+          # @return [String]
+          def task_path project, location, queue, task
+            self.class.task_path project, location, queue, task
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-tasks/synth.metadata
+++ b/google-cloud-tasks/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-03-01T11:41:04.784241Z",
+  "updateTime": "2019-03-19T23:56:23.654178Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.16.14",
-        "dockerImage": "googleapis/artman@sha256:f3d61ae45abaeefb6be5f228cda22732c2f1b00fb687c79c4bd4f2c42bb1e1a7"
+        "version": "0.16.18",
+        "dockerImage": "googleapis/artman@sha256:e8ac9200640e76d54643f370db71a1556bf254f565ce46b45a467bbcbacbdb37"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "41d72d444fbe445f4da89e13be02078734fb7875",
-        "internalRef": "236230004"
+        "sha": "285b7fb430c19b2939313d79ae4ee5170d01cf35",
+        "internalRef": "239259121"
       }
     }
   ],

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -19,6 +19,7 @@ import synthtool.gcp as gcp
 import synthtool.languages.ruby as ruby
 import logging
 import re
+from subprocess import call
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -102,3 +103,17 @@ s.replace(
     'gem.add_development_dependency "rubocop".*$',
     'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
+
+for version in ['v2beta2', 'v2beta3']:
+    # Require the helpers file
+    s.replace(
+        f'lib/google/cloud/tasks/{version}.rb',
+        f'require "google/cloud/tasks/{version}/cloud_tasks_client"',
+        '\n'.join([
+            f'require "google/cloud/tasks/{version}/cloud_tasks_client"',
+            f'require "google/cloud/tasks/{version}/helpers"',
+        ])
+    )
+
+# Generate the helper methods
+call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-tasks/synth/helpers.rb.erb
+++ b/google-cloud-tasks/synth/helpers.rb.erb
@@ -1,0 +1,41 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# # limitations under the License.
+ module Google
+  module Cloud
+    module Tasks
+      module <%= version.capitalize %>
+        class CloudTasksClient
+<%= 
+  helpers = []
+  class_methods.each do |method|
+    helpers << "# Alias for Google::Cloud::Tasks::#{version.capitalize}::CloudTasksClient.#{method}."
+    params[method].each do |param|
+      helpers << "# @param #{param} [String]"
+    end
+    helper_params = params[method].map(&:to_s).join(", ")
+    helpers += [
+      "# @return [String]",
+      "def #{method} #{helper_params}",
+      "  self.class.#{method} #{helper_params}",
+      "end",
+      ""
+    ]
+  end
+  helpers.map { |line| '          ' + line }[0...-1].join("\n")
+%>
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-tasks/synth/helpers_test.rb.erb
+++ b/google-cloud-tasks/synth/helpers_test.rb.erb
@@ -1,0 +1,61 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "minitest/autorun"
+require "minitest/spec"
+
+require "google/gax"
+
+require "google/cloud/tasks"
+require "google/cloud/tasks/<%= version %>/helpers"
+
+require "google/cloud/tasks/<%= version %>/cloud_tasks_client"
+
+class HelperMockTasksCredentials_<%= version %> < Google::Cloud::Tasks::<%= version.capitalize %>::Credentials
+  def initialize
+  end
+
+  def updater_proc
+    proc do
+      raise "The client was trying to make a grpc request. This should not " \
+          "happen since the grpc layer is being mocked."
+    end
+  end
+end
+
+describe Google::Cloud::Tasks::<%= version.capitalize %>::CloudTasksClient do
+  let(:mock_credentials) { HelperMockTasksCredentials_<%= version %>.new }
+
+<%= 
+  describe_block = []
+  class_methods.each do |method_name| 
+    describe_block += ["describe \"the #{method_name} instance method\" do"]
+    describe_block += [
+      "  it \"correctly calls Google::Cloud::Tasks::#{version.capitalize}::CloudTasksClient.#{method_name}\" do",
+      "    Google::Cloud::Tasks::#{version.capitalize}::Credentials.stub(:default, mock_credentials) do",
+      "      parameters = Google::Cloud::Tasks::#{version.capitalize}::CloudTasksClient.method(\"#{method_name}\").parameters.map { |arg| arg.last.to_s }",
+      "      client = Google::Cloud::Tasks.new version: :#{version}",
+      "      assert_equal(",
+      "        client.#{method_name}(*parameters),",
+      "        Google::Cloud::Tasks::#{version.capitalize}::CloudTasksClient.#{method_name}(*parameters)",
+      "      )",
+      "    end",
+      "  end",
+      "end",
+      ""
+    ]
+  end
+  describe_block.map { |line| "  " + line unless line.size == 0 }.join("\n")[0...-1]
+%>
+end

--- a/google-cloud-tasks/test/google/cloud/tasks/v2beta2/helpers_test.rb
+++ b/google-cloud-tasks/test/google/cloud/tasks/v2beta2/helpers_test.rb
@@ -1,0 +1,91 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "minitest/autorun"
+require "minitest/spec"
+
+require "google/gax"
+
+require "google/cloud/tasks"
+require "google/cloud/tasks/v2beta2/helpers"
+
+require "google/cloud/tasks/v2beta2/cloud_tasks_client"
+
+class HelperMockTasksCredentials_v2beta2 < Google::Cloud::Tasks::V2beta2::Credentials
+  def initialize
+  end
+
+  def updater_proc
+    proc do
+      raise "The client was trying to make a grpc request. This should not " \
+          "happen since the grpc layer is being mocked."
+    end
+  end
+end
+
+describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
+  let(:mock_credentials) { HelperMockTasksCredentials_v2beta2.new }
+
+  describe "the location_path instance method" do
+    it "correctly calls Google::Cloud::Tasks::V2beta2::CloudTasksClient.location_path" do
+      Google::Cloud::Tasks::V2beta2::Credentials.stub(:default, mock_credentials) do
+        parameters = Google::Cloud::Tasks::V2beta2::CloudTasksClient.method("location_path").parameters.map { |arg| arg.last.to_s }
+        client = Google::Cloud::Tasks.new version: :v2beta2
+        assert_equal(
+          client.location_path(*parameters),
+          Google::Cloud::Tasks::V2beta2::CloudTasksClient.location_path(*parameters)
+        )
+      end
+    end
+  end
+
+  describe "the project_path instance method" do
+    it "correctly calls Google::Cloud::Tasks::V2beta2::CloudTasksClient.project_path" do
+      Google::Cloud::Tasks::V2beta2::Credentials.stub(:default, mock_credentials) do
+        parameters = Google::Cloud::Tasks::V2beta2::CloudTasksClient.method("project_path").parameters.map { |arg| arg.last.to_s }
+        client = Google::Cloud::Tasks.new version: :v2beta2
+        assert_equal(
+          client.project_path(*parameters),
+          Google::Cloud::Tasks::V2beta2::CloudTasksClient.project_path(*parameters)
+        )
+      end
+    end
+  end
+
+  describe "the queue_path instance method" do
+    it "correctly calls Google::Cloud::Tasks::V2beta2::CloudTasksClient.queue_path" do
+      Google::Cloud::Tasks::V2beta2::Credentials.stub(:default, mock_credentials) do
+        parameters = Google::Cloud::Tasks::V2beta2::CloudTasksClient.method("queue_path").parameters.map { |arg| arg.last.to_s }
+        client = Google::Cloud::Tasks.new version: :v2beta2
+        assert_equal(
+          client.queue_path(*parameters),
+          Google::Cloud::Tasks::V2beta2::CloudTasksClient.queue_path(*parameters)
+        )
+      end
+    end
+  end
+
+  describe "the task_path instance method" do
+    it "correctly calls Google::Cloud::Tasks::V2beta2::CloudTasksClient.task_path" do
+      Google::Cloud::Tasks::V2beta2::Credentials.stub(:default, mock_credentials) do
+        parameters = Google::Cloud::Tasks::V2beta2::CloudTasksClient.method("task_path").parameters.map { |arg| arg.last.to_s }
+        client = Google::Cloud::Tasks.new version: :v2beta2
+        assert_equal(
+          client.task_path(*parameters),
+          Google::Cloud::Tasks::V2beta2::CloudTasksClient.task_path(*parameters)
+        )
+      end
+    end
+  end
+end

--- a/google-cloud-tasks/test/google/cloud/tasks/v2beta3/helpers_test.rb
+++ b/google-cloud-tasks/test/google/cloud/tasks/v2beta3/helpers_test.rb
@@ -1,0 +1,91 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "minitest/autorun"
+require "minitest/spec"
+
+require "google/gax"
+
+require "google/cloud/tasks"
+require "google/cloud/tasks/v2beta3/helpers"
+
+require "google/cloud/tasks/v2beta3/cloud_tasks_client"
+
+class HelperMockTasksCredentials_v2beta3 < Google::Cloud::Tasks::V2beta3::Credentials
+  def initialize
+  end
+
+  def updater_proc
+    proc do
+      raise "The client was trying to make a grpc request. This should not " \
+          "happen since the grpc layer is being mocked."
+    end
+  end
+end
+
+describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
+  let(:mock_credentials) { HelperMockTasksCredentials_v2beta3.new }
+
+  describe "the location_path instance method" do
+    it "correctly calls Google::Cloud::Tasks::V2beta3::CloudTasksClient.location_path" do
+      Google::Cloud::Tasks::V2beta3::Credentials.stub(:default, mock_credentials) do
+        parameters = Google::Cloud::Tasks::V2beta3::CloudTasksClient.method("location_path").parameters.map { |arg| arg.last.to_s }
+        client = Google::Cloud::Tasks.new version: :v2beta3
+        assert_equal(
+          client.location_path(*parameters),
+          Google::Cloud::Tasks::V2beta3::CloudTasksClient.location_path(*parameters)
+        )
+      end
+    end
+  end
+
+  describe "the project_path instance method" do
+    it "correctly calls Google::Cloud::Tasks::V2beta3::CloudTasksClient.project_path" do
+      Google::Cloud::Tasks::V2beta3::Credentials.stub(:default, mock_credentials) do
+        parameters = Google::Cloud::Tasks::V2beta3::CloudTasksClient.method("project_path").parameters.map { |arg| arg.last.to_s }
+        client = Google::Cloud::Tasks.new version: :v2beta3
+        assert_equal(
+          client.project_path(*parameters),
+          Google::Cloud::Tasks::V2beta3::CloudTasksClient.project_path(*parameters)
+        )
+      end
+    end
+  end
+
+  describe "the queue_path instance method" do
+    it "correctly calls Google::Cloud::Tasks::V2beta3::CloudTasksClient.queue_path" do
+      Google::Cloud::Tasks::V2beta3::Credentials.stub(:default, mock_credentials) do
+        parameters = Google::Cloud::Tasks::V2beta3::CloudTasksClient.method("queue_path").parameters.map { |arg| arg.last.to_s }
+        client = Google::Cloud::Tasks.new version: :v2beta3
+        assert_equal(
+          client.queue_path(*parameters),
+          Google::Cloud::Tasks::V2beta3::CloudTasksClient.queue_path(*parameters)
+        )
+      end
+    end
+  end
+
+  describe "the task_path instance method" do
+    it "correctly calls Google::Cloud::Tasks::V2beta3::CloudTasksClient.task_path" do
+      Google::Cloud::Tasks::V2beta3::Credentials.stub(:default, mock_credentials) do
+        parameters = Google::Cloud::Tasks::V2beta3::CloudTasksClient.method("task_path").parameters.map { |arg| arg.last.to_s }
+        client = Google::Cloud::Tasks.new version: :v2beta3
+        assert_equal(
+          client.task_path(*parameters),
+          Google::Cloud::Tasks::V2beta3::CloudTasksClient.task_path(*parameters)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Alias `Google::Cloud::Tasks::{Version}::CloudTasksClient.location_path` as instance method.
* Alias `Google::Cloud::Tasks::{Version}::CloudTasksClient.project_path` as instance method.
* Alias `Google::Cloud::Tasks::{Version}::CloudTasksClient.queue_path` as instance method.
* Alias `Google::Cloud::Tasks::{Version}::CloudTasksClient.task_path` as instance method.