### PR TITLE
Pub/Sub: Fix bug with chaining bang methods

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
@@ -40,7 +40,8 @@ module Google
           end
 
           def add *ack_ids
-            ack_ids.flatten!.compact!
+            ack_ids.flatten!
+            ack_ids.compact!
             return if ack_ids.empty?
 
             synchronize do
@@ -50,7 +51,8 @@ module Google
           end
 
           def remove *ack_ids
-            ack_ids.flatten!.compact!
+            ack_ids.flatten!
+            ack_ids.compact!
             return if ack_ids.empty?
 
             synchronize do


### PR DESCRIPTION
This PR fixes an issue introduced in #2273. The bug is that both `Array#flatten!` and `Array#compact!` will return `self` when changes are made, but return `nil` when no changes are made. This means that we can get inconsistent results when chaining these methods together, as was introduced in #2273. The fix is to call these bang methods on their own lines.

I have searched all the source code for all the other gems and this is the only place I see this being done.