### PR TITLE
Release google-cloud-scheduler 0.3.0

### DIFF
--- a/google-cloud-scheduler/CHANGELOG.md
+++ b/google-cloud-scheduler/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+### 0.3.0 / 2019-04-15
+
+* Add Job#attempt_deadline
+* Add HttpTarget#oauth_token
+* Add HttpTarget#oidc_token
+* Add OAuthToken
+* Add OidcToken
+* Extract gRPC header values from request
+* Update generated documentation
+
 ### 0.2.0 / 2019-03-12
 
 * Add v1 api version

--- a/google-cloud-scheduler/google-cloud-scheduler.gemspec
+++ b/google-cloud-scheduler/google-cloud-scheduler.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-scheduler"
-  gem.version       = "0.2.0"
+  gem.version       = "0.3.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Add Job#attempt_deadline
* Add HttpTarget#oauth_token
* Add HttpTarget#oidc_token
* Add OAuthToken
* Add OidcToken
* Extract gRPC header values from request
* Update generated documentation

This pull request was generated using releasetool.