### PR TITLE
Pub/Sub: Add Topic#kms_key

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -171,6 +171,9 @@ module Google
         #   optional. Label keys must start with a letter and each label in the
         #   list must have a different key. See [Creating and Managing
         #   Labels](https://cloud.google.com/pubsub/docs/labels).
+        # @param [String] kms_key The Cloud KMS encryption key that will be used
+        #   to protect access to messages published on this topic. Optional.
+        #   For example: `projects/a/locations/b/keyRings/c/cryptoKeys/d`
         # @param [Hash] async A hash of values to configure the topic's
         #   {AsyncPublisher} that is created when {Topic#publish_async}
         #   is called. Optional.
@@ -199,9 +202,11 @@ module Google
         #   pubsub = Google::Cloud::PubSub.new
         #   topic = pubsub.create_topic "my-topic"
         #
-        def create_topic topic_name, labels: nil, async: nil
+        def create_topic topic_name, labels: nil, kms_key: nil, async: nil
           ensure_service!
-          grpc = service.create_topic topic_name, labels: labels
+          grpc = service.create_topic topic_name,
+                                      labels:       labels,
+                                      kms_key_name: kms_key
           Topic.from_grpc grpc, service, async: async
         end
         alias new_topic create_topic

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -125,11 +125,12 @@ module Google
 
         ##
         # Creates the given topic with the given name.
-        def create_topic topic_name, labels: nil, options: {}
+        def create_topic topic_name, labels: nil, kms_key_name: nil, options: {}
           execute do
             publisher.create_topic topic_path(topic_name, options),
-                                   labels:  labels,
-                                   options: default_options
+                                   labels:       labels,
+                                   kms_key_name: kms_key_name,
+                                   options:      default_options
           end
         end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -133,6 +133,56 @@ module Google
         end
 
         ##
+        # The Cloud KMS encryption key that will be used to protect access
+        # to messages published on this topic.
+        # For example: `projects/a/locations/b/keyRings/c/cryptoKeys/d`
+        # The default value is `nil`, which means default encryption is used.
+        #
+        # Makes an API call to retrieve the labels values when called on a
+        # reference object. See {#reference?}.
+        #
+        # @return [String]
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   topic = pubsub.topic "my-topic"
+        #
+        #   topic.kms_key #=> "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+        #
+        def kms_key
+          ensure_grpc!
+          @grpc.kms_key_name
+        end
+
+        ##
+        # Set the Cloud KMS encryption key that will be used to protect access
+        # to messages published on this topic.
+        # For example: `projects/a/locations/b/keyRings/c/cryptoKeys/d`
+        # The default value is `nil`, which means default encryption is used.
+        #
+        # @param [String] new_kms_key_name New Cloud KMS key name
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   topic = pubsub.topic "my-topic"
+        #
+        #   key_name = "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+        #   topic.kms_key = key_name
+        #
+        def kms_key= new_kms_key_name
+          update_grpc = Google::Cloud::PubSub::V1::Topic.new \
+            name: name, kms_key_name: new_kms_key_name
+          @grpc = service.update_topic update_grpc, :kms_key_name
+          @resource_name = nil
+        end
+
+        ##
         # Permanently deletes the topic.
         #
         # @return [Boolean] Returns `true` if the topic was deleted.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -138,7 +138,7 @@ module Google
         # For example: `projects/a/locations/b/keyRings/c/cryptoKeys/d`
         # The default value is `nil`, which means default encryption is used.
         #
-        # Makes an API call to retrieve the labels values when called on a
+        # Makes an API call to retrieve the KMS encryption key when called on a
         # reference object. See {#reference?}.
         #
         # @return [String]

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -475,6 +475,21 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::PubSub::Topic#kms_key" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      this_topic = topic_resp "my-topic", kms_key_name: "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+      mock_publisher.expect :get_topic, this_topic, ["projects/my-project/topics/my-topic", Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::PubSub::Topic#kms_key=" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      this_topic = topic_resp "my-topic", kms_key_name: "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+      mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/my-topic", Hash]
+      mock_publisher.expect :update_topic, this_topic, [this_topic, Google::Protobuf::FieldMask.new(paths: ["kms_key_name"]), Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::PubSub::Topic#delete" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/my-topic", Hash]
@@ -614,8 +629,9 @@ def topics_hash num_topics, token = ""
   data
 end
 
-def topic_resp topic_name = "my-topic"
-  Google::Cloud::PubSub::V1::Topic.new name: topic_path(topic_name)
+def topic_resp topic_name = "my-topic", kms_key_name: nil
+  Google::Cloud::PubSub::V1::Topic.new name: topic_path(topic_name),
+                                       kms_key_name: kms_key_name
 end
 
 def topic_subscriptions_hash num_subs, token = nil

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
@@ -52,6 +52,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
     paged_enum_struct response
   end
   let(:labels) { { "foo" => "bar" } }
+  let(:kms_key) { "projects/a/locations/b/keyRings/c/cryptoKeys/d" }
 
   it "knows the project identifier" do
     pubsub.project.must_equal project
@@ -62,7 +63,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name)
     mock = Minitest::Mock.new
-    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, options: default_options]
+    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic = pubsub.create_topic new_topic_name
@@ -70,6 +71,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
     mock.verify
 
     topic.name.must_equal topic_path(new_topic_name)
+    topic.labels.must_be :empty?
+    topic.labels.must_be :frozen?
+    topic.kms_key.must_be :empty?
   end
 
   it "creates a topic with new_topic_alias" do
@@ -77,7 +81,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name)
     mock = Minitest::Mock.new
-    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, options: default_options]
+    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic = pubsub.new_topic new_topic_name
@@ -85,6 +89,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
     mock.verify
 
     topic.name.must_equal topic_path(new_topic_name)
+    topic.labels.must_be :empty?
+    topic.labels.must_be :frozen?
+    topic.kms_key.must_be :empty?
   end
 
   it "creates a topic with labels" do
@@ -92,7 +99,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name, labels: labels)
     mock = Minitest::Mock.new
-    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: labels, options: default_options]
+    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: labels, kms_key_name: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic = pubsub.create_topic new_topic_name, labels: labels
@@ -102,6 +109,25 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
     topic.name.must_equal topic_path(new_topic_name)
     topic.labels.must_equal labels
     topic.labels.must_be :frozen?
+    topic.kms_key.must_be :empty?
+  end
+
+  it "creates a topic with kms_key" do
+    new_topic_name = "new-topic-#{Time.now.to_i}"
+
+    create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name, kms_key_name: kms_key)
+    mock = Minitest::Mock.new
+    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: kms_key, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    topic = pubsub.create_topic new_topic_name, kms_key: kms_key
+
+    mock.verify
+
+    topic.name.must_equal topic_path(new_topic_name)
+    topic.labels.must_be :empty?
+    topic.labels.must_be :frozen?
+    topic.kms_key.must_equal kms_key
   end
 
   it "gets a topic" do

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -120,8 +120,8 @@ class MockPubsub < Minitest::Spec
     data
   end
 
-  def topic_hash topic_name, labels: nil
-    { name: topic_path(topic_name), labels: labels }
+  def topic_hash topic_name, labels: nil, kms_key_name: nil
+    { name: topic_path(topic_name), labels: labels, kms_key_name: kms_key_name }
   end
 
   def topic_subscriptions_hash num_subs, token = nil


### PR DESCRIPTION
Add the Cloud KMS encryption key that will be used to protect access to messages published on a topic.

[fixes #3347]