### PR TITLE
Release google-cloud-tasks 0.6.0

### DIFF
--- a/google-cloud-tasks/CHANGELOG.md
+++ b/google-cloud-tasks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.6.0 / 2019-03-28
+
+* Add v2 api version
+
 ### 0.5.0 / 2019-03-20
 
 * Alias the following CloudTasksClient class methods to instance methods.

--- a/google-cloud-tasks/google-cloud-tasks.gemspec
+++ b/google-cloud-tasks/google-cloud-tasks.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-tasks"
-  gem.version       = "0.5.0"
+  gem.version       = "0.6.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Add v2 api version

This pull request was generated using releasetool.