### PR TITLE
Firestore Collection Group queries

### DIFF
--- a/google-cloud-firestore/lib/google/cloud/firestore/client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/client.rb
@@ -140,6 +140,46 @@ module Google
         alias collection col
 
         ##
+        # Creates and returns a new Query that includes all documents in the
+        # database that are contained in a collection or subcollection with the
+        # given collection_id.
+        #
+        # @param [String] collection_id Identifies the collections to query
+        #   over. Every collection or subcollection with this ID as the last
+        #   segment of its path will be included. Cannot contain a slash (`/`).
+        #
+        # @return [Query] The created Query.
+        #
+        # @example
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #
+        #   # Get the cities collection group query
+        #   query = firestore.col_group "cities"
+        #
+        #   query.get do |city|
+        #     puts "#{city.document_id} has #{city[:population]} residents."
+        #   end
+        #
+        def col_group collection_id
+          if collection_id.include? "/"
+            raise ArgumentError, "Invalid collection_id: '#{collection_id}', " \
+              "must not contain '/'."
+          end
+          query = Google::Firestore::V1::StructuredQuery.new(
+            from: [
+              Google::Firestore::V1::StructuredQuery::CollectionSelector.new(
+                collection_id: collection_id, all_descendants: true
+              )
+            ]
+          )
+
+          Query.start query, service.documents_path, self
+        end
+        alias collection_group col_group
+
+        ##
         # Retrieves a document reference.
         #
         # @param [String] document_path A string representing the path of the

--- a/google-cloud-firestore/lib/google/cloud/firestore/collection_reference.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/collection_reference.rb
@@ -25,7 +25,7 @@ module Google
       ##
       # # CollectionReference
       #
-      # A collection reference object ise used for adding documents, getting
+      # A collection reference object is used for adding documents, getting
       # document references, and querying for documents (See {Query}).
       #
       # @example

--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -63,7 +63,7 @@ module Google
         attr_accessor :parent_path
 
         ##
-        # @private The Google::Firestore::V1::Query object.
+        # @private The Google::Firestore::V1::StructuredQuery object.
         attr_accessor :query
 
         ##

--- a/google-cloud-firestore/support/doctest_helper.rb
+++ b/google-cloud-firestore/support/doctest_helper.rb
@@ -134,6 +134,14 @@ YARD::Doctest.configure do |doctest|
   doctest.skip "Google::Cloud::Firestore::Client#collections"
   doctest.skip "Google::Cloud::Firestore::Client#list_collections"
 
+  doctest.before "Google::Cloud::Firestore::Client#col_group" do
+    mock_firestore do |mock|
+      mock.expect :run_query, run_query_resp, run_query_args
+    end
+  end
+  # Skip aliased methods
+  doctest.skip "Google::Cloud::Firestore::Client#collection_group"
+
   doctest.before "Google::Cloud::Firestore::Client#docs" do
     mock_firestore do |mock|
       mock.expect :run_query, run_query_resp, run_query_args

--- a/google-cloud-firestore/test/google/cloud/firestore/client/col_group_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/client/col_group_test.rb
@@ -1,0 +1,51 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Firestore::Client, :col_group, :mock_firestore do
+  let(:collection_id) { "my-collection-id" }
+  let(:collection_id_bad) { "a/b/my-collection-id" }
+
+  it "creates a collection group query" do
+    query = firestore.col_group(collection_id).where "foo", "==", "bar"
+
+    query.must_be_kind_of Google::Cloud::Firestore::Query
+    query_gapi = query.query
+    query_gapi.must_be_kind_of Google::Firestore::V1::StructuredQuery
+    query_gapi.from.size.must_equal 1
+    query_gapi.from.first.must_be_kind_of Google::Firestore::V1::StructuredQuery::CollectionSelector
+    query_gapi.from.first.all_descendants.must_equal true
+    query_gapi.from.first.collection_id.must_equal collection_id
+  end
+
+  it "creates a collection group query using collection_group alias" do
+    query = firestore.collection_group(collection_id).where "foo", "==", "bar"
+
+    query.must_be_kind_of Google::Cloud::Firestore::Query
+    query_gapi = query.query
+    query_gapi.must_be_kind_of Google::Firestore::V1::StructuredQuery
+    query_gapi.from.size.must_equal 1
+    query_gapi.from.first.must_be_kind_of Google::Firestore::V1::StructuredQuery::CollectionSelector
+    query_gapi.from.first.all_descendants.must_equal true
+    query_gapi.from.first.collection_id.must_equal collection_id
+  end
+
+  it "raises when collection_id contains a forward slash" do
+    error = expect do
+      firestore.col_group collection_id_bad
+    end.must_raise ArgumentError
+    error.message.must_equal "Invalid collection_id: 'a/b/my-collection-id', must not contain '/'."
+  end
+end


### PR DESCRIPTION
Collection Group queries add support for queries to Firestore that query documents by collection ID rather than by collection path. With this feature, users can now query for documents in collections that share a name, no matter where these collection are located.

Java: googleapis/google-cloud-java#4652
Node: googleapis/nodejs-firestore#578
Python: googleapis/google-cloud-python#7758