### PR TITLE
Cleanup Subscriber Threading Restart

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -255,7 +255,6 @@ module Google
           rescue StandardError => e
             synchronize do
               @subscriber.error! e
-              start_streaming! unless @stopped
             end
 
             retry

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -255,9 +255,7 @@ module Google
           rescue RestartStream
             retry
           rescue StandardError => e
-            synchronize do
-              @subscriber.error! e
-            end
+            @subscriber.error! e
 
             retry
           end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -246,7 +246,7 @@ module Google
             raise RestartStream unless synchronize { @stopped }
 
             # We must be stopped, tell the stream to quit.
-            @request_queue.push self
+            stop
           rescue GRPC::Cancelled, GRPC::DeadlineExceeded, GRPC::Internal,
                  GRPC::ResourceExhausted, GRPC::Unauthenticated,
                  GRPC::Unavailable, GRPC::Core::CallError


### PR DESCRIPTION
This PR has several minor refactorings. The most consequential is the removal of the call to `start_streaming!` from the Subscriber's background thread. This method will create a second background thread, but after this method is called the first background thread will retry. This means there is potential for multiple background threads. I haven't been able to observe this however.

There are some other minor changes, refinements to the synchronize block used to keep things thread safe. But the biggest change here is to only use retry to keep the background thread alive.