### PR TITLE
Change test fixture date-formatted String to Date in Lifecycle::Rule::Condition tests

### DIFF
--- a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
@@ -31,11 +31,12 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     http_method: ["*"],
     response_header: ["X-My-Custom-Header"]) }
   let(:bucket_cors_hash) { JSON.parse bucket_cors_gapi.to_json }
+  let(:bucket_lifecycle_created_before) { Date.parse("2013-01-15") }
   let(:bucket_lifecycle_gapi) do
     lifecycle_gapi lifecycle_rule_gapi("SetStorageClass",
                                        storage_class: "NEARLINE",
                                        age: 32,
-                                       created_before: "2013-01-15",
+                                       created_before: bucket_lifecycle_created_before,
                                        is_live: true,
                                        matches_storage_class: ["MULTI_REGIONAL"],
                                        num_newer_versions: 3)
@@ -493,7 +494,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       lifecycle = bucket.lifecycle do |l|
         l.add_set_storage_class_rule "NEARLINE",
                                      age: 32,
-                                     created_before: "2013-01-15",
+                                     created_before: bucket_lifecycle_created_before,
                                      is_live: true,
                                      matches_storage_class: ["MULTI_REGIONAL"],
                                      num_newer_versions: 3
@@ -506,7 +507,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       rule.action.must_equal "SetStorageClass"
       rule.storage_class.must_equal "NEARLINE"
       rule.age.must_equal 32
-      rule.created_before.must_equal "2013-01-15"
+      rule.created_before.must_equal bucket_lifecycle_created_before
       rule.is_live.must_equal true
       rule.matches_storage_class.must_equal ["MULTI_REGIONAL"]
       rule.num_newer_versions.must_equal 3
@@ -526,13 +527,14 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
           lifecycle_rule_gapi("SetStorageClass",
                               storage_class: "COLDLINE",
                               age: 32,
-                              created_before: "2013-01-15",
+                              created_before: bucket_lifecycle_created_before,
                               is_live: true,
                               matches_storage_class: ["MULTI_REGIONAL"],
                               num_newer_versions: 3),
           lifecycle_rule_gapi("Delete", age: 40, is_live: false)
         )
       )
+
       returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
         random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, nil, nil, bucket_lifecycle_hash).to_json
       mock.expect :patch_bucket, returned_bucket_gapi,
@@ -583,7 +585,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
             lifecycle_rule_gapi("SetStorageClass",
                                 storage_class: "NEARLINE",
                                 age: 32,
-                                created_before: "2013-01-15",
+                                created_before: bucket_lifecycle_created_before,
                                 is_live: true,
                                 matches_storage_class: ["MULTI_REGIONAL"],
                                 num_newer_versions: 3),
@@ -616,7 +618,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
             lifecycle_rule_gapi("SetStorageClass",
                                 storage_class: "NEARLINE",
                                 age: 32,
-                                created_before: "2013-01-15",
+                                created_before: bucket_lifecycle_created_before,
                                 is_live: true,
                                 matches_storage_class: ["MULTI_REGIONAL"],
                                 num_newer_versions: 3),


### PR DESCRIPTION
This is the narrowest possible fix for the 3 errors in recent CI builds (see full [log](https://source.cloud.google.com/results/invocations/7bd2d703-617a-4352-abc9-5b6f6b76ea7f/log)). I'll be happy to update with a more general solution once we better understand the scope of the problem.

```sh
  1) Error:
Google::Cloud::Storage::Bucket::update::mock_storage::lifecycle (Object Lifecycle Management)#test_0003_can update lifecycle inside of a block:
MockExpectationError: mocked method :patch_bucket called with unexpected arguments ["new-bucket-1558720909", #<Google::Apis::StorageV1::Bucket:0x000055e4ef8c2bc8 @lifecycle=#<Google::Apis::StorageV1::Bucket::Lifecycle:0x000055e4ef8c2da8 @rule=[#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule:0x000055e4ef8c3208 @action=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Action:0x000055e4ef8c3320 @storage_class="COLDLINE", @type="SetStorageClass">, @condition=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Condition:0x000055e4ef8c3438 @age=32, @created_before=#<Date: 2013-01-15 ((2456308j,0s,0n),+0s,2299161j)>, @is_live=true, @matches_storage_class=["MULTI_REGIONAL"], @num_newer_versions=3>>, #<Google::Apis::StorageV1::Bucket::Lifecycle::Rule:0x000055e4ef8c2ec0 @action=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Action:0x000055e4ef8c2fd8 @storage_class=nil, @type="Delete">, @condition=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Condition:0x000055e4ef8c30f0 @age=40, @created_before=nil, @is_live=false, @matches_storage_class=[], @num_newer_versions=nil>>]>>, {:predefined_acl=>nil, :predefined_default_object_acl=>nil, :user_project=>nil}]
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/service.rb:113:in `block in patch_bucket'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/service.rb:568:in `execute'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/service.rb:112:in `patch_bucket'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/bucket.rb:2058:in `patch_gapi!'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/bucket.rb:910:in `update'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb:544:in `block (3 levels) in <top (required)>'
  2) Error:
Google::Cloud::Storage::Bucket::update::mock_storage::lifecycle (Object Lifecycle Management)#test_0006_updates Lifecycle rules in a block to lifecycle:
MockExpectationError: mocked method :patch_bucket called with unexpected arguments ["new-bucket-1558720909", #<Google::Apis::StorageV1::Bucket:0x000055e4ef91b868 @lifecycle=#<Google::Apis::StorageV1::Bucket::Lifecycle:0x000055e4ef91ba48 @rule=[#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule:0x000055e4ef91bea8 @action=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Action:0x000055e4ef90e9d8 @storage_class="NEARLINE", @type="SetStorageClass">, @condition=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Condition:0x000055e4ef90c0c0 @age=32, @created_before=#<Date: 2013-01-15 ((2456308j,0s,0n),+0s,2299161j)>, @is_live=true, @matches_storage_class=["MULTI_REGIONAL"], @num_newer_versions=3>>, #<Google::Apis::StorageV1::Bucket::Lifecycle::Rule:0x000055e4ef91bb60 @action=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Action:0x000055e4ef91bc78 @storage_class=nil, @type="Delete">, @condition=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Condition:0x000055e4ef91bd90 @age=40, @created_before=nil, @is_live=false, @matches_storage_class=[], @num_newer_versions=nil>>]>>, {:predefined_acl=>nil, :predefined_default_object_acl=>nil, :user_project=>nil}]
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/service.rb:113:in `block in patch_bucket'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/service.rb:568:in `execute'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/service.rb:112:in `patch_bucket'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/bucket.rb:2058:in `patch_gapi!'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/bucket.rb:268:in `lifecycle'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb:634:in `block (3 levels) in <top (required)>'
  3) Error:
Google::Cloud::Storage::Bucket::update::mock_storage::lifecycle (Object Lifecycle Management)#test_0005_adds Lifecycle rules in a block to lifecycle:
MockExpectationError: mocked method :patch_bucket called with unexpected arguments ["new-bucket-1558720909", #<Google::Apis::StorageV1::Bucket:0x000055e4ef99c3a0 @lifecycle=#<Google::Apis::StorageV1::Bucket::Lifecycle:0x000055e4ef99c580 @rule=[#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule:0x000055e4ef99d070 @action=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Action:0x000055e4ef99d188 @storage_class="NEARLINE", @type="SetStorageClass">, @condition=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Condition:0x000055e4ef99d2a0 @age=32, @created_before=#<Date: 2013-01-15 ((2456308j,0s,0n),+0s,2299161j)>, @is_live=true, @matches_storage_class=["MULTI_REGIONAL"], @num_newer_versions=3>>, #<Google::Apis::StorageV1::Bucket::Lifecycle::Rule:0x000055e4ef99cd28 @action=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Action:0x000055e4ef99ce40 @storage_class=nil, @type="Delete">, @condition=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Condition:0x000055e4ef99cf58 @age=40, @created_before=nil, @is_live=false, @matches_storage_class=[], @num_newer_versions=nil>>, #<Google::Apis::StorageV1::Bucket::Lifecycle::Rule:0x000055e4ef99c9e0 @action=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Action:0x000055e4ef99caf8 @storage_class=nil, @type="Delete">, @condition=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Condition:0x000055e4ef99cc10 @age=nil, @created_before=nil, @is_live=false, @matches_storage_class=[], @num_newer_versions=8>>, #<Google::Apis::StorageV1::Bucket::Lifecycle::Rule:0x000055e4ef99c698 @action=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Action:0x000055e4ef99c7b0 @storage_class="COLDLINE", @type="SetStorageClass">, @condition=#<Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Condition:0x000055e4ef99c8c8 @age=nil, @created_before="2013-01-15", @is_live=nil, @matches_storage_class=["MULTI_REGIONAL", "REGIONAL"], @num_newer_versions=nil>>]>>, {:predefined_acl=>nil, :predefined_default_object_acl=>nil, :user_project=>nil}]
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/service.rb:113:in `block in patch_bucket'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/service.rb:568:in `execute'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/service.rb:112:in `patch_bucket'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/bucket.rb:2058:in `patch_gapi!'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/lib/google/cloud/storage/bucket.rb:910:in `update'
    /tmpfs/src/github/google-cloud-ruby/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb:603:in `block (3 levels) in <top (required)>'
```