### PR TITLE
Update SignerV2

### DIFF
--- a/google-cloud-storage/acceptance/storage/signed_url_test.rb
+++ b/google-cloud-storage/acceptance/storage/signed_url_test.rb
@@ -101,7 +101,6 @@ describe Google::Cloud::Storage, :storage do
                                content_type: "image/png", # Required for V2
                                headers: { "x-goog-resumable" => "start" },
                                version: :v2
-      puts "\n\n#{url}\n\n"
       uri = URI.parse url
       https = Net::HTTP.new uri.host,uri.port
       https.use_ssl = true

--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-api-client", "~> 0.26"
   gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
   gem.add_dependency "digest-crc", "~> 0.4"
+  gem.add_dependency "addressable", "~> 2.6.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v2.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v2.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+require "addressable/uri"
 require "base64"
 require "cgi"
 require "openssl"
@@ -42,10 +43,7 @@ module Google
           ##
           # The external path to the file.
           def ext_path
-            escaped_path = String(@path).split("/").map do |node|
-              CGI.escape node
-            end.join("/")
-            "/#{CGI.escape @bucket}/#{escaped_path}"
+            Addressable::URI.escape "/#{@bucket}/#{@path}"
           end
 
           ##

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 
-require "cgi"
 require "addressable/uri"
+require "cgi"
 require "openssl"
 require "google/cloud/storage/errors"
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v2_test.rb
@@ -141,14 +141,14 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
     it "properly escapes the path when generating signed_url" do
       Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
         signing_key_mock = Minitest::Mock.new
-        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello+world.txt"]
+        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello%20world.txt"]
         credentials.issuer = "native_client_email"
         credentials.signing_key = signing_key_mock
 
         signed_url = bucket.signed_url file_path
 
         signed_uri = URI signed_url
-        signed_uri.path.must_equal "/bucket/hello+world.txt"
+        signed_uri.path.must_equal "/bucket/hello%20world.txt"
 
         signed_url_params = CGI::parse signed_uri.query
         signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]

--- a/google-cloud-storage/test/google/cloud/storage/file_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_signed_url_v2_test.rb
@@ -142,14 +142,14 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
     it "properly escapes the path when generating signed_url" do
       Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
         signing_key_mock = Minitest::Mock.new
-        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello+world.txt"]
+        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello%20world.txt"]
         credentials.issuer = "native_client_email"
         credentials.signing_key = signing_key_mock
 
         signed_url = file.signed_url
 
         signed_uri = URI signed_url
-        signed_uri.path.must_equal "/bucket/hello+world.txt"
+        signed_uri.path.must_equal "/bucket/hello%20world.txt"
 
         signed_url_params = CGI::parse signed_uri.query
         signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v2_test.rb
@@ -121,14 +121,14 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v2, :lazy, :mock_storage 
     it "properly escapes the path when generating signed_url" do
       Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
         signing_key_mock = Minitest::Mock.new
-        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello+world.txt"]
+        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello%20world.txt"]
         credentials.issuer = "native_client_email"
         credentials.signing_key = signing_key_mock
 
         signed_url = bucket.signed_url file_path
 
         signed_uri = URI signed_url
-        signed_uri.path.must_equal "/bucket/hello+world.txt"
+        signed_uri.path.must_equal "/bucket/hello%20world.txt"
 
         signed_url_params = CGI::parse signed_uri.query
         signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v2_test.rb
@@ -141,14 +141,14 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
     it "properly escapes the path when generating signed_url" do
       Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
         signing_key_mock = Minitest::Mock.new
-        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello+world.txt"]
+        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello%20world.txt"]
         credentials.issuer = "native_client_email"
         credentials.signing_key = signing_key_mock
 
         signed_url = file.signed_url
 
         signed_uri = URI signed_url
-        signed_uri.path.must_equal "/bucket/hello+world.txt"
+        signed_uri.path.must_equal "/bucket/hello%20world.txt"
 
         signed_url_params = CGI::parse signed_uri.query
         signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]

--- a/google-cloud-storage/test/google/cloud/storage/project_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_signed_url_v2_test.rb
@@ -140,14 +140,14 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
     it "properly escapes the path when generating signed_url" do
       Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
         signing_key_mock = Minitest::Mock.new
-        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello+world.txt"]
+        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello%20world.txt"]
         credentials.issuer = "native_client_email"
         credentials.signing_key = signing_key_mock
 
         signed_url = storage.signed_url bucket_name, file_path
 
         signed_uri = URI signed_url
-        signed_uri.path.must_equal "/bucket/hello+world.txt"
+        signed_uri.path.must_equal "/bucket/hello%20world.txt"
 
         signed_url_params = CGI::parse signed_uri.query
         signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]


### PR DESCRIPTION
Replace `CGI` with `Addressable::URI` for path encoding.
Remove `puts` statement from acceptance test.

Thanks to @prapicault for identifying issue and fix!!!

[fixes #3064]