### PR TITLE
Add Pub/Sub reload

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -683,6 +683,28 @@ module Google
         end
 
         ##
+        # Reloads the subscription with current data from the Pub/Sub service.
+        #
+        # @return [Google::Cloud::PubSub::Subscription] Returns the reloaded
+        #   subscription
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   sub = pubsub.get_subscription "my-topic-sub"
+        #   sub.reload!
+        #
+        def reload!
+          ensure_service!
+          @grpc = service.get_subscription name
+          @resource_name = nil
+          self
+        end
+        alias refresh! reload!
+
+        ##
         # Gets the [Cloud IAM](https://cloud.google.com/iam/) access control
         # policy for this subscription.
         #
@@ -834,8 +856,7 @@ module Google
         # Ensures a Google::Cloud::PubSub::V1::Subscription object exists.
         def ensure_grpc!
           ensure_service!
-          @grpc = service.get_subscription name if reference?
-          @resource_name = nil
+          reload! if reference?
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -607,6 +607,27 @@ module Google
         end
 
         ##
+        # Reloads the topic with current data from the Pub/Sub service.
+        #
+        # @return [Google::Cloud::PubSub::Topic] Returns the reloaded topic
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   topic = pubsub.topic "my-topic"
+        #   topic.reload!
+        #
+        def reload!
+          ensure_service!
+          @grpc = service.get_topic name
+          @resource_name = nil
+          self
+        end
+        alias refresh! reload!
+
+        ##
         # @private New Topic from a Google::Cloud::PubSub::V1::Topic object.
         def self.from_grpc grpc, service, async: nil
           new.tap do |t|
@@ -638,8 +659,7 @@ module Google
         # Ensures a Google::Cloud::PubSub::V1::Topic object exists.
         def ensure_grpc!
           ensure_service!
-          @grpc = service.get_topic name if reference?
-          @resource_name = nil
+          reload! if reference?
         end
 
         ##

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -412,13 +412,7 @@ YARD::Doctest.configure do |doctest|
       mock_subscriber.expect :get_subscription, subscription_resp, [String, Hash]
     end
   end
-
-  doctest.before "Google::Cloud::PubSub::Subscription#refresh!" do
-    mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_subscriber.expect :get_subscription, subscription_resp, [String, Hash]
-      mock_subscriber.expect :get_subscription, subscription_resp, [String, Hash]
-    end
-  end
+  doctest.skip "Google::Cloud::PubSub::Subscription#refresh!"
 
   ##
   # Subscription::List
@@ -539,14 +533,7 @@ YARD::Doctest.configure do |doctest|
       mock_publisher.expect :get_topic, topic_resp, [String, Hash]
     end
   end
-
-  doctest.before "Google::Cloud::PubSub::Topic#refresh!" do
-    mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_publisher.expect :get_topic, topic_resp, [String, Hash]
-      mock_publisher.expect :get_topic, topic_resp, [String, Hash]
-    end
-  end
-
+  doctest.skip "Google::Cloud::PubSub::Topic#refresh!"
 
   ##
   # Topic::List

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -406,6 +406,20 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::PubSub::Subscription#reload!" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp, [String, Hash]
+      mock_subscriber.expect :get_subscription, subscription_resp, [String, Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::PubSub::Subscription#refresh!" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp, [String, Hash]
+      mock_subscriber.expect :get_subscription, subscription_resp, [String, Hash]
+    end
+  end
+
   ##
   # Subscription::List
 
@@ -518,6 +532,21 @@ YARD::Doctest.configure do |doctest|
       mock_publisher.expect :test_iam_permissions, topic_permissions_resp, ["projects/my-project/topics/my-topic", ["pubsub.topics.get", "pubsub.topics.publish"], Hash]
     end
   end
+
+  doctest.before "Google::Cloud::PubSub::Topic#reload!" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_publisher.expect :get_topic, topic_resp, [String, Hash]
+      mock_publisher.expect :get_topic, topic_resp, [String, Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::PubSub::Topic#refresh!" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_publisher.expect :get_topic, topic_resp, [String, Hash]
+      mock_publisher.expect :get_topic, topic_resp, [String, Hash]
+    end
+  end
+
 
   ##
   # Topic::List

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/reload_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/reload_test.rb
@@ -1,0 +1,82 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::PubSub::Subscription, :name, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_path) { subscription_path sub_name }
+  let(:sub_hash_old) { subscription_hash topic_name, sub_name }
+  let(:sub_hash_new) { subscription_hash topic_name, sub_name, 30, "http://example.net/endpoint", labels: { "foo" => "bar" } }
+  let(:sub_grpc_old) { Google::Cloud::PubSub::V1::Subscription.new sub_hash_old }
+  let(:sub_grpc_new) { Google::Cloud::PubSub::V1::Subscription.new sub_hash_new }
+  let(:sub_resource) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc_old, pubsub.service }
+  let(:sub_reference) { Google::Cloud::PubSub::Subscription.from_name sub_name, pubsub.service }
+
+  it "it has a reload method and a refresh alias" do
+    sub_resource.must_respond_to :reload!
+    sub_reference.must_respond_to :reload!
+
+    sub_resource.must_respond_to :refresh!
+    sub_reference.must_respond_to :refresh!
+  end
+
+  it "is reloads a resource by calling get_topic API" do
+    sub_resource.name.must_equal sub_path
+    sub_resource.topic.name.must_equal topic_path(topic_name)
+    sub_resource.deadline.must_equal 60
+    sub_resource.endpoint.must_equal "http://example.com/callback"
+    sub_resource.labels.must_be :empty?
+    sub_resource.wont_be :reference?
+    sub_resource.must_be :resource?
+
+    mock = Minitest::Mock.new
+    mock.expect :get_subscription, sub_grpc_new, [sub_path, options: default_options]
+    pubsub.service.mocked_subscriber = mock
+
+    sub_resource.reload!
+
+    mock.verify
+
+    sub_resource.name.must_equal sub_path
+    sub_resource.topic.name.must_equal topic_path(topic_name)
+    sub_resource.deadline.must_equal 30
+    sub_resource.endpoint.must_equal "http://example.net/endpoint"
+    sub_resource.labels.must_equal({ "foo" => "bar" })
+    sub_resource.wont_be :reference?
+    sub_resource.must_be :resource?
+  end
+
+  it "is reloads a reference by calling get_topic API" do
+    sub_reference.name.must_equal sub_path
+    sub_reference.must_be :reference?
+    sub_reference.wont_be :resource?
+
+    mock = Minitest::Mock.new
+    mock.expect :get_subscription, sub_grpc_new, [sub_path, options: default_options]
+    pubsub.service.mocked_subscriber = mock
+
+    sub_reference.reload!
+
+    mock.verify
+
+    sub_reference.name.must_equal sub_path
+    sub_reference.deadline.must_equal 30
+    sub_reference.endpoint.must_equal "http://example.net/endpoint"
+    sub_reference.labels.must_equal({ "foo" => "bar" })
+    sub_reference.wont_be :reference?
+    sub_reference.must_be :resource?
+  end
+end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/lazy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/lazy_test.rb
@@ -16,10 +16,22 @@ require "helper"
 
 describe Google::Cloud::PubSub::Topic, :reference, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
+  let(:topic_grpc) { Google::Cloud::PubSub::V1::Topic.new topic_hash(topic_name) }
+  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc topic_grpc, pubsub.service }
 
   it "is not reference when created with an HTTP method" do
     topic.wont_be :reference?
     topic.must_be :resource?
+  end
+
+  describe "reference topic" do
+    let :topic do
+      Google::Cloud::PubSub::Topic.from_name topic_name, pubsub.service
+    end
+
+    it "is reference" do
+      topic.must_be :reference?
+      topic.wont_be :resource?
+    end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/reload_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/reload_test.rb
@@ -1,0 +1,72 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::PubSub::Topic, :reload, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:old_labels) { { "foo" => "bar" } }
+  let(:topic_grpc_old) { Google::Cloud::PubSub::V1::Topic.new topic_hash(topic_name, labels: old_labels) }
+  let(:new_labels) { { "baz" => "bif" } }
+  let(:topic_grpc_new) { Google::Cloud::PubSub::V1::Topic.new topic_hash(topic_name, labels: new_labels) }
+  let(:topic_resource) { Google::Cloud::PubSub::Topic.from_grpc topic_grpc_old, pubsub.service }
+  let(:topic_reference) { Google::Cloud::PubSub::Topic.from_name topic_name, pubsub.service }
+
+  it "it has a reload method and a refresh alias" do
+    topic_resource.must_respond_to :reload!
+    topic_reference.must_respond_to :reload!
+
+    topic_resource.must_respond_to :refresh!
+    topic_reference.must_respond_to :refresh!
+  end
+
+  it "is reloads a resource by calling get_topic API" do
+    topic_resource.name.must_equal topic_path(topic_name)
+    topic_resource.labels.must_equal old_labels
+    topic_resource.wont_be :reference?
+    topic_resource.must_be :resource?
+
+    mock = Minitest::Mock.new
+    mock.expect :get_topic, topic_grpc_new, [topic_path(topic_name), options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    topic_resource.reload!
+
+    mock.verify
+
+    topic_resource.name.must_equal topic_path(topic_name)
+    topic_resource.labels.must_equal new_labels
+    topic_resource.wont_be :reference?
+    topic_resource.must_be :resource?
+  end
+
+  it "is reloads a reference by calling get_topic API" do
+    topic_reference.name.must_equal topic_path(topic_name)
+    topic_reference.must_be :reference?
+    topic_reference.wont_be :resource?
+
+    mock = Minitest::Mock.new
+    mock.expect :get_topic, topic_grpc_new, [topic_path(topic_name), options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    topic_reference.reload!
+
+    mock.verify
+
+    topic_reference.name.must_equal topic_path(topic_name)
+    topic_reference.labels.must_equal new_labels
+    topic_reference.wont_be :reference?
+    topic_reference.must_be :resource?
+  end
+end


### PR DESCRIPTION
Add reload to Pub/Sub Topic and Subscription. This matches how reference/resource objects are used in other gems.