### PR TITLE
Release google-cloud-bigtable 0.4.0

### DIFF
--- a/google-cloud-bigtable/CHANGELOG.md
+++ b/google-cloud-bigtable/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.4.0 / 2019-05-21
+
+* Add Google::Cloud::Bigtable::VERSION
+* Set gRPC headers to allow maximum message size
+* Fix errors in code sample documentation
+
 ### 0.3.1 / 2019-04-29
 
 * Add AUTHENTICATION.md guide.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/version.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigtable
-      VERSION = "0.3.1".freeze
+      VERSION = "0.4.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add Google::Cloud::Bigtable::VERSION
* Set gRPC headers to allow maximum message size
* Fix errors in code sample documentation

This pull request was generated using releasetool.