### PR TITLE
Release google-cloud-scheduler 1.0.0

### DIFF
--- a/google-cloud-scheduler/CHANGELOG.md
+++ b/google-cloud-scheduler/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+### 1.0.0 / 2019-05-24
+
+* GA release
+* Add Job#attempt_deadline
+  * Add HttpTarget#authorization_header
+  * Add HttpTarget#oauth_token (OAuthToken)
+  * Add HttpTarget#oidc_token (OidcToken)
+
 ### 0.3.1 / 2019-04-29
 
 * Add AUTHENTICATION.md guide.

--- a/google-cloud-scheduler/google-cloud-scheduler.gemspec
+++ b/google-cloud-scheduler/google-cloud-scheduler.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-scheduler"
-  gem.version       = "0.3.1"
+  gem.version       = "1.0.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud/google-cloud.gemspec
+++ b/google-cloud/google-cloud.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-recaptcha_enterprise", "~> 0.1"
   gem.add_dependency "google-cloud-redis", "~> 0.2"
   gem.add_dependency "google-cloud-resource_manager", "~> 0.29"
-  gem.add_dependency "google-cloud-scheduler", "~> 0.1"
+  gem.add_dependency "google-cloud-scheduler", "~> 1.0"
   gem.add_dependency "google-cloud-security_center", "~> 0.1"
   gem.add_dependency "google-cloud-spanner", "~> 1.3"
   gem.add_dependency "google-cloud-speech", "~> 0.29"


### PR DESCRIPTION
* GA release
* Add Job#attempt_deadline
  * Add HttpTarget#authorization_header
  * Add HttpTarget#oauth_token (OAuthToken)
  * Add HttpTarget#oidc_token (OidcToken)

This pull request was generated using releasetool.