### PR TITLE
Release google-cloud-tasks 1.0.0

### DIFF
--- a/google-cloud-tasks/CHANGELOG.md
+++ b/google-cloud-tasks/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+### 1.0.0 / 2019-05-24
+
+* GA release
+* Remove Queue#log_sampling_ratio (Breaking change)
+* Add Queue#stackdriver_logging_config
+* Add StackdriverLoggingConfig
+* Update IAM:
+  * Deprecate Policy#version
+  * Add Binding#condition
+  * Add Google::Type::Expr
+
 ### 0.7.1 / 2019-04-29
 
 * Add AUTHENTICATION.md guide.

--- a/google-cloud-tasks/google-cloud-tasks.gemspec
+++ b/google-cloud-tasks/google-cloud-tasks.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-tasks"
-  gem.version       = "0.7.1"
+  gem.version       = "1.0.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud/google-cloud.gemspec
+++ b/google-cloud/google-cloud.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-speech", "~> 0.29"
   gem.add_dependency "google-cloud-storage", "~> 1.10"
   gem.add_dependency "google-cloud-talent", "~> 0.1"
-  gem.add_dependency "google-cloud-tasks", "~> 0.2"
+  gem.add_dependency "google-cloud-tasks", "~> 1.0"
   gem.add_dependency "google-cloud-text_to_speech", "~> 0.1"
   gem.add_dependency "google-cloud-trace", "~> 0.31"
   gem.add_dependency "google-cloud-translate", "~> 1.2"


### PR DESCRIPTION
* GA release
* Remove Queue#log_sampling_ratio (Breaking change)
* Add Queue#stackdriver_logging_config
* Add StackdriverLoggingConfig
* Update IAM:
  * Deprecate Policy#version
  * Add Binding#condition
  * Add Google::Type::Expr

This pull request was generated using releasetool.