### PR TITLE
check response body after pushing gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -325,7 +325,9 @@ task :release, :tag do |t, args|
   gem_was_published = nil
   if File.file? path_to_be_pushed
     begin
-      puts ::Gems.push(File.new path_to_be_pushed)
+      response = ::Gems.push File.new path_to_be_pushed
+      puts response
+      raise unless response.include? "Successfully registered gem:"
       gem_was_published = true
       puts "Successfully built and pushed #{package} for version #{version}"
     rescue => e

--- a/Rakefile
+++ b/Rakefile
@@ -325,7 +325,7 @@ task :release, :tag do |t, args|
   gem_was_published = nil
   if File.file? path_to_be_pushed
     begin
-      ::Gems.push(File.new path_to_be_pushed)
+      puts ::Gems.push(File.new path_to_be_pushed)
       gem_was_published = true
       puts "Successfully built and pushed #{package} for version #{version}"
     rescue => e


### PR DESCRIPTION
`Gems.push` doesn't always fail when the post request fails. Running `bundle exec rake release[google-cloud-scheduler/v0.3.0]` "succeeds" even though it's already been published. Checking for success message manually.