### PR TITLE
Update synth.py to add AUTHENTICATION.md to file lists in *.gemspec and .yardopts

### DIFF
--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -135,13 +135,13 @@ for version in ['v1', 'v1beta1']:
 
 s.replace(
     'google-cloud-asset.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
 
 # Generate the helper methods

--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -133,5 +133,16 @@ for version in ['v1', 'v1beta1']:
         ])
     )
 
+s.replace(
+    'google-cloud-asset.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -110,3 +110,14 @@ s.replace(
     'gem.add_development_dependency "rubocop".*$',
     'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
+
+s.replace(
+    'google-cloud-bigquery-data_transfer.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -113,11 +113,11 @@ s.replace(
 
 s.replace(
     'google-cloud-bigquery-data_transfer.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -107,11 +107,11 @@ s.replace(
 
 s.replace(
     'google-cloud-container.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -104,3 +104,14 @@ s.replace(
     'require \'google/iam/v1/.*\n',
     ''
 )
+
+s.replace(
+    'google-cloud-container.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -134,11 +134,11 @@ s.replace(
 
 s.replace(
     'google-cloud-dataproc.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -131,3 +131,14 @@ s.replace(
     '\n\n(\\s+)class OperationsClient < Google::Longrunning::OperationsClient',
     '\n\n\\1# @private\n\\1class OperationsClient < Google::Longrunning::OperationsClient'
 )
+
+s.replace(
+    'google-cloud-dataproc.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)

--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -96,3 +96,14 @@ s.replace(
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )
+
+s.replace(
+    'google-cloud-dialogflow.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)

--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -99,11 +99,11 @@ s.replace(
 
 s.replace(
     'google-cloud-dialogflow.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -101,11 +101,11 @@ s.replace(
 
 s.replace(
     'google-cloud-dlp.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -98,3 +98,14 @@ s.replace(
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )
+
+s.replace(
+    'google-cloud-dlp.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)

--- a/google-cloud-irm/synth.py
+++ b/google-cloud-irm/synth.py
@@ -91,13 +91,13 @@ s.replace(
 
 s.replace(
     'google-cloud-irm.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
 
 # Generate the helper methods

--- a/google-cloud-irm/synth.py
+++ b/google-cloud-irm/synth.py
@@ -89,5 +89,16 @@ s.replace(
     ])
 )
 
+s.replace(
+    'google-cloud-irm.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -140,5 +140,16 @@ s.replace(
     ])
 )
 
+s.replace(
+    'google-cloud-kms.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -142,13 +142,13 @@ s.replace(
 
 s.replace(
     'google-cloud-kms.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
 
 # Generate the helper methods

--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -122,11 +122,11 @@ s.replace(
 
 s.replace(
     'google-cloud-language.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )

--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -119,3 +119,14 @@ s.replace(
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )
+
+s.replace(
+    'google-cloud-language.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -98,3 +98,14 @@ s.replace(
     'gem.add_development_dependency "rubocop".*$',
     'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
+
+s.replace(
+    'google-cloud-monitoring.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -101,11 +101,11 @@ s.replace(
 
 s.replace(
     'google-cloud-monitoring.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -129,11 +129,11 @@ s.replace(
 
 s.replace(
     'google-cloud-os_login.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -126,3 +126,14 @@ s.replace(
     'gem.add_development_dependency "rubocop".*$',
     'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
+
+s.replace(
+    'google-cloud-os_login.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)

--- a/google-cloud-phishing_protection/synth.py
+++ b/google-cloud-phishing_protection/synth.py
@@ -166,13 +166,13 @@ s.replace(
 
 s.replace(
     'google-cloud-phishing_protection.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
 
 # Generate the helper methods

--- a/google-cloud-phishing_protection/synth.py
+++ b/google-cloud-phishing_protection/synth.py
@@ -164,5 +164,16 @@ s.replace(
     ])
 )
 
+s.replace(
+    'google-cloud-phishing_protection.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-recaptcha_enterprise/synth.py
+++ b/google-cloud-recaptcha_enterprise/synth.py
@@ -155,13 +155,13 @@ s.replace(
 
 s.replace(
     'google-cloud-recaptcha_enterprise.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
 
 # Generate the helper methods

--- a/google-cloud-recaptcha_enterprise/synth.py
+++ b/google-cloud-recaptcha_enterprise/synth.py
@@ -153,5 +153,16 @@ s.replace(
     ])
 )
 
+s.replace(
+    'google-cloud-recaptcha_enterprise.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -129,3 +129,14 @@ s.replace(
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )
+
+s.replace(
+    'google-cloud-redis.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -132,11 +132,11 @@ s.replace(
 
 s.replace(
     'google-cloud-redis.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )

--- a/google-cloud-scheduler/synth.py
+++ b/google-cloud-scheduler/synth.py
@@ -112,13 +112,13 @@ s.replace(
 
 s.replace(
     'google-cloud-scheduler.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
 
 # Generate the helper methods

--- a/google-cloud-scheduler/synth.py
+++ b/google-cloud-scheduler/synth.py
@@ -110,5 +110,16 @@ s.replace(
     ])
 )
 
+s.replace(
+    'google-cloud-scheduler.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -172,13 +172,13 @@ s.replace(
 
 s.replace(
     'google-cloud-speech.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
 
 # https://github.com/googleapis/gapic-generator/issues/2393

--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -170,6 +170,17 @@ s.replace(
     'https://googleapis.github.io/google-cloud-ruby'
 )
 
+s.replace(
+    'google-cloud-speech.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2393
 s.replace(
     'google-cloud-speech.gemspec',

--- a/google-cloud-talent/synth.py
+++ b/google-cloud-talent/synth.py
@@ -127,13 +127,13 @@ s.replace(
 
 s.replace(
     'google-cloud-talent.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
 
 # Generate the helper methods

--- a/google-cloud-talent/synth.py
+++ b/google-cloud-talent/synth.py
@@ -125,5 +125,16 @@ s.replace(
     'https://cloud.google.com/talent-solution'
 )
 
+s.replace(
+    'google-cloud-talent.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)
+
 # Generate the helper methods
 call(f'bundle update && bundle exec rake generate_partials TALENT_SERVICES={",".join(services)}', shell=True)

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -142,5 +142,16 @@ s.replace(
     ])
 )
 
+s.replace(
+    'google-cloud-tasks.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -144,13 +144,13 @@ s.replace(
 
 s.replace(
     'google-cloud-tasks.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
 
 # Generate the helper methods

--- a/google-cloud-text_to_speech/.repo-metadata.json
+++ b/google-cloud-text_to_speech/.repo-metadata.json
@@ -2,5 +2,5 @@
   "distribution_name": "google-cloud-text_to_speech",
   "module_name": "TextToSpeech",
   "module_name_credentials": "TextToSpeech::V1",
-  "env_var_prefix": "TEXT_TO_SPEECH"
+  "env_var_prefix": "TEXTTOSPEECH"
 }

--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -88,11 +88,11 @@ s.replace(
 
 s.replace(
     'google-cloud-text_to_speech.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )

--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -85,3 +85,14 @@ s.replace(
     'gem.add_development_dependency "rubocop".*$',
     'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
+
+s.replace(
+    'google-cloud-text_to_speech.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -144,3 +144,14 @@ s.replace(
     'gem.add_development_dependency "rubocop".*$',
     'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
+
+s.replace(
+    'google-cloud-video_intelligence.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -147,11 +147,11 @@ s.replace(
 
 s.replace(
     'google-cloud-video_intelligence.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )

--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -142,22 +142,16 @@ s.replace(
     'gem.add_development_dependency "rubocop".*$',
     'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
-# Adds LICENSE to .yardopts
-s.replace(
-    '.yardopts',
-    'README.md',
-    '\n'.join(['README.md', 'LICENSE'])
-)
 
 s.replace(
     'google-cloud-vision.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
 
 # Generate the helper methods

--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -148,5 +148,17 @@ s.replace(
     'README.md',
     '\n'.join(['README.md', 'LICENSE'])
 )
+
+s.replace(
+    'google-cloud-vision.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-webrisk/synth.py
+++ b/google-cloud-webrisk/synth.py
@@ -69,12 +69,6 @@ s.replace(
     'gem.add_development_dependency "rubocop".*$',
     'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
-# Adds LICENSE to .yardopts
-s.replace(
-    '.yardopts',
-    'README.md',
-    '\n'.join(['README.md', 'LICENSE'])
-)
 # Fix product documentation links
 s.replace(
     ['README.md', 'lib/**/*.rb'],
@@ -84,11 +78,11 @@ s.replace(
 
 s.replace(
     'google-cloud-webrisk.gemspec',
-    '"README.md"',
-    '"README.md", "AUTHENTICATION.md"'
+    '"README.md", "LICENSE"',
+    '"README.md", "AUTHENTICATION.md", "LICENSE"'
 )
 s.replace(
     '.yardopts',
-    'README.md',
-    'README.md\nAUTHENTICATION.md'
+    'README.md\n',
+    'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )

--- a/google-cloud-webrisk/synth.py
+++ b/google-cloud-webrisk/synth.py
@@ -81,3 +81,14 @@ s.replace(
     'https://cloud.google.com/webrisk',
     'https://cloud.google.com/web-risk'
 )
+
+s.replace(
+    'google-cloud-webrisk.gemspec',
+    '"README.md"',
+    '"README.md", "AUTHENTICATION.md"'
+)
+s.replace(
+    '.yardopts',
+    'README.md',
+    'README.md\nAUTHENTICATION.md'
+)


### PR DESCRIPTION
Add AUTHENTICATION.md to file lists in *.gemspec and .yardopts

For background, see: googleapis/synthtool#225

[refs #2933]


Example result:

```sh
Chriss-iMac:google-cloud-asset quartzmo$ git diff
diff --git a/google-cloud-asset/.yardopts b/google-cloud-asset/.yardopts
index a221a1518..06724a8d2 100644
--- a/google-cloud-asset/.yardopts
+++ b/google-cloud-asset/.yardopts
@@ -7,3 +7,4 @@
 ./lib/**/*.rb
 -
 README.md
+AUTHENTICATION.md
diff --git a/google-cloud-asset/google-cloud-asset.gemspec b/google-cloud-asset/google-cloud-asset.gemspec
index 679d9ef0e..db09ab793 100644
--- a/google-cloud-asset/google-cloud-asset.gemspec
+++ b/google-cloud-asset/google-cloud-asset.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.platform      = Gem::Platform::RUBY
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +
-                      ["README.md", "LICENSE", ".yardopts"]
+                      ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
   gem.required_ruby_version = ">= 2.0.0"
```