### PR TITLE
Disable logpoint-related integration test due to logging service issues

### DIFF
--- a/google-cloud-debugger/acceptance/debugger/debugger_test.rb
+++ b/google-cloud-debugger/acceptance/debugger/debugger_test.rb
@@ -44,6 +44,8 @@ describe Google::Cloud::Debugger, :debugger do
   end
 
   it "catches and evaluates logpoint" do
+    skip "Listing log entries is unreliable"
+
     token = rand 0x10000000000
 
     set_test_logpoint token


### PR DESCRIPTION
Listing logs from the logging service is too flaky, probably due to the time it takes to reindex. Disabling the logpoint integration test for now.