### PR TITLE
Fix Spanner session limit bug

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -243,7 +243,14 @@ module Google
             @new_sessions_in_process += 1
           end
 
-          session = @client.create_new_session
+          begin
+            session = @client.create_new_session
+          rescue StandardError => e
+            @mutex.synchronize do
+              @new_sessions_in_process -= 1
+            end
+            raise e
+          end
 
           @mutex.synchronize do
             @new_sessions_in_process -= 1

--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -71,7 +71,6 @@ module Google
               return write_transaction.session if write_transaction
 
               if can_allocate_more_sessions?
-                @new_sessions_in_process += 1
                 action = :new
                 break
               end
@@ -127,7 +126,6 @@ module Google
               end
 
               if can_allocate_more_sessions?
-                @new_sessions_in_process += 1
                 action = :new
                 break
               end
@@ -204,7 +202,7 @@ module Google
           # init the thread pool
           @thread_pool = Concurrent::FixedThreadPool.new @threads
           # init the queues
-          @new_sessions_in_process = @min.to_i
+          @new_sessions_in_process = 0
           @all_sessions = []
           @session_queue = []
           @transaction_queue = []
@@ -241,15 +239,17 @@ module Google
         end
 
         def new_session!
+          @mutex.synchronize do
+            @new_sessions_in_process += 1
+          end
+
           session = @client.create_new_session
 
           @mutex.synchronize do
-            # don't add if the pool is closed
-            return session.release! if @closed
-
             @new_sessions_in_process -= 1
             all_sessions << session
           end
+
           session
         end
 

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/new_sessions_in_process_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/new_sessions_in_process_test.rb
@@ -1,0 +1,87 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Pool, :new_sessions_in_process, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let(:client) { spanner.client instance_id, database_id, pool: { min: 0, max: 4 } }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }
+  let(:pool) do
+    session.instance_variable_set :@last_updated_at, Time.now
+    p = client.instance_variable_get :@pool
+    p.all_sessions = [session]
+    p.session_queue = [session]
+    p.transaction_queue = []
+    p
+  end
+
+  after do
+    shutdown_client! client
+  end
+
+  it "does not increment new_sessions_in_process when create_session raises an error" do
+    stub = Object.new
+    def stub.create_session *args
+      gax_error = Google::Gax::GaxError.new "sumthin happen"
+      gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(11, "sumthin happen")
+      raise gax_error
+    end
+    spanner.service.mocked_service = stub
+
+    pool.all_sessions.size.must_equal 1
+    pool.session_queue.size.must_equal 1
+    pool.instance_variable_get(:@new_sessions_in_process).must_equal 0
+
+    s1 = pool.checkout_session # gets the one session from the queue
+
+    pool.all_sessions.size.must_equal 1
+    pool.session_queue.size.must_equal 0
+    pool.instance_variable_get(:@new_sessions_in_process).must_equal 0
+
+    raised_error = assert_raises Google::Cloud::Error do
+      pool.checkout_session
+    end
+    raised_error.message.must_equal "11:sumthin happen"
+
+    pool.all_sessions.size.must_equal 1
+    pool.session_queue.size.must_equal 0
+    pool.instance_variable_get(:@new_sessions_in_process).must_equal 0
+
+    10.times do
+      raised_error = assert_raises Google::Cloud::Error do
+        pool.checkout_session
+      end
+      raised_error.message.must_equal "11:sumthin happen"
+    end
+
+    pool.all_sessions.size.must_equal 1
+    pool.session_queue.size.must_equal 0
+    pool.instance_variable_get(:@new_sessions_in_process).must_equal 0
+
+    pool.checkin_session s1
+
+    shutdown_pool! pool
+
+    pool.all_sessions.size.must_equal 1
+    pool.session_queue.size.must_equal 1
+    pool.instance_variable_get(:@new_sessions_in_process).must_equal 0
+  end
+end


### PR DESCRIPTION
As reported in #3243, it is possible for the client to get into a bad state when errors are raised in the API call to create a new session, and handled outside of the client. If this happens too often, then the client will no longer allow new sessions to be created and raise `SessionLimitError`.

This PR attempts to solve this by decrementing the count when an error is raised.

[fixes #3243]