### PR TITLE
Release google-cloud-env 1.1.0

### DIFF
--- a/google-cloud-env/CHANGELOG.md
+++ b/google-cloud-env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 1.1.0 / 2019-05-29
+
+* Support disabling of the metadata cache
+* Support configurable retries when querying the metadata server
+* Support configuration of the metadata request timeout
+
 ### 1.0.5 / 2018-09-20
 
 * Update documentation.

--- a/google-cloud-env/lib/google/cloud/env/version.rb
+++ b/google-cloud-env/lib/google/cloud/env/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     class Env
-      VERSION = "1.0.5".freeze
+      VERSION = "1.1.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Support disabling of the metadata cache
* Support configurable retries when querying the metadata server
* Support configuration of the metadata request timeout

This pull request was generated using releasetool.