### PR TITLE
Release google-cloud-error_reporting 0.31.4

### DIFF
--- a/google-cloud-error_reporting/CHANGELOG.md
+++ b/google-cloud-error_reporting/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 0.31.4 / 2019-04-29
+
+* Add AUTHENTICATION.md guide.
+* Update documentation for common types.
+* Update generated code examples.
+* Extract gRPC header values from request.
+
 ### 0.31.3 / 2019-02-13
 
 * Fix bug (typo) in retrieving default on_error proc.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module ErrorReporting
-      VERSION = "0.31.3".freeze
+      VERSION = "0.31.4".freeze
     end
   end
 end


### PR DESCRIPTION
* Add AUTHENTICATION.md guide.
* Update documentation for common types.
* Update generated code examples.
* Extract gRPC header values from request.

This pull request was generated using releasetool.