### PR TITLE
Release google-cloud-redis 0.3.0

### DIFF
--- a/google-cloud-redis/CHANGELOG.md
+++ b/google-cloud-redis/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+### 0.3.0 / 2019-04-29
+
+* Add Instance#persistence_iam_identity attribute.
+* Add CloudRedisClient#import_instance.
+* Add CloudRedisClient#export_instance.
+* Add CloudRedisClient#failover_instance.
+* Add ListInstancesResponse#unreachable.
+* Add AUTHENTICATION.md guide.
+* Update generated documentation for common types.
+* Update generated documentation.
+* Extract gRPC header values from request.
+
 ### 0.2.3 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-redis/CHANGELOG.md
+++ b/google-cloud-redis/CHANGELOG.md
@@ -3,8 +3,6 @@
 ### 0.3.0 / 2019-04-29
 
 * Add Instance#persistence_iam_identity attribute.
-* Add CloudRedisClient#import_instance.
-* Add CloudRedisClient#export_instance.
 * Add CloudRedisClient#failover_instance.
 * Add ListInstancesResponse#unreachable.
 * Add AUTHENTICATION.md guide.

--- a/google-cloud-redis/google-cloud-redis.gemspec
+++ b/google-cloud-redis/google-cloud-redis.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-redis"
-  gem.version       = "0.2.3"
+  gem.version       = "0.3.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Add Instance#persistence_iam_identity attribute.
* Add CloudRedisClient#failover_instance.
* Add ListInstancesResponse#unreachable.
* Add AUTHENTICATION.md guide.
* Update generated documentation for common types.
* Update generated documentation.
* Extract gRPC header values from request.

This pull request was generated using releasetool.