### PR TITLE
Release google-cloud-security_center 0.2.0

### DIFF
--- a/google-cloud-security_center/CHANGELOG.md
+++ b/google-cloud-security_center/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 0.2.0 / 2019-05-03
+
+* Update SecurityCenterClient#run_asset_discovery response value.
+  * The long running Operation response type has been updated to
+    RunAssetDiscoveryResponse instead of Google::Protobuf::Empty.
+* Add RunAssetDiscoveryResponse.
+
 ### 0.1.1 / 2019-04-29
 
 * Add AUTHENTICATION.md guide.

--- a/google-cloud-security_center/CHANGELOG.md
+++ b/google-cloud-security_center/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-### 0.2.0 / 2019-05-03
+### 0.2.0 / 2019-05-06
 
 * Update SecurityCenterClient#run_asset_discovery response value.
   * The long running Operation response type has been updated to

--- a/google-cloud-security_center/google-cloud-security_center.gemspec
+++ b/google-cloud-security_center/google-cloud-security_center.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-security_center"
-  gem.version       = "0.1.1"
+  gem.version       = "0.2.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Update SecurityCenterClient#run_asset_discovery response value.
  * The long running Operation response type has been updated to
    RunAssetDiscoveryResponse instead of Google::Protobuf::Empty.
* Add RunAssetDiscoveryResponse.

<details><summary>Commits since previous release</summary><pre><code>commit 6788ff8d83a601925f6545d61d6c0f07e62b8846
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Fri May 3 10:46:31 2019 -0700

    Update generated google-cloud-security_center files (#3283)
    
    * Update SecurityCenterClient#run_asset_discovery response value.
      * The long running Operation response type has been updated to
        RunAssetDiscoveryResponse instead of Google::Protobuf::Empty.

commit 40b3c6c754bfb9c2da46a17179c168647643d2fd
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Wed May 1 11:41:31 2019 -0700

    Update generated google-cloud-security_center files (#3277)
    
    * Add RunAssetDiscoveryResponse.
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-security_center/lib/google/cloud/security_center/v1.rb b/google-cloud-security_center/lib/google/cloud/security_center/v1.rb
index 89fc10473..91544c929 100644
--- a/google-cloud-security_center/lib/google/cloud/security_center/v1.rb
+++ b/google-cloud-security_center/lib/google/cloud/security_center/v1.rb
@@ -15,6 +15,7 @@
 
 require "google/cloud/security_center/v1/security_center_client"
 require "google/cloud/security_center/v1/helpers"
+require "google/cloud/security_center/v1/run_asset_discovery_response_pb"
 
 module Google
   module Cloud
diff --git a/google-cloud-security_center/lib/google/cloud/security_center/v1/run_asset_discovery_response_pb.rb b/google-cloud-security_center/lib/google/cloud/security_center/v1/run_asset_discovery_response_pb.rb
new file mode 100644
index 000000000..e5da384b2
--- /dev/null
+++ b/google-cloud-security_center/lib/google/cloud/security_center/v1/run_asset_discovery_response_pb.rb
@@ -0,0 +1,26 @@
+# Generated by the protocol buffer compiler.  DO NOT EDIT!
+# source: google/cloud/security_center/v1/run_asset_discovery_response.proto
+
+
+require 'google/protobuf'
+
+require 'google/protobuf/duration_pb'
+require 'google/protobuf/timestamp_pb'
+require 'google/api/annotations_pb'
+Google::Protobuf::DescriptorPool.generated_pool.build do
+  add_message "google.cloud.securitycenter.v1.RunAssetDiscoveryResponse" do
+    optional :state, :enum, 1, "google.cloud.securitycenter.v1.RunAssetDiscoveryResponse.State"
+    optional :duration, :message, 2, "google.protobuf.Duration"
+  end
+  add_enum "google.cloud.securitycenter.v1.RunAssetDiscoveryResponse.State" do
+    value :STATE_UNSPECIFIED, 0
+    value :COMPLETED, 1
+    value :SUPERSEDED, 2
+    value :TERMINATED, 3
+  end
+end
+
+module Google::Cloud::SecurityCenter::V1
+  RunAssetDiscoveryResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.securitycenter.v1.RunAssetDiscoveryResponse").msgclass
+  RunAssetDiscoveryResponse::State = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.securitycenter.v1.RunAssetDiscoveryResponse.State").enummodule
+end
diff --git a/google-cloud-security_center/lib/google/cloud/security_center/v1/security_center_client.rb b/google-cloud-security_center/lib/google/cloud/security_center/v1/security_center_client.rb
index e84059a4b..d8b04a3f1 100644
--- a/google-cloud-security_center/lib/google/cloud/security_center/v1/security_center_client.rb
+++ b/google-cloud-security_center/lib/google/cloud/security_center/v1/security_center_client.rb
@@ -1435,7 +1435,7 @@ module Google
             operation = Google::Gax::Operation.new(
               @run_asset_discovery.call(req, options),
               @operations_client,
-              Google::Protobuf::Empty,
+              Google::Cloud::SecurityCenter::V1::RunAssetDiscoveryResponse,
               Google::Protobuf::Empty,
               call_options: options
             )
diff --git a/google-cloud-security_center/synth.metadata b/google-cloud-security_center/synth.metadata
index 7b9246c76..9f87c87c2 100644
--- a/google-cloud-security_center/synth.metadata
+++ b/google-cloud-security_center/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-04-27T10:45:20.197845Z",
+  "updateTime": "2019-05-03T10:41:19.156510Z",
   "sources": [
     {
       "generator": {
@@ -12,15 +12,15 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "808110e242c682d7ac2bab6d9c49fc3bf72d7604",
-        "internalRef": "245313728"
+        "sha": "fe77c6737fda6d3c43cc4666aff7d27be61fbfb6",
+        "internalRef": "246437748"
       }
     },
     {
       "template": {
         "name": "ruby_library",
         "origin": "synthtool.gcp",
-        "version": "2019.4.10"
+        "version": "2019.5.2"
       }
     }
   ],
diff --git a/google-cloud-security_center/test/google/cloud/security_center/v1/security_center_client_test.rb b/google-cloud-security_center/test/google/cloud/security_center/v1/security_center_client_test.rb
index 79d9251e0..e93cd370f 100644
--- a/google-cloud-security_center/test/google/cloud/security_center/v1/security_center_client_test.rb
+++ b/google-cloud-security_center/test/google/cloud/security_center/v1/security_center_client_test.rb
@@ -883,7 +883,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax::to_proto(expected_response, Google::Protobuf::Empty)
+      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::SecurityCenter::V1::RunAssetDiscoveryResponse)
       result = Google::Protobuf::Any.new
       result.pack(expected_response)
       operation = Google::Longrunning::Operation.new(

```

</details>

This pull request was generated using releasetool.