### PR TITLE
Release google-cloud-security_center 0.1.1

### DIFF
--- a/google-cloud-security_center/CHANGELOG.md
+++ b/google-cloud-security_center/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.1.1 / 2019-04-29
+
+* Add AUTHENTICATION.md guide.
+
 ### 0.1.0 / 2019-04-25
 
 * Initial release.

--- a/google-cloud-security_center/google-cloud-security_center.gemspec
+++ b/google-cloud-security_center/google-cloud-security_center.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-security_center"
-  gem.version       = "0.1.0"
+  gem.version       = "0.1.1"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Add AUTHENTICATION.md guide.

This pull request was generated using releasetool.