### PR TITLE
Release google-cloud-tasks 0.5.0

### DIFF
--- a/google-cloud-tasks/CHANGELOG.md
+++ b/google-cloud-tasks/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### 0.5.0 / 2019-03-20
 
-* add instance aliases for class methods
+* Alias the following CloudTasksClient class methods to instance methods.
+  * location_path
+  * project_path
+  * queue_path
+  * task_path
 
 ### 0.4.0 / 2019-03-12
 

--- a/google-cloud-tasks/CHANGELOG.md
+++ b/google-cloud-tasks/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.5.0 / 2019-03-20
 
-* add instance aliases for class methods (#3034)
+* add instance aliases for class methods
 
 ### 0.4.0 / 2019-03-12
 

--- a/google-cloud-tasks/CHANGELOG.md
+++ b/google-cloud-tasks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.5.0 / 2019-03-20
+
+* add instance aliases for class methods (#3034)
+
 ### 0.4.0 / 2019-03-12
 
 * Add HTTP Request to V2beta3

--- a/google-cloud-tasks/google-cloud-tasks.gemspec
+++ b/google-cloud-tasks/google-cloud-tasks.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-tasks"
-  gem.version       = "0.4.0"
+  gem.version       = "0.5.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Alias the following CloudTasksClient class methods to instance methods.
  * location_path
  * project_path
  * queue_path
  * task_path

This pull request was generated using releasetool.