### PR TITLE
Release google-cloud-asset 0.2.0

### DIFF
--- a/google-cloud-asset/CHANGELOG.md
+++ b/google-cloud-asset/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.2.0 / 2019-03-21
+
+* Add v1 api version
+* Alias AssetServiceClient::project_path to instance method
+* Update documentation
+
 ### 0.1.2 / 2019-02-01
 
 * Update documentation.

--- a/google-cloud-asset/google-cloud-asset.gemspec
+++ b/google-cloud-asset/google-cloud-asset.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-asset"
-  gem.version       = "0.1.2"
+  gem.version       = "0.2.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Add v1 api version
* Alias AssetServiceClient::project_path to instance method
* Update documentation

This pull request was generated using releasetool.