### PR TITLE
Upgrade Pub/Sub to concurrent-ruby Promises framework

### DIFF
--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-gax", "~> 1.3"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
-  gem.add_dependency "concurrent-ruby", "~> 1.0"
+  gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
@@ -193,10 +193,10 @@ module Google
 
         def init_resources!
           @first_published_at   ||= Time.now
-          @publish_thread_pool  ||= Concurrent::FixedThreadPool.new \
-            @publish_threads
-          @callback_thread_pool ||= Concurrent::FixedThreadPool.new \
-            @callback_threads
+          @publish_thread_pool  ||= Concurrent::CachedThreadPool.new \
+            max_threads: @publish_threads
+          @callback_thread_pool ||= Concurrent::CachedThreadPool.new \
+            max_threads: @callback_threads
           @thread ||= Thread.new { run_background }
         end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -266,13 +266,15 @@ module Google
           def perform_callback_async rec_msg
             return unless callback_thread_pool.running?
 
-            Concurrent::Future.new executor: callback_thread_pool do
+            Concurrent::Promises.future_on(
+              callback_thread_pool, @subscriber, rec_msg
+            ) do |sub, msg|
               begin
-                @subscriber.callback.call rec_msg
+                sub.callback.call msg
               rescue StandardError => callback_error
-                @subscriber.error! callback_error
+                sub.error! callback_error
               end
-            end.execute
+            end
           end
 
           def start_streaming!

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -48,8 +48,8 @@ module Google
             @pause_cond = new_cond
 
             @inventory = Inventory.new self, @subscriber.stream_inventory
-            @callback_thread_pool = Concurrent::FixedThreadPool.new \
-              @subscriber.callback_threads
+            @callback_thread_pool = Concurrent::CachedThreadPool.new \
+              max_threads: @subscriber.callback_threads
 
             @stream_keepalive_task = Concurrent::TimerTask.new(
               execution_interval: 30

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
@@ -187,7 +187,8 @@ module Google
           end
 
           def with_threadpool
-            pool = Concurrent::FixedThreadPool.new @subscriber.push_threads
+            pool = Concurrent::CachedThreadPool.new \
+              max_threads: @subscriber.push_threads
 
             yield pool
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
@@ -205,13 +205,13 @@ module Google
           end
 
           def add_future pool
-            Concurrent::Future.new executor: pool do
+            Concurrent::Promises.future_on pool do
               begin
                 yield
               rescue StandardError => error
                 error! error
               end
-            end.execute
+            end
           end
         end
       end


### PR DESCRIPTION
This PR moves Pub/Sub to the concurrent-ruby 1.1, and switches to the Promises framework.

Also, the use of FixedThreadPool has been replaced with CachedThreadPool, which should lower resource utilization when the library is lightly used.