### PR TITLE
Release google-cloud-trace 0.34.2

### DIFF
--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 0.34.2 / 2019-04-29
+
+* Add AUTHENTICATION.md guide.
+* Update generated documentation.
+* Update generated code examples.
+* Extract gRPC header values from request.
+
 ### 0.34.1 / 2019-02-13
 
 * Fix bug (typo) in retrieving default on_error proc.

--- a/google-cloud-trace/lib/google/cloud/trace/version.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Trace
-      VERSION = "0.34.1".freeze
+      VERSION = "0.34.2".freeze
     end
   end
 end


### PR DESCRIPTION
* Add AUTHENTICATION.md guide.
* Update generated documentation.
* Update generated code examples.
* Extract gRPC header values from request.

This pull request was generated using releasetool.