### PR TITLE
Fix trace test

### DIFF
--- a/google-cloud-trace/test/google/cloud/trace/utils_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/utils_test.rb
@@ -39,7 +39,7 @@ describe Google::Cloud::Trace::Utils do
     # Float math is imprecise, so we're faking a sorta-equal
     result = Google::Cloud::Trace::Utils.time_to_grpc(time_float)
     result.seconds.must_equal secs
-    result.nanos.truncate(-3).must_equal nsecs.truncate(-3)
+    result.nanos.must_be_close_to nsecs, 1000
   end
 
   it "converts int objects to proto objects" do


### PR DESCRIPTION
The test was failing on Ruby 2.3, due to how truncate was used.
ArgumentError: wrong number of arguments (given 1, expected 0)

[fixes #3333]