### PR TITLE
Set Bigtable max length headers

### DIFF
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
@@ -72,7 +72,7 @@ module Google
         end
 
         def chan_args
-          { "grpc.max_send_message_length"    => -1,
+          { "grpc.max_send_message_length" => -1,
             "grpc.max_receive_message_length" => -1 }
         end
 

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
@@ -68,7 +68,12 @@ module Google
 
         def channel default_host
           require "grpc"
-          GRPC::Core::Channel.new((host || default_host), nil, chan_creds)
+          GRPC::Core::Channel.new((host || default_host), chan_args, chan_creds)
+        end
+
+        def chan_args
+          { "grpc.max_send_message_length"    => -1,
+            "grpc.max_receive_message_length" => -1 }
         end
 
         def chan_creds


### PR DESCRIPTION
This allows the gRPC client to use the max message size.

[fixes #3394]