### PR TITLE
Allow floats in Google::Cloud::Trace::Utils.time_to_grpc

### DIFF
--- a/google-cloud-trace/lib/google/cloud/trace/utils.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/utils.rb
@@ -30,20 +30,14 @@ module Google
         def self.time_to_grpc time
           return nil if time.nil?
 
-          # This is called with different types of objects. Extract
-          # the nanoseconds appropriately.
-          nanos = case
-                  when time.is_a?(Time)
-                    time.nsec
-                  when time.is_a?(Float)
-                    # Float only appear to have 6 digits of precision. Toss the rest. :shrug:
-                    (time.modulo(1) * 1_000_000).truncate * 1_000
-                  else
-                    0
-                  end
+          # sometimes this gets called with time as a float or
+          # int. Coerce into a time object, and move on.
+          time = Time.at(time) if time.is_a? Numeric
+
+          raise ArgumentError unless time.is_a? Time
 
           Google::Protobuf::Timestamp.new seconds: time.to_i,
-                                          nanos: nanos
+                                          nanos: time.nsec
         end
 
         ##

--- a/google-cloud-trace/lib/google/cloud/trace/utils.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/utils.rb
@@ -32,7 +32,6 @@ module Google
 
           # This is called with different types of objects. Extract
           # the nanoseconds appropriately.
-          puts "SEPH: ", time.class, time
           nanos = case
                   when time.is_a?(Time)
                     time.nsec

--- a/google-cloud-trace/lib/google/cloud/trace/utils.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/utils.rb
@@ -29,8 +29,21 @@ module Google
         #
         def self.time_to_grpc time
           return nil if time.nil?
+
+          # This is called with different types of objects. Extract
+          # the nanoseconds appropriately.
+          nanos = case time.class
+                  when Time
+                    time.nsec
+                  when Float
+                    # Float only appear to have 6 digits of precision. Toss the rest. :shrug:
+                    (time.modulo(1) * 1_000_000).truncate * 1_000
+                  else
+                    0
+                  end
+
           Google::Protobuf::Timestamp.new seconds: time.to_i,
-                                          nanos: time.nsec
+                                          nanos: nanos
         end
 
         ##

--- a/google-cloud-trace/lib/google/cloud/trace/utils.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/utils.rb
@@ -32,10 +32,11 @@ module Google
 
           # This is called with different types of objects. Extract
           # the nanoseconds appropriately.
-          nanos = case time.class
-                  when Time
+          puts "SEPH: ", time.class, time
+          nanos = case
+                  when time.is_a?(Time)
                     time.nsec
-                  when Float
+                  when time.is_a?(Float)
                     # Float only appear to have 6 digits of precision. Toss the rest. :shrug:
                     (time.modulo(1) * 1_000_000).truncate * 1_000
                   else

--- a/google-cloud-trace/test/google/cloud/trace/utils_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/utils_test.rb
@@ -20,6 +20,10 @@ describe Google::Cloud::Trace::Utils do
   let(:time_proto) {
     Google::Protobuf::Timestamp.new seconds: secs, nanos: nsecs
   }
+  let(:time_proto_truncated) {
+    Google::Protobuf::Timestamp.new seconds: secs, nanos: 1000 * (nsecs / 1000)
+  }
+
   let(:time_obj) {
     Time.at(secs, Rational(nsecs, 1000))
   }
@@ -27,6 +31,12 @@ describe Google::Cloud::Trace::Utils do
   it "converts time objects to proto objects" do
     Google::Cloud::Trace::Utils.time_to_grpc(time_obj).must_equal time_proto
   end
+
+  it "converts float objects to proto objects" do
+    Google::Cloud::Trace::Utils.time_to_grpc(secs + nsecs.to_f / 1000000000).must_equal time_proto_truncated
+  end
+
+
 
   it "converts proto objects to time objects" do
     Google::Cloud::Trace::Utils.grpc_to_time(time_proto).must_equal time_obj


### PR DESCRIPTION
Allow floats to be passed into spans.

Fixes: https://github.com/googleapis/google-cloud-ruby/issues/3299