### PR TITLE
Release google-cloud-talent 0.3.0

### DIFF
--- a/google-cloud-talent/CHANGELOG.md
+++ b/google-cloud-talent/CHANGELOG.md
@@ -7,8 +7,7 @@
 * Remove Profile#resume_hrxml (Breaking change)
 * Add PersonStructuredName#preferred_name
 * Add Tenant#keyword_searchable_profile_custom_attributes
-* Update error retry configuration.
-* Update generated documentation.
+* Update generated documentation
 
 ### 0.2.0 / 2019-04-29
 

--- a/google-cloud-talent/CHANGELOG.md
+++ b/google-cloud-talent/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+### 0.3.0 / 2019-05-10
+
+* Add Resume resource
+* Add Profile#resume
+* Remove Profile#resume_hrxml (Breaking change)
+* Add PersonStructuredName#preferred_name
+* Add Tenant#keyword_searchable_profile_custom_attributes
+* Update error retry configuration.
+* Update generated documentation.
+
 ### 0.2.0 / 2019-04-29
 
 This is a breaking change.

--- a/google-cloud-talent/CHANGELOG.md
+++ b/google-cloud-talent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 0.3.0 / 2019-05-10
 
+This is a breaking change.
+
 * Add Resume resource
 * Add Profile#resume
 * Remove Profile#resume_hrxml (Breaking change)

--- a/google-cloud-talent/google-cloud-talent.gemspec
+++ b/google-cloud-talent/google-cloud-talent.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-talent"
-  gem.version       = "0.2.0"
+  gem.version       = "0.3.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
* Add Resume resource
* Add Profile#resume
* Remove Profile#resume_hrxml (Breaking change)
* Add PersonStructuredName#preferred_name
* Add Tenant#keyword_searchable_profile_custom_attributes
* Update error retry configuration.
* Update generated documentation.

<details><summary>Commits since previous release</summary><pre><code>commit 4d01f136bdcf6699e5511152adbf4ef248a4f531
Author: Graham Paye <paye@google.com>
Date:   Thu May 9 18:17:11 2019 -0700

    add DEADLINE_EXCEEDED to retry codes (#3349)

commit bc5675f33974a7f21e6ff358de452265729db694
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Wed May 8 11:37:01 2019 -0700

    Re-generate google-cloud-talent files (#3326)
    
    * Add Resume resource
    * Add Profile#resume
    * Remove Profile#resume_hrxml (Breaking change)
    * Add PersonStructuredName#preferred_name
    * Add Tenant#keyword_searchable_profile_custom_attributes
    * Update error retry configuration.
    * Update generated documentation.
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/application.rb b/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/application.rb
index a6de965d4..6222c5a2f 100644
--- a/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/application.rb
+++ b/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/application.rb
@@ -33,14 +33,12 @@ module Google
         #     Required.
         #
         #     Client side application identifier, used to uniquely identify the
-        #     recruiter.
+        #     application.
         #
         #     The maximum number of allowed characters is 255.
         # @!attribute [rw] profile
         #   @return [String]
-        #     Required.
-        #
-        #     Resource name of the candidate of this application.
+        #     Output only. Resource name of the candidate of this application.
         #
         #     The format is
         #     "projects/{project_id}/tenants/{tenant_id}/profiles/{profile_id}",
diff --git a/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/common.rb b/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/common.rb
index 37ae09bd1..0610982fd 100644
--- a/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/common.rb
+++ b/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/common.rb
@@ -26,9 +26,8 @@ module Google
         #     End of the period (exclusive).
         class TimestampRange; end
 
-        # Output only.
-        #
-        # A resource that represents a location with full geographic information.
+        # Output only. A resource that represents a location with full geographic
+        # information.
         # @!attribute [rw] location_type
         #   @return [Google::Cloud::Talent::V4beta1::Location::LocationType]
         #     The type of a location, which corresponds to the address lines field of
@@ -159,9 +158,8 @@ module Google
         #     service.
         class RequestMetadata; end
 
-        # Output only.
-        #
-        # Additional information returned to client, such as debugging information.
+        # Output only. Additional information returned to client, such as debugging
+        # information.
         # @!attribute [rw] request_id
         #   @return [String]
         #     A unique id associated with this call.
@@ -244,9 +242,7 @@ module Google
         #     Default is false.
         class CustomAttribute; end
 
-        # Output only.
-        #
-        # Spell check result.
+        # Output only. Spell check result.
         # @!attribute [rw] corrected
         #   @return [true, false]
         #     Indicates if the query was corrected by the spell checker.
diff --git a/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/filters.rb b/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/filters.rb
index c233a7cfb..44fe64fb5 100644
--- a/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/filters.rb
+++ b/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/filters.rb
@@ -183,7 +183,7 @@ module Google
         #
         #     This filter specifies a list of job names to be excluded during search.
         #
-        #     At most 200 excluded job names are allowed.
+        #     At most 400 excluded job names are allowed.
         class JobQuery; end
 
         # Filters to apply when performing the search query.
diff --git a/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/profile.rb b/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/profile.rb
index 6d250bbda..ec3147d4d 100644
--- a/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/profile.rb
+++ b/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/profile.rb
@@ -60,10 +60,8 @@ module Google
         #     The cluster id of the profile to associate with other profile(s) for the
         #     same candidate.
         #
-        #     A random UUID is assigned if {Google::Cloud::Talent::V4beta1::Profile#group_id group_id} isn't provided. To ensure
-        #     global uniqueness, customized {Google::Cloud::Talent::V4beta1::Profile#group_id group_id} isn't supported. If
-        #     {Google::Cloud::Talent::V4beta1::Profile#group_id group_id} is set, there must be at least one other profile with the
-        #     same system generated {Google::Cloud::Talent::V4beta1::Profile#group_id group_id}, otherwise an error is thrown.
+        #     This field should be generated by the customer. If a value is not provided,
+        #     a random UUI is assigned to this field of the profile.
         #
         #     This is used to link multiple profiles to the same candidate. For example,
         #     a client has a candidate with two profiles, where one was created recently
@@ -86,23 +84,11 @@ module Google
         #     Optional.
         #
         #     The timestamp when the profile was last updated at this source.
-        # @!attribute [rw] resume_hrxml
-        #   @return [String]
+        # @!attribute [rw] resume
+        #   @return [Google::Cloud::Talent::V4beta1::Resume]
         #     Optional.
         #
-        #     The profile contents in HR-XML format.
-        #     See http://schemas.liquid-technologies.com/hr-xml/2007-04-15/ for more
-        #     information about Human Resources XML.
-        #
-        #     Users can create a profile with only {Google::Cloud::Talent::V4beta1::Profile#resume_hrxml resume_hrxml} field. For example,
-        #     the API parses the {Google::Cloud::Talent::V4beta1::Profile#resume_hrxml resume_hrxml} and creates a profile with all
-        #     structured fields populated, for example. {Google::Cloud::Talent::V4beta1::EmploymentRecord EmploymentRecord},
-        #     {Google::Cloud::Talent::V4beta1::EducationRecord EducationRecord}, and so on. An error is thrown if the {Google::Cloud::Talent::V4beta1::Profile#resume_hrxml resume_hrxml}
-        #     can't be parsed.
-        #
-        #     If the {Google::Cloud::Talent::V4beta1::Profile#resume_hrxml resume_hrxml} is provided during profile creation or update,
-        #     any other structured data provided in the profile is ignored. The
-        #     API populates these fields by parsing the HR-XML.
+        #     The resume representing this profile.
         # @!attribute [rw] person_names
         #   @return [Array<Google::Cloud::Talent::V4beta1::PersonName>]
         #     Optional.
@@ -227,9 +213,44 @@ module Google
         # @!attribute [rw] keyword_snippet
         #   @return [String]
         #     Output only. Keyword snippet shows how the search result is related to a
-        #     search query.
+        #     search query.  This is only returned in {Google::Cloud::Talent::V4beta1::SearchProfilesResponse SearchProfilesResponse}.
         class Profile; end
 
+        # Resource that represents a resume.
+        # @!attribute [rw] structured_resume
+        #   @return [String]
+        #     Optional.
+        #
+        #     Users can create a profile with only this field field, if {Google::Cloud::Talent::V4beta1::Resume#resume_type resume_type}
+        #     is {HRXML}. For example, the API parses this field and creates a profile
+        #     with all structured fields populated, for example. {Google::Cloud::Talent::V4beta1::EmploymentRecord EmploymentRecord},
+        #     {Google::Cloud::Talent::V4beta1::EducationRecord EducationRecord}, and so on. An error is thrown if this field cannot be
+        #     parsed.
+        #
+        #     If this field is provided during profile creation or update,
+        #     any other structured data provided in the profile is ignored. The
+        #     API populates these fields by parsing this field.
+        # @!attribute [rw] resume_type
+        #   @return [Google::Cloud::Talent::V4beta1::Resume::ResumeType]
+        #     Optional.
+        #
+        #     The format of {Google::Cloud::Talent::V4beta1::Resume#structured_resume structured_resume}.
+        class Resume
+          # The format of a structured resume.
+          module ResumeType
+            # Default value.
+            RESUME_TYPE_UNSPECIFIED = 0
+
+            # The profile contents in HR-XML format.
+            # See http://schemas.liquid-technologies.com/hr-xml/2007-04-15/ for more
+            # information about Human Resources XML.
+            HRXML = 1
+
+            # Resume type not specified.
+            OTHER_RESUME_TYPE = 2
+          end
+        end
+
         # Resource that represents the name of a person.
         # @!attribute [rw] formatted_name
         #   @return [String]
@@ -248,7 +269,10 @@ module Google
         #   @return [String]
         #     Optional.
         #
-        #     Preferred name for the person.
+        #     Preferred name for the person. This field is ignored if {Google::Cloud::Talent::V4beta1::PersonName#structured_name structured_name}
+        #     is provided.
+        #
+        #     Number of characters allowed is 100.
         class PersonName
           # Resource that represents a person's structured name.
           # @!attribute [rw] given_name
@@ -260,6 +284,13 @@ module Google
           #     It's derived from {Google::Cloud::Talent::V4beta1::PersonName#formatted_name formatted_name} if not provided.
           #
           #     Number of characters allowed is 100.
+          # @!attribute [rw] preferred_name
+          #   @return [String]
+          #     Optional.
+          #
+          #     Preferred given/first name or nickname.
+          #
+          #     Number of characters allowed is 100.
           # @!attribute [rw] middle_initial
           #   @return [String]
           #     Optional.
@@ -451,19 +482,6 @@ module Google
         #     Optional.
         #
         #     Start date of the employment.
-        #
-        #     It can be a partial date (only year, or only year and month), but must be
-        #     valid. Otherwise an error is thrown.
-        #
-        #     Examples:
-        #     {"year": 2017, "month": 2, "day": 28} is valid.
-        #     {"year": 2020, "month": 1, "date": 31} is valid.
-        #     {"year": 2018, "month": 12} is valid (partial date).
-        #     {"year": 2018} is valid (partial date).
-        #     {"year": 2015, "day": 21} is not valid (month is missing but day is
-        #     presented).
-        #     {"year": 2018, "month": 13} is not valid (invalid month).
-        #     {"year": 2017, "month": 1, "day": 32} is not valid (invalid day).
         # @!attribute [rw] end_date
         #   @return [Google::Type::Date]
         #     Optional.
diff --git a/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/profile_service.rb b/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/profile_service.rb
index 4b8711117..4321a98dc 100644
--- a/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/profile_service.rb
+++ b/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/profile_service.rb
@@ -296,15 +296,9 @@ module Google
         #     * application_outcome_notes: The application outcome reason specifies the
         #       reasons behind the outcome of the job application.
         #       See {Google::Cloud::Talent::V4beta1::ApplicationOutcomeNotesFilter ApplicationOutcomeNotesFilter} for more details.
-        #     * application_last_stage: The application last stage specifies the last
-        #       stage of job application.
-        #       See {ApplicationLastStageFilter} for more details.
         #     * application_job_title: The application job title specifies the job
         #       applied for in the application.
         #       See {Google::Cloud::Talent::V4beta1::ApplicationJobFilter ApplicationJobFilter} for more details.
-        #     * application_status: The application status specifies the status of job
-        #       application.
-        #       See {ApplicationStatusFilter} for more details.
         #     * hirable_status: Hirable status specifies the profile's hirable status.
         #     * string_custom_attribute: String custom attributes. Values can be accessed
         #       via square bracket notation like string_custom_attribute["key1"].
diff --git a/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/tenant.rb b/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/tenant.rb
index 432da4ab8..df079e08e 100644
--- a/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/tenant.rb
+++ b/google-cloud-talent/lib/google/cloud/talent/v4beta1/doc/google/cloud/talent/v4beta1/tenant.rb
@@ -45,6 +45,16 @@ module Google
         #     improvements across other tenants.
         #
         #     Defaults behavior is {Google::Cloud::Talent::V4beta1::Tenant::DataUsageType::ISOLATED DataUsageType::ISOLATED} if it's unset.
+        # @!attribute [rw] keyword_searchable_profile_custom_attributes
+        #   @return [Array<String>]
+        #     Optional.
+        #
+        #     A list of keys of filterable {Google::Cloud::Talent::V4beta1::Profile#custom_attributes Profile#custom_attributes}, whose
+        #     corresponding `string_values` are used in keyword searches. Profiles with
+        #     `string_values` under these specified field keys are returned if any
+        #     of the values match the search keyword. Custom field values with
+        #     parenthesis, brackets and special symbols are not searchable as-is,
+        #     and must be surrounded by quotes.
         class Tenant
           # Enum that represents how user data owned by the tenant is used.
           module DataUsageType
diff --git a/google-cloud-talent/lib/google/cloud/talent/v4beta1/job_pb.rb b/google-cloud-talent/lib/google/cloud/talent/v4beta1/job_pb.rb
index d2b2e7a76..1f13f9d52 100644
--- a/google-cloud-talent/lib/google/cloud/talent/v4beta1/job_pb.rb
+++ b/google-cloud-talent/lib/google/cloud/talent/v4beta1/job_pb.rb
@@ -7,6 +7,7 @@ require 'google/protobuf'
 require 'google/cloud/talent/v4beta1/common_pb'
 require 'google/protobuf/timestamp_pb'
 require 'google/protobuf/wrappers_pb'
+require 'google/type/postal_address_pb'
 require 'google/api/annotations_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.talent.v4beta1.Job" do
diff --git a/google-cloud-talent/lib/google/cloud/talent/v4beta1/profile_pb.rb b/google-cloud-talent/lib/google/cloud/talent/v4beta1/profile_pb.rb
index 6c624587d..dda6b5d90 100644
--- a/google-cloud-talent/lib/google/cloud/talent/v4beta1/profile_pb.rb
+++ b/google-cloud-talent/lib/google/cloud/talent/v4beta1/profile_pb.rb
@@ -23,7 +23,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :is_hirable, :message, 6, "google.protobuf.BoolValue"
     optional :create_time, :message, 7, "google.protobuf.Timestamp"
     optional :update_time, :message, 8, "google.protobuf.Timestamp"
-    optional :resume_hrxml, :string, 10
+    optional :resume, :message, 53, "google.cloud.talent.v4beta1.Resume"
     repeated :person_names, :message, 11, "google.cloud.talent.v4beta1.PersonName"
     repeated :addresses, :message, 12, "google.cloud.talent.v4beta1.Address"
     repeated :email_addresses, :message, 13, "google.cloud.talent.v4beta1.Email"
@@ -43,6 +43,15 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :processed, :bool, 27
     optional :keyword_snippet, :string, 28
   end
+  add_message "google.cloud.talent.v4beta1.Resume" do
+    optional :structured_resume, :string, 1
+    optional :resume_type, :enum, 2, "google.cloud.talent.v4beta1.Resume.ResumeType"
+  end
+  add_enum "google.cloud.talent.v4beta1.Resume.ResumeType" do
+    value :RESUME_TYPE_UNSPECIFIED, 0
+    value :HRXML, 1
+    value :OTHER_RESUME_TYPE, 2
+  end
   add_message "google.cloud.talent.v4beta1.PersonName" do
     optional :preferred_name, :string, 3
     oneof :person_name do
@@ -52,6 +61,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   end
   add_message "google.cloud.talent.v4beta1.PersonName.PersonStructuredName" do
     optional :given_name, :string, 1
+    optional :preferred_name, :string, 6
     optional :middle_initial, :string, 2
     optional :family_name, :string, 3
     repeated :suffixes, :string, 4
@@ -171,6 +181,8 @@ module Google
     module Talent
       module V4beta1
         Profile = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.talent.v4beta1.Profile").msgclass
+        Resume = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.talent.v4beta1.Resume").msgclass
+        Resume::ResumeType = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.talent.v4beta1.Resume.ResumeType").enummodule
         PersonName = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.talent.v4beta1.PersonName").msgclass
         PersonName::PersonStructuredName = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.talent.v4beta1.PersonName.PersonStructuredName").msgclass
         Address = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.talent.v4beta1.Address").msgclass
diff --git a/google-cloud-talent/lib/google/cloud/talent/v4beta1/profile_service_client.rb b/google-cloud-talent/lib/google/cloud/talent/v4beta1/profile_service_client.rb
index f32702613..d1a51db58 100644
--- a/google-cloud-talent/lib/google/cloud/talent/v4beta1/profile_service_client.rb
+++ b/google-cloud-talent/lib/google/cloud/talent/v4beta1/profile_service_client.rb
@@ -669,15 +669,9 @@ module Google
           #   * application_outcome_notes: The application outcome reason specifies the
           #     reasons behind the outcome of the job application.
           #     See {Google::Cloud::Talent::V4beta1::ApplicationOutcomeNotesFilter ApplicationOutcomeNotesFilter} for more details.
-          #   * application_last_stage: The application last stage specifies the last
-          #     stage of job application.
-          #     See {ApplicationLastStageFilter} for more details.
           #   * application_job_title: The application job title specifies the job
           #     applied for in the application.
           #     See {Google::Cloud::Talent::V4beta1::ApplicationJobFilter ApplicationJobFilter} for more details.
-          #   * application_status: The application status specifies the status of job
-          #     application.
-          #     See {ApplicationStatusFilter} for more details.
           #   * hirable_status: Hirable status specifies the profile's hirable status.
           #   * string_custom_attribute: String custom attributes. Values can be accessed
           #     via square bracket notation like string_custom_attribute["key1"].
diff --git a/google-cloud-talent/lib/google/cloud/talent/v4beta1/tenant_pb.rb b/google-cloud-talent/lib/google/cloud/talent/v4beta1/tenant_pb.rb
index ad972a2d8..32655c5f4 100644
--- a/google-cloud-talent/lib/google/cloud/talent/v4beta1/tenant_pb.rb
+++ b/google-cloud-talent/lib/google/cloud/talent/v4beta1/tenant_pb.rb
@@ -11,6 +11,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :name, :string, 1
     optional :external_id, :string, 2
     optional :usage_type, :enum, 3, "google.cloud.talent.v4beta1.Tenant.DataUsageType"
+    repeated :keyword_searchable_profile_custom_attributes, :string, 4
   end
   add_enum "google.cloud.talent.v4beta1.Tenant.DataUsageType" do
     value :DATA_USAGE_TYPE_UNSPECIFIED, 0
diff --git a/google-cloud-talent/synth.metadata b/google-cloud-talent/synth.metadata
index cc989c290..ffbb972e6 100644
--- a/google-cloud-talent/synth.metadata
+++ b/google-cloud-talent/synth.metadata
@@ -1,26 +1,26 @@
 {
-  "updateTime": "2019-04-27T10:46:05.124681Z",
+  "updateTime": "2019-05-09T18:29:58.755077Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.17.1",
-        "dockerImage": "googleapis/artman@sha256:a40ca4dd4ef031c0ded4df4909ffdf7b3f20d29b23e682ef991eb60ba0ca6025"
+        "version": "0.19.0",
+        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "808110e242c682d7ac2bab6d9c49fc3bf72d7604",
-        "internalRef": "245313728"
+        "sha": "f86c9531dc49d41267e2117ece1ea29840f15ce3",
+        "internalRef": "247457584"
       }
     },
     {
       "template": {
         "name": "ruby_library",
         "origin": "synthtool.gcp",
-        "version": "2019.4.10"
+        "version": "2019.5.2"
       }
     }
   ],
diff --git a/google-cloud-talent/test/google/cloud/talent/v4beta1/profile_service_client_test.rb b/google-cloud-talent/test/google/cloud/talent/v4beta1/profile_service_client_test.rb
index 4c0a1ddcd..96a6bde48 100644
--- a/google-cloud-talent/test/google/cloud/talent/v4beta1/profile_service_client_test.rb
+++ b/google-cloud-talent/test/google/cloud/talent/v4beta1/profile_service_client_test.rb
@@ -153,7 +153,6 @@ describe Google::Cloud::Talent::V4beta1::ProfileServiceClient do
       source = "source-896505829"
       uri = "uri116076"
       group_id = "groupId506361563"
-      resume_hrxml = "resumeHrxml1834730555"
       processed = true
       keyword_snippet = "keywordSnippet1325317319"
       expected_response = {
@@ -162,7 +161,6 @@ describe Google::Cloud::Talent::V4beta1::ProfileServiceClient do
         source: source,
         uri: uri,
         group_id: group_id,
-        resume_hrxml: resume_hrxml,
         processed: processed,
         keyword_snippet: keyword_snippet
       }
@@ -246,7 +244,6 @@ describe Google::Cloud::Talent::V4beta1::ProfileServiceClient do
       source = "source-896505829"
       uri = "uri116076"
       group_id = "groupId506361563"
-      resume_hrxml = "resumeHrxml1834730555"
       processed = true
       keyword_snippet = "keywordSnippet1325317319"
       expected_response = {
@@ -255,7 +252,6 @@ describe Google::Cloud::Talent::V4beta1::ProfileServiceClient do
         source: source,
         uri: uri,
         group_id: group_id,
-        resume_hrxml: resume_hrxml,
         processed: processed,
         keyword_snippet: keyword_snippet
       }
@@ -336,7 +332,6 @@ describe Google::Cloud::Talent::V4beta1::ProfileServiceClient do
       source = "source-896505829"
       uri = "uri116076"
       group_id = "groupId506361563"
-      resume_hrxml = "resumeHrxml1834730555"
       processed = true
       keyword_snippet = "keywordSnippet1325317319"
       expected_response = {
@@ -345,7 +340,6 @@ describe Google::Cloud::Talent::V4beta1::ProfileServiceClient do
         source: source,
         uri: uri,
         group_id: group_id,
-        resume_hrxml: resume_hrxml,
         processed: processed,
         keyword_snippet: keyword_snippet
       }

```

</details>

This pull request was generated using releasetool.