### PR TITLE
Release google-cloud-pubsub 0.36.0

### DIFF
--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+### 0.36.0 / 2019-05-21
+
+* Add Topic#kms_key
+  * Add the Cloud KMS encryption key that will be used to
+    protect access to messages published on a topic.
+* Updates to the low-level API:
+  * Add Topic#kms_key_name (experimental)
+  * Snapshots no longer marked beta.
+  * Update IAM documentation.
+
 ### 0.35.0 / 2019-04-25
 
 * Add Subscription#push_config and Subscription::PushConfig

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module PubSub
-      VERSION = "0.35.0".freeze
+      VERSION = "0.36.0".freeze
     end
 
     Pubsub = PubSub unless const_defined? :Pubsub


### PR DESCRIPTION
* Add Topic#kms_key
  * Add the Cloud KMS encryption key that will be used to
    protect access to messages published on a topic.
* Updates to the low-level API:
  * Add Topic#kms_key_name (experimental)
  * Snapshots no longer marked beta.
  * Update IAM documentation.

This pull request was generated using releasetool.