### PR TITLE
fix pubsub tests

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -46,7 +46,7 @@ describe Google::Cloud::PubSub, :pubsub do
   describe "Topic", :pubsub do
 
     it "should be listed" do
-      topics = pubsub.topics
+      topics = pubsub.topics.all
       topics.each do |topic|
         topic.must_be_kind_of Google::Cloud::PubSub::Topic
       end
@@ -54,7 +54,7 @@ describe Google::Cloud::PubSub, :pubsub do
     end
 
     it "should return a token if there are more results" do
-      topic_count = pubsub.topics.count
+      topic_count = pubsub.topics.all.count
       topics = pubsub.topics max: (topic_count - 1)
       topics.count.must_equal (topic_count - 1)
       topics.each do |topic|
@@ -115,7 +115,7 @@ describe Google::Cloud::PubSub, :pubsub do
     end
 
     it "should list all subscriptions registered to the topic" do
-      subscriptions = pubsub.subscriptions
+      subscriptions = pubsub.subscriptions.all
       subscriptions.each do |subscription|
         # subscriptions on project are objects...
         subscription.must_be_kind_of Google::Cloud::PubSub::Subscription
@@ -124,7 +124,7 @@ describe Google::Cloud::PubSub, :pubsub do
     end
 
     it "should return a token if there are more results" do
-      sub_count = pubsub.subscriptions.count
+      sub_count = pubsub.subscriptions.all.count
       subscriptions = pubsub.subscriptions max: (sub_count - 1)
       subscriptions.count.must_equal (sub_count - 1)
       subscriptions.each do |subscription|

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
@@ -95,9 +95,9 @@ describe Google::Cloud::PubSub::Subscriber, :acknowledge, :mock_pubsub do
 
     subscriber_retries = 0
     while called < 3
-      fail "total number of calls were never made" if subscriber_retries > 100
+      fail "total number of calls were never made" if subscriber_retries > 200
       subscriber_retries += 1
-      sleep 0.03
+      sleep 0.01
     end
 
     subscriber.stop

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
@@ -89,7 +89,7 @@ describe Google::Cloud::PubSub::Subscriber, :acknowledge, :mock_pubsub do
 
       assert_kind_of Google::Cloud::PubSub::ReceivedMessage, msg
       msg.ack!
-      called +=1
+      called += 1
     end
     subscriber.start
 
@@ -97,7 +97,7 @@ describe Google::Cloud::PubSub::Subscriber, :acknowledge, :mock_pubsub do
     while called < 3
       fail "total number of calls were never made" if subscriber_retries > 100
       subscriber_retries += 1
-      sleep 0.01
+      sleep 0.03
     end
 
     subscriber.stop


### PR DESCRIPTION
* topics and subscriptions both default to 100. Updated acceptance tests to accomodate this.
* Increase subscriber retries for acknowledge_test to reduce flakiness