### PR TITLE
Remove messages from inventory after callback

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -267,12 +267,14 @@ module Google
             return unless callback_thread_pool.running?
 
             Concurrent::Promises.future_on(
-              callback_thread_pool, @subscriber, rec_msg
-            ) do |sub, msg|
+              callback_thread_pool, @subscriber, @inventory, rec_msg
+            ) do |sub, inv, msg|
               begin
                 sub.callback.call msg
               rescue StandardError => callback_error
                 sub.error! callback_error
+              ensure
+                inv.remove msg.ack_id
               end
             end
           end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -501,8 +501,12 @@ module Google
         end
 
         ##
-        # Create a {Subscriber} object that receives  and processes messages
-        # using the code provided in the callback.
+        # Create a {Subscriber} object that receives and processes messages
+        # using the code provided in the callback. Messages passed to the
+        # callback should acknowledge ({ReceivedMessage#acknowledge!}) or reject
+        # ({ReceivedMessage#reject!}) the message. If no action is taken, the
+        # message will be removed from the subscriber and made available for
+        # redelivery after the callback is completed.
         #
         # @param [Numeric] deadline The default number of seconds the stream
         #   will hold received messages before modifying the message's ack

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
@@ -1,0 +1,156 @@
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
+  let(:sub_path) { sub_grpc.name }
+  let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
+  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message1-msg-goes-here", 1111) }
+  let(:rec_msg2_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message2-msg-goes-here", 1112) }
+  let(:rec_msg3_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message3-msg-goes-here", 1113) }
+
+  it "removes a single message from inventory, even when ack or nack are not called" do
+    rec_message_msg = "pulled-message"
+    rec_message_ack_id = 123456789
+    pull_res = Google::Cloud::PubSub::V1::StreamingPullResponse.new rec_messages_hash(rec_message_msg, rec_message_ack_id)
+    response_groups = [[pull_res]]
+
+    stub = StreamingPullStub.new response_groups
+    called = false
+
+    subscription.service.mocked_subscriber = stub
+    subscriber = subscription.listen streams: 1 do |result|
+      # flush the initial buffer before any callbacks are processed
+      subscriber.buffer.flush! unless called
+
+      assert_equal ["ack-id-123456789"], subscriber.stream_pool.first.inventory.ack_ids
+
+      assert_kind_of Google::Cloud::PubSub::ReceivedMessage, result
+      assert_equal rec_message_msg, result.data
+      assert_equal "ack-id-#{rec_message_ack_id}", result.ack_id
+      sleep 0.01
+
+      called = true
+    end
+    subscriber.start
+
+    subscriber_retries = 0
+    while !called
+      fail "total number of calls were never made" if subscriber_retries > 100
+      subscriber_retries += 1
+      sleep 0.01
+    end
+
+    sleep 0.01
+    assert_empty subscriber.stream_pool.first.inventory.ack_ids
+
+    subscriber.stop
+    subscriber.wait!
+
+    stub.requests.map(&:to_a).must_equal [
+      [Google::Cloud::PubSub::V1::StreamingPullRequest.new(
+        subscription: sub_path,
+        stream_ack_deadline_seconds: 60
+      )]
+    ]
+
+    # pusher thread pool may deliver out of order, which stinks...
+    ack_msg_ids = []
+    stub.acknowledge_requests.each do |ack_sub_path, msg_ids|
+      assert_equal ack_sub_path, sub_path
+      ack_msg_ids += msg_ids
+    end
+    assert_empty ack_msg_ids
+
+    # pusher thread pool may deliver out of order, which stinks...
+    mod_ack_hash = {}
+    stub.modify_ack_deadline_requests.each do |ack_sub_path, msg_ids, deadline|
+      assert_equal ack_sub_path, sub_path
+      if mod_ack_hash.key? deadline
+        mod_ack_hash[deadline] += msg_ids
+      else
+        mod_ack_hash[deadline] = msg_ids
+      end
+    end
+    mod_ack_hash[60].sort.must_equal ["ack-id-123456789"]
+  end
+
+  it "removes multiple messages from inventory, even when ack or nack are not called" do
+    pull_res = Google::Cloud::PubSub::V1::StreamingPullResponse.new received_messages: [rec_msg1_grpc, rec_msg2_grpc, rec_msg3_grpc]
+    response_groups = [[pull_res]]
+
+    stub = StreamingPullStub.new response_groups
+    called = 0
+
+    subscription.service.mocked_subscriber = stub
+    subscriber = subscription.listen streams: 1 do |msg|
+      # flush the initial buffer before any callbacks are processed
+      subscriber.buffer.flush! if called.zero?
+
+      refute_empty subscriber.stream_pool.first.inventory.ack_ids
+
+      assert_kind_of Google::Cloud::PubSub::ReceivedMessage, msg
+      called += 1
+    end
+    subscriber.start
+
+    subscriber_retries = 0
+    while called < 3
+      fail "total number of calls were never made" if subscriber_retries > 200
+      subscriber_retries += 1
+      sleep 0.01
+    end
+
+    sleep 0.01
+    assert_empty subscriber.stream_pool.first.inventory.ack_ids
+
+    subscriber.stop
+    subscriber.wait!
+
+    stub.requests.map(&:to_a).must_equal [
+      [Google::Cloud::PubSub::V1::StreamingPullRequest.new(
+        subscription: sub_path,
+        stream_ack_deadline_seconds: 60
+      )]
+    ]
+
+    # pusher thread pool may deliver out of order, which stinks...
+    ack_msg_ids = []
+    stub.acknowledge_requests.each do |ack_sub_path, msg_ids|
+      assert_equal ack_sub_path, sub_path
+      ack_msg_ids += msg_ids
+    end
+    assert_empty ack_msg_ids
+
+    # pusher thread pool may deliver out of order, which stinks...
+    mod_ack_hash = {}
+    stub.modify_ack_deadline_requests.each do |ack_sub_path, msg_ids, deadline|
+      assert_equal ack_sub_path, sub_path
+      if mod_ack_hash.key? deadline
+        mod_ack_hash[deadline] += msg_ids
+      else
+        mod_ack_hash[deadline] = msg_ids
+      end
+    end
+    mod_ack_hash[60].sort.must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
+  end
+end


### PR DESCRIPTION
This change prevents the Subscriber Inventory from filling up when
messages are never acked or nacked in the user callback.
This might happen due to an error in the user callback code.
Removing a message from the inventory will cause the message to be
redelivered and reprocessed.