### PR TITLE
Disable gRPC Service Config

### DIFF
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
@@ -73,7 +73,8 @@ module Google
 
         def chan_args
           { "grpc.max_send_message_length" => -1,
-            "grpc.max_receive_message_length" => -1 }
+            "grpc.max_receive_message_length" => -1,
+            "grpc.service_config_disable_resolution" => 1 }
         end
 
         def chan_creds

--- a/google-cloud-datastore/lib/google/cloud/datastore/service.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
@@ -41,7 +41,11 @@ module Google
 
         def channel
           require "grpc"
-          GRPC::Core::Channel.new host, nil, chan_creds
+          GRPC::Core::Channel.new host, chan_args, chan_creds
+        end
+
+        def chan_args
+          { "grpc.service_config_disable_resolution" => 1 }
         end
 
         def chan_creds

--- a/google-cloud-firestore/lib/google/cloud/firestore/service.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/service.rb
@@ -41,7 +41,11 @@ module Google
 
         def channel
           require "grpc"
-          GRPC::Core::Channel.new host, nil, chan_creds
+          GRPC::Core::Channel.new host, chan_args, chan_creds
+        end
+
+        def chan_args
+          { "grpc.service_config_disable_resolution" => 1 }
         end
 
         def chan_creds

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -46,9 +46,10 @@ module Google
         end
 
         def chan_args
-          { "grpc.max_send_message_length"    => -1,
-            "grpc.max_receive_message_length" => -1,
-            "grpc.keepalive_time_ms"          => 300000 }
+          { "grpc.max_send_message_length"           => -1,
+            "grpc.max_receive_message_length"        => -1,
+            "grpc.keepalive_time_ms"                 => 300000,
+            "grpc.service_config_disable_resolution" => 1 }
         end
 
         def chan_creds


### PR DESCRIPTION
Update all GAPIC clients that are created using a GRPC Channel object to disable the gRPC service config resolution by adding the channel argument. This is needed until the gRPC service config is fully implemented/adopted. See googleapis/gax-ruby#213 and googleapis/gapic-generator#2778.