### PR TITLE
 Resolve BigDecimal deprecation warnings

### DIFF
--- a/google-cloud-pubsub/test/google/cloud/pubsub/convert/number_to_duration_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/convert/number_to_duration_test.rb
@@ -54,7 +54,7 @@ describe Google::Cloud::PubSub::Convert, :number_to_duration, :mock_pubsub do
   end
 
   it "converts a BigDecimal" do
-    number = BigDecimal.new "643383279502884.1971693993751058209749445923078164062"
+    number = BigDecimal "643383279502884.1971693993751058209749445923078164062"
     duration = Google::Cloud::PubSub::Convert.number_to_duration number
     duration.must_be_kind_of Google::Protobuf::Duration
     duration.seconds.must_equal 643383279502884
@@ -62,7 +62,7 @@ describe Google::Cloud::PubSub::Convert, :number_to_duration, :mock_pubsub do
   end
 
   it "converts a negative BigDecimal" do
-    number = BigDecimal.new "-643383279502884.1971693993751058209749445923078164062"
+    number = BigDecimal "-643383279502884.1971693993751058209749445923078164062"
     duration = Google::Cloud::PubSub::Convert.number_to_duration number
     duration.must_be_kind_of Google::Protobuf::Duration
     # This should really be -643383279502884, but BigDecimal is doing something here...

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
@@ -54,7 +54,7 @@ describe Google::Cloud::Spanner::Convert, :number_to_duration, :mock_spanner do
   end
 
   it "converts a BigDecimal" do
-    number = BigDecimal.new "643383279502884.1971693993751058209749445923078164062"
+    number = BigDecimal "643383279502884.1971693993751058209749445923078164062"
     duration = Google::Cloud::Spanner::Convert.number_to_duration number
     duration.must_be_kind_of Google::Protobuf::Duration
     duration.seconds.must_equal 643383279502884
@@ -62,7 +62,7 @@ describe Google::Cloud::Spanner::Convert, :number_to_duration, :mock_spanner do
   end
 
   it "converts a negative BigDecimal" do
-    number = BigDecimal.new "-643383279502884.1971693993751058209749445923078164062"
+    number = BigDecimal "-643383279502884.1971693993751058209749445923078164062"
     duration = Google::Cloud::Spanner::Convert.number_to_duration number
     duration.must_be_kind_of Google::Protobuf::Duration
     # This should really be -643383279502884, but BigDecimal is doing something here...


### PR DESCRIPTION
The tests show warnings on Ruby 2.6 because `BigDecimal.new` is deprecated. This PR resolves those warnings.

[fixes #3390]