### PR TITLE
Release google-cloud-spanner 1.9.1

### DIFF
--- a/google-cloud-spanner/CHANGELOG.md
+++ b/google-cloud-spanner/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+### 1.9.1 / 2019-04-30
+
+* Fix Spanner session limit bug.
+* Update AUTHENTICATION.md guide.
+* Update documentation for common types.
+* Update generated documentation.
+* Extract gRPC header values from request.
+
 ### 1.9.0 / 2019-03-08
 
 * Spanner Batch DML.

--- a/google-cloud-spanner/lib/google/cloud/spanner/version.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Spanner
-      VERSION = "1.9.0".freeze
+      VERSION = "1.9.1".freeze
     end
   end
 end


### PR DESCRIPTION
* Fix Spanner session limit bug.
* Update AUTHENTICATION.md guide.
* Update documentation for common types.
* Update generated documentation.
* Extract gRPC header values from request.

This pull request was generated using releasetool.