### PR TITLE
feat(firestore): add commit_response to Client#transaction

### DIFF
--- a/google-cloud-firestore/lib/google/cloud/firestore/client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/client.rb
@@ -595,11 +595,11 @@ module Google
         #
         # @param [Integer] max_retries The maximum number of retries for
         #   transactions failed due to errors. Default is 5. Optional.
-        # @param [Integer] commit_response If true, the return value from this
-        #   method will be a `Google::Cloud::Firestore::CommitResponse` object
-        #   with a `commit_time` attribute. If omitted or false, the return
+        # @param [Boolean] commit_response When `true`, the return value from
+        #   this method will be a `Google::Cloud::Firestore::CommitResponse`
+        #   object with a `commit_time` attribute. Otherwise, the return
         #   value from this method will be the return value of the provided
-        #   yield block. Default is false. Optional.
+        #   yield block. Default is `false`. Optional.
         #
         # @yield [transaction] The block for reading data and making changes.
         # @yieldparam [Transaction] transaction The transaction object for

--- a/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
@@ -604,6 +604,7 @@ module Google
 
         ##
         # @private commit the transaction
+        # @return [CommitResponse] The response from committing the changes.
         def commit
           ensure_not_closed!
 


### PR DESCRIPTION
BREAKING CHANGE: The default return value of `Client#transaction` has been
changed to **the return value of the yielded block**. Pass `commit_response: true`
for the previous default behavior of returning the `CommitResponse` with timestamp.

[fixes #3388]