### PR TITLE
Add Subscription#expires_in

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -288,11 +288,9 @@ module Google
         #   to unset.
         #
         def expires_in= ttl
-          new_expiration_policy = if ttl
-                                    Google::Pubsub::V1::ExpirationPolicy.new(
-                                      ttl: Convert.number_to_duration(ttl)
-                                    )
-                                  end
+          new_expiration_policy = Google::Pubsub::V1::ExpirationPolicy.new(
+            ttl: Convert.number_to_duration(ttl)
+          )
 
           update_grpc = Google::Cloud::PubSub::V1::Subscription.new \
             name: name, expiration_policy: new_expiration_policy

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -262,7 +262,7 @@ module Google
         # long as any connected subscriber is successfully consuming messages
         # from the subscription or is issuing operations on the subscription.
         #
-        # If `expires_in` is not set, a *default* value of of 31 days will be
+        # If {#expires_in=} is not set, a *default* value of of 31 days will be
         # used. The minimum allowed value is 1 day.
         #
         # Makes an API call to retrieve the labels value when called on a
@@ -282,7 +282,10 @@ module Google
         # Sets the duration (in seconds) for when a subscription expires after
         # the subscription goes inactive.
         #
-        # @param [Numeric, nil] ttl The expiration duration, or `nil` to unset.
+        # See also {#expires_in}.
+        #
+        # @param [Numeric, nil] ttl The expiration duration in seconds, or `nil`
+        #   to unset.
         #
         def expires_in= ttl
           new_expiration_policy = if ttl

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -257,6 +257,47 @@ module Google
         end
 
         ##
+        # The duration (in seconds) for when a subscription expires after the
+        # subscription goes inactive. A subscription is considered active as
+        # long as any connected subscriber is successfully consuming messages
+        # from the subscription or is issuing operations on the subscription.
+        #
+        # If `expires_in` is not set, a *default* value of of 31 days will be
+        # used. The minimum allowed value is 1 day.
+        #
+        # Makes an API call to retrieve the labels value when called on a
+        # reference object. See {#reference?}.
+        #
+        # @return [Numeric, nil] The expiration duration, or `nil` if unset.
+        #
+        def expires_in
+          ensure_grpc!
+
+          return nil if @grpc.expiration_policy.nil?
+
+          Convert.duration_to_number @grpc.expiration_policy.ttl
+        end
+
+        ##
+        # Sets the duration (in seconds) for when a subscription expires after
+        # the subscription goes inactive.
+        #
+        # @param [Numeric, nil] ttl The expiration duration, or `nil` to unset.
+        #
+        def expires_in= ttl
+          new_expiration_policy = if ttl
+                                    Google::Pubsub::V1::ExpirationPolicy.new(
+                                      ttl: Convert.number_to_duration(ttl)
+                                    )
+                                  end
+
+          update_grpc = Google::Cloud::PubSub::V1::Subscription.new \
+            name: name, expiration_policy: new_expiration_policy
+          @grpc = service.update_subscription update_grpc, :expiration_policy
+          @resource_name = nil
+        end
+
+        ##
         # Determines whether the subscription exists in the Pub/Sub service.
         #
         # Makes an API call to determine whether the subscription resource

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -156,6 +156,24 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     subscription.expires_in = week_seconds
 
     mock.verify
+
+    subscription.expires_in.must_equal week_seconds
+  end
+
+  it "can update the expires_in to nil" do
+    expiration_policy = Google::Cloud::PubSub::V1::ExpirationPolicy.new
+    update_sub = Google::Cloud::PubSub::V1::Subscription.new \
+      name: sub_path, expiration_policy: expiration_policy
+    update_mask = Google::Protobuf::FieldMask.new paths: ["expiration_policy"]
+    mock = Minitest::Mock.new
+    mock.expect :update_subscription, update_sub, [update_sub, update_mask, options: default_options]
+    pubsub.service.mocked_subscriber = mock
+
+    subscription.expires_in = nil
+
+    mock.verify
+
+    subscription.expires_in.must_be :nil?
   end
 
   describe :reference do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -126,6 +126,38 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     subscription.labels.must_equal labels
   end
 
+  it "can update the endpoint" do
+    new_push_endpoint = "https://foo.bar/baz"
+
+    push_config = Google::Cloud::PubSub::V1::PushConfig.new(push_endpoint: new_push_endpoint)
+    mpc_res = nil
+    mock = Minitest::Mock.new
+    mock.expect :modify_push_config, mpc_res, [subscription_path(sub_name), push_config, options: default_options]
+    pubsub.service.mocked_subscriber = mock
+
+    subscription.endpoint = new_push_endpoint
+
+    mock.verify
+  end
+
+  it "can update the expires_in" do
+    week_seconds = 60*60*24*7
+
+    expiration_policy = Google::Cloud::PubSub::V1::ExpirationPolicy.new(
+      ttl: Google::Cloud::PubSub::Convert.number_to_duration(week_seconds)
+    )
+    update_sub = Google::Cloud::PubSub::V1::Subscription.new \
+      name: sub_path, expiration_policy: expiration_policy
+    update_mask = Google::Protobuf::FieldMask.new paths: ["expiration_policy"]
+    mock = Minitest::Mock.new
+    mock.expect :update_subscription, update_sub, [update_sub, update_mask, options: default_options]
+    pubsub.service.mocked_subscriber = mock
+
+    subscription.expires_in = week_seconds
+
+    mock.verify
+  end
+
   describe :reference do
     let(:subscription) { Google::Cloud::PubSub::Subscription.from_name sub_name, pubsub.service }
 
@@ -215,6 +247,133 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
       subscription.wont_be :reference?
       subscription.must_be :resource?
       subscription.labels.must_equal new_labels
+    end
+
+    it "makes an HTTP API call to update endpoint" do
+      new_push_endpoint = "https://foo.bar/baz"
+
+      push_config = Google::Cloud::PubSub::V1::PushConfig.new(push_endpoint: new_push_endpoint)
+      mpc_res = nil
+      mock = Minitest::Mock.new
+      mock.expect :modify_push_config, mpc_res, [subscription_path(sub_name), push_config, options: default_options]
+      pubsub.service.mocked_subscriber = mock
+
+      subscription.endpoint = new_push_endpoint
+
+      mock.verify
+    end
+
+    it "makes an HTTP API call to update expires_in" do
+      week_seconds = 60*60*24*7
+
+      expiration_policy = Google::Cloud::PubSub::V1::ExpirationPolicy.new(
+        ttl: Google::Cloud::PubSub::Convert.number_to_duration(week_seconds)
+      )
+      update_sub = Google::Cloud::PubSub::V1::Subscription.new \
+        name: sub_path, expiration_policy: expiration_policy
+      update_mask = Google::Protobuf::FieldMask.new paths: ["expiration_policy"]
+      mock = Minitest::Mock.new
+      mock.expect :update_subscription, update_sub, [update_sub, update_mask, options: default_options]
+      pubsub.service.mocked_subscriber = mock
+
+      subscription.expires_in = week_seconds
+
+      mock.verify
+    end
+  end
+
+  describe "reference subscription object of a subscription that does not exist" do
+    let :subscription do
+      Google::Cloud::PubSub::Subscription.from_name sub_name,
+                                            pubsub.service
+    end
+
+    it "raises NotFoundError when updating deadline" do
+      stub = Object.new
+      def stub.update_subscription *args
+        gax_error = Google::Gax::GaxError.new "not found"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        raise gax_error
+      end
+      subscription.service.mocked_subscriber = stub
+
+      expect do
+        subscription.deadline = 30
+      end.must_raise Google::Cloud::NotFoundError
+    end
+
+    it "raises NotFoundError when updating retain_acked" do
+      stub = Object.new
+      def stub.update_subscription *args
+        gax_error = Google::Gax::GaxError.new "not found"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        raise gax_error
+      end
+      subscription.service.mocked_subscriber = stub
+
+      expect do
+        subscription.retain_acked = true
+      end.must_raise Google::Cloud::NotFoundError
+    end
+
+    it "raises NotFoundError when updating retention" do
+      stub = Object.new
+      def stub.update_subscription *args
+        gax_error = Google::Gax::GaxError.new "not found"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        raise gax_error
+      end
+      subscription.service.mocked_subscriber = stub
+
+      expect do
+        subscription.retention = 600.2
+      end.must_raise Google::Cloud::NotFoundError
+    end
+
+    it "raises NotFoundError when updating labels" do
+      stub = Object.new
+      def stub.update_subscription *args
+        gax_error = Google::Gax::GaxError.new "not found"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        raise gax_error
+      end
+      subscription.service.mocked_subscriber = stub
+
+      expect do
+        subscription.labels = new_labels
+      end.must_raise Google::Cloud::NotFoundError
+    end
+
+    it "raises NotFoundError when updating endpoint" do
+      new_push_endpoint = "https://foo.bar/baz"
+
+      stub = Object.new
+      def stub.modify_push_config *args
+        gax_error = Google::Gax::GaxError.new "not found"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        raise gax_error
+      end
+      subscription.service.mocked_subscriber = stub
+
+      expect do
+        subscription.endpoint = new_push_endpoint
+      end.must_raise Google::Cloud::NotFoundError
+    end
+
+    it "raises NotFoundError when updating expires_in" do
+      week_seconds = 60*60*24*7
+
+      stub = Object.new
+      def stub.update_subscription *args
+        gax_error = Google::Gax::GaxError.new "not found"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        raise gax_error
+      end
+      subscription.service.mocked_subscriber = stub
+
+      expect do
+        subscription.expires_in = week_seconds
+      end.must_raise Google::Cloud::NotFoundError
     end
   end
 end

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -151,7 +151,8 @@ class MockPubsub < Minitest::Spec
       ack_deadline_seconds: deadline,
       retain_acked_messages: true,
       message_retention_duration: { seconds: 600, nanos: 900000000 }, # 600.9 seconds
-      labels: labels
+      labels: labels,
+      expiration_policy: { ttl: { seconds: 172800, nanos: 0 } }, # 2 days
     }
   end
 


### PR DESCRIPTION
Add `expires_in` getter and setter methods that get/set the `ttl` value on ExpirationPolicy.

I decided to expose `expires_in` instead of an ExpirationPolicy because there is only the one field on ExpirationPolicy. If/when ExpirationPolicy adds more fields we can expose this structure while still allowing `expires_in` to directly access that value.

[closes #2775]