### PR TITLE
Lower addressable dependency

### DIFF
--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-api-client", "~> 0.26"
   gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
   gem.add_dependency "digest-crc", "~> 0.4"
-  gem.add_dependency "addressable", "~> 2.6.0"
+  gem.add_dependency "addressable", "~> 2.5"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"


### PR DESCRIPTION
The fix for #4997 added a dependency to the most recent version of addressable which is 2.6 (tbh iirc this is likely what I had put in my original PR for this bug).
This PR reduces the dependency to ~> 2.5 in order to ease the use of the google-cloud-storage.
Given that:
- the only use of Addressable is in google-cloud-storage
- that the only use is `Addressable::URI.escape`
- the changes between 2.5.2 and 2.6 are not changing the said code https://github.com/sporkmonger/addressable/compare/addressable-2.5.2..addressable-2.6.0

I think it should be safe to change this dependency.
HTH