### PR TITLE
Update synth.py to copy common synthtool templates (AUTHENTICATION.md)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -655,6 +655,18 @@ namespace :kokoro do
   end
 end
 
+desc "Runs python -m synthtool for each gem containing a synth.py file (see https://github.com/googleapis/synthtool)"
+task :synthtool do
+  gapic_gems.each do |gem|
+    Dir.chdir gem do
+      Bundler.with_clean_env do
+        header "Run `python -m synthtool` for #{gem}"
+        sh "python -m synthtool"
+      end
+    end
+  end
+end
+
 def run_command_with_timeout command, timeout
   job = Process.spawn(command)
   begin
@@ -743,6 +755,10 @@ def valid_gems
     spec = Gem::Specification::load("#{gem}/#{gem}.gemspec")
     spec.required_ruby_version.satisfied_by? Gem::Version.new(RUBY_VERSION)
   }
+end
+
+def gapic_gems
+  gems.select { |gem| File.exist? "#{gem}/synth.py" }
 end
 
 def valid_gems_with_coverage_filters

--- a/google-cloud-asset/.repo-metadata.json
+++ b/google-cloud-asset/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-asset",
+  "module_name": "Asset",
+  "module_name_credentials": "Asset::V1",
+  "env_var_prefix": "ASSET"
+}

--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -47,6 +47,10 @@ s.copy(v1beta1_library / 'lib/google/cloud/asset/v1beta1.rb')
 s.copy(v1beta1_library / 'lib/google/cloud/asset/v1beta1')
 s.copy(v1beta1_library / 'test/google/cloud/asset/v1beta1')
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-asset.gemspec',

--- a/google-cloud-bigquery-data_transfer/.repo-metadata.json
+++ b/google-cloud-bigquery-data_transfer/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-bigquery-data_transfer",
+  "module_name": "Bigquery::DataTransfer",
+  "module_name_credentials": "Bigquery::DataTransfer::V1",
+  "env_var_prefix": "DATA_TRANSFER"
+}

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -38,6 +38,10 @@ s.copy(v1_library / '.gitignore')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-bigquery-data_transfer.gemspec', merge=ruby.merge_gemspec)
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # PERMANENT: Use custom credentials env variable names
 s.replace(
     'lib/google/cloud/bigquery/data_transfer/v1/credentials.rb',

--- a/google-cloud-bigtable/.repo-metadata.json
+++ b/google-cloud-bigtable/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-bigtable",
+  "module_name": "Bigtable",
+  "module_name_credentials": "Bigtable::V2",
+  "env_var_prefix": "BIGTABLE"
+}

--- a/google-cloud-bigtable/synth.py
+++ b/google-cloud-bigtable/synth.py
@@ -43,6 +43,10 @@ s.copy(v2_admin_library / 'lib/google/cloud/bigtable/admin.rb')
 s.copy(v2_admin_library / 'lib/google/bigtable/admin/v2')
 s.copy(v2_admin_library / 'test/google/cloud/bigtable/admin/v2')
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # PERMANENT: We're combining bigtable and bigtable-admin into one gem.
 s.replace(
     [

--- a/google-cloud-container/.repo-metadata.json
+++ b/google-cloud-container/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-container",
+  "module_name": "Container",
+  "module_name_credentials": "Container::V1",
+  "env_var_prefix": "CONTAINER"
+}

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -35,6 +35,10 @@ s.copy(v1beta1_library / 'lib/google/container/v1beta1')
 s.copy(v1beta1_library / 'lib/google/cloud/container/v1beta1.rb')
 s.copy(v1beta1_library / 'test/google/cloud/container/v1beta1')
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 v1_library = gapic.ruby_library(
     'container', 'v1', config_path='/google/container/artman_container_v1.yaml',
     artman_output_name='google-cloud-ruby/google-cloud-container'

--- a/google-cloud-dataproc/.repo-metadata.json
+++ b/google-cloud-dataproc/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-dataproc",
+  "module_name": "Dataproc",
+  "module_name_credentials": "Dataproc::V1",
+  "env_var_prefix": "DATAPROC"
+}

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -46,6 +46,10 @@ s.copy(v1beta2 / 'lib/google/cloud/dataproc/v1beta2.rb')
 s.copy(v1beta2 / 'acceptance/google/cloud/dataproc/v1beta2')
 s.copy(v1beta2 / 'test/google/cloud/dataproc/v1beta2')
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-datastore/.repo-metadata.json
+++ b/google-cloud-datastore/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-datastore",
+  "module_name": "Datastore",
+  "module_name_credentials": "Datastore::V1",
+  "env_var_prefix": "DATASTORE"
+}

--- a/google-cloud-datastore/synth.py
+++ b/google-cloud-datastore/synth.py
@@ -33,6 +33,10 @@ s.copy(v1_library / 'lib/google/datastore/v1')
 # Omitting lib/google/cloud/datastore/v1.rb for now because we are not exposing
 # the low-level API.
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # https://github.com/googleapis/gapic-generator/issues/2124
 s.replace(
     'lib/google/cloud/datastore/v1/credentials.rb',

--- a/google-cloud-debugger/.repo-metadata.json
+++ b/google-cloud-debugger/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-debugger",
+  "module_name": "Debugger",
+  "module_name_credentials": "Debugger::V2",
+  "env_var_prefix": "DEBUGGER"
+}

--- a/google-cloud-debugger/synth.py
+++ b/google-cloud-debugger/synth.py
@@ -33,6 +33,10 @@ s.copy(v2_library / 'lib/google/cloud/debugger/v2.rb')
 s.copy(v2_library / 'lib/google/devtools')
 s.copy(v2_library / 'test/google/cloud/debugger/v2')
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # PERMANENT: Handwritten layer owns Debugger.new so low-level clients need to
 # use Debugger::V2.new instead of Debugger.new(version: :v2). Update the
 # examples and tests.

--- a/google-cloud-dialogflow/.repo-metadata.json
+++ b/google-cloud-dialogflow/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-dialogflow",
+  "module_name": "Dialogflow",
+  "module_name_credentials": "Dialogflow::V2",
+  "env_var_prefix": "DIALOGFLOW"
+}

--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -37,6 +37,10 @@ s.copy(v2_library / '.gitignore')
 s.copy(v2_library / '.yardopts')
 s.copy(v2_library / 'google-cloud-dialogflow.gemspec', merge=ruby.merge_gemspec)
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # https://github.com/googleapis/gapic-generator/issues/2232
 s.replace(
     [

--- a/google-cloud-dlp/.repo-metadata.json
+++ b/google-cloud-dlp/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-dlp",
+  "module_name": "Dlp",
+  "module_name_credentials": "Dlp::V2",
+  "env_var_prefix": "DLP"
+}

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -36,6 +36,10 @@ s.copy(v2_library / '.gitignore')
 s.copy(v2_library / '.yardopts')
 s.copy(v2_library / 'google-cloud-dlp.gemspec', merge=ruby.merge_gemspec)
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-error_reporting/.repo-metadata.json
+++ b/google-cloud-error_reporting/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-error_reporting",
+  "module_name": "ErrorReporting",
+  "module_name_credentials": "ErrorReporting::V1beta1",
+  "env_var_prefix": "ERROR_REPORTING"
+}

--- a/google-cloud-error_reporting/synth.py
+++ b/google-cloud-error_reporting/synth.py
@@ -31,6 +31,10 @@ v1beta1_library = gapic.ruby_library(
 s.copy(v1beta1_library / 'lib/google/cloud/error_reporting/v1beta1')
 s.copy(v1beta1_library / 'lib/google/devtools/clouderrorreporting/v1beta1')
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # Omitting lib/google/cloud/error_reporting/v1beta1.rb for now because we are
 # not exposing the low-level API.
 

--- a/google-cloud-firestore/.repo-metadata.json
+++ b/google-cloud-firestore/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-firestore",
+  "module_name": "Firestore",
+  "module_name_credentials": "Firestore::V1",
+  "env_var_prefix": "FIRESTORE"
+}

--- a/google-cloud-firestore/synth.py
+++ b/google-cloud-firestore/synth.py
@@ -43,6 +43,10 @@ s.copy(v1beta1_library / 'lib/google/cloud/firestore/v1beta1.rb')
 s.copy(v1beta1_library / 'lib/google/firestore/v1beta1')
 s.copy(v1beta1_library / 'test/google/cloud/firestore/v1beta1')
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # PERMANENT: Handwritten layer owns Firestore.new so low-level clients need to
 # use Firestore::V1beta1.new instead of Firestore.new(version: :v1beta1).
 # Update the examples and tests.

--- a/google-cloud-irm/.repo-metadata.json
+++ b/google-cloud-irm/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-irm",
+  "module_name": "Irm",
+  "module_name_credentials": "Irm::V1alpha2",
+  "env_var_prefix": "IRM"
+}

--- a/google-cloud-irm/synth.py
+++ b/google-cloud-irm/synth.py
@@ -38,6 +38,10 @@ s.copy(v1alpha2 / '.gitignore')
 s.copy(v1alpha2 / '.yardopts')
 s.copy(v1alpha2 / 'google-cloud-irm.gemspec', merge=ruby.merge_gemspec)
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
     'lib/google/cloud/irm/*/*_client.rb',

--- a/google-cloud-kms/.repo-metadata.json
+++ b/google-cloud-kms/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-kms",
+  "module_name": "Kms",
+  "module_name_credentials": "Kms::V1",
+  "env_var_prefix": "KMS"
+}

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -39,6 +39,10 @@ s.copy(v1_library / '.gitignore')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-kms.gemspec', merge=ruby.merge_gemspec)
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # PERMANENT: API name for cloudkms
 s.replace(
     [

--- a/google-cloud-language/.repo-metadata.json
+++ b/google-cloud-language/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-language",
+  "module_name": "Language",
+  "module_name_credentials": "Language::V1",
+  "env_var_prefix": "LANGUAGE"
+}

--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -50,6 +50,10 @@ s.copy(v1beta2_library / 'lib/google/cloud/language/v1beta2.rb')
 s.copy(v1beta2_library / 'lib/google/cloud/language/v1beta2')
 s.copy(v1beta2_library / 'test/google/cloud/language/v1beta2')
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [

--- a/google-cloud-logging/.repo-metadata.json
+++ b/google-cloud-logging/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-logging",
+  "module_name": "Logging",
+  "module_name_credentials": "Logging::V2",
+  "env_var_prefix": "LOGGING"
+}

--- a/google-cloud-logging/synth.py
+++ b/google-cloud-logging/synth.py
@@ -34,6 +34,10 @@ s.copy(v2_library / 'lib/google/logging/v2')
 # Omitting lib/google/cloud/logging/v2.rb for now because we are not exposing
 # the low-level API.
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # PERMANENT: Handwritten layer owns Logging.new so low-level clients need to
 # use Logging::V2.new instead of Logging.new(version: :v2). Update the
 # examples and tests.

--- a/google-cloud-monitoring/.repo-metadata.json
+++ b/google-cloud-monitoring/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-monitoring",
+  "module_name": "Monitoring",
+  "module_name_credentials": "Monitoring::V3",
+  "env_var_prefix": "MONITORING"
+}

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -39,6 +39,10 @@ s.copy(v3_library / '.gitignore')
 s.copy(v3_library / '.yardopts')
 s.copy(v3_library / 'google-cloud-monitoring.gemspec', merge=ruby.merge_gemspec)
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # PERMANENT: Use a compatible version of googleapis-common-protos-types
 s.replace(
     'google-cloud-monitoring.gemspec',

--- a/google-cloud-os_login/.repo-metadata.json
+++ b/google-cloud-os_login/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-os_login",
+  "module_name": "OsLogin",
+  "module_name_credentials": "OsLogin::V1",
+  "env_var_prefix": "OS_LOGIN"
+}

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -42,6 +42,10 @@ s.copy(v1_library / '.gitignore')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-os_login.gemspec', merge=ruby.merge_gemspec)
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 v1beta_library = gapic.ruby_library(
     'oslogin', 'v1beta',
     config_path='/google/cloud/oslogin/artman_oslogin_v1beta.yaml',

--- a/google-cloud-phishing_protection/.repo-metadata.json
+++ b/google-cloud-phishing_protection/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-phishing_protection",
+  "module_name": "PhishingProtection",
+  "module_name_credentials": "PhishingProtection::V1beta1",
+  "env_var_prefix": "PHISHING_PROTECTION"
+}

--- a/google-cloud-phishing_protection/synth.py
+++ b/google-cloud-phishing_protection/synth.py
@@ -41,6 +41,10 @@ s.copy(v1beta1_library / '.gitignore')
 s.copy(v1beta1_library / '.yardopts')
 s.copy(v1beta1_library / 'google-cloud-phishing_protection.gemspec', merge=ruby.merge_gemspec)
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-phishing_protection.gemspec',

--- a/google-cloud-pubsub/.repo-metadata.json
+++ b/google-cloud-pubsub/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-pubsub",
+  "module_name": "PubSub",
+  "module_name_credentials": "PubSub::V1",
+  "env_var_prefix": "PUBSUB"
+}

--- a/google-cloud-pubsub/synth.py
+++ b/google-cloud-pubsub/synth.py
@@ -34,6 +34,10 @@ os.rename(v1_library / 'lib/google/cloud/pub_sub.rb', v1_library / 'lib/google/c
 s.copy(v1_library / 'lib/google/cloud/pubsub/v1')
 s.copy(v1_library / 'lib/google/pubsub/v1')
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # Omitting lib/google/cloud/pusbusb/v1.rb for now because we are not exposing
 # the low-level API.
 

--- a/google-cloud-recaptcha_enterprise/.repo-metadata.json
+++ b/google-cloud-recaptcha_enterprise/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-recaptcha_enterprise",
+  "module_name": "RecaptchaEnterprise",
+  "module_name_credentials": "RecaptchaEnterprise::V1beta1",
+  "env_var_prefix": "RECAPTCHA_ENTERPRISE"
+}

--- a/google-cloud-recaptcha_enterprise/synth.py
+++ b/google-cloud-recaptcha_enterprise/synth.py
@@ -39,6 +39,10 @@ s.copy(v1beta1_library / '.gitignore')
 s.copy(v1beta1_library / '.yardopts')
 s.copy(v1beta1_library / 'google-cloud-recaptcha_enterprise.gemspec', merge=ruby.merge_gemspec)
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-recaptcha_enterprise.gemspec',

--- a/google-cloud-redis/.repo-metadata.json
+++ b/google-cloud-redis/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-redis",
+  "module_name": "Redis",
+  "module_name_credentials": "Redis::V1",
+  "env_var_prefix": "REDIS"
+}

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -39,6 +39,10 @@ s.copy(v1_library / '.gitignore')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-redis.gemspec', merge=ruby.merge_gemspec)
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 v1beta1_library = gapic.ruby_library(
     'redis', 'v1beta1',
     artman_output_name='google-cloud-ruby/google-cloud-redis'

--- a/google-cloud-scheduler/.repo-metadata.json
+++ b/google-cloud-scheduler/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-scheduler",
+  "module_name": "Scheduler",
+  "module_name_credentials": "Scheduler::V1",
+  "env_var_prefix": "SCHEDULER"
+}

--- a/google-cloud-scheduler/synth.py
+++ b/google-cloud-scheduler/synth.py
@@ -38,6 +38,10 @@ s.copy(v1beta1_library / 'lib/google/cloud/scheduler/v1beta1')
 s.copy(v1beta1_library / 'lib/google/cloud/scheduler/v1beta1.rb')
 s.copy(v1beta1_library / 'test/google/cloud/scheduler/v1beta1')
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 
 v1_library = gapic.ruby_library(
     'scheduler',

--- a/google-cloud-spanner/.repo-metadata.json
+++ b/google-cloud-spanner/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-spanner",
+  "module_name": "Spanner",
+  "module_name_credentials": "Spanner::V1",
+  "env_var_prefix": "SPANNER"
+}

--- a/google-cloud-spanner/synth.py
+++ b/google-cloud-spanner/synth.py
@@ -42,6 +42,10 @@ s.copy(v1_database_library / 'lib/google/cloud/spanner/admin/database/v1')
 s.copy(v1_database_library / 'lib/google/spanner/admin/database/v1')
 s.copy(v1_database_library / 'test/google/cloud/spanner/admin/database/v1')
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 v1_instance_library = gapic.ruby_library(
     'spanneradmininstance', 'v1',
     config_path='/google/spanner/admin/instance/artman_spanner_admin_instance.yaml',

--- a/google-cloud-speech/.repo-metadata.json
+++ b/google-cloud-speech/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-speech",
+  "module_name": "Speech",
+  "module_name_credentials": "Speech::V1",
+  "env_var_prefix": "SPEECH"
+}

--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -40,6 +40,10 @@ s.copy(v1_library / '.gitignore')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-speech.gemspec', merge=ruby.merge_gemspec)
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 v1p1beta1_library = gapic.ruby_library(
     'speech', 'v1p1beta1',
     artman_output_name='google-cloud-ruby/google-cloud-speech'

--- a/google-cloud-talent/.repo-metadata.json
+++ b/google-cloud-talent/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-talent",
+  "module_name": "Talent",
+  "module_name_credentials": "Talent::V4beta1",
+  "env_var_prefix": "TALENT"
+}

--- a/google-cloud-talent/synth.py
+++ b/google-cloud-talent/synth.py
@@ -40,6 +40,10 @@ s.copy(v4beta1 / '.gitignore')
 s.copy(v4beta1 / '.yardopts')
 s.copy(v4beta1 / 'google-cloud-talent.gemspec', merge=ruby.merge_gemspec)
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
     'lib/google/cloud/talent/*/*_client.rb',

--- a/google-cloud-tasks/.repo-metadata.json
+++ b/google-cloud-tasks/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-tasks",
+  "module_name": "Tasks",
+  "module_name_credentials": "Tasks::V2",
+  "env_var_prefix": "TASKS"
+}

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -56,6 +56,10 @@ s.copy(v2_library / '.gitignore')
 s.copy(v2_library / '.yardopts')
 s.copy(v2_library / 'google-cloud-tasks.gemspec', merge=ruby.merge_gemspec)
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-tasks.gemspec',

--- a/google-cloud-text_to_speech/.repo-metadata.json
+++ b/google-cloud-text_to_speech/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-text_to_speech",
+  "module_name": "TextToSpeech",
+  "module_name_credentials": "TextToSpeech::V1",
+  "env_var_prefix": "TEXT_TO_SPEECH"
+}

--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -45,6 +45,10 @@ s.copy(v1beta1_library / 'lib/google/cloud/text_to_speech/v1beta1.rb')
 s.copy(v1beta1_library / 'lib/google/cloud/texttospeech/v1beta1')
 s.copy(v1beta1_library / 'test/google/cloud/text_to_speech/v1beta1')
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
     'lib/google/cloud/text_to_speech/*/*_client.rb',

--- a/google-cloud-trace/.repo-metadata.json
+++ b/google-cloud-trace/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-trace",
+  "module_name": "Trace",
+  "module_name_credentials": "Trace::V2",
+  "env_var_prefix": "TRACE"
+}

--- a/google-cloud-trace/synth.py
+++ b/google-cloud-trace/synth.py
@@ -42,6 +42,10 @@ s.copy(v2_library / 'lib/google/devtools/cloudtrace/v2')
 # Omitting lib/google/cloud/trace/v{1,2}.rb for now because we are not exposing
 # the low-level API.
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # https://github.com/googleapis/gapic-generator/issues/2124
 s.replace(
     [

--- a/google-cloud-video_intelligence/.repo-metadata.json
+++ b/google-cloud-video_intelligence/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-video_intelligence",
+  "module_name": "VideoIntelligence",
+  "module_name_credentials": "VideoIntelligence::V1",
+  "env_var_prefix": "VIDEO_INTELLIGENCE"
+}

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -79,6 +79,10 @@ s.copy(v1beta2_library / 'lib/google/cloud/video_intelligence/v1beta2.rb')
 s.copy(v1beta2_library / 'lib/google/cloud/videointelligence/v1beta2')
 s.copy(v1beta2_library / 'test/google/cloud/video_intelligence/v1beta2')
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # PERMANENT: API name for videointelligence
 s.replace(
     [

--- a/google-cloud-vision/.repo-metadata.json
+++ b/google-cloud-vision/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-vision",
+  "module_name": "Vision",
+  "module_name_credentials": "Vision::V1",
+  "env_var_prefix": "VISION"
+}

--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -48,6 +48,10 @@ s.copy(v1p3beta1 / 'lib/google/cloud/vision/v1p3beta1.rb')
 s.copy(v1p3beta1 / 'acceptance/google/cloud/vision/v1p3beta1')
 s.copy(v1p3beta1 / 'test/google/cloud/vision/v1p3beta1')
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
+
 # PERMANENT: Add migration guide to docs
 s.replace(
     'lib/google/cloud/vision.rb',

--- a/google-cloud-webrisk/.repo-metadata.json
+++ b/google-cloud-webrisk/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "google-cloud-webrisk",
+  "module_name": "Webrisk",
+  "module_name_credentials": "Webrisk::V1beta1",
+  "env_var_prefix": "WEBRISK"
+}

--- a/google-cloud-webrisk/synth.py
+++ b/google-cloud-webrisk/synth.py
@@ -37,6 +37,9 @@ s.copy(v1beta1 / '.gitignore')
 s.copy(v1beta1 / '.yardopts')
 s.copy(v1beta1 / 'google-cloud-webrisk.gemspec', merge=ruby.merge_gemspec)
 
+# Copy common templates
+templates = gcp.CommonTemplates().ruby_library()
+s.copy(templates)
 
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(


### PR DESCRIPTION
Update `synth.py` and add `.repo-metadata.json` to copy common `synthtool` templates (just `AUTHENTICATION.md` for now) in all gapic gems.

See googleapis/synthtool#225

/cc @busunkim96 

[fixes #2933]