### PR TITLE
Add mime types dependency

### DIFF
--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-api-client", "~> 0.23"
   gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
+  gem.add_dependency "mime-types", "~> 3.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
   gem.add_dependency "digest-crc", "~> 0.4"
   gem.add_dependency "addressable", "~> 2.5"
+  gem.add_dependency "mime-types", "~> 3.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"


### PR DESCRIPTION
Add an explicit dependency to the gems that use `MIME::Types`:

- [x] BigQuery
- [x] Storage