### PR TITLE
Release google-cloud-datastore 1.5.2

### DIFF
--- a/google-cloud-datastore/CHANGELOG.md
+++ b/google-cloud-datastore/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 1.5.2 / 2019-04-29
+
+* Add AUTHENTICATION.md guide.
+* Update generated documentation.
+* Extract gRPC header values from request.
+
 ### 1.5.1 / 2019-02-13
 
 * Add `ReadOnlyTransaction` convenience methods:

--- a/google-cloud-datastore/lib/google/cloud/datastore/version.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Datastore
-      VERSION = "1.5.1".freeze
+      VERSION = "1.5.2".freeze
     end
   end
 end


### PR DESCRIPTION
* Add AUTHENTICATION.md guide.
* Update generated documentation.
* Extract gRPC header values from request.

This pull request was generated using releasetool.