### PR TITLE
Release google-cloud-pubsub 0.35.0

### DIFF
--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Release History
 
+### 0.35.0 / 2019-04-25
+
+* Add Subscription#push_config and Subscription::PushConfig
+* Add Subscription#expires_in
+* Add Topic#reload!
+* Add Subscription#reload!
+* Update low-level generated files  
+  * Add PushConfig#oidc_token
+  * Add ordering_key to PubsubMessage.
+  * Add enable_message_ordering to Subscription.
+  * Extract gRPC header values from request.
+  * Update documentation.
+
 ### 0.34.1 / 2019-02-13
 
 * Fix bug (typo) in retrieving default on_error proc.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module PubSub
-      VERSION = "0.34.1".freeze
+      VERSION = "0.35.0".freeze
     end
 
     Pubsub = PubSub unless const_defined? :Pubsub


### PR DESCRIPTION
* Add Subscription#push_config and Subscription::PushConfig
* Add Subscription#expires_in
* Add Topic#reload!
* Add Subscription#reload!
* Update low-level generated files  
  * Add PushConfig#oidc_token
  * Add ordering_key to PubsubMessage.
  * Add enable_message_ordering to Subscription.
  * Extract gRPC header values from request.
  * Update documentation.

This pull request was generated using releasetool.