### PR TITLE
Release google-cloud-dlp 0.9.0

### DIFF
--- a/google-cloud-dlp/CHANGELOG.md
+++ b/google-cloud-dlp/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Release History
 
+### 0.9.0 / 2019-04-09
+
+* Extract gRPC header values from request
+* Update V2::DlpServiceClient:
+  * Add Add filter optional argument to list_job_triggers
+    * Add ListJobTriggersRequest#filter
+  * Add activate_job_trigger
+    * Add ActivateJobTriggerRequest
+* Update V2 classes:
+  * Add InfoTypeDescription#description
+  * Add Action#job_notification_emails
+    * Add Action::JobNotificationEmails class
+  * Add CustomInfoType::Regex#group_indexes
+  * Add RecordKey#id_values
+  * Add FileType::IMAGE enumerated value
+* Update documentation
+* Add CryptoDeterministicConfig
+* Add PrimitiveTransformation#crypto_deterministic_config
+* Update documented regex to allow underscores in values for template_id, job_id, trigger_id, stored_info_type_id
+
 ### 0.8.0 / 2018-11-15
 
 * Add StoredInfoType CRUD+List access methods:

--- a/google-cloud-dlp/CHANGELOG.md
+++ b/google-cloud-dlp/CHANGELOG.md
@@ -15,10 +15,10 @@
   * Add CustomInfoType::Regex#group_indexes
   * Add RecordKey#id_values
   * Add FileType::IMAGE enumerated value
-* Update documentation
 * Add CryptoDeterministicConfig
 * Add PrimitiveTransformation#crypto_deterministic_config
-* Update documented regex to allow underscores in values for template_id, job_id, trigger_id, stored_info_type_id
+* Update documented regex to allow underscores in values for template_id, job_id, trigger_id, and stored_info_type_id
+* Update documentation
 
 ### 0.8.0 / 2018-11-15
 

--- a/google-cloud-dlp/CHANGELOG.md
+++ b/google-cloud-dlp/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### 0.9.0 / 2019-04-09
 
-* Extract gRPC header values from request
 * Update V2::DlpServiceClient:
   * Add Add filter optional argument to list_job_triggers
     * Add ListJobTriggersRequest#filter
@@ -18,6 +17,7 @@
 * Add CryptoDeterministicConfig
 * Add PrimitiveTransformation#crypto_deterministic_config
 * Update documented regex to allow underscores in values for template_id, job_id, trigger_id, and stored_info_type_id
+* Extract gRPC header values from request
 * Update documentation
 
 ### 0.8.0 / 2018-11-15

--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dlp"
-  gem.version       = "0.8.0"
+  gem.version       = "0.9.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Extract gRPC header values from request
* Update V2::DlpServiceClient:
  * Add Add filter optional argument to list_job_triggers
    * Add ListJobTriggersRequest#filter
  * Add activate_job_trigger
    * Add ActivateJobTriggerRequest
* Update V2 classes:
  * Add InfoTypeDescription#description
  * Add Action#job_notification_emails
    * Add Action::JobNotificationEmails class
  * Add CustomInfoType::Regex#group_indexes
  * Add RecordKey#id_values
  * Add FileType::IMAGE enumerated value
* Update documentation
* Add CryptoDeterministicConfig
* Add PrimitiveTransformation#crypto_deterministic_config
* Update documented regex to allow underscores in values for template_id, job_id, trigger_id, stored_info_type_id

This pull request was generated using releasetool.