### PR TITLE
Release google-cloud-storage 1.18.1

### DIFF
--- a/google-cloud-storage/CHANGELOG.md
+++ b/google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.18.1 / 2019-04-29
+
+* Update Storage Bucket Policy Only documentation.
+
 ### 1.18.0 / 2019-04-09
 
 * Add support for V4 signed URLs.

--- a/google-cloud-storage/lib/google/cloud/storage/version.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Storage
-      VERSION = "1.18.0".freeze
+      VERSION = "1.18.1".freeze
     end
   end
 end


### PR DESCRIPTION
* Update Storage Bucket Policy Only documentation.

This pull request was generated using releasetool.