### PR TITLE
build: get magictokens from FASTCONFIGPUSH

### DIFF
--- a/.kokoro/release/common.cfg
+++ b/.kokoro/release/common.cfg
@@ -23,6 +23,7 @@ before_action {
     keystore_resource {
       keystore_config_id: 73713
       keyname: "releasetool-magictoken"
+      backend_type: FASTCONFIGPUSH
     }
   }
 }
@@ -33,6 +34,7 @@ before_action {
     keystore_resource {
       keystore_config_id: 73713
       keyname: "magic-github-proxy-api-key"
+      backend_type: FASTCONFIGPUSH
     }
   }
 }


### PR DESCRIPTION
We recently updated these keys. It takes a long time for keystore updates to propagate, so switching to FASTCONFIGPUSH, which should allow access in 1-2 days.