### PR TITLE
Add Topic#persistence_regions

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -192,8 +192,8 @@ module Google
         # at the project or organization level, which will result in all publish
         # operations failing.
         #
-        # Makes an API call to retrieve the labels values when called on a
-        # reference object. See {#reference?}.
+        # Makes an API call to retrieve the list of GCP region IDs values when
+        # called on a reference object. See {#reference?}.
         #
         # @return [Array<String>]
         #

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -183,6 +183,36 @@ module Google
         end
 
         ##
+        # The list of GCP region IDs where messages that are published to the
+        # topic may be persisted in storage.
+        #
+        # Messages published by publishers running in non-allowed GCP regions
+        # (or running outside of GCP altogether) will be routed for storage in
+        # one of the allowed regions. An empty list indicates a misconfiguration
+        # at the project or organization level, which will result in all publish
+        # operations failing.
+        #
+        # Makes an API call to retrieve the labels values when called on a
+        # reference object. See {#reference?}.
+        #
+        # @return [Array<String>]
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   topic = pubsub.topic "my-topic"
+        #
+        #   topic.persistence_regions #=> ["us-central1", "us-central2"]
+        #
+        def persistence_regions
+          ensure_grpc!
+          return [] if @grpc.message_storage_policy.nil?
+          Array @grpc.message_storage_policy.allowed_persistence_regions
+        end
+
+        ##
         # Permanently deletes the topic.
         #
         # @return [Boolean] Returns `true` if the topic was deleted.

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -490,6 +490,13 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::PubSub::Topic#persistence_regions" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      this_topic = topic_resp "my-topic", persistence_regions: ["us-central1", "us-central2"]
+      mock_publisher.expect :get_topic, this_topic, ["projects/my-project/topics/my-topic", Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::PubSub::Topic#delete" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/my-topic", Hash]
@@ -629,9 +636,15 @@ def topics_hash num_topics, token = ""
   data
 end
 
-def topic_resp topic_name = "my-topic", kms_key_name: nil
-  Google::Cloud::PubSub::V1::Topic.new name: topic_path(topic_name),
-                                       kms_key_name: kms_key_name
+def topic_resp topic_name = "my-topic", kms_key_name: nil, persistence_regions: nil
+  topic = Google::Cloud::PubSub::V1::Topic.new name: topic_path(topic_name),
+                                               kms_key_name: kms_key_name
+  if persistence_regions
+    topic.message_storage_policy = Google::Cloud::PubSub::V1::MessageStoragePolicy.new(
+      allowed_persistence_regions: persistence_regions
+    )
+  end
+  topic
 end
 
 def topic_subscriptions_hash num_subs, token = nil

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/attrs_test.rb
@@ -110,5 +110,25 @@ describe Google::Cloud::PubSub::Topic, :attributes, :mock_pubsub do
 
       mock.verify
     end
+
+    describe "no MessageStoragePolicy" do
+      let(:topic_grpc) { Google::Cloud::PubSub::V1::Topic.new topic_hash(topic_name, labels: labels) }
+
+      it "accesses persistence_regions by making an API call" do
+        topic.must_be :reference?
+        topic.wont_be :resource?
+
+        mock = Minitest::Mock.new
+        mock.expect :get_topic, topic_grpc, [topic_path(topic_name), options: default_options]
+        topic.service.mocked_publisher = mock
+
+        topic.persistence_regions.must_be :empty?
+
+        topic.wont_be :reference?
+        topic.must_be :resource?
+
+        mock.verify
+      end
+    end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/attrs_test.rb
@@ -1,0 +1,114 @@
+# Copyright 2015 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::PubSub::Topic, :attributes, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:labels) { { "foo" => "bar" } }
+  let(:kms_key_name) { "projects/a/locations/b/keyRings/c/cryptoKeys/d" }
+  let(:persistence_regions) { ["us-central1", "us-central2"] }
+  let(:topic_grpc) { Google::Cloud::PubSub::V1::Topic.new topic_hash(topic_name, labels: labels, kms_key_name: kms_key_name, persistence_regions: persistence_regions) }
+  let(:topic) { Google::Cloud::PubSub::Topic.from_grpc topic_grpc, pubsub.service }
+
+  it "is not reference when created with an HTTP method" do
+    topic.wont_be :reference?
+    topic.must_be :resource?
+  end
+
+  it "accesses name without making an API call" do
+    topic.name.must_equal topic_path(topic_name)
+  end
+
+  it "accesses labels without making an API call" do
+    topic.labels.must_equal labels
+  end
+
+  it "accesses kms_key without making an API call" do
+    topic.kms_key.must_equal kms_key_name
+  end
+
+  it "accesses persistence_regions without making an API call" do
+    topic.persistence_regions.must_equal persistence_regions
+  end
+
+  describe "reference topic" do
+    let :topic do
+      Google::Cloud::PubSub::Topic.from_name topic_name, pubsub.service
+    end
+
+    it "is reference" do
+      topic.must_be :reference?
+      topic.wont_be :resource?
+    end
+
+    it "accesses name without making an API call" do
+      topic.must_be :reference?
+      topic.wont_be :resource?
+
+      topic.name.must_equal topic_path(topic_name)
+
+      topic.must_be :reference?
+      topic.wont_be :resource?
+    end
+
+    it "accesses labels by making an API call" do
+      topic.must_be :reference?
+      topic.wont_be :resource?
+
+      mock = Minitest::Mock.new
+      mock.expect :get_topic, topic_grpc, [topic_path(topic_name), options: default_options]
+      topic.service.mocked_publisher = mock
+
+      topic.labels.must_equal labels
+
+      topic.wont_be :reference?
+      topic.must_be :resource?
+
+      mock.verify
+    end
+
+    it "accesses kms_key by making an API call" do
+      topic.must_be :reference?
+      topic.wont_be :resource?
+
+      mock = Minitest::Mock.new
+      mock.expect :get_topic, topic_grpc, [topic_path(topic_name), options: default_options]
+      topic.service.mocked_publisher = mock
+
+      topic.kms_key.must_equal kms_key_name
+
+      topic.wont_be :reference?
+      topic.must_be :resource?
+
+      mock.verify
+    end
+
+    it "accesses persistence_regions by making an API call" do
+      topic.must_be :reference?
+      topic.wont_be :resource?
+
+      mock = Minitest::Mock.new
+      mock.expect :get_topic, topic_grpc, [topic_path(topic_name), options: default_options]
+      topic.service.mocked_publisher = mock
+
+      topic.persistence_regions.must_equal persistence_regions
+
+      topic.wont_be :reference?
+      topic.must_be :resource?
+
+      mock.verify
+    end
+  end
+end

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -120,8 +120,12 @@ class MockPubsub < Minitest::Spec
     data
   end
 
-  def topic_hash topic_name, labels: nil, kms_key_name: nil
-    { name: topic_path(topic_name), labels: labels, kms_key_name: kms_key_name }
+  def topic_hash topic_name, labels: nil, kms_key_name: nil, persistence_regions: nil
+    hash = { name: topic_path(topic_name), labels: labels, kms_key_name: kms_key_name }
+    if persistence_regions
+      hash[:message_storage_policy] = { allowed_persistence_regions: persistence_regions }
+    end
+    hash
   end
 
   def topic_subscriptions_hash num_subs, token = nil


### PR DESCRIPTION
This PR adds the `Topic#persistence_regions` method to the public API. It calls `MessageStoragePolicy#allowed_persistence_regions` from the low-level API.

[closes #3389]