### PR TITLE
Release google-cloud-storage 1.18.0

### DIFF
--- a/google-cloud-storage/CHANGELOG.md
+++ b/google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+### 1.18.0 / 2019-04-09
+
+* Add support for V4 signed URLs.
+  * Add version param to #signed_url.
+* Fix file path encoding for V2 signed URLs.
+  * Change CGI encoding to URI (percent) encoding to fix URLs containing spaces in file path.
+* Fix documentation typo.
+
 ### 1.17.0 / 2019-02-07
 
 * Add support for Bucket Policy Only with `Bucket#policy_only?`,

--- a/google-cloud-storage/lib/google/cloud/storage/version.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Storage
-      VERSION = "1.17.0".freeze
+      VERSION = "1.18.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add support for V4 signed URLs.
  * Add version param to #signed_url.
* Fix file path encoding for V2 signed URLs.
  * Change CGI encoding to URI (percent) encoding.
* Fix documentation typo.

This pull request was generated using releasetool.