### PR TITLE
Release google-cloud-bigquery-data_transfer 0.2.4

### DIFF
--- a/google-cloud-bigquery-data_transfer/CHANGELOG.md
+++ b/google-cloud-bigquery-data_transfer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 0.2.4 / 2019-04-29
+
+* Add AUTHENTICATION.md guide.
+* Update generated documentation.
+* Update generated code examples.
+* Extract gRPC header values from request.
+
 ### 0.2.3 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec
+++ b/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-bigquery-data_transfer"
-  gem.version       = "0.2.3"
+  gem.version       = "0.2.4"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Add AUTHENTICATION.md guide.
* Update generated documentation.
* Update generated code examples.
* Extract gRPC header values from request.

This pull request was generated using releasetool.