### PR TITLE
Fix unit tests to check for both custom and wrapper exception types

### DIFF
--- a/google-cloud-asset/synth.metadata
+++ b/google-cloud-asset/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:37:22.006143Z",
+  "updateTime": "2019-05-30T00:54:33.236345Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -170,3 +170,11 @@ for version in ['v1', 'v1beta1']:
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate', shell=True)
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1', 'v1beta1']:
+    s.replace(
+        f'test/google/cloud/asset/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-asset/test/google/cloud/asset/v1/asset_service_client_test.rb
+++ b/google-cloud-asset/test/google/cloud/asset/v1/asset_service_client_test.rb
@@ -175,7 +175,7 @@ describe Google::Cloud::Asset::V1::AssetServiceClient do
           client = Google::Cloud::Asset.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.export_assets(parent, output_config)
           end
 
@@ -264,7 +264,7 @@ describe Google::Cloud::Asset::V1::AssetServiceClient do
           client = Google::Cloud::Asset.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.batch_get_assets_history(
               parent,
               content_type,

--- a/google-cloud-asset/test/google/cloud/asset/v1beta1/asset_service_client_test.rb
+++ b/google-cloud-asset/test/google/cloud/asset/v1beta1/asset_service_client_test.rb
@@ -175,7 +175,7 @@ describe Google::Cloud::Asset::V1beta1::AssetServiceClient do
           client = Google::Cloud::Asset.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.export_assets(formatted_parent, output_config)
           end
 
@@ -264,7 +264,7 @@ describe Google::Cloud::Asset::V1beta1::AssetServiceClient do
           client = Google::Cloud::Asset.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.batch_get_assets_history(
               formatted_parent,
               content_type,

--- a/google-cloud-bigquery-data_transfer/synth.metadata
+++ b/google-cloud-bigquery-data_transfer/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:37:37.591677Z",
+  "updateTime": "2019-05-30T00:53:14.681155Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -143,3 +143,11 @@ s.replace(
     'package_version = (.+)',
     'package_version = Google::Cloud::Bigquery::DataTransfer::VERSION'
 )
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1']:
+    s.replace(
+        f'test/google/cloud/bigquery/data_transfer/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb
+++ b/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb
@@ -154,7 +154,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
           client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_data_source(formatted_name)
           end
 
@@ -226,7 +226,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
           client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_data_sources(formatted_parent)
           end
 
@@ -322,7 +322,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
           client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_transfer_config(formatted_parent, transfer_config)
           end
 
@@ -418,7 +418,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
           client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_transfer_config(transfer_config, update_mask)
           end
 
@@ -487,7 +487,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
           client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_transfer_config(formatted_name)
           end
 
@@ -579,7 +579,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
           client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_transfer_config(formatted_name)
           end
 
@@ -651,7 +651,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
           client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_transfer_configs(formatted_parent)
           end
 
@@ -740,7 +740,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
           client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.schedule_transfer_runs(
               formatted_parent,
               start_time,
@@ -828,7 +828,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
           client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_transfer_run(formatted_name)
           end
 
@@ -897,7 +897,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
           client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_transfer_run(formatted_name)
           end
 
@@ -969,7 +969,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
           client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_transfer_runs(formatted_parent)
           end
 
@@ -1041,7 +1041,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
           client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_transfer_logs(formatted_parent)
           end
 
@@ -1115,7 +1115,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
           client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.check_valid_creds(formatted_name)
           end
 

--- a/google-cloud-bigtable/synth.metadata
+++ b/google-cloud-bigtable/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:37:56.450481Z",
+  "updateTime": "2019-05-30T00:51:53.360327Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     }
   ],

--- a/google-cloud-bigtable/synth.py
+++ b/google-cloud-bigtable/synth.py
@@ -155,3 +155,16 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Bigtable::VERSION'
 )
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v2']:
+    s.replace(
+        f'test/google/cloud/bigtable/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )
+    s.replace(
+        f'test/google/cloud/bigtable/admin/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
@@ -199,7 +199,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_instance(
               formatted_parent,
               instance_id,
@@ -279,7 +279,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_instance(formatted_name)
           end
 
@@ -353,7 +353,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_instances(formatted_parent)
           end
 
@@ -450,7 +450,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_instance(
               formatted_name,
               display_name,
@@ -575,7 +575,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.partial_update_instance(instance, update_mask)
           end
 
@@ -644,7 +644,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_instance(formatted_name)
           end
 
@@ -783,7 +783,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_cluster(
               formatted_parent,
               cluster_id,
@@ -867,7 +867,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_cluster(formatted_name)
           end
 
@@ -941,7 +941,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_clusters(formatted_parent)
           end
 
@@ -1066,7 +1066,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_cluster(formatted_name, serve_nodes)
           end
 
@@ -1135,7 +1135,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_cluster(formatted_name)
           end
 
@@ -1231,7 +1231,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_app_profile(
               formatted_parent,
               app_profile_id,
@@ -1315,7 +1315,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_app_profile(formatted_name)
           end
 
@@ -1387,7 +1387,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_app_profiles(formatted_parent)
           end
 
@@ -1512,7 +1512,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_app_profile(app_profile, update_mask)
           end
 
@@ -1585,7 +1585,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_app_profile(formatted_name, ignore_warnings)
           end
 
@@ -1660,7 +1660,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_iam_policy(formatted_resource)
           end
 
@@ -1739,7 +1739,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.set_iam_policy(formatted_resource, policy)
           end
 
@@ -1816,7 +1816,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.test_iam_permissions(formatted_resource, permissions)
           end
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_test.rb
@@ -147,7 +147,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_table(
               formatted_parent,
               table_id,
@@ -284,7 +284,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_table_from_snapshot(
               formatted_parent,
               table_id,
@@ -360,7 +360,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_tables(formatted_parent)
           end
 
@@ -434,7 +434,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_table(formatted_name)
           end
 
@@ -503,7 +503,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_table(formatted_name)
           end
 
@@ -587,7 +587,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.modify_column_families(formatted_name, modifications)
           end
 
@@ -656,7 +656,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.drop_row_range(formatted_name)
           end
 
@@ -730,7 +730,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.generate_consistency_token(formatted_name)
           end
 
@@ -808,7 +808,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.check_consistency(formatted_name, consistency_token)
           end
 
@@ -955,7 +955,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.snapshot_table(
               formatted_name,
               cluster,
@@ -1040,7 +1040,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_snapshot(formatted_name)
           end
 
@@ -1112,7 +1112,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_snapshots(formatted_parent)
           end
 
@@ -1181,7 +1181,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_snapshot(formatted_name)
           end
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/v2/bigtable_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/v2/bigtable_client_test.rb
@@ -124,7 +124,7 @@ describe Google::Cloud::Bigtable::V2::BigtableClient do
           client = Google::Cloud::Bigtable::V2.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.read_rows(formatted_table_name)
           end
 
@@ -193,7 +193,7 @@ describe Google::Cloud::Bigtable::V2::BigtableClient do
           client = Google::Cloud::Bigtable::V2.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.sample_row_keys(formatted_table_name)
           end
 
@@ -288,7 +288,7 @@ describe Google::Cloud::Bigtable::V2::BigtableClient do
           client = Google::Cloud::Bigtable::V2.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.mutate_row(
               formatted_table_name,
               row_key,
@@ -369,7 +369,7 @@ describe Google::Cloud::Bigtable::V2::BigtableClient do
           client = Google::Cloud::Bigtable::V2.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.mutate_rows(formatted_table_name, entries)
           end
 
@@ -447,7 +447,7 @@ describe Google::Cloud::Bigtable::V2::BigtableClient do
           client = Google::Cloud::Bigtable::V2.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.check_and_mutate_row(formatted_table_name, row_key)
           end
 
@@ -542,7 +542,7 @@ describe Google::Cloud::Bigtable::V2::BigtableClient do
           client = Google::Cloud::Bigtable::V2.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.read_modify_write_row(
               formatted_table_name,
               row_key,

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -138,3 +138,11 @@ for version in ['v1', 'v1beta1']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Container::VERSION'
     )
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1', 'v1beta1']:
+    s.replace(
+        f'test/google/cloud/container/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-container/test/google/cloud/container/v1/cluster_manager_client_test.rb
+++ b/google-cloud-container/test/google/cloud/container/v1/cluster_manager_client_test.rb
@@ -133,7 +133,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_clusters(project_id, zone)
           end
 
@@ -269,7 +269,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_cluster(
               project_id,
               zone,
@@ -381,7 +381,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_cluster(
               project_id,
               zone,
@@ -499,7 +499,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_cluster(
               project_id,
               zone,
@@ -630,7 +630,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_node_pool(
               project_id,
               zone,
@@ -757,7 +757,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_node_pool_autoscaling(
               project_id,
               zone,
@@ -877,7 +877,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_logging_service(
               project_id,
               zone,
@@ -996,7 +996,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_monitoring_service(
               project_id,
               zone,
@@ -1115,7 +1115,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_addons_config(
               project_id,
               zone,
@@ -1234,7 +1234,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_locations(
               project_id,
               zone,
@@ -1353,7 +1353,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_master(
               project_id,
               zone,
@@ -1478,7 +1478,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_master_auth(
               project_id,
               zone,
@@ -1592,7 +1592,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_cluster(
               project_id,
               zone,
@@ -1673,7 +1673,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_operations(project_id, zone)
           end
 
@@ -1781,7 +1781,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_operation(
               project_id,
               zone,
@@ -1870,7 +1870,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.cancel_operation(
               project_id,
               zone,
@@ -1953,7 +1953,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_server_config(project_id, zone)
           end
 
@@ -2042,7 +2042,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_node_pools(
               project_id,
               zone,
@@ -2152,7 +2152,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_node_pool(
               project_id,
               zone,
@@ -2271,7 +2271,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_node_pool(
               project_id,
               zone,
@@ -2390,7 +2390,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_node_pool(
               project_id,
               zone,
@@ -2509,7 +2509,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.rollback_node_pool_upgrade(
               project_id,
               zone,
@@ -2634,7 +2634,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_node_pool_management(
               project_id,
               zone,
@@ -2760,7 +2760,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_labels(
               project_id,
               zone,
@@ -2880,7 +2880,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_legacy_abac(
               project_id,
               zone,
@@ -2993,7 +2993,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.start_ip_rotation(
               project_id,
               zone,
@@ -3105,7 +3105,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.complete_ip_rotation(
               project_id,
               zone,
@@ -3229,7 +3229,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_node_pool_size(
               project_id,
               zone,
@@ -3349,7 +3349,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_network_policy(
               project_id,
               zone,
@@ -3468,7 +3468,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_maintenance_policy(
               project_id,
               zone,

--- a/google-cloud-container/test/google/cloud/container/v1beta1/cluster_manager_client_test.rb
+++ b/google-cloud-container/test/google/cloud/container/v1beta1/cluster_manager_client_test.rb
@@ -133,7 +133,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.list_clusters(project_id, zone)
           end
 
@@ -277,7 +277,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.get_cluster(
               project_id,
               zone,
@@ -389,7 +389,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.create_cluster(
               project_id,
               zone,
@@ -507,7 +507,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.update_cluster(
               project_id,
               zone,
@@ -638,7 +638,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.update_node_pool(
               project_id,
               zone,
@@ -765,7 +765,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.set_node_pool_autoscaling(
               project_id,
               zone,
@@ -885,7 +885,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.set_logging_service(
               project_id,
               zone,
@@ -1004,7 +1004,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.set_monitoring_service(
               project_id,
               zone,
@@ -1123,7 +1123,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.set_addons_config(
               project_id,
               zone,
@@ -1242,7 +1242,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.set_locations(
               project_id,
               zone,
@@ -1361,7 +1361,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.update_master(
               project_id,
               zone,
@@ -1486,7 +1486,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.set_master_auth(
               project_id,
               zone,
@@ -1600,7 +1600,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.delete_cluster(
               project_id,
               zone,
@@ -1681,7 +1681,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.list_operations(project_id, zone)
           end
 
@@ -1789,7 +1789,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.get_operation(
               project_id,
               zone,
@@ -1878,7 +1878,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.cancel_operation(
               project_id,
               zone,
@@ -1961,7 +1961,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.get_server_config(project_id, zone)
           end
 
@@ -2050,7 +2050,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.list_node_pools(
               project_id,
               zone,
@@ -2160,7 +2160,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.get_node_pool(
               project_id,
               zone,
@@ -2279,7 +2279,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.create_node_pool(
               project_id,
               zone,
@@ -2398,7 +2398,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.delete_node_pool(
               project_id,
               zone,
@@ -2517,7 +2517,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.rollback_node_pool_upgrade(
               project_id,
               zone,
@@ -2642,7 +2642,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.set_node_pool_management(
               project_id,
               zone,
@@ -2768,7 +2768,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.set_labels(
               project_id,
               zone,
@@ -2888,7 +2888,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.set_legacy_abac(
               project_id,
               zone,
@@ -3001,7 +3001,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.start_ip_rotation(
               project_id,
               zone,
@@ -3113,7 +3113,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.complete_ip_rotation(
               project_id,
               zone,
@@ -3237,7 +3237,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.set_node_pool_size(
               project_id,
               zone,
@@ -3357,7 +3357,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.set_network_policy(
               project_id,
               zone,
@@ -3476,7 +3476,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.set_maintenance_policy(
               project_id,
               zone,
@@ -3553,7 +3553,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.list_usable_subnetworks(parent)
           end
 
@@ -3627,7 +3627,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
           client = Google::Cloud::Container.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.list_locations(parent)
           end
 

--- a/google-cloud-debugger/synth.metadata
+++ b/google-cloud-debugger/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:39:06.538326Z",
+  "updateTime": "2019-05-30T00:45:14.150410Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     }
   ],

--- a/google-cloud-debugger/synth.py
+++ b/google-cloud-debugger/synth.py
@@ -113,3 +113,11 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Debugger::VERSION'
 )
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v2']:
+    s.replace(
+        f'test/google/cloud/debugger/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-debugger/test/google/cloud/debugger/v2/controller2_client_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/v2/controller2_client_test.rb
@@ -129,7 +129,7 @@ describe Google::Cloud::Debugger::V2::Controller2Client do
           client = Google::Cloud::Debugger::V2::Controller2.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.register_debuggee(debuggee)
           end
 
@@ -204,7 +204,7 @@ describe Google::Cloud::Debugger::V2::Controller2Client do
           client = Google::Cloud::Debugger::V2::Controller2.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_active_breakpoints(debuggee_id)
           end
 
@@ -281,7 +281,7 @@ describe Google::Cloud::Debugger::V2::Controller2Client do
           client = Google::Cloud::Debugger::V2::Controller2.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_active_breakpoint(debuggee_id, breakpoint)
           end
 

--- a/google-cloud-debugger/test/google/cloud/debugger/v2/debugger2_client_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/v2/debugger2_client_test.rb
@@ -145,7 +145,7 @@ describe Google::Cloud::Debugger::V2::Debugger2Client do
           client = Google::Cloud::Debugger::V2::Debugger2.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.set_breakpoint(
               debuggee_id,
               breakpoint,
@@ -238,7 +238,7 @@ describe Google::Cloud::Debugger::V2::Debugger2Client do
           client = Google::Cloud::Debugger::V2::Debugger2.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_breakpoint(
               debuggee_id,
               breakpoint_id,
@@ -327,7 +327,7 @@ describe Google::Cloud::Debugger::V2::Debugger2Client do
           client = Google::Cloud::Debugger::V2::Debugger2.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_breakpoint(
               debuggee_id,
               breakpoint_id,
@@ -409,7 +409,7 @@ describe Google::Cloud::Debugger::V2::Debugger2Client do
           client = Google::Cloud::Debugger::V2::Debugger2.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_breakpoints(debuggee_id, client_version)
           end
 
@@ -486,7 +486,7 @@ describe Google::Cloud::Debugger::V2::Debugger2Client do
           client = Google::Cloud::Debugger::V2::Debugger2.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_debuggees(project, client_version)
           end
 

--- a/google-cloud-dialogflow/synth.metadata
+++ b/google-cloud-dialogflow/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-21T10:40:23.596346Z",
+  "updateTime": "2019-05-30T00:43:51.837253Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.20.0",
-        "dockerImage": "googleapis/artman@sha256:3246adac900f4bdbd62920e80de2e5877380e44036b3feae13667ec255ebf5ec"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "32a10f69e2c9ce15bba13ab1ff928bacebb25160",
-        "internalRef": "249058354"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -107,3 +107,11 @@ s.replace(
     'README.md\n',
     'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v2']:
+    s.replace(
+        f'test/google/cloud/dialogflow/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/agents_client_test.rb
+++ b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/agents_client_test.rb
@@ -147,7 +147,7 @@ describe Google::Cloud::Dialogflow::V2::AgentsClient do
           client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_agent(formatted_parent)
           end
 
@@ -219,7 +219,7 @@ describe Google::Cloud::Dialogflow::V2::AgentsClient do
           client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.search_agents(formatted_parent)
           end
 
@@ -331,7 +331,7 @@ describe Google::Cloud::Dialogflow::V2::AgentsClient do
           client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.train_agent(formatted_parent)
           end
 
@@ -444,7 +444,7 @@ describe Google::Cloud::Dialogflow::V2::AgentsClient do
           client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.export_agent(formatted_parent)
           end
 
@@ -556,7 +556,7 @@ describe Google::Cloud::Dialogflow::V2::AgentsClient do
           client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.import_agent(formatted_parent)
           end
 
@@ -668,7 +668,7 @@ describe Google::Cloud::Dialogflow::V2::AgentsClient do
           client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.restore_agent(formatted_parent)
           end
 

--- a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/contexts_client_test.rb
+++ b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/contexts_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Dialogflow::V2::ContextsClient do
           client = Google::Cloud::Dialogflow::Contexts.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_contexts(formatted_parent)
           end
 
@@ -203,7 +203,7 @@ describe Google::Cloud::Dialogflow::V2::ContextsClient do
           client = Google::Cloud::Dialogflow::Contexts.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_context(formatted_name)
           end
 
@@ -282,7 +282,7 @@ describe Google::Cloud::Dialogflow::V2::ContextsClient do
           client = Google::Cloud::Dialogflow::Contexts.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_context(formatted_parent, context)
           end
 
@@ -357,7 +357,7 @@ describe Google::Cloud::Dialogflow::V2::ContextsClient do
           client = Google::Cloud::Dialogflow::Contexts.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_context(context)
           end
 
@@ -426,7 +426,7 @@ describe Google::Cloud::Dialogflow::V2::ContextsClient do
           client = Google::Cloud::Dialogflow::Contexts.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_context(formatted_name)
           end
 
@@ -495,7 +495,7 @@ describe Google::Cloud::Dialogflow::V2::ContextsClient do
           client = Google::Cloud::Dialogflow::Contexts.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_all_contexts(formatted_parent)
           end
 

--- a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/entity_types_client_test.rb
+++ b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/entity_types_client_test.rb
@@ -129,7 +129,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_entity_types(formatted_parent)
           end
 
@@ -204,7 +204,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_entity_type(formatted_name)
           end
 
@@ -283,7 +283,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_entity_type(formatted_parent, entity_type)
           end
 
@@ -358,7 +358,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_entity_type(entity_type)
           end
 
@@ -427,7 +427,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_entity_type(formatted_name)
           end
 
@@ -539,7 +539,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.batch_update_entity_types(formatted_parent)
           end
 
@@ -657,7 +657,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.batch_delete_entity_types(formatted_parent, entity_type_names)
           end
 
@@ -784,7 +784,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.batch_create_entities(formatted_parent, entities)
           end
 
@@ -911,7 +911,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.batch_update_entities(formatted_parent, entities)
           end
 
@@ -1029,7 +1029,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.batch_delete_entities(formatted_parent, entity_values)
           end
 

--- a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/intents_client_test.rb
+++ b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/intents_client_test.rb
@@ -129,7 +129,7 @@ describe Google::Cloud::Dialogflow::V2::IntentsClient do
           client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_intents(formatted_parent)
           end
 
@@ -221,7 +221,7 @@ describe Google::Cloud::Dialogflow::V2::IntentsClient do
           client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_intent(formatted_name)
           end
 
@@ -317,7 +317,7 @@ describe Google::Cloud::Dialogflow::V2::IntentsClient do
           client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_intent(formatted_parent, intent)
           end
 
@@ -413,7 +413,7 @@ describe Google::Cloud::Dialogflow::V2::IntentsClient do
           client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_intent(intent, language_code)
           end
 
@@ -482,7 +482,7 @@ describe Google::Cloud::Dialogflow::V2::IntentsClient do
           client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_intent(formatted_name)
           end
 
@@ -600,7 +600,7 @@ describe Google::Cloud::Dialogflow::V2::IntentsClient do
           client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.batch_update_intents(formatted_parent, language_code)
           end
 
@@ -727,7 +727,7 @@ describe Google::Cloud::Dialogflow::V2::IntentsClient do
           client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.batch_delete_intents(formatted_parent, intents)
           end
 

--- a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/session_entity_types_client_test.rb
+++ b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/session_entity_types_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Dialogflow::V2::SessionEntityTypesClient do
           client = Google::Cloud::Dialogflow::SessionEntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_session_entity_types(formatted_parent)
           end
 
@@ -202,7 +202,7 @@ describe Google::Cloud::Dialogflow::V2::SessionEntityTypesClient do
           client = Google::Cloud::Dialogflow::SessionEntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_session_entity_type(formatted_name)
           end
 
@@ -280,7 +280,7 @@ describe Google::Cloud::Dialogflow::V2::SessionEntityTypesClient do
           client = Google::Cloud::Dialogflow::SessionEntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_session_entity_type(formatted_parent, session_entity_type)
           end
 
@@ -354,7 +354,7 @@ describe Google::Cloud::Dialogflow::V2::SessionEntityTypesClient do
           client = Google::Cloud::Dialogflow::SessionEntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_session_entity_type(session_entity_type)
           end
 
@@ -423,7 +423,7 @@ describe Google::Cloud::Dialogflow::V2::SessionEntityTypesClient do
           client = Google::Cloud::Dialogflow::SessionEntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_session_entity_type(formatted_name)
           end
 

--- a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/sessions_client_test.rb
+++ b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/sessions_client_test.rb
@@ -135,7 +135,7 @@ describe Google::Cloud::Dialogflow::V2::SessionsClient do
           client = Google::Cloud::Dialogflow::Sessions.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.detect_intent(formatted_session, query_input)
           end
 
@@ -212,7 +212,7 @@ describe Google::Cloud::Dialogflow::V2::SessionsClient do
           client = Google::Cloud::Dialogflow::Sessions.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.streaming_detect_intent([request])
           end
 

--- a/google-cloud-dlp/synth.metadata
+++ b/google-cloud-dlp/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:39:37.601074Z",
+  "updateTime": "2019-05-30T00:42:54.227168Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -109,3 +109,11 @@ s.replace(
     'README.md\n',
     'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v2']:
+    s.replace(
+        f'test/google/cloud/dlp/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-dlp/test/google/cloud/dlp/v2/dlp_service_client_test.rb
+++ b/google-cloud-dlp/test/google/cloud/dlp/v2/dlp_service_client_test.rb
@@ -129,7 +129,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.inspect_content(formatted_parent)
           end
 
@@ -204,7 +204,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.redact_image(formatted_parent)
           end
 
@@ -277,7 +277,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.deidentify_content(formatted_parent)
           end
 
@@ -350,7 +350,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.reidentify_content(formatted_parent)
           end
 
@@ -413,7 +413,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_info_types
           end
 
@@ -493,7 +493,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_inspect_template(formatted_parent)
           end
 
@@ -573,7 +573,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_inspect_template(formatted_name)
           end
 
@@ -643,7 +643,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_inspect_template
           end
 
@@ -715,7 +715,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_inspect_templates(formatted_parent)
           end
 
@@ -784,7 +784,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_inspect_template(formatted_name)
           end
 
@@ -864,7 +864,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_deidentify_template(formatted_parent)
           end
 
@@ -944,7 +944,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_deidentify_template(formatted_name)
           end
 
@@ -1024,7 +1024,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_deidentify_template(formatted_name)
           end
 
@@ -1096,7 +1096,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_deidentify_templates(formatted_parent)
           end
 
@@ -1165,7 +1165,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_deidentify_template(formatted_name)
           end
 
@@ -1240,7 +1240,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_dlp_job(formatted_parent)
           end
 
@@ -1312,7 +1312,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_dlp_jobs(formatted_parent)
           end
 
@@ -1387,7 +1387,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_dlp_job(formatted_name)
           end
 
@@ -1456,7 +1456,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_dlp_job(formatted_name)
           end
 
@@ -1525,7 +1525,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.cancel_dlp_job(formatted_name)
           end
 
@@ -1597,7 +1597,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_job_triggers(formatted_parent)
           end
 
@@ -1677,7 +1677,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_job_trigger(formatted_name)
           end
 
@@ -1746,7 +1746,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_job_trigger(name)
           end
 
@@ -1826,7 +1826,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_job_trigger(formatted_name)
           end
 
@@ -1906,7 +1906,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_job_trigger(formatted_parent)
           end
 
@@ -1980,7 +1980,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_stored_info_type(formatted_parent)
           end
 
@@ -2054,7 +2054,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_stored_info_type(formatted_name)
           end
 
@@ -2128,7 +2128,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_stored_info_type(formatted_name)
           end
 
@@ -2200,7 +2200,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_stored_info_types(formatted_parent)
           end
 
@@ -2269,7 +2269,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
           client = Google::Cloud::Dlp.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_stored_info_type(formatted_name)
           end
 

--- a/google-cloud-firestore/synth.metadata
+++ b/google-cloud-firestore/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:40:15.228954Z",
+  "updateTime": "2019-05-30T00:41:27.484340Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     }
   ],

--- a/google-cloud-firestore/synth.py
+++ b/google-cloud-firestore/synth.py
@@ -111,3 +111,11 @@ s.replace(
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
 )
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1', 'v1beta1']:
+    s.replace(
+        f'test/google/cloud/firestore/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-firestore/test/google/cloud/firestore/v1/firestore_client_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/v1/firestore_client_test.rb
@@ -130,7 +130,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_document(formatted_name)
           end
 
@@ -206,7 +206,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_documents(formatted_parent, collection_id)
           end
 
@@ -302,7 +302,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_document(
               formatted_parent,
               collection_id,
@@ -385,7 +385,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_document(document, update_mask)
           end
 
@@ -454,7 +454,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_document(formatted_name)
           end
 
@@ -527,7 +527,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.batch_get_documents(formatted_database, documents)
           end
 
@@ -601,7 +601,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.begin_transaction(formatted_database)
           end
 
@@ -684,7 +684,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.commit(formatted_database, writes)
           end
 
@@ -757,7 +757,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.rollback(formatted_database, transaction)
           end
 
@@ -826,7 +826,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.run_query(formatted_parent)
           end
 
@@ -899,7 +899,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.write([request])
           end
 
@@ -970,7 +970,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.listen([request])
           end
 
@@ -1042,7 +1042,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_collection_ids(formatted_parent)
           end
 

--- a/google-cloud-firestore/test/google/cloud/firestore/v1beta1/firestore_client_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/v1beta1/firestore_client_test.rb
@@ -130,7 +130,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.get_document(formatted_name)
           end
 
@@ -206,7 +206,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.list_documents(formatted_parent, collection_id)
           end
 
@@ -302,7 +302,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.create_document(
               formatted_parent,
               collection_id,
@@ -385,7 +385,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.update_document(document, update_mask)
           end
 
@@ -454,7 +454,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.delete_document(formatted_name)
           end
 
@@ -527,7 +527,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.batch_get_documents(formatted_database, documents)
           end
 
@@ -601,7 +601,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.begin_transaction(formatted_database)
           end
 
@@ -684,7 +684,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.commit(formatted_database, writes)
           end
 
@@ -757,7 +757,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.rollback(formatted_database, transaction)
           end
 
@@ -826,7 +826,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.run_query(formatted_parent)
           end
 
@@ -899,7 +899,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.write([request])
           end
 
@@ -970,7 +970,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.listen([request])
           end
 
@@ -1042,7 +1042,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.list_collection_ids(formatted_parent)
           end
 

--- a/google-cloud-irm/synth.metadata
+++ b/google-cloud-irm/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:40:33.864270Z",
+  "updateTime": "2019-05-30T00:39:26.794290Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-irm/synth.py
+++ b/google-cloud-irm/synth.py
@@ -102,3 +102,11 @@ s.replace(
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1alpha2']:
+    s.replace(
+        f'test/google/cloud/irm/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-irm/test/google/cloud/irm/v1alpha2/incident_service_client_test.rb
+++ b/google-cloud-irm/test/google/cloud/irm/v1alpha2/incident_service_client_test.rb
@@ -142,7 +142,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.create_incident(incident, formatted_parent)
           end
 
@@ -224,7 +224,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.get_incident(formatted_name)
           end
 
@@ -296,7 +296,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.search_incidents(formatted_parent)
           end
 
@@ -378,7 +378,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.update_incident(incident)
           end
 
@@ -450,7 +450,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.search_similar_incidents(formatted_name)
           end
 
@@ -529,7 +529,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.create_annotation(formatted_parent, annotation)
           end
 
@@ -601,7 +601,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.list_annotations(formatted_parent)
           end
 
@@ -680,7 +680,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.create_tag(formatted_parent, tag)
           end
 
@@ -749,7 +749,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.delete_tag(formatted_name)
           end
 
@@ -821,7 +821,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.list_tags(formatted_parent)
           end
 
@@ -911,7 +911,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.create_signal(formatted_parent, signal)
           end
 
@@ -983,7 +983,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.search_signals(formatted_parent)
           end
 
@@ -1069,7 +1069,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.get_signal(formatted_name)
           end
 
@@ -1155,7 +1155,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.update_signal(signal)
           end
 
@@ -1228,7 +1228,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.escalate_incident(incident)
           end
 
@@ -1314,7 +1314,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.create_artifact(formatted_parent, artifact)
           end
 
@@ -1386,7 +1386,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.list_artifacts(formatted_parent)
           end
 
@@ -1468,7 +1468,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.update_artifact(artifact)
           end
 
@@ -1537,7 +1537,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.delete_artifact(formatted_name)
           end
 
@@ -1628,7 +1628,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.send_shift_handoff(
               formatted_parent,
               recipients,
@@ -1711,7 +1711,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.create_subscription(formatted_parent, subscription)
           end
 
@@ -1786,7 +1786,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.update_subscription(subscription)
           end
 
@@ -1858,7 +1858,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.list_subscriptions(formatted_parent)
           end
 
@@ -1927,7 +1927,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.delete_subscription(formatted_name)
           end
 
@@ -2006,7 +2006,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.create_incident_role_assignment(formatted_parent, incident_role_assignment)
           end
 
@@ -2075,7 +2075,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.delete_incident_role_assignment(formatted_name)
           end
 
@@ -2147,7 +2147,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.list_incident_role_assignments(formatted_parent)
           end
 
@@ -2226,7 +2226,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.request_incident_role_handover(formatted_name, new_assignee)
           end
 
@@ -2305,7 +2305,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.confirm_incident_role_handover(formatted_name, new_assignee)
           end
 
@@ -2384,7 +2384,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.force_incident_role_handover(formatted_name, new_assignee)
           end
 
@@ -2463,7 +2463,7 @@ describe Google::Cloud::Irm::V1alpha2::IncidentServiceClient do
           client = Google::Cloud::Irm.new(version: :v1alpha2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1alpha2 do
             client.cancel_incident_role_handover(formatted_name, new_assignee)
           end
 

--- a/google-cloud-kms/synth.metadata
+++ b/google-cloud-kms/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-07T10:39:46.225437Z",
+  "updateTime": "2019-05-30T00:38:02.642224Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "5aeb4179d0c424be6b1b228bce7ec75ec24f3d12",
-        "internalRef": "246901187"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -153,3 +153,11 @@ s.replace(
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1']:
+    s.replace(
+        f'test/google/cloud/kms/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-kms/test/google/cloud/kms/v1/key_management_service_client_test.rb
+++ b/google-cloud-kms/test/google/cloud/kms/v1/key_management_service_client_test.rb
@@ -134,7 +134,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_key_rings(formatted_parent)
           end
 
@@ -211,7 +211,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_crypto_keys(formatted_parent)
           end
 
@@ -288,7 +288,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_crypto_key_versions(formatted_parent)
           end
 
@@ -362,7 +362,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_key_ring(formatted_name)
           end
 
@@ -436,7 +436,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_crypto_key(formatted_name)
           end
 
@@ -510,7 +510,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_crypto_key_version(formatted_name)
           end
 
@@ -600,7 +600,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_key_ring(
               formatted_parent,
               key_ring_id,
@@ -712,7 +712,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_crypto_key(
               formatted_parent,
               crypto_key_id,
@@ -794,7 +794,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_crypto_key_version(formatted_parent, crypto_key_version)
           end
 
@@ -872,7 +872,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_crypto_key(crypto_key, update_mask)
           end
 
@@ -950,7 +950,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_crypto_key_version(crypto_key_version, update_mask)
           end
 
@@ -1029,7 +1029,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.encrypt(formatted_name, plaintext)
           end
 
@@ -1107,7 +1107,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.decrypt(formatted_name, ciphertext)
           end
 
@@ -1185,7 +1185,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_crypto_key_primary_version(formatted_name, crypto_key_version_id)
           end
 
@@ -1259,7 +1259,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.destroy_crypto_key_version(formatted_name)
           end
 
@@ -1333,7 +1333,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.restore_crypto_key_version(formatted_name)
           end
 
@@ -1407,7 +1407,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_public_key(formatted_name)
           end
 
@@ -1485,7 +1485,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.asymmetric_decrypt(formatted_name, ciphertext)
           end
 
@@ -1563,7 +1563,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.asymmetric_sign(formatted_name, digest)
           end
 
@@ -1642,7 +1642,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_iam_policy(formatted_resource, policy)
           end
 
@@ -1717,7 +1717,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_iam_policy(formatted_resource)
           end
 
@@ -1794,7 +1794,7 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
           client = Google::Cloud::Kms.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.test_iam_permissions(formatted_resource, permissions)
           end
 

--- a/google-cloud-monitoring/synth.metadata
+++ b/google-cloud-monitoring/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-11T10:39:51.695333Z",
+  "updateTime": "2019-05-30T00:36:25.067893Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "32b08107fa1710f46287c17d5bb2016e443ed3ba",
-        "internalRef": "247684466"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -109,3 +109,11 @@ s.replace(
     'README.md\n',
     'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v3']:
+    s.replace(
+        f'test/google/cloud/monitoring/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/alert_policy_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/alert_policy_service_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Monitoring::V3::AlertPolicyServiceClient do
           client = Google::Cloud::Monitoring::AlertPolicy.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_alert_policies(formatted_name)
           end
 
@@ -203,7 +203,7 @@ describe Google::Cloud::Monitoring::V3::AlertPolicyServiceClient do
           client = Google::Cloud::Monitoring::AlertPolicy.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.get_alert_policy(formatted_name)
           end
 
@@ -282,7 +282,7 @@ describe Google::Cloud::Monitoring::V3::AlertPolicyServiceClient do
           client = Google::Cloud::Monitoring::AlertPolicy.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.create_alert_policy(formatted_name, alert_policy)
           end
 
@@ -351,7 +351,7 @@ describe Google::Cloud::Monitoring::V3::AlertPolicyServiceClient do
           client = Google::Cloud::Monitoring::AlertPolicy.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.delete_alert_policy(formatted_name)
           end
 
@@ -426,7 +426,7 @@ describe Google::Cloud::Monitoring::V3::AlertPolicyServiceClient do
           client = Google::Cloud::Monitoring::AlertPolicy.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.update_alert_policy(alert_policy)
           end
 

--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/group_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/group_service_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
           client = Google::Cloud::Monitoring::Group.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_groups(formatted_name)
           end
 
@@ -212,7 +212,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
           client = Google::Cloud::Monitoring::Group.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.get_group(formatted_name)
           end
 
@@ -300,7 +300,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
           client = Google::Cloud::Monitoring::Group.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.create_group(formatted_name, group)
           end
 
@@ -384,7 +384,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
           client = Google::Cloud::Monitoring::Group.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.update_group(group)
           end
 
@@ -453,7 +453,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
           client = Google::Cloud::Monitoring::Group.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.delete_group(formatted_name)
           end
 
@@ -530,7 +530,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
           client = Google::Cloud::Monitoring::Group.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_group_members(formatted_name)
           end
 

--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/metric_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/metric_service_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_monitored_resource_descriptors(formatted_name)
           end
 
@@ -210,7 +210,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.get_monitored_resource_descriptor(formatted_name)
           end
 
@@ -282,7 +282,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_metric_descriptors(formatted_name)
           end
 
@@ -366,7 +366,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.get_metric_descriptor(formatted_name)
           end
 
@@ -454,7 +454,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.create_metric_descriptor(formatted_name, metric_descriptor)
           end
 
@@ -523,7 +523,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.delete_metric_descriptor(formatted_name)
           end
 
@@ -612,7 +612,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_time_series(
               formatted_name,
               filter,
@@ -696,7 +696,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.create_time_series(formatted_name, time_series)
           end
 

--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/notification_channel_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/notification_channel_service_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Monitoring::V3::NotificationChannelServiceClient do
           client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_notification_channel_descriptors(formatted_name)
           end
 
@@ -210,7 +210,7 @@ describe Google::Cloud::Monitoring::V3::NotificationChannelServiceClient do
           client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.get_notification_channel_descriptor(formatted_name)
           end
 
@@ -282,7 +282,7 @@ describe Google::Cloud::Monitoring::V3::NotificationChannelServiceClient do
           client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_notification_channels(formatted_name)
           end
 
@@ -364,7 +364,7 @@ describe Google::Cloud::Monitoring::V3::NotificationChannelServiceClient do
           client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.get_notification_channel(formatted_name)
           end
 
@@ -450,7 +450,7 @@ describe Google::Cloud::Monitoring::V3::NotificationChannelServiceClient do
           client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.create_notification_channel(formatted_name, notification_channel)
           end
 
@@ -532,7 +532,7 @@ describe Google::Cloud::Monitoring::V3::NotificationChannelServiceClient do
           client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.update_notification_channel(notification_channel)
           end
 
@@ -601,7 +601,7 @@ describe Google::Cloud::Monitoring::V3::NotificationChannelServiceClient do
           client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.delete_notification_channel(formatted_name)
           end
 

--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/uptime_check_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/uptime_check_service_client_test.rb
@@ -133,7 +133,7 @@ describe Google::Cloud::Monitoring::V3::UptimeCheckServiceClient do
           client = Google::Cloud::Monitoring::UptimeCheck.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_uptime_check_configs(formatted_parent)
           end
 
@@ -213,7 +213,7 @@ describe Google::Cloud::Monitoring::V3::UptimeCheckServiceClient do
           client = Google::Cloud::Monitoring::UptimeCheck.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.get_uptime_check_config(formatted_name)
           end
 
@@ -297,7 +297,7 @@ describe Google::Cloud::Monitoring::V3::UptimeCheckServiceClient do
           client = Google::Cloud::Monitoring::UptimeCheck.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.create_uptime_check_config(formatted_parent, uptime_check_config)
           end
 
@@ -377,7 +377,7 @@ describe Google::Cloud::Monitoring::V3::UptimeCheckServiceClient do
           client = Google::Cloud::Monitoring::UptimeCheck.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.update_uptime_check_config(uptime_check_config)
           end
 
@@ -446,7 +446,7 @@ describe Google::Cloud::Monitoring::V3::UptimeCheckServiceClient do
           client = Google::Cloud::Monitoring::UptimeCheck.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.delete_uptime_check_config(formatted_name)
           end
 
@@ -508,7 +508,7 @@ describe Google::Cloud::Monitoring::V3::UptimeCheckServiceClient do
           client = Google::Cloud::Monitoring::UptimeCheck.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_uptime_check_ips
           end
 

--- a/google-cloud-phishing_protection/synth.metadata
+++ b/google-cloud-phishing_protection/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:42:02.536474Z",
+  "updateTime": "2019-05-30T00:34:42.809673Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-phishing_protection/synth.py
+++ b/google-cloud-phishing_protection/synth.py
@@ -177,3 +177,11 @@ s.replace(
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1beta1']:
+    s.replace(
+        f'test/google/cloud/phishing_protection/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-phishing_protection/test/google/cloud/phishing_protection/v1beta1/phishing_protection_client_test.rb
+++ b/google-cloud-phishing_protection/test/google/cloud/phishing_protection/v1beta1/phishing_protection_client_test.rb
@@ -133,7 +133,7 @@ describe Google::Cloud::PhishingProtection::V1beta1::PhishingProtectionClient do
           client = Google::Cloud::PhishingProtection.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.report_phishing(formatted_parent, uri)
           end
 

--- a/google-cloud-recaptcha_enterprise/synth.metadata
+++ b/google-cloud-recaptcha_enterprise/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:42:21.638054Z",
+  "updateTime": "2019-05-30T00:33:20.746309Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-recaptcha_enterprise/synth.py
+++ b/google-cloud-recaptcha_enterprise/synth.py
@@ -166,3 +166,11 @@ s.replace(
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1beta1']:
+    s.replace(
+        f'test/google/cloud/recaptcha_enterprise/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-recaptcha_enterprise/test/google/cloud/recaptcha_enterprise/v1beta1/recaptcha_enterprise_client_test.rb
+++ b/google-cloud-recaptcha_enterprise/test/google/cloud/recaptcha_enterprise/v1beta1/recaptcha_enterprise_client_test.rb
@@ -135,7 +135,7 @@ describe Google::Cloud::RecaptchaEnterprise::V1beta1::RecaptchaEnterpriseClient 
           client = Google::Cloud::RecaptchaEnterprise.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.create_assessment(formatted_parent, assessment)
           end
 
@@ -212,7 +212,7 @@ describe Google::Cloud::RecaptchaEnterprise::V1beta1::RecaptchaEnterpriseClient 
           client = Google::Cloud::RecaptchaEnterprise.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.annotate_assessment(formatted_name, annotation)
           end
 

--- a/google-cloud-redis/synth.metadata
+++ b/google-cloud-redis/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:42:39.627315Z",
+  "updateTime": "2019-05-30T00:32:18.089928Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -140,3 +140,11 @@ s.replace(
     'README.md\n',
     'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1', 'v1beta1']:
+    s.replace(
+        f'test/google/cloud/redis/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-redis/test/google/cloud/redis/v1/cloud_redis_client_test.rb
+++ b/google-cloud-redis/test/google/cloud/redis/v1/cloud_redis_client_test.rb
@@ -129,7 +129,7 @@ describe Google::Cloud::Redis::V1::CloudRedisClient do
           client = Google::Cloud::Redis.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_instances(formatted_parent)
           end
 
@@ -227,7 +227,7 @@ describe Google::Cloud::Redis::V1::CloudRedisClient do
           client = Google::Cloud::Redis.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_instance(formatted_name)
           end
 
@@ -390,7 +390,7 @@ describe Google::Cloud::Redis::V1::CloudRedisClient do
           client = Google::Cloud::Redis.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_instance(
               formatted_parent,
               instance_id,
@@ -552,7 +552,7 @@ describe Google::Cloud::Redis::V1::CloudRedisClient do
           client = Google::Cloud::Redis.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_instance(update_mask, instance)
           end
 
@@ -664,7 +664,7 @@ describe Google::Cloud::Redis::V1::CloudRedisClient do
           client = Google::Cloud::Redis.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_instance(formatted_name)
           end
 
@@ -807,7 +807,7 @@ describe Google::Cloud::Redis::V1::CloudRedisClient do
           client = Google::Cloud::Redis.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.failover_instance(formatted_name, data_protection_mode)
           end
 

--- a/google-cloud-redis/test/google/cloud/redis/v1beta1/cloud_redis_client_test.rb
+++ b/google-cloud-redis/test/google/cloud/redis/v1beta1/cloud_redis_client_test.rb
@@ -129,7 +129,7 @@ describe Google::Cloud::Redis::V1beta1::CloudRedisClient do
           client = Google::Cloud::Redis.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.list_instances(formatted_parent)
           end
 
@@ -227,7 +227,7 @@ describe Google::Cloud::Redis::V1beta1::CloudRedisClient do
           client = Google::Cloud::Redis.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.get_instance(formatted_name)
           end
 
@@ -390,7 +390,7 @@ describe Google::Cloud::Redis::V1beta1::CloudRedisClient do
           client = Google::Cloud::Redis.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.create_instance(
               formatted_parent,
               instance_id,
@@ -552,7 +552,7 @@ describe Google::Cloud::Redis::V1beta1::CloudRedisClient do
           client = Google::Cloud::Redis.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.update_instance(update_mask, instance)
           end
 
@@ -664,7 +664,7 @@ describe Google::Cloud::Redis::V1beta1::CloudRedisClient do
           client = Google::Cloud::Redis.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.delete_instance(formatted_name)
           end
 
@@ -807,7 +807,7 @@ describe Google::Cloud::Redis::V1beta1::CloudRedisClient do
           client = Google::Cloud::Redis.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.failover_instance(formatted_name, data_protection_mode)
           end
 

--- a/google-cloud-scheduler/synth.metadata
+++ b/google-cloud-scheduler/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-16T10:41:30.407967Z",
+  "updateTime": "2019-05-30T00:30:38.998401Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "fcf9612e65e7b4e1aee55fa07dbf028f1e3cdac6",
-        "internalRef": "248477824"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-scheduler/synth.py
+++ b/google-cloud-scheduler/synth.py
@@ -123,3 +123,11 @@ s.replace(
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1', 'v1beta1']:
+    s.replace(
+        f'test/google/cloud/scheduler/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-scheduler/test/google/cloud/scheduler/v1/cloud_scheduler_client_test.rb
+++ b/google-cloud-scheduler/test/google/cloud/scheduler/v1/cloud_scheduler_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Scheduler::V1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_jobs(formatted_parent)
           end
 
@@ -210,7 +210,7 @@ describe Google::Cloud::Scheduler::V1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_job(formatted_name)
           end
 
@@ -296,7 +296,7 @@ describe Google::Cloud::Scheduler::V1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_job(formatted_parent, job)
           end
 
@@ -382,7 +382,7 @@ describe Google::Cloud::Scheduler::V1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_job(job, update_mask)
           end
 
@@ -451,7 +451,7 @@ describe Google::Cloud::Scheduler::V1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_job(formatted_name)
           end
 
@@ -533,7 +533,7 @@ describe Google::Cloud::Scheduler::V1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.pause_job(formatted_name)
           end
 
@@ -615,7 +615,7 @@ describe Google::Cloud::Scheduler::V1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.resume_job(formatted_name)
           end
 
@@ -697,7 +697,7 @@ describe Google::Cloud::Scheduler::V1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.run_job(formatted_name)
           end
 

--- a/google-cloud-scheduler/test/google/cloud/scheduler/v1beta1/cloud_scheduler_client_test.rb
+++ b/google-cloud-scheduler/test/google/cloud/scheduler/v1beta1/cloud_scheduler_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Scheduler::V1beta1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.list_jobs(formatted_parent)
           end
 
@@ -210,7 +210,7 @@ describe Google::Cloud::Scheduler::V1beta1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.get_job(formatted_name)
           end
 
@@ -296,7 +296,7 @@ describe Google::Cloud::Scheduler::V1beta1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.create_job(formatted_parent, job)
           end
 
@@ -378,7 +378,7 @@ describe Google::Cloud::Scheduler::V1beta1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.update_job(job)
           end
 
@@ -447,7 +447,7 @@ describe Google::Cloud::Scheduler::V1beta1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.delete_job(formatted_name)
           end
 
@@ -529,7 +529,7 @@ describe Google::Cloud::Scheduler::V1beta1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.pause_job(formatted_name)
           end
 
@@ -611,7 +611,7 @@ describe Google::Cloud::Scheduler::V1beta1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.resume_job(formatted_name)
           end
 
@@ -693,7 +693,7 @@ describe Google::Cloud::Scheduler::V1beta1::CloudSchedulerClient do
           client = Google::Cloud::Scheduler.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.run_job(formatted_name)
           end
 

--- a/google-cloud-security_center/synth.metadata
+++ b/google-cloud-security_center/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:43:18.383679Z",
+  "updateTime": "2019-05-30T00:28:53.080931Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-security_center/synth.py
+++ b/google-cloud-security_center/synth.py
@@ -144,3 +144,11 @@ s.replace(
 
 # Generate the helper methods
 subprocess.call('bundle update && bundle exec rake generate_partials', shell=True)
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1']:
+    s.replace(
+        f'test/google/cloud/security_center/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-security_center/test/google/cloud/security_center/v1/security_center_client_test.rb
+++ b/google-cloud-security_center/test/google/cloud/security_center/v1/security_center_client_test.rb
@@ -141,7 +141,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_source(formatted_parent, source)
           end
 
@@ -241,7 +241,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_finding(
               formatted_parent,
               finding_id,
@@ -320,7 +320,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_iam_policy(formatted_resource)
           end
 
@@ -395,7 +395,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_organization_settings(formatted_name)
           end
 
@@ -475,7 +475,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_source(formatted_name)
           end
 
@@ -556,7 +556,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.group_assets(formatted_parent, group_by)
           end
 
@@ -637,7 +637,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.group_findings(formatted_parent, group_by)
           end
 
@@ -714,7 +714,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_assets(formatted_parent)
           end
 
@@ -791,7 +791,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_findings(formatted_parent)
           end
 
@@ -863,7 +863,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_sources(formatted_parent)
           end
 
@@ -975,7 +975,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.run_asset_discovery(formatted_parent)
           end
 
@@ -1075,7 +1075,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_finding_state(
               formatted_name,
               state,
@@ -1158,7 +1158,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_iam_policy(formatted_resource, policy)
           end
 
@@ -1235,7 +1235,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.test_iam_permissions(formatted_resource, permissions)
           end
 
@@ -1319,7 +1319,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_finding(finding)
           end
 
@@ -1394,7 +1394,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_organization_settings(organization_settings)
           end
 
@@ -1474,7 +1474,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_source(source)
           end
 
@@ -1548,7 +1548,7 @@ describe Google::Cloud::SecurityCenter::V1::SecurityCenterClient do
           client = Google::Cloud::SecurityCenter.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_security_marks(security_marks)
           end
 

--- a/google-cloud-spanner/synth.metadata
+++ b/google-cloud-spanner/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:43:41.182995Z",
+  "updateTime": "2019-05-30T00:26:05.978698Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     }
   ],

--- a/google-cloud-spanner/synth.py
+++ b/google-cloud-spanner/synth.py
@@ -163,3 +163,21 @@ s.replace(
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
 )
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1']:
+    s.replace(
+        f'test/google/cloud/spanner/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )
+    s.replace(
+        f'test/google/cloud/spanner/admin/database/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )
+    s.replace(
+        f'test/google/cloud/spanner/admin/instance/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb
@@ -129,7 +129,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_databases(formatted_parent)
           end
 
@@ -248,7 +248,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_database(formatted_parent, create_statement)
           end
 
@@ -322,7 +322,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_database(formatted_name)
           end
 
@@ -440,7 +440,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_database_ddl(formatted_database, statements)
           end
 
@@ -509,7 +509,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.drop_database(formatted_database)
           end
 
@@ -582,7 +582,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_database_ddl(formatted_database)
           end
 
@@ -661,7 +661,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_iam_policy(formatted_resource, policy)
           end
 
@@ -736,7 +736,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_iam_policy(formatted_resource)
           end
 
@@ -813,7 +813,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.test_iam_permissions(formatted_resource, permissions)
           end
 

--- a/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb
@@ -129,7 +129,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_instance_configs(formatted_parent)
           end
 
@@ -204,7 +204,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_instance_config(formatted_name)
           end
 
@@ -276,7 +276,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_instances(formatted_parent)
           end
 
@@ -358,7 +358,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_instance(formatted_name)
           end
 
@@ -499,7 +499,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_instance(
               formatted_parent,
               instance_id,
@@ -630,7 +630,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_instance(instance, field_mask)
           end
 
@@ -699,7 +699,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_instance(formatted_name)
           end
 
@@ -778,7 +778,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_iam_policy(formatted_resource, policy)
           end
 
@@ -853,7 +853,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_iam_policy(formatted_resource)
           end
 
@@ -930,7 +930,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.test_iam_permissions(formatted_resource, permissions)
           end
 

--- a/google-cloud-spanner/test/google/cloud/spanner/v1/spanner_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/v1/spanner_client_test.rb
@@ -130,7 +130,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_session(formatted_database)
           end
 
@@ -204,7 +204,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_session(formatted_name)
           end
 
@@ -276,7 +276,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_sessions(formatted_database)
           end
 
@@ -345,7 +345,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_session(formatted_name)
           end
 
@@ -422,7 +422,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.execute_sql(formatted_session, sql)
           end
 
@@ -495,7 +495,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.execute_streaming_sql(formatted_session, sql)
           end
 
@@ -596,7 +596,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.execute_batch_dml(
               formatted_session,
               transaction,
@@ -696,7 +696,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.read(
               formatted_session,
               table,
@@ -787,7 +787,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.streaming_read(
               formatted_session,
               table,
@@ -870,7 +870,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.begin_transaction(formatted_session, options_)
           end
 
@@ -953,7 +953,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.commit(formatted_session, mutations)
           end
 
@@ -1026,7 +1026,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.rollback(formatted_session, transaction_id)
           end
 
@@ -1103,7 +1103,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.partition_query(formatted_session, sql)
           end
 
@@ -1192,7 +1192,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.partition_read(
               formatted_session,
               table,

--- a/google-cloud-speech/synth.metadata
+++ b/google-cloud-speech/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-23T10:45:25.394681Z",
+  "updateTime": "2019-05-30T00:21:56.569843Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.20.0",
-        "dockerImage": "googleapis/artman@sha256:3246adac900f4bdbd62920e80de2e5877380e44036b3feae13667ec255ebf5ec"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "f792303254ea54442d03ca470ffb38930bda7806",
-        "internalRef": "249516437"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -187,3 +187,11 @@ s.replace(
     'gem.add_development_dependency "rubocop".*$',
     'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1', 'v1p1beta1']:
+    s.replace(
+        f'test/google/cloud/speech/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-speech/test/google/cloud/speech/v1/speech_client_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/v1/speech_client_test.rb
@@ -150,7 +150,7 @@ describe Google::Cloud::Speech::V1::SpeechClient do
           client = Google::Cloud::Speech.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.recognize(config, audio)
           end
 
@@ -292,7 +292,7 @@ describe Google::Cloud::Speech::V1::SpeechClient do
           client = Google::Cloud::Speech.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.long_running_recognize(config, audio)
           end
 

--- a/google-cloud-speech/test/google/cloud/speech/v1p1beta1/speech_client_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/v1p1beta1/speech_client_test.rb
@@ -150,7 +150,7 @@ describe Google::Cloud::Speech::V1p1beta1::SpeechClient do
           client = Google::Cloud::Speech.new(version: :v1p1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p1beta1 do
             client.recognize(config, audio)
           end
 
@@ -292,7 +292,7 @@ describe Google::Cloud::Speech::V1p1beta1::SpeechClient do
           client = Google::Cloud::Speech.new(version: :v1p1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p1beta1 do
             client.long_running_recognize(config, audio)
           end
 

--- a/google-cloud-talent/synth.metadata
+++ b/google-cloud-talent/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-05-29T10:44:29.616548Z",
+  "updateTime": "2019-05-30T00:19:16.962643Z",
   "sources": [
     {
       "generator": {
@@ -12,8 +12,8 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "fa15c3006e27b87a20c7a9ffbb7bbe4149c61387",
-        "internalRef": "250401304"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-talent/synth.py
+++ b/google-cloud-talent/synth.py
@@ -138,3 +138,11 @@ s.replace(
 
 # Generate the helper methods
 call(f'bundle update && bundle exec rake generate_partials TALENT_SERVICES={",".join(services)}', shell=True)
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v4beta1']:
+    s.replace(
+        f'test/google/cloud/talent/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-talent/test/google/cloud/talent/v4beta1/application_service_client_test.rb
+++ b/google-cloud-talent/test/google/cloud/talent/v4beta1/application_service_client_test.rb
@@ -148,7 +148,7 @@ describe Google::Cloud::Talent::V4beta1::ApplicationServiceClient do
           client = Google::Cloud::Talent::ApplicationService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.create_application(formatted_parent, application)
           end
 
@@ -236,7 +236,7 @@ describe Google::Cloud::Talent::V4beta1::ApplicationServiceClient do
           client = Google::Cloud::Talent::ApplicationService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.get_application(formatted_name)
           end
 
@@ -324,7 +324,7 @@ describe Google::Cloud::Talent::V4beta1::ApplicationServiceClient do
           client = Google::Cloud::Talent::ApplicationService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.update_application(application)
           end
 
@@ -393,7 +393,7 @@ describe Google::Cloud::Talent::V4beta1::ApplicationServiceClient do
           client = Google::Cloud::Talent::ApplicationService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.delete_application(formatted_name)
           end
 
@@ -465,7 +465,7 @@ describe Google::Cloud::Talent::V4beta1::ApplicationServiceClient do
           client = Google::Cloud::Talent::ApplicationService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.list_applications(formatted_parent)
           end
 

--- a/google-cloud-talent/test/google/cloud/talent/v4beta1/company_service_client_test.rb
+++ b/google-cloud-talent/test/google/cloud/talent/v4beta1/company_service_client_test.rb
@@ -154,7 +154,7 @@ describe Google::Cloud::Talent::V4beta1::CompanyServiceClient do
           client = Google::Cloud::Talent::CompanyService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.create_company(formatted_parent, company)
           end
 
@@ -248,7 +248,7 @@ describe Google::Cloud::Talent::V4beta1::CompanyServiceClient do
           client = Google::Cloud::Talent::CompanyService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.get_company(formatted_name)
           end
 
@@ -342,7 +342,7 @@ describe Google::Cloud::Talent::V4beta1::CompanyServiceClient do
           client = Google::Cloud::Talent::CompanyService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.update_company(company)
           end
 
@@ -411,7 +411,7 @@ describe Google::Cloud::Talent::V4beta1::CompanyServiceClient do
           client = Google::Cloud::Talent::CompanyService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.delete_company(formatted_name)
           end
 
@@ -483,7 +483,7 @@ describe Google::Cloud::Talent::V4beta1::CompanyServiceClient do
           client = Google::Cloud::Talent::CompanyService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.list_companies(formatted_parent)
           end
 

--- a/google-cloud-talent/test/google/cloud/talent/v4beta1/completion_client_test.rb
+++ b/google-cloud-talent/test/google/cloud/talent/v4beta1/completion_client_test.rb
@@ -145,7 +145,7 @@ describe Google::Cloud::Talent::V4beta1::CompletionClient do
           client = Google::Cloud::Talent::Completion.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.complete_query(
               formatted_parent,
               query,

--- a/google-cloud-talent/test/google/cloud/talent/v4beta1/event_service_client_test.rb
+++ b/google-cloud-talent/test/google/cloud/talent/v4beta1/event_service_client_test.rb
@@ -140,7 +140,7 @@ describe Google::Cloud::Talent::V4beta1::EventServiceClient do
           client = Google::Cloud::Talent::Event.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.create_client_event(formatted_parent, client_event)
           end
 

--- a/google-cloud-talent/test/google/cloud/talent/v4beta1/job_service_client_test.rb
+++ b/google-cloud-talent/test/google/cloud/talent/v4beta1/job_service_client_test.rb
@@ -159,7 +159,7 @@ describe Google::Cloud::Talent::V4beta1::JobServiceClient do
           client = Google::Cloud::Talent::JobService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.create_job(formatted_parent, job)
           end
 
@@ -257,7 +257,7 @@ describe Google::Cloud::Talent::V4beta1::JobServiceClient do
           client = Google::Cloud::Talent::JobService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.get_job(formatted_name)
           end
 
@@ -355,7 +355,7 @@ describe Google::Cloud::Talent::V4beta1::JobServiceClient do
           client = Google::Cloud::Talent::JobService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.update_job(job)
           end
 
@@ -424,7 +424,7 @@ describe Google::Cloud::Talent::V4beta1::JobServiceClient do
           client = Google::Cloud::Talent::JobService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.delete_job(formatted_name)
           end
 
@@ -500,7 +500,7 @@ describe Google::Cloud::Talent::V4beta1::JobServiceClient do
           client = Google::Cloud::Talent::JobService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.list_jobs(formatted_parent, filter)
           end
 
@@ -573,7 +573,7 @@ describe Google::Cloud::Talent::V4beta1::JobServiceClient do
           client = Google::Cloud::Talent::JobService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.batch_delete_jobs(formatted_parent, filter)
           end
 
@@ -658,7 +658,7 @@ describe Google::Cloud::Talent::V4beta1::JobServiceClient do
           client = Google::Cloud::Talent::JobService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.search_jobs(formatted_parent, request_metadata)
           end
 
@@ -743,7 +743,7 @@ describe Google::Cloud::Talent::V4beta1::JobServiceClient do
           client = Google::Cloud::Talent::JobService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.search_jobs_for_alert(formatted_parent, request_metadata)
           end
 
@@ -870,7 +870,7 @@ describe Google::Cloud::Talent::V4beta1::JobServiceClient do
           client = Google::Cloud::Talent::JobService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.batch_create_jobs(formatted_parent, jobs)
           end
 
@@ -997,7 +997,7 @@ describe Google::Cloud::Talent::V4beta1::JobServiceClient do
           client = Google::Cloud::Talent::JobService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.batch_update_jobs(formatted_parent, jobs)
           end
 

--- a/google-cloud-talent/test/google/cloud/talent/v4beta1/profile_service_client_test.rb
+++ b/google-cloud-talent/test/google/cloud/talent/v4beta1/profile_service_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Talent::V4beta1::ProfileServiceClient do
           client = Google::Cloud::Talent::ProfileService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.list_profiles(formatted_parent)
           end
 
@@ -220,7 +220,7 @@ describe Google::Cloud::Talent::V4beta1::ProfileServiceClient do
           client = Google::Cloud::Talent::ProfileService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.create_profile(formatted_parent, profile)
           end
 
@@ -308,7 +308,7 @@ describe Google::Cloud::Talent::V4beta1::ProfileServiceClient do
           client = Google::Cloud::Talent::ProfileService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.get_profile(formatted_name)
           end
 
@@ -396,7 +396,7 @@ describe Google::Cloud::Talent::V4beta1::ProfileServiceClient do
           client = Google::Cloud::Talent::ProfileService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.update_profile(profile)
           end
 
@@ -465,7 +465,7 @@ describe Google::Cloud::Talent::V4beta1::ProfileServiceClient do
           client = Google::Cloud::Talent::ProfileService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.delete_profile(formatted_name)
           end
 
@@ -546,7 +546,7 @@ describe Google::Cloud::Talent::V4beta1::ProfileServiceClient do
           client = Google::Cloud::Talent::ProfileService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.search_profiles(formatted_parent, request_metadata)
           end
 

--- a/google-cloud-talent/test/google/cloud/talent/v4beta1/tenant_service_client_test.rb
+++ b/google-cloud-talent/test/google/cloud/talent/v4beta1/tenant_service_client_test.rb
@@ -135,7 +135,7 @@ describe Google::Cloud::Talent::V4beta1::TenantServiceClient do
           client = Google::Cloud::Talent::TenantService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.create_tenant(formatted_parent, tenant)
           end
 
@@ -210,7 +210,7 @@ describe Google::Cloud::Talent::V4beta1::TenantServiceClient do
           client = Google::Cloud::Talent::TenantService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.get_tenant(formatted_name)
           end
 
@@ -285,7 +285,7 @@ describe Google::Cloud::Talent::V4beta1::TenantServiceClient do
           client = Google::Cloud::Talent::TenantService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.update_tenant(tenant)
           end
 
@@ -354,7 +354,7 @@ describe Google::Cloud::Talent::V4beta1::TenantServiceClient do
           client = Google::Cloud::Talent::TenantService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.delete_tenant(formatted_name)
           end
 
@@ -426,7 +426,7 @@ describe Google::Cloud::Talent::V4beta1::TenantServiceClient do
           client = Google::Cloud::Talent::TenantService.new(version: :v4beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v4beta1 do
             client.list_tenants(formatted_parent)
           end
 

--- a/google-cloud-tasks/synth.metadata
+++ b/google-cloud-tasks/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-16T10:42:54.407257Z",
+  "updateTime": "2019-05-30T00:16:12.917635Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "fcf9612e65e7b4e1aee55fa07dbf028f1e3cdac6",
-        "internalRef": "248477824"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -155,3 +155,11 @@ s.replace(
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v2beta2', 'v2beta3', 'v2']:
+    s.replace(
+        f'test/google/cloud/tasks/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-tasks/test/google/cloud/tasks/v2/cloud_tasks_client_test.rb
+++ b/google-cloud-tasks/test/google/cloud/tasks/v2/cloud_tasks_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_queues(formatted_parent)
           end
 
@@ -202,7 +202,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_queue(formatted_name)
           end
 
@@ -280,7 +280,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_queue(formatted_parent, queue)
           end
 
@@ -354,7 +354,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_queue(queue)
           end
 
@@ -423,7 +423,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_queue(formatted_name)
           end
 
@@ -497,7 +497,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.purge_queue(formatted_name)
           end
 
@@ -571,7 +571,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.pause_queue(formatted_name)
           end
 
@@ -645,7 +645,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.resume_queue(formatted_name)
           end
 
@@ -720,7 +720,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_iam_policy(formatted_resource)
           end
 
@@ -799,7 +799,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.set_iam_policy(formatted_resource, policy)
           end
 
@@ -876,7 +876,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.test_iam_permissions(formatted_resource, permissions)
           end
 
@@ -948,7 +948,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_tasks(formatted_parent)
           end
 
@@ -1028,7 +1028,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_task(formatted_name)
           end
 
@@ -1112,7 +1112,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_task(formatted_parent, task)
           end
 
@@ -1181,7 +1181,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_task(formatted_name)
           end
 
@@ -1261,7 +1261,7 @@ describe Google::Cloud::Tasks::V2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.run_task(formatted_name)
           end
 

--- a/google-cloud-tasks/test/google/cloud/tasks/v2beta2/cloud_tasks_client_test.rb
+++ b/google-cloud-tasks/test/google/cloud/tasks/v2beta2/cloud_tasks_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.list_queues(formatted_parent)
           end
 
@@ -202,7 +202,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.get_queue(formatted_name)
           end
 
@@ -280,7 +280,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.create_queue(formatted_parent, queue)
           end
 
@@ -354,7 +354,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.update_queue(queue)
           end
 
@@ -423,7 +423,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.delete_queue(formatted_name)
           end
 
@@ -497,7 +497,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.purge_queue(formatted_name)
           end
 
@@ -571,7 +571,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.pause_queue(formatted_name)
           end
 
@@ -645,7 +645,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.resume_queue(formatted_name)
           end
 
@@ -720,7 +720,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.get_iam_policy(formatted_resource)
           end
 
@@ -799,7 +799,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.set_iam_policy(formatted_resource, policy)
           end
 
@@ -876,7 +876,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.test_iam_permissions(formatted_resource, permissions)
           end
 
@@ -948,7 +948,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.list_tasks(formatted_parent)
           end
 
@@ -1022,7 +1022,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.get_task(formatted_name)
           end
 
@@ -1100,7 +1100,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.create_task(formatted_parent, task)
           end
 
@@ -1169,7 +1169,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.delete_task(formatted_name)
           end
 
@@ -1246,7 +1246,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.lease_tasks(formatted_parent, lease_duration)
           end
 
@@ -1319,7 +1319,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.acknowledge_task(formatted_name, schedule_time)
           end
 
@@ -1409,7 +1409,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.renew_lease(
               formatted_name,
               schedule_time,
@@ -1491,7 +1491,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.cancel_lease(formatted_name, schedule_time)
           end
 
@@ -1565,7 +1565,7 @@ describe Google::Cloud::Tasks::V2beta2::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta2 do
             client.run_task(formatted_name)
           end
 

--- a/google-cloud-tasks/test/google/cloud/tasks/v2beta3/cloud_tasks_client_test.rb
+++ b/google-cloud-tasks/test/google/cloud/tasks/v2beta3/cloud_tasks_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.list_queues(formatted_parent)
           end
 
@@ -202,7 +202,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.get_queue(formatted_name)
           end
 
@@ -280,7 +280,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.create_queue(formatted_parent, queue)
           end
 
@@ -354,7 +354,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.update_queue(queue)
           end
 
@@ -423,7 +423,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.delete_queue(formatted_name)
           end
 
@@ -497,7 +497,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.purge_queue(formatted_name)
           end
 
@@ -571,7 +571,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.pause_queue(formatted_name)
           end
 
@@ -645,7 +645,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.resume_queue(formatted_name)
           end
 
@@ -720,7 +720,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.get_iam_policy(formatted_resource)
           end
 
@@ -799,7 +799,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.set_iam_policy(formatted_resource, policy)
           end
 
@@ -876,7 +876,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.test_iam_permissions(formatted_resource, permissions)
           end
 
@@ -948,7 +948,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.list_tasks(formatted_parent)
           end
 
@@ -1028,7 +1028,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.get_task(formatted_name)
           end
 
@@ -1112,7 +1112,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.create_task(formatted_parent, task)
           end
 
@@ -1181,7 +1181,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.delete_task(formatted_name)
           end
 
@@ -1261,7 +1261,7 @@ describe Google::Cloud::Tasks::V2beta3::CloudTasksClient do
           client = Google::Cloud::Tasks.new(version: :v2beta3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2beta3 do
             client.run_task(formatted_name)
           end
 

--- a/google-cloud-vision/synth.metadata
+++ b/google-cloud-vision/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-05-25T10:43:41.198197Z",
+  "updateTime": "2019-05-30T00:08:48.391017Z",
   "sources": [
     {
       "generator": {
@@ -12,8 +12,8 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7ca19138ccebe219a67be2245200e821b3e32123",
-        "internalRef": "249916728"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {

--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -156,3 +156,11 @@ s.replace(
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1', 'v1p3beta1']:
+    s.replace(
+        f'test/google/cloud/vision/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )

--- a/google-cloud-vision/test/google/cloud/vision/v1/image_annotator_client_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/v1/image_annotator_client_test.rb
@@ -136,7 +136,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotatorClient do
           client = Google::Cloud::Vision::ImageAnnotator.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.batch_annotate_images(requests)
           end
 
@@ -215,7 +215,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotatorClient do
           client = Google::Cloud::Vision::ImageAnnotator.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.batch_annotate_files(requests)
           end
 
@@ -342,7 +342,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotatorClient do
           client = Google::Cloud::Vision::ImageAnnotator.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.async_batch_annotate_images(requests, output_config)
           end
 
@@ -463,7 +463,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotatorClient do
           client = Google::Cloud::Vision::ImageAnnotator.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.async_batch_annotate_files(requests)
           end
 

--- a/google-cloud-vision/test/google/cloud/vision/v1/product_search_client_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/v1/product_search_client_test.rb
@@ -136,7 +136,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_product_set(formatted_parent, product_set)
           end
 
@@ -208,7 +208,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_product_sets(formatted_parent)
           end
 
@@ -283,7 +283,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_product_set(formatted_name)
           end
 
@@ -358,7 +358,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_product_set(product_set)
           end
 
@@ -427,7 +427,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_product_set(formatted_name)
           end
 
@@ -513,7 +513,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_product(formatted_parent, product)
           end
 
@@ -585,7 +585,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_products(formatted_parent)
           end
 
@@ -667,7 +667,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_product(formatted_name)
           end
 
@@ -749,7 +749,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_product(product)
           end
 
@@ -818,7 +818,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_product(formatted_name)
           end
 
@@ -897,7 +897,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_reference_image(formatted_parent, reference_image)
           end
 
@@ -966,7 +966,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_reference_image(formatted_name)
           end
 
@@ -1043,7 +1043,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_reference_images(formatted_parent)
           end
 
@@ -1118,7 +1118,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_reference_image(formatted_name)
           end
 
@@ -1191,7 +1191,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.add_product_to_product_set(formatted_name, formatted_product)
           end
 
@@ -1264,7 +1264,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.remove_product_from_product_set(formatted_name, formatted_product)
           end
 
@@ -1336,7 +1336,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_products_in_product_set(formatted_name)
           end
 
@@ -1454,7 +1454,7 @@ describe Google::Cloud::Vision::V1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.import_product_sets(formatted_parent, input_config)
           end
 

--- a/google-cloud-vision/test/google/cloud/vision/v1p3beta1/image_annotator_client_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/v1p3beta1/image_annotator_client_test.rb
@@ -136,7 +136,7 @@ describe Google::Cloud::Vision::V1p3beta1::ImageAnnotatorClient do
           client = Google::Cloud::Vision::ImageAnnotator.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.batch_annotate_images(requests)
           end
 
@@ -257,7 +257,7 @@ describe Google::Cloud::Vision::V1p3beta1::ImageAnnotatorClient do
           client = Google::Cloud::Vision::ImageAnnotator.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.async_batch_annotate_files(requests)
           end
 

--- a/google-cloud-vision/test/google/cloud/vision/v1p3beta1/product_search_client_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/v1p3beta1/product_search_client_test.rb
@@ -148,7 +148,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.create_product_set(
               formatted_parent,
               product_set,
@@ -224,7 +224,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.list_product_sets(formatted_parent)
           end
 
@@ -299,7 +299,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.get_product_set(formatted_name)
           end
 
@@ -378,7 +378,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.update_product_set(product_set, update_mask)
           end
 
@@ -447,7 +447,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.delete_product_set(formatted_name)
           end
 
@@ -545,7 +545,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.create_product(
               formatted_parent,
               product,
@@ -621,7 +621,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.list_products(formatted_parent)
           end
 
@@ -703,7 +703,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.get_product(formatted_name)
           end
 
@@ -789,7 +789,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.update_product(product, update_mask)
           end
 
@@ -858,7 +858,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.delete_product(formatted_name)
           end
 
@@ -949,7 +949,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.create_reference_image(
               formatted_parent,
               reference_image,
@@ -1022,7 +1022,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.delete_reference_image(formatted_name)
           end
 
@@ -1099,7 +1099,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.list_reference_images(formatted_parent)
           end
 
@@ -1174,7 +1174,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.get_reference_image(formatted_name)
           end
 
@@ -1247,7 +1247,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.add_product_to_product_set(formatted_name, product)
           end
 
@@ -1320,7 +1320,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.remove_product_from_product_set(formatted_name, product)
           end
 
@@ -1392,7 +1392,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.list_products_in_product_set(formatted_name)
           end
 
@@ -1510,7 +1510,7 @@ describe Google::Cloud::Vision::V1p3beta1::ProductSearchClient do
           client = Google::Cloud::Vision::ProductSearch.new(version: :v1p3beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p3beta1 do
             client.import_product_sets(formatted_parent, input_config)
           end
 


### PR DESCRIPTION
This should cover all currently affected libraries. (We'll let CI double-check.) There were a few auto-gen libraries that are not affected (presumably because all calls are idempotent). I did not modify those.