### PR TITLE
Add Subscription#push_config

### DIFF
--- a/google-cloud-pubsub/README.md
+++ b/google-cloud-pubsub/README.md
@@ -1,5 +1,7 @@
 # google-cloud-pubsub
 
+O HAI GIT FORCE PUSH!!!
+
 [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) ([docs](https://cloud.google.com/pubsub/docs/reference/rest/)) is designed to provide reliable, many-to-many, asynchronous messaging between applications. Publisher applications can send messages to a “topic” and other applications can subscribe to that topic to receive the messages. By decoupling senders and receivers, Google Cloud Pub/Sub allows developers to communicate between independently written applications.
 
 - [google-cloud-pubsub API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-pubsub/latest)

--- a/google-cloud-pubsub/README.md
+++ b/google-cloud-pubsub/README.md
@@ -1,7 +1,5 @@
 # google-cloud-pubsub
 
-O HAI GIT FORCE PUSH!!!
-
 [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) ([docs](https://cloud.google.com/pubsub/docs/reference/rest/)) is designed to provide reliable, many-to-many, asynchronous messaging between applications. Publisher applications can send messages to a “topic” and other applications can subscribe to that topic to receive the messages. By decoupling senders and receivers, Google Cloud Pub/Sub allows developers to communicate between independently written applications.
 
 - [google-cloud-pubsub API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-pubsub/latest)

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -190,7 +190,8 @@ module Google
 
         ##
         # Returns the URL locating the endpoint to which messages should be
-        # pushed.
+        # pushed. For example, a Webhook endpoint might use
+        # "https://example.com/push".
         #
         # Makes an API call to retrieve the endpoint value when called on a
         # reference object. See {#reference?}.
@@ -204,6 +205,7 @@ module Google
 
         ##
         # Sets the URL locating the endpoint to which messages should be pushed.
+        # For example, a Webhook endpoint might use "https://example.com/push".
         #
         # @param [String] new_endpoint The new endpoint value.
         #

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -238,6 +238,27 @@ module Google
         #
         # @return [Subscription::PushConfig]
         #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   sub = pubsub.subscription "my-topic-sub"
+        #   sub.push_config.endpoint #=> "http://example.com/callback"
+        #   sub.push_config.authentication.email #=> "user@example.com"
+        #   sub.push_config.authentication.audience #=> "client-12345"
+        #
+        # @example Update the push configuration by passing a block:
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #   sub = pubsub.subscription "my-subscription"
+        #
+        #   sub.push_config do |pc|
+        #     pc.endpoint = "http://example.net/callback"
+        #     pc.set_oidc_token "user@example.net", "client-67890"
+        #   end
+        #
         def push_config
           ensure_service!
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/push_config.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/push_config.rb
@@ -75,6 +75,14 @@ module Google
           end
 
           ##
+          # Checks whether authentication is an {OidcToken}.
+          #
+          # @return [Boolean]
+          def oidc_token?
+            authentication.is_a? OidcToken
+          end
+
+          ##
           # Sets the authentication method to use an {OidcToken}.
           #
           # @param [String] email Service account email.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/push_config.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/push_config.rb
@@ -29,7 +29,8 @@ module Google
           end
 
           ##
-          # A URL locating the endpoint to which messages should be pushed.
+          # A URL locating the endpoint to which messages should be pushed. For
+          # example, a Webhook endpoint might use "https://example.com/push".
           #
           # @return [String]
           def endpoint
@@ -38,7 +39,8 @@ module Google
 
           ##
           # Sets the URL locating the endpoint to which messages should be
-          # pushed.
+          # pushed. For example, a Webhook endpoint might use
+          # "https://example.com/push".
           #
           # @param [String, nil] new_endpoint New URL value
           def endpoint= new_endpoint

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/push_config.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/push_config.rb
@@ -19,13 +19,16 @@ module Google
   module Cloud
     module PubSub
       class Subscription
+        ##
         # Configuration for a push delivery endpoint.
         class PushConfig
+          ##
           # @private
           def initialize
             @grpc = Google::Cloud::PubSub::V1::PushConfig.new
           end
 
+          ##
           # A URL locating the endpoint to which messages should be pushed.
           #
           # @return [String]
@@ -33,6 +36,7 @@ module Google
             @grpc.push_endpoint
           end
 
+          ##
           # Sets the URL locating the endpoint to which messages should be
           # pushed.
           #
@@ -41,6 +45,7 @@ module Google
             @grpc.push_endpoint = String new_endpoint
           end
 
+          ##
           # The authentication method used by push endpoints to verify the
           # source of push requests.
           #
@@ -52,6 +57,7 @@ module Google
             OidcToken.from_grpc @grpc.oidc_token
           end
 
+          ##
           # Sets the authentication method used by push endpoints to verify the
           # source of push requests.
           #
@@ -66,6 +72,7 @@ module Google
             end
           end
 
+          ##
           # Sets the authentication method to use an {OidcToken}.
           #
           # @param [String] email Service account email.
@@ -78,6 +85,7 @@ module Google
             self.authentication = oidc_token
           end
 
+          ##
           # The format of the pushed message. This attribute indicates the
           # version of the data expected by the endpoint. This controls the
           # shape of the pushed message (i.e., its fields and metadata). The
@@ -98,6 +106,7 @@ module Google
             @grpc.attributes["x-goog-version"]
           end
 
+          ##
           # Sets the format of the pushed message.
           #
           # The possible values for this attribute are:
@@ -116,11 +125,13 @@ module Google
             end
           end
 
+          ##
           # @private
           def to_grpc
             @grpc
           end
 
+          ##
           # @private
           def self.from_grpc grpc
             new.tap do |pc|
@@ -128,14 +139,17 @@ module Google
             end
           end
 
+          ##
           # Contains information needed for generating an [OpenID Connect
           # token](https://developers.google.com/identity/protocols/OpenIDConnect).
           class OidcToken
+            ##
             # @private
             def initialize
               @grpc = Google::Cloud::PubSub::V1::PushConfig::OidcToken.new
             end
 
+            ##
             # Service account email to be used for generating the OIDC token.
             #
             # @return [String]
@@ -143,6 +157,7 @@ module Google
               @grpc.service_account_email
             end
 
+            ##
             # Service account email to be used for generating the OIDC token.
             #
             # @param [String] new_email New service account email value.
@@ -150,6 +165,7 @@ module Google
               @grpc.service_account_email = new_email
             end
 
+            ##
             # Audience to be used when generating OIDC token. The audience claim
             # identifies the recipients that the JWT is intended for. The
             # audience value is a single case-sensitive string.
@@ -165,6 +181,7 @@ module Google
               @grpc.audience
             end
 
+            ##
             # Sets the audience to be used when generating OIDC token.
             #
             # @param [String] new_audience New audience value.
@@ -172,11 +189,13 @@ module Google
               @grpc.audience = new_audience
             end
 
+            ##
             # @private
             def to_grpc
               @grpc
             end
 
+            ##
             # @private
             def self.from_grpc grpc
               grpc ||= Google::Cloud::PubSub::V1::PushConfig::OidcToken.new

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/push_config.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/push_config.rb
@@ -21,6 +21,28 @@ module Google
       class Subscription
         ##
         # Configuration for a push delivery endpoint.
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   sub = pubsub.subscription "my-topic-sub"
+        #   sub.push_config.endpoint #=> "http://example.com/callback"
+        #   sub.push_config.authentication.email #=> "user@example.com"
+        #   sub.push_config.authentication.audience #=> "client-12345"
+        #
+        # @example Update the push configuration by passing a block:
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #   sub = pubsub.subscription "my-subscription"
+        #
+        #   sub.push_config do |pc|
+        #     pc.endpoint = "http://example.net/callback"
+        #     pc.set_oidc_token "user@example.net", "client-67890"
+        #   end
+        #
         class PushConfig
           ##
           # @private

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/push_config.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/push_config.rb
@@ -1,0 +1,193 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/pubsub/v1/pubsub_pb"
+
+module Google
+  module Cloud
+    module PubSub
+      class Subscription
+        # Configuration for a push delivery endpoint.
+        class PushConfig
+          # @private
+          def initialize
+            @grpc = Google::Cloud::PubSub::V1::PushConfig.new
+          end
+
+          # A URL locating the endpoint to which messages should be pushed.
+          #
+          # @return [String]
+          def endpoint
+            @grpc.push_endpoint
+          end
+
+          # Sets the URL locating the endpoint to which messages should be
+          # pushed.
+          #
+          # @param [String, nil] new_endpoint New URL value
+          def endpoint= new_endpoint
+            @grpc.push_endpoint = String new_endpoint
+          end
+
+          # The authentication method used by push endpoints to verify the
+          # source of push requests.
+          #
+          # @return [OidcToken, nil] An OIDC JWT token if specified, `nil`
+          #   otherwise.
+          def authentication
+            return nil unless @grpc.authentication_method == :oidc_token
+
+            OidcToken.from_grpc @grpc.oidc_token
+          end
+
+          # Sets the authentication method used by push endpoints to verify the
+          # source of push requests.
+          #
+          # @param [OidcToken, nil] new_auth An authentication value.
+          def authentication= new_auth
+            if new_auth.nil?
+              @grpc.oidc_token = nil
+            else
+              raise ArgumentError unless new_auth.is_a? OidcToken
+
+              @grpc.oidc_token = new_auth.to_grpc
+            end
+          end
+
+          # Sets the authentication method to use an {OidcToken}.
+          #
+          # @param [String] email Service account email.
+          # @param [String] audience Audience to be used.
+          def set_oidc_token email, audience
+            oidc_token = OidcToken.new.tap do |token|
+              token.email = email
+              token.audience = audience
+            end
+            self.authentication = oidc_token
+          end
+
+          # The format of the pushed message. This attribute indicates the
+          # version of the data expected by the endpoint. This controls the
+          # shape of the pushed message (i.e., its fields and metadata). The
+          # endpoint version is based on the version of the Pub/Sub API.
+          #
+          # If not present during the Subscription creation, it will default to
+          # the version of the API used to make such call.
+          #
+          # The possible values for this attribute are:
+          #
+          # * `v1beta1`: uses the push format defined in the v1beta1 Pub/Sub
+          #   API.
+          # * `v1` or `v1beta2`: uses the push format defined in the v1 Pub/Sub
+          #   API.
+          #
+          # @return [String]
+          def version
+            @grpc.attributes["x-goog-version"]
+          end
+
+          # Sets the format of the pushed message.
+          #
+          # The possible values for this attribute are:
+          #
+          # * `v1beta1`: uses the push format defined in the v1beta1 Pub/Sub
+          #   API.
+          # * `v1` or `v1beta2`: uses the push format defined in the v1 Pub/Sub
+          #   API.
+          #
+          # @param [String, nil] new_version The new version value.
+          def version= new_version
+            if new_version.nil?
+              @grpc.attributes.delete "x-goog-version"
+            else
+              @grpc.attributes["x-goog-version"] = new_version
+            end
+          end
+
+          # @private
+          def to_grpc
+            @grpc
+          end
+
+          # @private
+          def self.from_grpc grpc
+            new.tap do |pc|
+              pc.instance_variable_set :@grpc, grpc.dup if grpc
+            end
+          end
+
+          # Contains information needed for generating an [OpenID Connect
+          # token](https://developers.google.com/identity/protocols/OpenIDConnect).
+          class OidcToken
+            # @private
+            def initialize
+              @grpc = Google::Cloud::PubSub::V1::PushConfig::OidcToken.new
+            end
+
+            # Service account email to be used for generating the OIDC token.
+            #
+            # @return [String]
+            def email
+              @grpc.service_account_email
+            end
+
+            # Service account email to be used for generating the OIDC token.
+            #
+            # @param [String] new_email New service account email value.
+            def email= new_email
+              @grpc.service_account_email = new_email
+            end
+
+            # Audience to be used when generating OIDC token. The audience claim
+            # identifies the recipients that the JWT is intended for. The
+            # audience value is a single case-sensitive string.
+            #
+            # Having multiple values (array) for the audience field is not
+            # supported.
+            #
+            # More info about the OIDC JWT token audience here:
+            # https://tools.ietf.org/html/rfc7519#section-4.1.3
+            #
+            # @return [String]
+            def audience
+              @grpc.audience
+            end
+
+            # Sets the audience to be used when generating OIDC token.
+            #
+            # @param [String] new_audience New audience value.
+            def audience= new_audience
+              @grpc.audience = new_audience
+            end
+
+            # @private
+            def to_grpc
+              @grpc
+            end
+
+            # @private
+            def self.from_grpc grpc
+              grpc ||= Google::Cloud::PubSub::V1::PushConfig::OidcToken.new
+
+              new.tap do |pc|
+                pc.instance_variable_set :@grpc, grpc.dup
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -414,6 +414,33 @@ YARD::Doctest.configure do |doctest|
   end
   doctest.skip "Google::Cloud::PubSub::Subscription#refresh!"
 
+  doctest.before "Google::Cloud::PubSub::Subscription#push_config" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp, [String, Hash]
+    end
+  end
+  doctest.before "Google::Cloud::PubSub::Subscription#push_config@Update the push configuration by passing a block:" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp, [String, Hash]
+      mock_subscriber.expect :update_subscription, subscription_resp, [Google::Cloud::PubSub::V1::Subscription, Google::Protobuf::FieldMask, Hash]
+    end
+  end
+
+  ##
+  # Subscription::PushConfig
+
+  doctest.before "Google::Cloud::PubSub::Subscription::PushConfig" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp, [String, Hash]
+    end
+  end
+  doctest.before "Google::Cloud::PubSub::Subscription::PushConfig@Update the push configuration by passing a block:" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp, [String, Hash]
+      mock_subscriber.expect :update_subscription, subscription_resp, [Google::Cloud::PubSub::V1::Subscription, Google::Protobuf::FieldMask, Hash]
+    end
+  end
+
   ##
   # Subscription::List
 
@@ -614,7 +641,13 @@ def subscription_hash topic_name, sub_name,
                       endpoint = "http://example.com/callback", labels: nil
   { name: subscription_path(sub_name),
     topic: topic_path(topic_name),
-    push_config: { "push_endpoint" => endpoint },
+    push_config: {
+      push_endpoint: endpoint,
+      oidc_token: {
+        service_account_email: "user@example.com",
+        audience: "client-12345"
+      }
+    },
     ack_deadline_seconds: deadline,
     retain_acked_messages: true,
     message_retention_duration: { seconds: 600, nanos: 900000000 }, # 600.9 seconds

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
@@ -71,6 +71,7 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
     subscription.push_config.authentication.must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig::OidcToken
     subscription.push_config.authentication.email.must_equal "user@example.com"
     subscription.push_config.authentication.audience.must_equal "client-12345"
+    subscription.push_config.must_be :oidc_token?
   end
 
   describe "reference subscription object of a subscription that does exist" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
@@ -65,7 +65,15 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
     subscription.expires_in.must_equal two_days_seconds
   end
 
-  describe "reference subscription object of a subscription exists" do
+  it "gets push_config from the Google API object" do
+    subscription.push_config.must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig
+    subscription.push_config.endpoint.must_equal sub_endpoint
+    subscription.push_config.authentication.must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig::OidcToken
+    subscription.push_config.authentication.email.must_equal "user@example.com"
+    subscription.push_config.authentication.audience.must_equal "client-12345"
+  end
+
+  describe "reference subscription object of a subscription that does exist" do
     let :subscription do
       Google::Cloud::PubSub::Subscription.from_name sub_name,
                                             pubsub.service
@@ -131,6 +139,12 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
 
       mock.verify
     end
+
+    it "does not make an HTTP API call to access push_config" do
+      subscription.push_config.must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig
+      subscription.push_config.endpoint.must_be :empty?
+      subscription.push_config.authentication.must_be :nil?
+    end
   end
 
   describe "reference subscription object of a subscription that does not exist" do
@@ -193,6 +207,12 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       expect do
         subscription.expires_in
       end.must_raise Google::Cloud::NotFoundError
+    end
+
+    it "does not raise NotFoundError when accessing push_config" do
+      subscription.push_config.must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig
+      subscription.push_config.endpoint.must_be :empty?
+      subscription.push_config.authentication.must_be :nil?
     end
   end
 end

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -147,7 +147,13 @@ class MockPubsub < Minitest::Spec
                         endpoint = "http://example.com/callback", labels: nil
     { name: subscription_path(sub_name),
       topic: topic_path(topic_name),
-      push_config: { push_endpoint: endpoint },
+      push_config: {
+        push_endpoint: endpoint,
+        oidc_token: {
+          service_account_email: "user@example.com",
+          audience: "client-12345"
+        }
+      },
       ack_deadline_seconds: deadline,
       retain_acked_messages: true,
       message_retention_duration: { seconds: 600, nanos: 900000000 }, # 600.9 seconds


### PR DESCRIPTION
Add `Subscription#push_config` and `Subscription::PushConfig`. This exposes more information about how the subscription pushes to an external HTTP endpoint, including setting authentication on the call to the endpoint (only OidcToken for now), and what API version to use for formatting the data sent.

[closes #3048]