### PR TITLE
Fix errors in bigtable code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,9 @@ entry = table.new_mutation_entry("user-1")
 entry.set_cell(
   "cf-1",
   "field-1",
-  "XYZ"
+  "XYZ",
   timestamp: Time.now.to_i * 1000 # Time stamp in milli seconds.
-).delete_from_column("cf2", "field02")
+).delete_cells("cf2", "field02")
 
 table.mutate_row(entry)
 ```

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
@@ -485,9 +485,9 @@ module Google
         #   entry.set_cell(
         #     "cf-1",
         #     "field-1",
-        #     "XYZ"
+        #     "XYZ",
         #     timestamp: Time.now.to_i * 1000 # Time stamp in milli seconds.
-        #   ).delete_from_column("cf2", "field02")
+        #   ).delete_cells("cf2", "field02")
         #
         #   table.mutate_row(entry)
         #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
@@ -96,7 +96,7 @@ module Google
         #   entry.set_cell(
         #     "cf-1",
         #     "field-1",
-        #     "XYZ"
+        #     "XYZ",
         #     timestamp: Time.now.to_i * 1000 # Time stamp in millis seconds.
         #   )
         #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
@@ -66,9 +66,9 @@ module Google
         #   entry.set_cell(
         #     "cf-1",
         #     "field-1",
-        #     "XYZ"
+        #     "XYZ",
         #     timestamp: Time.now.to_i * 1000 # Time stamp in milli seconds.
-        #   ).delete_from_column("cf2", "field02")
+        #   ).delete_cells("cf2", "field02")
         #
         #   table.mutate_row(entry)
         #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
@@ -217,7 +217,7 @@ module Google
         #     "field-1",
         #     "XYZ",
         #     timestamp: Time.now.to_i * 1000 # Time stamp in micro seconds.
-        #   ).delete_from_column("cf2", "field02")
+        #   ).delete_cells("cf2", "field02")
         #
         #   otherwise_mutations = Google::Cloud::Bigtable::MutationEntry.new
         #   otherwise_mutations.delete_from_family("cf3")

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
@@ -359,9 +359,9 @@ module Google
         #   entry.set_cell(
         #     "cf-1",
         #     "field-1",
-        #     "XYZ"
+        #     "XYZ",
         #     timestamp: Time.now.to_i * 1000  # Timestamp in milliseconds.
-        #   ).delete_from_column("cf2", "field02")
+        #   ).delete_cells("cf2", "field02")
         #
         #   table.mutate_row(entry)
         # @example Read rows using app profile routing


### PR DESCRIPTION
The code samples for cloud bigtable have a couple of errors:
1. There is a missing comma
2. `entry` is a `Google::Cloud::Bigtable::MutationEntry` not a
`Google::Bigtable::V2::Mutation` and such does not have a method
`delete_from_column` I've changed this to `delete_cells` so the code has the same
gist but is functional :)