### PR TITLE
Release google-cloud-dataproc 0.4.0

### DIFF
--- a/google-cloud-dataproc/CHANGELOG.md
+++ b/google-cloud-dataproc/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Release History
 
+### 0.4.0 / 2019-06-11
+
+* Add AutoscalingPolicyServiceClient
+  * AutoscalingPolicyServiceClient#create_autoscaling_policy
+  * AutoscalingPolicyServiceClient#update_autoscaling_policy
+  * AutoscalingPolicyServiceClient#get_autoscaling_policy
+  * AutoscalingPolicyServiceClient#list_autoscaling_policies
+  * AutoscalingPolicyServiceClient#delete_autoscaling_policy
+  * Add ClusterConfig attributes:
+    * Add ClusterConfig#autoscaling_config (AutoscalingConfig)
+    * Add ClusterConfig#endpoint_config (EndpointConfig)
+    * Add ClusterConfig#security_config (SecurityConfig)
+  * Add GceClusterConfig#reservation_affinity (ReservationAffinity)
+  * Add SoftwareConfig#optional_components (Component)
+  * Add Job#spark_r_job (SparkRJob)
+* Add VERSION constant
+
 ### 0.3.1 / 2019-04-29
 
 * Add AUTHENTICATION.md guide.

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/version.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Dataproc
-      VERSION = "0.3.1".freeze
+      VERSION = "0.4.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add AutoscalingPolicyServiceClient
  * AutoscalingPolicyServiceClient#create_autoscaling_policy
  * AutoscalingPolicyServiceClient#update_autoscaling_policy
  * AutoscalingPolicyServiceClient#get_autoscaling_policy
  * AutoscalingPolicyServiceClient#list_autoscaling_policies
  * AutoscalingPolicyServiceClient#delete_autoscaling_policy
  * Add ClusterConfig attributes:
    * Add ClusterConfig#autoscaling_config (AutoscalingConfig)
    * Add ClusterConfig#endpoint_config (EndpointConfig)
    * Add ClusterConfig#security_config (SecurityConfig)
  * Add GceClusterConfig#reservation_affinity (ReservationAffinity)
  * Add SoftwareConfig#optional_components (Component)
  * Add Job#spark_r_job (SparkRJob)
* Add VERSION constant

<details><summary>Commits since previous release</summary><pre><code>commit 7bda995bf5454b645858793f24a719f0938d1e05
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Tue Jun 4 13:20:22 2019 -0700

    feat(dataproc): Add AutoscalingPolicyServiceClient
    
    * Add AutoscalingPolicyServiceClient
      * AutoscalingPolicyServiceClient#create_autoscaling_policy
      * AutoscalingPolicyServiceClient#update_autoscaling_policy
      * AutoscalingPolicyServiceClient#get_autoscaling_policy
      * AutoscalingPolicyServiceClient#list_autoscaling_policies
      * AutoscalingPolicyServiceClient#delete_autoscaling_policy
    * Add ClusterConfig attributes:
      * Add ClusterConfig#autoscaling_config (AutoscalingConfig)
      * Add ClusterConfig#endpoint_config (EndpointConfig)
      * Add ClusterConfig#security_config (SecurityConfig)
    * Add GceClusterConfig#reservation_affinity (ReservationAffinity)
    * Add SoftwareConfig#optional_components (Component)
    * Add Job#spark_r_job (SparkRJob)
    
    [pr #3432]

commit ea562c18e376f461f529bd5b535931af5593e4a1
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 4 10:14:49 2019 -0700

    add version.rb and remove Gem.loaded_specs (#3391)

commit 24e09375443694b1ef70e2016352cb8db65509c9
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed May 29 07:48:20 2019 -0700

    Update dataproc synth script to fix AutoscalingPolicy name collision (#3421)

commit b8f07c4c259f7ebcabc75e979cccaa7a24b285b1
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Fri May 10 10:37:59 2019 -0700

    Update generated google-cloud-dataproc files (#3354)
    
    * Revert error retry configuration.

commit 55a3f7afef0d17114ef5265bf080993dc65ab9bf
Author: Graham Paye <paye@google.com>
Date:   Thu May 9 11:38:29 2019 -0700

    dataproc - add version.rb and use it in place of Gem.loaded_specs (#3342)

commit 752d2ebb6e037d840fa8dd533d17dc3929f2a1ff
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Wed May 8 10:01:53 2019 -0700

    Update generated google-cloud-dataproc files (#3308)
    
    * Update error retry configuration.
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-dataproc/google-cloud-dataproc.gemspec b/google-cloud-dataproc/google-cloud-dataproc.gemspec
index 76a6a9feb..a3816b364 100644
--- a/google-cloud-dataproc/google-cloud-dataproc.gemspec
+++ b/google-cloud-dataproc/google-cloud-dataproc.gemspec
@@ -1,9 +1,10 @@
 # -*- ruby -*-
 # encoding: utf-8
+require File.expand_path("../lib/google/cloud/dataproc/version", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dataproc"
-  gem.version       = "0.3.1"
+  gem.version       = Google::Cloud::Dataproc::VERSION
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc.rb b/google-cloud-dataproc/lib/google/cloud/dataproc.rb
index 41d3aac04..a1dfe25c4 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc.rb
@@ -109,6 +109,59 @@ module Google
         .select { |dir| File.exist?(dir + ".rb") }
         .map { |dir| File.basename(dir) }
 
+      module AutoscalingPolicyService
+        ##
+        # The API interface for managing autoscaling policies in the
+        # Google Cloud Dataproc API.
+        #
+        # @param version [Symbol, String]
+        #   The major version of the service to be used. By default :v1
+        #   is used.
+        # @overload new(version:, credentials:, scopes:, client_config:, timeout:)
+        #   @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+        #     Provides the means for authenticating requests made by the client. This parameter can
+        #     be many types.
+        #     A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
+        #     authenticating requests made by this client.
+        #     A `String` will be treated as the path to the keyfile to be used for the construction of
+        #     credentials for this client.
+        #     A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+        #     credentials for this client.
+        #     A `GRPC::Core::Channel` will be used to make calls through.
+        #     A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+        #     should already be composed with a `GRPC::Core::CallCredentials` object.
+        #     A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+        #     metadata for requests, generally, to give OAuth credentials.
+        #   @param scopes [Array<String>]
+        #     The OAuth scopes for this service. This parameter is ignored if
+        #     an updater_proc is supplied.
+        #   @param client_config [Hash]
+        #     A Hash for call options for each method. See
+        #     Google::Gax#construct_settings for the structure of
+        #     this data. Falls back to the default config if not specified
+        #     or the specified config is missing data points.
+        #   @param timeout [Numeric]
+        #     The default timeout, in seconds, for calls made through this client.
+        #   @param metadata [Hash]
+        #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param exception_transformer [Proc]
+        #     An optional proc that intercepts any exceptions raised during an API call to inject
+        #     custom error handling.
+        def self.new(*args, version: :v1, **kwargs)
+          unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)
+            raise "The version: #{version} is not available. The available versions " \
+              "are: [#{AVAILABLE_VERSIONS.join(", ")}]"
+          end
+
+          require "#{FILE_DIR}/#{version.to_s.downcase}"
+          version_module = Google::Cloud::Dataproc
+            .constants
+            .select {|sym| sym.to_s.downcase == version.to_s.downcase}
+            .first
+          Google::Cloud::Dataproc.const_get(version_module)::AutoscalingPolicyService.new(*args, **kwargs)
+        end
+      end
+
       module ClusterController
         ##
         # The ClusterControllerService provides methods to manage clusters
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/cluster_controller_client.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/cluster_controller_client.rb
index 47202eb0e..d6c75b316 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/cluster_controller_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/cluster_controller_client.rb
@@ -29,6 +29,7 @@ require "google/longrunning/operations_client"
 
 require "google/cloud/dataproc/v1/clusters_pb"
 require "google/cloud/dataproc/v1/credentials"
+require "google/cloud/dataproc/version"
 
 module Google
   module Cloud
@@ -146,7 +147,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-dataproc'].version.version
+            package_version = Google::Cloud::Dataproc::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
@@ -234,11 +235,10 @@ module Google
           #   can also be provided.
           # @param request_id [String]
           #   Optional. A unique id used to identify the request. If the server
-          #   receives two
-          #   {Google::Cloud::Dataproc::V1::CreateClusterRequest CreateClusterRequest}
-          #   requests  with the same id, then the second request will be ignored and the
-          #   first {Google::Longrunning::Operation} created
-          #   and stored in the backend is returned.
+          #   receives two {Google::Cloud::Dataproc::V1::CreateClusterRequest CreateClusterRequest} requests  with the same
+          #   id, then the second request will be ignored and the
+          #   first {Google::Longrunning::Operation} created and stored in the backend
+          #   is returned.
           #
           #   It is recommended to always set this value to a
           #   [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
@@ -391,11 +391,10 @@ module Google
           #   can also be provided.
           # @param request_id [String]
           #   Optional. A unique id used to identify the request. If the server
-          #   receives two
-          #   {Google::Cloud::Dataproc::V1::UpdateClusterRequest UpdateClusterRequest}
-          #   requests  with the same id, then the second request will be ignored and the
-          #   first {Google::Longrunning::Operation} created
-          #   and stored in the backend is returned.
+          #   receives two {Google::Cloud::Dataproc::V1::UpdateClusterRequest UpdateClusterRequest} requests  with the same
+          #   id, then the second request will be ignored and the
+          #   first {Google::Longrunning::Operation} created and stored in the
+          #   backend is returned.
           #
           #   It is recommended to always set this value to a
           #   [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
@@ -498,11 +497,10 @@ module Google
           #   (with error NOT_FOUND) if cluster with specified UUID does not exist.
           # @param request_id [String]
           #   Optional. A unique id used to identify the request. If the server
-          #   receives two
-          #   {Google::Cloud::Dataproc::V1::DeleteClusterRequest DeleteClusterRequest}
-          #   requests  with the same id, then the second request will be ignored and the
-          #   first {Google::Longrunning::Operation} created
-          #   and stored in the backend is returned.
+          #   receives two {Google::Cloud::Dataproc::V1::DeleteClusterRequest DeleteClusterRequest} requests  with the same
+          #   id, then the second request will be ignored and the
+          #   first {Google::Longrunning::Operation} created and stored in the
+          #   backend is returned.
           #
           #   It is recommended to always set this value to a
           #   [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/clusters_pb.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/clusters_pb.rb
index b838deaa7..a87aede11 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/clusters_pb.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/clusters_pb.rb
@@ -6,6 +6,7 @@ require 'google/protobuf'
 
 require 'google/api/annotations_pb'
 require 'google/cloud/dataproc/v1/operations_pb'
+require 'google/cloud/dataproc/v1/shared_pb'
 require 'google/longrunning/operations_pb'
 require 'google/protobuf/duration_pb'
 require 'google/protobuf/field_mask_pb'
@@ -93,6 +94,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.dataproc.v1.SoftwareConfig" do
     optional :image_version, :string, 1
     map :properties, :string, :string, 2
+    repeated :optional_components, :enum, 3, "google.cloud.dataproc.v1.Component"
   end
   add_message "google.cloud.dataproc.v1.ClusterMetrics" do
     map :hdfs_metrics, :string, :int64, 1
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/clusters_services_pb.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/clusters_services_pb.rb
index 71410c6c4..b10a82d0c 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/clusters_services_pb.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/clusters_services_pb.rb
@@ -1,7 +1,7 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
 # Source: google/cloud/dataproc/v1/clusters.proto for package 'google.cloud.dataproc.v1'
 # Original file comments:
-# Copyright 2018 Google LLC.
+# Copyright 2019 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/clusters.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/clusters.rb
index 5dc613e82..0c5cba3ff 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/clusters.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/clusters.rb
@@ -60,15 +60,18 @@ module Google
         # The cluster config.
         # @!attribute [rw] config_bucket
         #   @return [String]
-        #     Optional. A Cloud Storage staging bucket used for sharing generated
-        #     SSH keys and config. If you do not specify a staging bucket, Cloud
-        #     Dataproc will determine an appropriate Cloud Storage location (US,
+        #     Optional. A Google Cloud Storage bucket used to stage job
+        #     dependencies, config files, and job driver console output.
+        #     If you do not specify a staging bucket, Cloud
+        #     Dataproc will determine a Cloud Storage location (US,
         #     ASIA, or EU) for your cluster's staging bucket according to the Google
-        #     Compute Engine zone where your cluster is deployed, and then it will create
-        #     and manage this project-level, per-location bucket for you.
+        #     Compute Engine zone where your cluster is deployed, and then create
+        #     and manage this project-level, per-location bucket (see
+        #     [Cloud Dataproc staging
+        #     bucket](/dataproc/docs/concepts/configuring-clusters/staging-bucket)).
         # @!attribute [rw] gce_cluster_config
         #   @return [Google::Cloud::Dataproc::V1::GceClusterConfig]
-        #     Required. The shared Compute Engine config settings for
+        #     Optional. The shared Compute Engine config settings for
         #     all instances in a cluster.
         # @!attribute [rw] master_config
         #   @return [Google::Cloud::Dataproc::V1::InstanceGroupConfig]
@@ -147,8 +150,8 @@ module Google
         #
         #     A full URL, partial URI, or short name are valid. Examples:
         #
-        #     * `https://www.googleapis.com/compute/v1/projects/[project_id]/regions/us-east1/sub0`
-        #     * `projects/[project_id]/regions/us-east1/sub0`
+        #     * `https://www.googleapis.com/compute/v1/projects/[project_id]/regions/us-east1/subnetworks/sub0`
+        #     * `projects/[project_id]/regions/us-east1/subnetworks/sub0`
         #     * `sub0`
         # @!attribute [rw] internal_ip_only
         #   @return [true, false]
@@ -381,13 +384,13 @@ module Google
         #     such as "1.2" (including a subminor version, such as "1.2.29"), or the
         #     ["preview"
         #     version](/dataproc/docs/concepts/versioning/dataproc-versions#other_versions).
-        #     If unspecified, it defaults to the latest version.
+        #     If unspecified, it defaults to the latest Debian version.
         # @!attribute [rw] properties
         #   @return [Hash{String => String}]
         #     Optional. The properties to set on daemon config files.
         #
-        #     Property keys are specified in `prefix:property` format, such as
-        #     `core:fs.defaultFS`. The following are supported prefixes
+        #     Property keys are specified in `prefix:property` format, for example
+        #     `core:hadoop.tmp.dir`. The following are supported prefixes
         #     and their mappings:
         #
         #     * capacity-scheduler: `capacity-scheduler.xml`
@@ -402,6 +405,9 @@ module Google
         #
         #     For more information, see
         #     [Cluster properties](https://cloud.google.com/dataproc/docs/concepts/cluster-properties).
+        # @!attribute [rw] optional_components
+        #   @return [Array<Google::Cloud::Dataproc::V1::Component>]
+        #     The set of optional components to activate on the cluster.
         class SoftwareConfig; end
 
         # Contains cluster daemon metrics, such as HDFS and YARN stats.
@@ -430,11 +436,10 @@ module Google
         # @!attribute [rw] request_id
         #   @return [String]
         #     Optional. A unique id used to identify the request. If the server
-        #     receives two
-        #     {Google::Cloud::Dataproc::V1::CreateClusterRequest CreateClusterRequest}
-        #     requests  with the same id, then the second request will be ignored and the
-        #     first {Google::Longrunning::Operation} created
-        #     and stored in the backend is returned.
+        #     receives two {Google::Cloud::Dataproc::V1::CreateClusterRequest CreateClusterRequest} requests  with the same
+        #     id, then the second request will be ignored and the
+        #     first {Google::Longrunning::Operation} created and stored in the backend
+        #     is returned.
         #
         #     It is recommended to always set this value to a
         #     [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
@@ -519,11 +524,10 @@ module Google
         # @!attribute [rw] request_id
         #   @return [String]
         #     Optional. A unique id used to identify the request. If the server
-        #     receives two
-        #     {Google::Cloud::Dataproc::V1::UpdateClusterRequest UpdateClusterRequest}
-        #     requests  with the same id, then the second request will be ignored and the
-        #     first {Google::Longrunning::Operation} created
-        #     and stored in the backend is returned.
+        #     receives two {Google::Cloud::Dataproc::V1::UpdateClusterRequest UpdateClusterRequest} requests  with the same
+        #     id, then the second request will be ignored and the
+        #     first {Google::Longrunning::Operation} created and stored in the
+        #     backend is returned.
         #
         #     It is recommended to always set this value to a
         #     [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
@@ -550,11 +554,10 @@ module Google
         # @!attribute [rw] request_id
         #   @return [String]
         #     Optional. A unique id used to identify the request. If the server
-        #     receives two
-        #     {Google::Cloud::Dataproc::V1::DeleteClusterRequest DeleteClusterRequest}
-        #     requests  with the same id, then the second request will be ignored and the
-        #     first {Google::Longrunning::Operation} created
-        #     and stored in the backend is returned.
+        #     receives two {Google::Cloud::Dataproc::V1::DeleteClusterRequest DeleteClusterRequest} requests  with the same
+        #     id, then the second request will be ignored and the
+        #     first {Google::Longrunning::Operation} created and stored in the
+        #     backend is returned.
         #
         #     It is recommended to always set this value to a
         #     [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/jobs.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/jobs.rb
index df6dab07b..2e6f1df03 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/jobs.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/jobs.rb
@@ -386,11 +386,12 @@ module Google
         #     belongs to.
         # @!attribute [rw] job_id
         #   @return [String]
-        #     Optional. The job ID, which must be unique within the project. The job ID
-        #     is generated by the server upon job submission or provided by the user as a
-        #     means to perform retries without creating duplicate jobs. The ID must
-        #     contain only letters (a-z, A-Z), numbers (0-9), underscores (_), or
-        #     hyphens (-). The maximum length is 100 characters.
+        #     Optional. The job ID, which must be unique within the project.
+        #
+        #     The ID must contain only letters (a-z, A-Z), numbers (0-9),
+        #     underscores (_), or hyphens (-). The maximum length is 100 characters.
+        #
+        #     If not specified by the caller, the job ID will be provided by the server.
         class JobReference; end
 
         # A YARN application created by a job. Application information is a subset of
@@ -544,8 +545,8 @@ module Google
         # @!attribute [rw] request_id
         #   @return [String]
         #     Optional. A unique id used to identify the request. If the server
-        #     receives two {Google::Cloud::Dataproc::V1::SubmitJobRequest SubmitJobRequest}
-        #     requests  with the same id, then the second request will be ignored and the
+        #     receives two {Google::Cloud::Dataproc::V1::SubmitJobRequest SubmitJobRequest} requests  with the same
+        #     id, then the second request will be ignored and the
         #     first {Google::Cloud::Dataproc::V1::Job Job} created and stored in the backend
         #     is returned.
         #
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/workflow_templates.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/workflow_templates.rb
index eac6fde06..00d90ee7b 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/workflow_templates.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/workflow_templates.rb
@@ -136,8 +136,8 @@ module Google
         #
         #     The step id is used as prefix for job id, as job
         #     `goog-dataproc-workflow-step-id` label, and in
-        #     {Google::Cloud::Dataproc::V1::OrderedJob#prerequisite_step_ids prerequisiteStepIds}
-        #     field from other steps.
+        #     {Google::Cloud::Dataproc::V1::OrderedJob#prerequisite_step_ids prerequisiteStepIds} field from other
+        #     steps.
         #
         #     The id must contain only letters (a-z, A-Z), numbers (0-9),
         #     underscores (_), and hyphens (-). Cannot begin or end with underscore
@@ -205,10 +205,10 @@ module Google
         #     A field is allowed to appear in at most one parameter's list of field
         #     paths.
         #
-        #     A field path is similar in syntax to a
-        #     {Google::Protobuf::FieldMask}. For example, a
-        #     field path that references the zone field of a workflow template's cluster
-        #     selector would be specified as `placement.clusterSelector.zone`.
+        #     A field path is similar in syntax to a {Google::Protobuf::FieldMask}.
+        #     For example, a field path that references the zone field of a workflow
+        #     template's cluster selector would be specified as
+        #     `placement.clusterSelector.zone`.
         #
         #     Also, field paths can reference fields using the following syntax:
         #
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/job_controller_client.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/job_controller_client.rb
index 8785163ca..9c3374e1a 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/job_controller_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/job_controller_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/cloud/dataproc/v1/jobs_pb"
 require "google/cloud/dataproc/v1/credentials"
+require "google/cloud/dataproc/version"
 
 module Google
   module Cloud
@@ -129,7 +130,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-dataproc'].version.version
+            package_version = Google::Cloud::Dataproc::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
@@ -217,8 +218,8 @@ module Google
           #   can also be provided.
           # @param request_id [String]
           #   Optional. A unique id used to identify the request. If the server
-          #   receives two {Google::Cloud::Dataproc::V1::SubmitJobRequest SubmitJobRequest}
-          #   requests  with the same id, then the second request will be ignored and the
+          #   receives two {Google::Cloud::Dataproc::V1::SubmitJobRequest SubmitJobRequest} requests  with the same
+          #   id, then the second request will be ignored and the
           #   first {Google::Cloud::Dataproc::V1::Job Job} created and stored in the backend
           #   is returned.
           #
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/jobs_services_pb.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/jobs_services_pb.rb
index cd7f8b530..37cda4c8c 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/jobs_services_pb.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/jobs_services_pb.rb
@@ -1,7 +1,7 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
 # Source: google/cloud/dataproc/v1/jobs.proto for package 'google.cloud.dataproc.v1'
 # Original file comments:
-# Copyright 2018 Google LLC.
+# Copyright 2019 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/shared_pb.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/shared_pb.rb
new file mode 100644
index 000000000..8487efcbc
--- /dev/null
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/shared_pb.rb
@@ -0,0 +1,26 @@
+# Generated by the protocol buffer compiler.  DO NOT EDIT!
+# source: google/cloud/dataproc/v1/shared.proto
+
+
+require 'google/protobuf'
+
+require 'google/api/annotations_pb'
+Google::Protobuf::DescriptorPool.generated_pool.build do
+  add_enum "google.cloud.dataproc.v1.Component" do
+    value :COMPONENT_UNSPECIFIED, 0
+    value :ANACONDA, 5
+    value :HIVE_WEBHCAT, 3
+    value :JUPYTER, 1
+    value :ZEPPELIN, 4
+  end
+end
+
+module Google
+  module Cloud
+    module Dataproc
+      module V1
+        Component = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1.Component").enummodule
+      end
+    end
+  end
+end
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/workflow_template_service_client.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/workflow_template_service_client.rb
index 5f34d9180..cf3664951 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/workflow_template_service_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/workflow_template_service_client.rb
@@ -29,6 +29,7 @@ require "google/longrunning/operations_client"
 
 require "google/cloud/dataproc/v1/workflow_templates_pb"
 require "google/cloud/dataproc/v1/credentials"
+require "google/cloud/dataproc/version"
 
 module Google
   module Cloud
@@ -181,7 +182,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-dataproc'].version.version
+            package_version = Google::Cloud::Dataproc::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
@@ -473,8 +474,7 @@ module Google
           # Instantiates a template and begins execution.
           #
           # This method is equivalent to executing the sequence
-          # {Google::Cloud::Dataproc::V1::WorkflowTemplateService::CreateWorkflowTemplate CreateWorkflowTemplate},
-          # {Google::Cloud::Dataproc::V1::WorkflowTemplateService::InstantiateWorkflowTemplate InstantiateWorkflowTemplate},
+          # {Google::Cloud::Dataproc::V1::WorkflowTemplateService::CreateWorkflowTemplate CreateWorkflowTemplate}, {Google::Cloud::Dataproc::V1::WorkflowTemplateService::InstantiateWorkflowTemplate InstantiateWorkflowTemplate},
           # {Google::Cloud::Dataproc::V1::WorkflowTemplateService::DeleteWorkflowTemplate DeleteWorkflowTemplate}.
           #
           # The returned Operation can be used to track execution of
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/workflow_templates_services_pb.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/workflow_templates_services_pb.rb
index b11368209..ea402fc61 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/workflow_templates_services_pb.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/workflow_templates_services_pb.rb
@@ -1,7 +1,7 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
 # Source: google/cloud/dataproc/v1/workflow_templates.proto for package 'google.cloud.dataproc.v1'
 # Original file comments:
-# Copyright 2018 Google LLC.
+# Copyright 2019 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,8 +65,7 @@ module Google
             # Instantiates a template and begins execution.
             #
             # This method is equivalent to executing the sequence
-            # [CreateWorkflowTemplate][google.cloud.dataproc.v1.WorkflowTemplateService.CreateWorkflowTemplate],
-            # [InstantiateWorkflowTemplate][google.cloud.dataproc.v1.WorkflowTemplateService.InstantiateWorkflowTemplate],
+            # [CreateWorkflowTemplate][google.cloud.dataproc.v1.WorkflowTemplateService.CreateWorkflowTemplate], [InstantiateWorkflowTemplate][google.cloud.dataproc.v1.WorkflowTemplateService.InstantiateWorkflowTemplate],
             # [DeleteWorkflowTemplate][google.cloud.dataproc.v1.WorkflowTemplateService.DeleteWorkflowTemplate].
             #
             # The returned Operation can be used to track execution of
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2.rb
index ba10106a8..a4ef7ea11 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+require "google/cloud/dataproc/v1beta2/autoscaling_policy_service_client"
 require "google/cloud/dataproc/v1beta2/cluster_controller_client"
 require "google/cloud/dataproc/v1beta2/job_controller_client"
 require "google/cloud/dataproc/v1beta2/workflow_template_service_client"
@@ -106,6 +107,63 @@ module Google
       module V1beta2
         # rubocop:enable LineLength
 
+        module AutoscalingPolicyService
+          ##
+          # The API interface for managing autoscaling policies in the
+          # Google Cloud Dataproc API.
+          #
+          # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+          #   Provides the means for authenticating requests made by the client. This parameter can
+          #   be many types.
+          #   A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
+          #   authenticating requests made by this client.
+          #   A `String` will be treated as the path to the keyfile to be used for the construction of
+          #   credentials for this client.
+          #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+          #   credentials for this client.
+          #   A `GRPC::Core::Channel` will be used to make calls through.
+          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+          #   should already be composed with a `GRPC::Core::CallCredentials` object.
+          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+          #   metadata for requests, generally, to give OAuth credentials.
+          # @param scopes [Array<String>]
+          #   The OAuth scopes for this service. This parameter is ignored if
+          #   an updater_proc is supplied.
+          # @param client_config [Hash]
+          #   A Hash for call options for each method. See
+          #   Google::Gax#construct_settings for the structure of
+          #   this data. Falls back to the default config if not specified
+          #   or the specified config is missing data points.
+          # @param timeout [Numeric]
+          #   The default timeout, in seconds, for calls made through this client.
+          # @param metadata [Hash]
+          #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param exception_transformer [Proc]
+          #   An optional proc that intercepts any exceptions raised during an API call to inject
+          #   custom error handling.
+          def self.new \
+              credentials: nil,
+              scopes: nil,
+              client_config: nil,
+              timeout: nil,
+              metadata: nil,
+              exception_transformer: nil,
+              lib_name: nil,
+              lib_version: nil
+            kwargs = {
+              credentials: credentials,
+              scopes: scopes,
+              client_config: client_config,
+              timeout: timeout,
+              metadata: metadata,
+              exception_transformer: exception_transformer,
+              lib_name: lib_name,
+              lib_version: lib_version
+            }.select { |_, v| v != nil }
+            Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient.new(**kwargs)
+          end
+        end
+
         module ClusterController
           ##
           # The ClusterControllerService provides methods to manage clusters
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policies_pb.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policies_pb.rb
new file mode 100644
index 000000000..7b3e40780
--- /dev/null
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policies_pb.rb
@@ -0,0 +1,81 @@
+# Generated by the protocol buffer compiler.  DO NOT EDIT!
+# source: google/cloud/dataproc/v1beta2/autoscaling_policies.proto
+
+
+require 'google/protobuf'
+
+require 'google/api/annotations_pb'
+require 'google/cloud/dataproc/v1beta2/clusters_pb'
+require 'google/cloud/dataproc/v1beta2/jobs_pb'
+require 'google/longrunning/operations_pb'
+require 'google/protobuf/duration_pb'
+require 'google/protobuf/empty_pb'
+require 'google/protobuf/timestamp_pb'
+Google::Protobuf::DescriptorPool.generated_pool.build do
+  add_message "google.cloud.dataproc.v1beta2.AutoscalingPolicy" do
+    optional :id, :string, 1
+    optional :name, :string, 2
+    optional :worker_config, :message, 4, "google.cloud.dataproc.v1beta2.InstanceGroupAutoscalingPolicyConfig"
+    optional :secondary_worker_config, :message, 5, "google.cloud.dataproc.v1beta2.InstanceGroupAutoscalingPolicyConfig"
+    oneof :algorithm do
+      optional :basic_algorithm, :message, 3, "google.cloud.dataproc.v1beta2.BasicAutoscalingAlgorithm"
+    end
+  end
+  add_message "google.cloud.dataproc.v1beta2.BasicAutoscalingAlgorithm" do
+    optional :yarn_config, :message, 1, "google.cloud.dataproc.v1beta2.BasicYarnAutoscalingConfig"
+    optional :cooldown_period, :message, 2, "google.protobuf.Duration"
+  end
+  add_message "google.cloud.dataproc.v1beta2.BasicYarnAutoscalingConfig" do
+    optional :graceful_decommission_timeout, :message, 5, "google.protobuf.Duration"
+    optional :scale_up_factor, :double, 1
+    optional :scale_down_factor, :double, 2
+    optional :scale_up_min_worker_fraction, :double, 3
+    optional :scale_down_min_worker_fraction, :double, 4
+  end
+  add_message "google.cloud.dataproc.v1beta2.InstanceGroupAutoscalingPolicyConfig" do
+    optional :min_instances, :int32, 1
+    optional :max_instances, :int32, 2
+    optional :weight, :int32, 3
+  end
+  add_message "google.cloud.dataproc.v1beta2.CreateAutoscalingPolicyRequest" do
+    optional :parent, :string, 1
+    optional :policy, :message, 2, "google.cloud.dataproc.v1beta2.AutoscalingPolicy"
+  end
+  add_message "google.cloud.dataproc.v1beta2.GetAutoscalingPolicyRequest" do
+    optional :name, :string, 1
+  end
+  add_message "google.cloud.dataproc.v1beta2.UpdateAutoscalingPolicyRequest" do
+    optional :policy, :message, 1, "google.cloud.dataproc.v1beta2.AutoscalingPolicy"
+  end
+  add_message "google.cloud.dataproc.v1beta2.DeleteAutoscalingPolicyRequest" do
+    optional :name, :string, 1
+  end
+  add_message "google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesRequest" do
+    optional :parent, :string, 1
+    optional :page_size, :int32, 2
+    optional :page_token, :string, 3
+  end
+  add_message "google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesResponse" do
+    repeated :policies, :message, 1, "google.cloud.dataproc.v1beta2.AutoscalingPolicy"
+    optional :next_page_token, :string, 2
+  end
+end
+
+module Google
+  module Cloud
+    module Dataproc
+      module V1beta2
+        AutoscalingPolicy = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.AutoscalingPolicy").msgclass
+        BasicAutoscalingAlgorithm = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.BasicAutoscalingAlgorithm").msgclass
+        BasicYarnAutoscalingConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.BasicYarnAutoscalingConfig").msgclass
+        InstanceGroupAutoscalingPolicyConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.InstanceGroupAutoscalingPolicyConfig").msgclass
+        CreateAutoscalingPolicyRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.CreateAutoscalingPolicyRequest").msgclass
+        GetAutoscalingPolicyRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.GetAutoscalingPolicyRequest").msgclass
+        UpdateAutoscalingPolicyRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.UpdateAutoscalingPolicyRequest").msgclass
+        DeleteAutoscalingPolicyRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.DeleteAutoscalingPolicyRequest").msgclass
+        ListAutoscalingPoliciesRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesRequest").msgclass
+        ListAutoscalingPoliciesResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesResponse").msgclass
+      end
+    end
+  end
+end
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policies_services_pb.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policies_services_pb.rb
new file mode 100644
index 000000000..31a91e3d2
--- /dev/null
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policies_services_pb.rb
@@ -0,0 +1,60 @@
+# Generated by the protocol buffer compiler.  DO NOT EDIT!
+# Source: google/cloud/dataproc/v1beta2/autoscaling_policies.proto for package 'google.cloud.dataproc.v1beta2'
+# Original file comments:
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+
+require 'grpc'
+require 'google/cloud/dataproc/v1beta2/autoscaling_policies_pb'
+
+module Google
+  module Cloud
+    module Dataproc
+      module V1beta2
+        module AutoscalingPolicyService
+          # The API interface for managing autoscaling policies in the
+          # Google Cloud Dataproc API.
+          class Service
+
+            include GRPC::GenericService
+
+            self.marshal_class_method = :encode
+            self.unmarshal_class_method = :decode
+            self.service_name = 'google.cloud.dataproc.v1beta2.AutoscalingPolicyService'
+
+            # Creates new autoscaling policy.
+            rpc :CreateAutoscalingPolicy, CreateAutoscalingPolicyRequest, AutoscalingPolicy
+            # Updates (replaces) autoscaling policy.
+            #
+            # Disabled check for update_mask, because all updates will be full
+            # replacements.
+            rpc :UpdateAutoscalingPolicy, UpdateAutoscalingPolicyRequest, AutoscalingPolicy
+            # Retrieves autoscaling policy.
+            rpc :GetAutoscalingPolicy, GetAutoscalingPolicyRequest, AutoscalingPolicy
+            # Lists autoscaling policies in the project.
+            rpc :ListAutoscalingPolicies, ListAutoscalingPoliciesRequest, ListAutoscalingPoliciesResponse
+            # Deletes an autoscaling policy. It is an error to delete an autoscaling
+            # policy that is in use by one or more clusters.
+            rpc :DeleteAutoscalingPolicy, DeleteAutoscalingPolicyRequest, Google::Protobuf::Empty
+          end
+
+          Stub = Service.rpc_stub_class
+        end
+      end
+    end
+  end
+end
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policy_service_client.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policy_service_client.rb
new file mode 100644
index 000000000..f96a08aa4
--- /dev/null
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policy_service_client.rb
@@ -0,0 +1,457 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# EDITING INSTRUCTIONS
+# This file was generated from the file
+# https://github.com/googleapis/googleapis/blob/master/google/cloud/dataproc/v1beta2/autoscaling_policies.proto,
+# and updates to that file get reflected here through a refresh process.
+# For the short term, the refresh process will only be runnable by Google
+# engineers.
+
+
+require "json"
+require "pathname"
+
+require "google/gax"
+
+require "google/cloud/dataproc/v1beta2/autoscaling_policies_pb"
+require "google/cloud/dataproc/v1beta2/credentials"
+require "google/cloud/dataproc/version"
+
+module Google
+  module Cloud
+    module Dataproc
+      module V1beta2
+        # The API interface for managing autoscaling policies in the
+        # Google Cloud Dataproc API.
+        #
+        # @!attribute [r] autoscaling_policy_service_stub
+        #   @return [Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyService::Stub]
+        class AutoscalingPolicyServiceClient
+          # @private
+          attr_reader :autoscaling_policy_service_stub
+
+          # The default address of the service.
+          SERVICE_ADDRESS = "dataproc.googleapis.com".freeze
+
+          # The default port of the service.
+          DEFAULT_SERVICE_PORT = 443
+
+          # The default set of gRPC interceptors.
+          GRPC_INTERCEPTORS = []
+
+          DEFAULT_TIMEOUT = 30
+
+          PAGE_DESCRIPTORS = {
+            "list_autoscaling_policies" => Google::Gax::PageDescriptor.new(
+              "page_token",
+              "next_page_token",
+              "policies")
+          }.freeze
+
+          private_constant :PAGE_DESCRIPTORS
+
+          # The scopes needed to make gRPC calls to all of the methods defined in
+          # this service.
+          ALL_SCOPES = [
+            "https://www.googleapis.com/auth/cloud-platform"
+          ].freeze
+
+
+          AUTOSCALING_POLICY_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+            "projects/{project}/regions/{region}/autoscalingPolicies/{autoscaling_policy}"
+          )
+
+          private_constant :AUTOSCALING_POLICY_PATH_TEMPLATE
+
+          REGION_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+            "projects/{project}/regions/{region}"
+          )
+
+          private_constant :REGION_PATH_TEMPLATE
+
+          # Returns a fully-qualified autoscaling_policy resource name string.
+          # @param project [String]
+          # @param region [String]
+          # @param autoscaling_policy [String]
+          # @return [String]
+          def self.autoscaling_policy_path project, region, autoscaling_policy
+            AUTOSCALING_POLICY_PATH_TEMPLATE.render(
+              :"project" => project,
+              :"region" => region,
+              :"autoscaling_policy" => autoscaling_policy
+            )
+          end
+
+          # Returns a fully-qualified region resource name string.
+          # @param project [String]
+          # @param region [String]
+          # @return [String]
+          def self.region_path project, region
+            REGION_PATH_TEMPLATE.render(
+              :"project" => project,
+              :"region" => region
+            )
+          end
+
+          # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+          #   Provides the means for authenticating requests made by the client. This parameter can
+          #   be many types.
+          #   A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
+          #   authenticating requests made by this client.
+          #   A `String` will be treated as the path to the keyfile to be used for the construction of
+          #   credentials for this client.
+          #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+          #   credentials for this client.
+          #   A `GRPC::Core::Channel` will be used to make calls through.
+          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+          #   should already be composed with a `GRPC::Core::CallCredentials` object.
+          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+          #   metadata for requests, generally, to give OAuth credentials.
+          # @param scopes [Array<String>]
+          #   The OAuth scopes for this service. This parameter is ignored if
+          #   an updater_proc is supplied.
+          # @param client_config [Hash]
+          #   A Hash for call options for each method. See
+          #   Google::Gax#construct_settings for the structure of
+          #   this data. Falls back to the default config if not specified
+          #   or the specified config is missing data points.
+          # @param timeout [Numeric]
+          #   The default timeout, in seconds, for calls made through this client.
+          # @param metadata [Hash]
+          #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param exception_transformer [Proc]
+          #   An optional proc that intercepts any exceptions raised during an API call to inject
+          #   custom error handling.
+          def initialize \
+              credentials: nil,
+              scopes: ALL_SCOPES,
+              client_config: {},
+              timeout: DEFAULT_TIMEOUT,
+              metadata: nil,
+              exception_transformer: nil,
+              lib_name: nil,
+              lib_version: ""
+            # These require statements are intentionally placed here to initialize
+            # the gRPC module only when it's required.
+            # See https://github.com/googleapis/toolkit/issues/446
+            require "google/gax/grpc"
+            require "google/cloud/dataproc/v1beta2/autoscaling_policies_services_pb"
+
+            credentials ||= Google::Cloud::Dataproc::V1beta2::Credentials.default
+
+            if credentials.is_a?(String) || credentials.is_a?(Hash)
+              updater_proc = Google::Cloud::Dataproc::V1beta2::Credentials.new(credentials).updater_proc
+            end
+            if credentials.is_a?(GRPC::Core::Channel)
+              channel = credentials
+            end
+            if credentials.is_a?(GRPC::Core::ChannelCredentials)
+              chan_creds = credentials
+            end
+            if credentials.is_a?(Proc)
+              updater_proc = credentials
+            end
+            if credentials.is_a?(Google::Auth::Credentials)
+              updater_proc = credentials.updater_proc
+            end
+
+            package_version = Google::Cloud::Dataproc::VERSION
+
+            google_api_client = "gl-ruby/#{RUBY_VERSION}"
+            google_api_client << " #{lib_name}/#{lib_version}" if lib_name
+            google_api_client << " gapic/#{package_version} gax/#{Google::Gax::VERSION}"
+            google_api_client << " grpc/#{GRPC::VERSION}"
+            google_api_client.freeze
+
+            headers = { :"x-goog-api-client" => google_api_client }
+            headers.merge!(metadata) unless metadata.nil?
+            client_config_file = Pathname.new(__dir__).join(
+              "autoscaling_policy_service_client_config.json"
+            )
+            defaults = client_config_file.open do |f|
+              Google::Gax.construct_settings(
+                "google.cloud.dataproc.v1beta2.AutoscalingPolicyService",
+                JSON.parse(f.read),
+                client_config,
+                Google::Gax::Grpc::STATUS_CODE_NAMES,
+                timeout,
+                page_descriptors: PAGE_DESCRIPTORS,
+                errors: Google::Gax::Grpc::API_ERRORS,
+                metadata: headers
+              )
+            end
+
+            # Allow overriding the service path/port in subclasses.
+            service_path = self.class::SERVICE_ADDRESS
+            port = self.class::DEFAULT_SERVICE_PORT
+            interceptors = self.class::GRPC_INTERCEPTORS
+            @autoscaling_policy_service_stub = Google::Gax::Grpc.create_stub(
+              service_path,
+              port,
+              chan_creds: chan_creds,
+              channel: channel,
+              updater_proc: updater_proc,
+              scopes: scopes,
+              interceptors: interceptors,
+              &Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyService::Stub.method(:new)
+            )
+
+            @create_autoscaling_policy = Google::Gax.create_api_call(
+              @autoscaling_policy_service_stub.method(:create_autoscaling_policy),
+              defaults["create_autoscaling_policy"],
+              exception_transformer: exception_transformer,
+              params_extractor: proc do |request|
+                {'parent' => request.parent}
+              end
+            )
+            @update_autoscaling_policy = Google::Gax.create_api_call(
+              @autoscaling_policy_service_stub.method(:update_autoscaling_policy),
+              defaults["update_autoscaling_policy"],
+              exception_transformer: exception_transformer,
+              params_extractor: proc do |request|
+                {'policy.name' => request.policy.name}
+              end
+            )
+            @get_autoscaling_policy = Google::Gax.create_api_call(
+              @autoscaling_policy_service_stub.method(:get_autoscaling_policy),
+              defaults["get_autoscaling_policy"],
+              exception_transformer: exception_transformer,
+              params_extractor: proc do |request|
+                {'name' => request.name}
+              end
+            )
+            @list_autoscaling_policies = Google::Gax.create_api_call(
+              @autoscaling_policy_service_stub.method(:list_autoscaling_policies),
+              defaults["list_autoscaling_policies"],
+              exception_transformer: exception_transformer,
+              params_extractor: proc do |request|
+                {'parent' => request.parent}
+              end
+            )
+            @delete_autoscaling_policy = Google::Gax.create_api_call(
+              @autoscaling_policy_service_stub.method(:delete_autoscaling_policy),
+              defaults["delete_autoscaling_policy"],
+              exception_transformer: exception_transformer,
+              params_extractor: proc do |request|
+                {'name' => request.name}
+              end
+            )
+          end
+
+          # Service calls
+
+          # Creates new autoscaling policy.
+          #
+          # @param parent [String]
+          #   Required. The "resource name" of the region, as described
+          #   in https://cloud.google.com/apis/design/resource_names of the form
+          #   `projects/{project_id}/regions/{region}`.
+          # @param policy [Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy | Hash]
+          #   The autoscaling policy to create.
+          #   A hash of the same form as `Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy`
+          #   can also be provided.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @yield [result, operation] Access the result along with the RPC operation
+          # @yieldparam result [Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
+          # @return [Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/dataproc"
+          #
+          #   autoscaling_policy_client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+          #   formatted_parent = Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient.region_path("[PROJECT]", "[REGION]")
+          #
+          #   # TODO: Initialize `policy`:
+          #   policy = {}
+          #   response = autoscaling_policy_client.create_autoscaling_policy(formatted_parent, policy)
+
+          def create_autoscaling_policy \
+              parent,
+              policy,
+              options: nil,
+              &block
+            req = {
+              parent: parent,
+              policy: policy
+            }.delete_if { |_, v| v.nil? }
+            req = Google::Gax::to_proto(req, Google::Cloud::Dataproc::V1beta2::CreateAutoscalingPolicyRequest)
+            @create_autoscaling_policy.call(req, options, &block)
+          end
+
+          # Updates (replaces) autoscaling policy.
+          #
+          # Disabled check for update_mask, because all updates will be full
+          # replacements.
+          #
+          # @param policy [Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy | Hash]
+          #   Required. The updated autoscaling policy.
+          #   A hash of the same form as `Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy`
+          #   can also be provided.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @yield [result, operation] Access the result along with the RPC operation
+          # @yieldparam result [Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
+          # @return [Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/dataproc"
+          #
+          #   autoscaling_policy_client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+          #
+          #   # TODO: Initialize `policy`:
+          #   policy = {}
+          #   response = autoscaling_policy_client.update_autoscaling_policy(policy)
+
+          def update_autoscaling_policy \
+              policy,
+              options: nil,
+              &block
+            req = {
+              policy: policy
+            }.delete_if { |_, v| v.nil? }
+            req = Google::Gax::to_proto(req, Google::Cloud::Dataproc::V1beta2::UpdateAutoscalingPolicyRequest)
+            @update_autoscaling_policy.call(req, options, &block)
+          end
+
+          # Retrieves autoscaling policy.
+          #
+          # @param name [String]
+          #   Required. The "resource name" of the autoscaling policy, as described
+          #   in https://cloud.google.com/apis/design/resource_names of the form
+          #   `projects/{project_id}/regions/{region}/autoscalingPolicies/{policy_id}`.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @yield [result, operation] Access the result along with the RPC operation
+          # @yieldparam result [Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
+          # @return [Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/dataproc"
+          #
+          #   autoscaling_policy_client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+          #   formatted_name = Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient.autoscaling_policy_path("[PROJECT]", "[REGION]", "[AUTOSCALING_POLICY]")
+          #   response = autoscaling_policy_client.get_autoscaling_policy(formatted_name)
+
+          def get_autoscaling_policy \
+              name,
+              options: nil,
+              &block
+            req = {
+              name: name
+            }.delete_if { |_, v| v.nil? }
+            req = Google::Gax::to_proto(req, Google::Cloud::Dataproc::V1beta2::GetAutoscalingPolicyRequest)
+            @get_autoscaling_policy.call(req, options, &block)
+          end
+
+          # Lists autoscaling policies in the project.
+          #
+          # @param parent [String]
+          #   Required. The "resource name" of the region, as described
+          #   in https://cloud.google.com/apis/design/resource_names of the form
+          #   `projects/{project_id}/regions/{region}`
+          # @param page_size [Integer]
+          #   The maximum number of resources contained in the underlying API
+          #   response. If page streaming is performed per-resource, this
+          #   parameter does not affect the return value. If page streaming is
+          #   performed per-page, this determines the maximum number of
+          #   resources in a page.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @yield [result, operation] Access the result along with the RPC operation
+          # @yieldparam result [Google::Gax::PagedEnumerable<Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy>]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
+          # @return [Google::Gax::PagedEnumerable<Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy>]
+          #   An enumerable of Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy instances.
+          #   See Google::Gax::PagedEnumerable documentation for other
+          #   operations such as per-page iteration or access to the response
+          #   object.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/dataproc"
+          #
+          #   autoscaling_policy_client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+          #   formatted_parent = Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient.region_path("[PROJECT]", "[REGION]")
+          #
+          #   # Iterate over all results.
+          #   autoscaling_policy_client.list_autoscaling_policies(formatted_parent).each do |element|
+          #     # Process element.
+          #   end
+          #
+          #   # Or iterate over results one page at a time.
+          #   autoscaling_policy_client.list_autoscaling_policies(formatted_parent).each_page do |page|
+          #     # Process each page at a time.
+          #     page.each do |element|
+          #       # Process element.
+          #     end
+          #   end
+
+          def list_autoscaling_policies \
+              parent,
+              page_size: nil,
+              options: nil,
+              &block
+            req = {
+              parent: parent,
+              page_size: page_size
+            }.delete_if { |_, v| v.nil? }
+            req = Google::Gax::to_proto(req, Google::Cloud::Dataproc::V1beta2::ListAutoscalingPoliciesRequest)
+            @list_autoscaling_policies.call(req, options, &block)
+          end
+
+          # Deletes an autoscaling policy. It is an error to delete an autoscaling
+          # policy that is in use by one or more clusters.
+          #
+          # @param name [String]
+          #   Required. The "resource name" of the autoscaling policy, as described
+          #   in https://cloud.google.com/apis/design/resource_names of the form
+          #   `projects/{project_id}/regions/{region}/autoscalingPolicies/{policy_id}`.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @yield [result, operation] Access the result along with the RPC operation
+          # @yieldparam result []
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/dataproc"
+          #
+          #   autoscaling_policy_client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+          #   formatted_name = Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient.autoscaling_policy_path("[PROJECT]", "[REGION]", "[AUTOSCALING_POLICY]")
+          #   autoscaling_policy_client.delete_autoscaling_policy(formatted_name)
+
+          def delete_autoscaling_policy \
+              name,
+              options: nil,
+              &block
+            req = {
+              name: name
+            }.delete_if { |_, v| v.nil? }
+            req = Google::Gax::to_proto(req, Google::Cloud::Dataproc::V1beta2::DeleteAutoscalingPolicyRequest)
+            @delete_autoscaling_policy.call(req, options, &block)
+            nil
+          end
+        end
+      end
+    end
+  end
+end
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policy_service_client_config.json b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policy_service_client_config.json
new file mode 100644
index 000000000..869ecf0f1
--- /dev/null
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policy_service_client_config.json
@@ -0,0 +1,51 @@
+{
+  "interfaces": {
+    "google.cloud.dataproc.v1beta2.AutoscalingPolicyService": {
+      "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
+      },
+      "retry_params": {
+        "default": {
+          "initial_retry_delay_millis": 100,
+          "retry_delay_multiplier": 1.3,
+          "max_retry_delay_millis": 60000,
+          "initial_rpc_timeout_millis": 20000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 20000,
+          "total_timeout_millis": 600000
+        }
+      },
+      "methods": {
+        "CreateAutoscalingPolicy": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "UpdateAutoscalingPolicy": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "GetAutoscalingPolicy": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "ListAutoscalingPolicies": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DeleteAutoscalingPolicy": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        }
+      }
+    }
+  }
+}
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/cluster_controller_client.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/cluster_controller_client.rb
index b06073fdf..696894c5e 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/cluster_controller_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/cluster_controller_client.rb
@@ -29,6 +29,7 @@ require "google/longrunning/operations_client"
 
 require "google/cloud/dataproc/v1beta2/clusters_pb"
 require "google/cloud/dataproc/v1beta2/credentials"
+require "google/cloud/dataproc/version"
 
 module Google
   module Cloud
@@ -146,7 +147,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-dataproc'].version.version
+            package_version = Google::Cloud::Dataproc::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
@@ -234,11 +235,10 @@ module Google
           #   can also be provided.
           # @param request_id [String]
           #   Optional. A unique id used to identify the request. If the server
-          #   receives two
-          #   {Google::Cloud::Dataproc::V1beta2::CreateClusterRequest CreateClusterRequest}
-          #   requests  with the same id, then the second request will be ignored and the
-          #   first {Google::Longrunning::Operation} created
-          #   and stored in the backend is returned.
+          #   receives two {Google::Cloud::Dataproc::V1beta2::CreateClusterRequest CreateClusterRequest} requests  with the same
+          #   id, then the second request will be ignored and the
+          #   first {Google::Longrunning::Operation} created and stored in the backend
+          #   is returned.
           #
           #   It is recommended to always set this value to a
           #   [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
@@ -384,6 +384,10 @@ module Google
           #   <td>config.lifecycle_config.idle_delete_ttl</td><td>Update Idle TTL
           #   duration</td>
           #   </tr>
+          #   <tr>
+          #   <td>config.autoscaling_config.policy_uri</td><td>Use, stop using, or change
+          #   autoscaling policies</td>
+          #   </tr>
           #   </table>
           #   A hash of the same form as `Google::Protobuf::FieldMask`
           #   can also be provided.
@@ -400,11 +404,10 @@ module Google
           #   can also be provided.
           # @param request_id [String]
           #   Optional. A unique id used to identify the request. If the server
-          #   receives two
-          #   {Google::Cloud::Dataproc::V1beta2::UpdateClusterRequest UpdateClusterRequest}
-          #   requests  with the same id, then the second request will be ignored and the
-          #   first {Google::Longrunning::Operation} created
-          #   and stored in the backend is returned.
+          #   receives two {Google::Cloud::Dataproc::V1beta2::UpdateClusterRequest UpdateClusterRequest} requests  with the same
+          #   id, then the second request will be ignored and the
+          #   first {Google::Longrunning::Operation} created and stored in the
+          #   backend is returned.
           #
           #   It is recommended to always set this value to a
           #   [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
@@ -507,11 +510,10 @@ module Google
           #   (with error NOT_FOUND) if cluster with specified UUID does not exist.
           # @param request_id [String]
           #   Optional. A unique id used to identify the request. If the server
-          #   receives two
-          #   {Google::Cloud::Dataproc::V1beta2::DeleteClusterRequest DeleteClusterRequest}
-          #   requests  with the same id, then the second request will be ignored and the
-          #   first {Google::Longrunning::Operation} created
-          #   and stored in the backend is returned.
+          #   receives two {Google::Cloud::Dataproc::V1beta2::DeleteClusterRequest DeleteClusterRequest} requests  with the same
+          #   id, then the second request will be ignored and the
+          #   first {Google::Longrunning::Operation} created and stored in the
+          #   backend is returned.
           #
           #   It is recommended to always set this value to a
           #   [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/clusters_pb.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/clusters_pb.rb
index 9255a16b6..22db8628b 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/clusters_pb.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/clusters_pb.rb
@@ -32,6 +32,16 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :lifecycle_config, :message, 14, "google.cloud.dataproc.v1beta2.LifecycleConfig"
     repeated :initialization_actions, :message, 11, "google.cloud.dataproc.v1beta2.NodeInitializationAction"
     optional :encryption_config, :message, 15, "google.cloud.dataproc.v1beta2.EncryptionConfig"
+    optional :autoscaling_config, :message, 16, "google.cloud.dataproc.v1beta2.AutoscalingConfig"
+    optional :endpoint_config, :message, 17, "google.cloud.dataproc.v1beta2.EndpointConfig"
+    optional :security_config, :message, 18, "google.cloud.dataproc.v1beta2.SecurityConfig"
+  end
+  add_message "google.cloud.dataproc.v1beta2.EndpointConfig" do
+    map :http_ports, :string, :string, 1
+    optional :enable_http_port_access, :bool, 2
+  end
+  add_message "google.cloud.dataproc.v1beta2.AutoscalingConfig" do
+    optional :policy_uri, :string, 1
   end
   add_message "google.cloud.dataproc.v1beta2.EncryptionConfig" do
     optional :gce_pd_kms_key_name, :string, 1
@@ -45,6 +55,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     repeated :service_account_scopes, :string, 3
     repeated :tags, :string, 4
     map :metadata, :string, :string, 5
+    optional :reservation_affinity, :message, 11, "google.cloud.dataproc.v1beta2.ReservationAffinity"
   end
   add_message "google.cloud.dataproc.v1beta2.InstanceGroupConfig" do
     optional :num_instances, :int32, 1
@@ -77,6 +88,25 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :auto_delete_ttl, :message, 3, "google.protobuf.Duration"
     end
   end
+  add_message "google.cloud.dataproc.v1beta2.SecurityConfig" do
+    optional :kerberos_config, :message, 1, "google.cloud.dataproc.v1beta2.KerberosConfig"
+  end
+  add_message "google.cloud.dataproc.v1beta2.KerberosConfig" do
+    optional :enable_kerberos, :bool, 1
+    optional :root_principal_password_uri, :string, 2
+    optional :kms_key_uri, :string, 3
+    optional :keystore_uri, :string, 4
+    optional :truststore_uri, :string, 5
+    optional :keystore_password_uri, :string, 6
+    optional :key_password_uri, :string, 7
+    optional :truststore_password_uri, :string, 8
+    optional :cross_realm_trust_realm, :string, 9
+    optional :cross_realm_trust_kdc, :string, 10
+    optional :cross_realm_trust_admin_server, :string, 11
+    optional :cross_realm_trust_shared_password_uri, :string, 12
+    optional :kdc_db_key_uri, :string, 13
+    optional :tgt_lifetime_hours, :int32, 14
+  end
   add_message "google.cloud.dataproc.v1beta2.NodeInitializationAction" do
     optional :executable_file, :string, 1
     optional :execution_timeout, :message, 2, "google.protobuf.Duration"
@@ -103,6 +133,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.dataproc.v1beta2.SoftwareConfig" do
     optional :image_version, :string, 1
     map :properties, :string, :string, 2
+    repeated :optional_components, :enum, 3, "google.cloud.dataproc.v1beta2.Component"
   end
   add_message "google.cloud.dataproc.v1beta2.ClusterMetrics" do
     map :hdfs_metrics, :string, :int64, 1
@@ -154,6 +185,17 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.dataproc.v1beta2.DiagnoseClusterResults" do
     optional :output_uri, :string, 1
   end
+  add_message "google.cloud.dataproc.v1beta2.ReservationAffinity" do
+    optional :consume_reservation_type, :enum, 1, "google.cloud.dataproc.v1beta2.ReservationAffinity.Type"
+    optional :key, :string, 2
+    repeated :values, :string, 3
+  end
+  add_enum "google.cloud.dataproc.v1beta2.ReservationAffinity.Type" do
+    value :TYPE_UNSPECIFIED, 0
+    value :NO_RESERVATION, 1
+    value :ANY_RESERVATION, 2
+    value :SPECIFIC_RESERVATION, 3
+  end
 end
 
 module Google
@@ -162,6 +204,8 @@ module Google
       module V1beta2
         Cluster = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.Cluster").msgclass
         ClusterConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.ClusterConfig").msgclass
+        EndpointConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.EndpointConfig").msgclass
+        AutoscalingConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.AutoscalingConfig").msgclass
         EncryptionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.EncryptionConfig").msgclass
         GceClusterConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.GceClusterConfig").msgclass
         InstanceGroupConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.InstanceGroupConfig").msgclass
@@ -169,6 +213,8 @@ module Google
         AcceleratorConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.AcceleratorConfig").msgclass
         DiskConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.DiskConfig").msgclass
         LifecycleConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.LifecycleConfig").msgclass
+        SecurityConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.SecurityConfig").msgclass
+        KerberosConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.KerberosConfig").msgclass
         NodeInitializationAction = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.NodeInitializationAction").msgclass
         ClusterStatus = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.ClusterStatus").msgclass
         ClusterStatus::State = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.ClusterStatus.State").enummodule
@@ -183,6 +229,8 @@ module Google
         ListClustersResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.ListClustersResponse").msgclass
         DiagnoseClusterRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.DiagnoseClusterRequest").msgclass
         DiagnoseClusterResults = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.DiagnoseClusterResults").msgclass
+        ReservationAffinity = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.ReservationAffinity").msgclass
+        ReservationAffinity::Type = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.ReservationAffinity.Type").enummodule
       end
     end
   end
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/clusters_services_pb.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/clusters_services_pb.rb
index 818ad564a..2d971741d 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/clusters_services_pb.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/clusters_services_pb.rb
@@ -1,7 +1,7 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
 # Source: google/cloud/dataproc/v1beta2/clusters.proto for package 'google.cloud.dataproc.v1beta2'
 # Original file comments:
-# Copyright 2018 Google LLC.
+# Copyright 2019 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/autoscaling_policies.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/autoscaling_policies.rb
new file mode 100644
index 000000000..2b327112e
--- /dev/null
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/autoscaling_policies.rb
@@ -0,0 +1,202 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Dataproc
+      module V1beta2
+        # Describes an autoscaling policy for Dataproc cluster autoscaler.
+        # @!attribute [rw] id
+        #   @return [String]
+        #     Required. The policy id.
+        #
+        #     The id must contain only letters (a-z, A-Z), numbers (0-9),
+        #     underscores (_), and hyphens (-). Cannot begin or end with underscore
+        #     or hyphen. Must consist of between 3 and 50 characters.
+        # @!attribute [rw] name
+        #   @return [String]
+        #     Output only. The "resource name" of the policy, as described
+        #     in https://cloud.google.com/apis/design/resource_names of the form
+        #     `projects/{project_id}/regions/{region}/autoscalingPolicies/{policy_id}`.
+        # @!attribute [rw] basic_algorithm
+        #   @return [Google::Cloud::Dataproc::V1beta2::BasicAutoscalingAlgorithm]
+        # @!attribute [rw] worker_config
+        #   @return [Google::Cloud::Dataproc::V1beta2::InstanceGroupAutoscalingPolicyConfig]
+        #     Required. Describes how the autoscaler will operate for primary workers.
+        # @!attribute [rw] secondary_worker_config
+        #   @return [Google::Cloud::Dataproc::V1beta2::InstanceGroupAutoscalingPolicyConfig]
+        #     Optional. Describes how the autoscaler will operate for secondary workers.
+        class AutoscalingPolicy; end
+
+        # Basic algorithm for autoscaling.
+        # @!attribute [rw] yarn_config
+        #   @return [Google::Cloud::Dataproc::V1beta2::BasicYarnAutoscalingConfig]
+        #     Required. YARN autoscaling configuration.
+        # @!attribute [rw] cooldown_period
+        #   @return [Google::Protobuf::Duration]
+        #     Optional. Duration between scaling events. A scaling period starts after
+        #     the update operation from the previous event has completed.
+        #
+        #     Bounds: [2m, 1d]. Default: 2m.
+        class BasicAutoscalingAlgorithm; end
+
+        # Basic autoscaling configurations for YARN.
+        # @!attribute [rw] graceful_decommission_timeout
+        #   @return [Google::Protobuf::Duration]
+        #     Required. Timeout for YARN graceful decommissioning of Node Managers.
+        #     Specifies the duration to wait for jobs to complete before forcefully
+        #     removing workers (and potentially interrupting jobs). Only applicable to
+        #     downscaling operations.
+        #
+        #     Bounds: [0s, 1d].
+        # @!attribute [rw] scale_up_factor
+        #   @return [Float]
+        #     Required. Fraction of average pending memory in the last cooldown period
+        #     for which to add workers. A scale-up factor of 1.0 will result in scaling
+        #     up so that there is no pending memory remaining after the update (more
+        #     aggressive scaling). A scale-up factor closer to 0 will result in a smaller
+        #     magnitude of scaling up (less aggressive scaling).
+        #
+        #     Bounds: [0.0, 1.0].
+        # @!attribute [rw] scale_down_factor
+        #   @return [Float]
+        #     Required. Fraction of average pending memory in the last cooldown period
+        #     for which to remove workers. A scale-down factor of 1 will result in
+        #     scaling down so that there is no available memory remaining after the
+        #     update (more aggressive scaling). A scale-down factor of 0 disables
+        #     removing workers, which can be beneficial for autoscaling a single job.
+        #
+        #     Bounds: [0.0, 1.0].
+        # @!attribute [rw] scale_up_min_worker_fraction
+        #   @return [Float]
+        #     Optional. Minimum scale-up threshold as a fraction of total cluster size
+        #     before scaling occurs. For example, in a 20-worker cluster, a threshold of
+        #     0.1 means the autoscaler must recommend at least a 2-worker scale-up for
+        #     the cluster to scale. A threshold of 0 means the autoscaler will scale up
+        #     on any recommended change.
+        #
+        #     Bounds: [0.0, 1.0]. Default: 0.0.
+        # @!attribute [rw] scale_down_min_worker_fraction
+        #   @return [Float]
+        #     Optional. Minimum scale-down threshold as a fraction of total cluster size
+        #     before scaling occurs. For example, in a 20-worker cluster, a threshold of
+        #     0.1 means the autoscaler must recommend at least a 2 worker scale-down for
+        #     the cluster to scale. A threshold of 0 means the autoscaler will scale down
+        #     on any recommended change.
+        #
+        #     Bounds: [0.0, 1.0]. Default: 0.0.
+        class BasicYarnAutoscalingConfig; end
+
+        # Configuration for the size bounds of an instance group, including its
+        # proportional size to other groups.
+        # @!attribute [rw] min_instances
+        #   @return [Integer]
+        #     Optional. Minimum number of instances for this group.
+        #
+        #     Primary workers - Bounds: [2, max_instances]. Default: 2.
+        #     Secondary workers - Bounds: [0, max_instances]. Default: 0.
+        # @!attribute [rw] max_instances
+        #   @return [Integer]
+        #     Optional. Maximum number of instances for this group. Required for primary
+        #     workers. Note that by default, clusters will not use secondary workers.
+        #     Required for secondary workers if the minimum secondary instances is set.
+        #
+        #     Primary workers - Bounds: [min_instances, ). Required.
+        #     Secondary workers - Bounds: [min_instances, ). Default: 0.
+        # @!attribute [rw] weight
+        #   @return [Integer]
+        #     Optional. Weight for the instance group, which is used to determine the
+        #     fraction of total workers in the cluster from this instance group.
+        #     For example, if primary workers have weight 2, and secondary workers have
+        #     weight 1, the cluster will have approximately 2 primary workers for each
+        #     secondary worker.
+        #
+        #     The cluster may not reach the specified balance if constrained
+        #     by min/max bounds or other autoscaling settings. For example, if
+        #     `max_instances` for secondary workers is 0, then only primary workers will
+        #     be added. The cluster can also be out of balance when created.
+        #
+        #     If weight is not set on any instance group, the cluster will default to
+        #     equal weight for all groups: the cluster will attempt to maintain an equal
+        #     number of workers in each group within the configured size bounds for each
+        #     group. If weight is set for one group only, the cluster will default to
+        #     zero weight on the unset group. For example if weight is set only on
+        #     primary workers, the cluster will use primary workers only and no
+        #     secondary workers.
+        class InstanceGroupAutoscalingPolicyConfig; end
+
+        # A request to create an autoscaling policy.
+        # @!attribute [rw] parent
+        #   @return [String]
+        #     Required. The "resource name" of the region, as described
+        #     in https://cloud.google.com/apis/design/resource_names of the form
+        #     `projects/{project_id}/regions/{region}`.
+        # @!attribute [rw] policy
+        #   @return [Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy]
+        #     The autoscaling policy to create.
+        class CreateAutoscalingPolicyRequest; end
+
+        # A request to fetch an autoscaling policy.
+        # @!attribute [rw] name
+        #   @return [String]
+        #     Required. The "resource name" of the autoscaling policy, as described
+        #     in https://cloud.google.com/apis/design/resource_names of the form
+        #     `projects/{project_id}/regions/{region}/autoscalingPolicies/{policy_id}`.
+        class GetAutoscalingPolicyRequest; end
+
+        # A request to update an autoscaling policy.
+        # @!attribute [rw] policy
+        #   @return [Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy]
+        #     Required. The updated autoscaling policy.
+        class UpdateAutoscalingPolicyRequest; end
+
+        # A request to delete an autoscaling policy.
+        #
+        # Autoscaling policies in use by one or more clusters will not be deleted.
+        # @!attribute [rw] name
+        #   @return [String]
+        #     Required. The "resource name" of the autoscaling policy, as described
+        #     in https://cloud.google.com/apis/design/resource_names of the form
+        #     `projects/{project_id}/regions/{region}/autoscalingPolicies/{policy_id}`.
+        class DeleteAutoscalingPolicyRequest; end
+
+        # A request to list autoscaling policies in a project.
+        # @!attribute [rw] parent
+        #   @return [String]
+        #     Required. The "resource name" of the region, as described
+        #     in https://cloud.google.com/apis/design/resource_names of the form
+        #     `projects/{project_id}/regions/{region}`
+        # @!attribute [rw] page_size
+        #   @return [Integer]
+        #     Optional. The maximum number of results to return in each response.
+        # @!attribute [rw] page_token
+        #   @return [String]
+        #     Optional. The page token, returned by a previous call, to request the
+        #     next page of results.
+        class ListAutoscalingPoliciesRequest; end
+
+        # A response to a request to list autoscaling policies in a project.
+        # @!attribute [rw] policies
+        #   @return [Array<Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy>]
+        #     Output only. Autoscaling policies list.
+        # @!attribute [rw] next_page_token
+        #   @return [String]
+        #     Output only. This token is included in the response if there are more
+        #     results to fetch.
+        class ListAutoscalingPoliciesResponse; end
+      end
+    end
+  end
+end
\ No newline at end of file
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/clusters.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/clusters.rb
index 2ec07cd40..945d69e0c 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/clusters.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/clusters.rb
@@ -60,15 +60,18 @@ module Google
         # The cluster config.
         # @!attribute [rw] config_bucket
         #   @return [String]
-        #     Optional. A Cloud Storage staging bucket used for sharing generated
-        #     SSH keys and config. If you do not specify a staging bucket, Cloud
-        #     Dataproc will determine an appropriate Cloud Storage location (US,
+        #     Optional. A Google Cloud Storage bucket used to stage job
+        #     dependencies, config files, and job driver console output.
+        #     If you do not specify a staging bucket, Cloud
+        #     Dataproc will determine a Cloud Storage location (US,
         #     ASIA, or EU) for your cluster's staging bucket according to the Google
-        #     Compute Engine zone where your cluster is deployed, and then it will create
-        #     and manage this project-level, per-location bucket for you.
+        #     Compute Engine zone where your cluster is deployed, and then create
+        #     and manage this project-level, per-location bucket (see
+        #     [Cloud Dataproc staging
+        #     bucket](/dataproc/docs/concepts/configuring-clusters/staging-bucket)).
         # @!attribute [rw] gce_cluster_config
         #   @return [Google::Cloud::Dataproc::V1beta2::GceClusterConfig]
-        #     Required. The shared Compute Engine config settings for
+        #     Optional. The shared Compute Engine config settings for
         #     all instances in a cluster.
         # @!attribute [rw] master_config
         #   @return [Google::Cloud::Dataproc::V1beta2::InstanceGroupConfig]
@@ -106,8 +109,43 @@ module Google
         # @!attribute [rw] encryption_config
         #   @return [Google::Cloud::Dataproc::V1beta2::EncryptionConfig]
         #     Optional. Encryption settings for the cluster.
+        # @!attribute [rw] autoscaling_config
+        #   @return [Google::Cloud::Dataproc::V1beta2::AutoscalingConfig]
+        #     Optional. Autoscaling config for the policy associated with the cluster.
+        #     Cluster does not autoscale if this field is unset.
+        # @!attribute [rw] endpoint_config
+        #   @return [Google::Cloud::Dataproc::V1beta2::EndpointConfig]
+        #     Optional. Port/endpoint configuration for this cluster
+        # @!attribute [rw] security_config
+        #   @return [Google::Cloud::Dataproc::V1beta2::SecurityConfig]
+        #     Optional. Security related configuration.
         class ClusterConfig; end
 
+        # Endpoint config for this cluster
+        # @!attribute [rw] http_ports
+        #   @return [Hash{String => String}]
+        #     Output only. The map of port descriptions to URLs. Will only be populated
+        #     if enable_http_port_access is true.
+        # @!attribute [rw] enable_http_port_access
+        #   @return [true, false]
+        #     Optional. If true, enable http access to specific ports on the cluster
+        #     from external sources. Defaults to false.
+        class EndpointConfig; end
+
+        # Autoscaling Policy config associated with the cluster.
+        # @!attribute [rw] policy_uri
+        #   @return [String]
+        #     Optional. The autoscaling policy used by the cluster.
+        #
+        #     Only resource names including projectid and location (region) are valid.
+        #     Examples:
+        #
+        #     * `https://www.googleapis.com/compute/v1/projects/[project_id]/locations/[dataproc_region]/autoscalingPolicies/[policy_id]`
+        #     * `projects/[project_id]/locations/[dataproc_region]/autoscalingPolicies/[policy_id]`
+        #
+        #     Note that the policy must be in the same project and Cloud Dataproc region.
+        class AutoscalingConfig; end
+
         # Encryption settings for the cluster.
         # @!attribute [rw] gce_pd_kms_key_name
         #   @return [String]
@@ -150,8 +188,8 @@ module Google
         #
         #     A full URL, partial URI, or short name are valid. Examples:
         #
-        #     * `https://www.googleapis.com/compute/v1/projects/[project_id]/regions/us-east1/sub0`
-        #     * `projects/[project_id]/regions/us-east1/sub0`
+        #     * `https://www.googleapis.com/compute/v1/projects/[project_id]/regions/us-east1/subnetworks/sub0`
+        #     * `projects/[project_id]/regions/us-east1/subnetworks/sub0`
         #     * `sub0`
         # @!attribute [rw] internal_ip_only
         #   @return [true, false]
@@ -199,6 +237,9 @@ module Google
         #     The Compute Engine metadata entries to add to all instances (see
         #     [Project and instance
         #     metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata#project_and_instance_metadata)).
+        # @!attribute [rw] reservation_affinity
+        #   @return [Google::Cloud::Dataproc::V1beta2::ReservationAffinity]
+        #     Optional. Reservation Affinity for consuming Zonal reservation.
         class GceClusterConfig; end
 
         # Optional. The config settings for Compute Engine resources in
@@ -272,8 +313,9 @@ module Google
         # @!attribute [rw] accelerator_type_uri
         #   @return [String]
         #     Full URL, partial URI, or short name of the accelerator type resource to
-        #     expose to this instance. See [Compute Engine AcceleratorTypes](
-        #     /compute/docs/reference/beta/acceleratorTypes)
+        #     expose to this instance. See
+        #     [Compute Engine
+        #     AcceleratorTypes](/compute/docs/reference/beta/acceleratorTypes)
         #
         #     Examples
         #     * `https://www.googleapis.com/compute/beta/projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80`
@@ -329,6 +371,77 @@ module Google
         #     Example: **"1d"**, to delete the cluster 1 day after its creation..
         class LifecycleConfig; end
 
+        # Security related configuration, including encryption, Kerberos, etc.
+        # @!attribute [rw] kerberos_config
+        #   @return [Google::Cloud::Dataproc::V1beta2::KerberosConfig]
+        #     Kerberos related configuration.
+        class SecurityConfig; end
+
+        # Specifies Kerberos related configuration.
+        # @!attribute [rw] enable_kerberos
+        #   @return [true, false]
+        #     Optional. Flag to indicate whether to Kerberize the cluster.
+        # @!attribute [rw] root_principal_password_uri
+        #   @return [String]
+        #     Required. The Cloud Storage URI of a KMS encrypted file containing the root
+        #     principal password.
+        # @!attribute [rw] kms_key_uri
+        #   @return [String]
+        #     Required. The uri of the KMS key used to encrypt various sensitive
+        #     files.
+        # @!attribute [rw] keystore_uri
+        #   @return [String]
+        #     Optional. The Cloud Storage URI of the keystore file used for SSL
+        #     encryption. If not provided, Dataproc will provide a self-signed
+        #     certificate.
+        # @!attribute [rw] truststore_uri
+        #   @return [String]
+        #     Optional. The Cloud Storage URI of the truststore file used for SSL
+        #     encryption. If not provided, Dataproc will provide a self-signed
+        #     certificate.
+        # @!attribute [rw] keystore_password_uri
+        #   @return [String]
+        #     Optional. The Cloud Storage URI of a KMS encrypted file containing the
+        #     password to the user provided keystore. For the self-signed certificate,
+        #     this password is generated by Dataproc.
+        # @!attribute [rw] key_password_uri
+        #   @return [String]
+        #     Optional. The Cloud Storage URI of a KMS encrypted file containing the
+        #     password to the user provided key. For the self-signed certificate, this
+        #     password is generated by Dataproc.
+        # @!attribute [rw] truststore_password_uri
+        #   @return [String]
+        #     Optional. The Cloud Storage URI of a KMS encrypted file containing the
+        #     password to the user provided truststore. For the self-signed certificate,
+        #     this password is generated by Dataproc.
+        # @!attribute [rw] cross_realm_trust_realm
+        #   @return [String]
+        #     Optional. The remote realm the Dataproc on-cluster KDC will trust, should
+        #     the user enable cross realm trust.
+        # @!attribute [rw] cross_realm_trust_kdc
+        #   @return [String]
+        #     Optional. The KDC (IP or hostname) for the remote trusted realm in a cross
+        #     realm trust relationship.
+        # @!attribute [rw] cross_realm_trust_admin_server
+        #   @return [String]
+        #     Optional. The admin server (IP or hostname) for the remote trusted realm in
+        #     a cross realm trust relationship.
+        # @!attribute [rw] cross_realm_trust_shared_password_uri
+        #   @return [String]
+        #     Optional. The Cloud Storage URI of a KMS encrypted file containing the
+        #     shared password between the on-cluster Kerberos realm and the remote
+        #     trusted realm, in a cross realm trust relationship.
+        # @!attribute [rw] kdc_db_key_uri
+        #   @return [String]
+        #     Optional. The Cloud Storage URI of a KMS encrypted file containing the
+        #     master key of the KDC database.
+        # @!attribute [rw] tgt_lifetime_hours
+        #   @return [Integer]
+        #     Optional. The lifetime of the ticket granting ticket, in hours.
+        #     If not specified, or user specifies 0, then default value 10
+        #     will be used.
+        class KerberosConfig; end
+
         # Specifies an executable to run on a fully configured node and a
         # timeout period for executable completion.
         # @!attribute [rw] executable_file
@@ -407,13 +520,13 @@ module Google
         #     such as "1.2" (including a subminor version, such as "1.2.29"), or the
         #     ["preview"
         #     version](/dataproc/docs/concepts/versioning/dataproc-versions#other_versions).
-        #     If unspecified, it defaults to the latest version.
+        #     If unspecified, it defaults to the latest Debian version.
         # @!attribute [rw] properties
         #   @return [Hash{String => String}]
         #     Optional. The properties to set on daemon config files.
         #
-        #     Property keys are specified in `prefix:property` format, such as
-        #     `core:fs.defaultFS`. The following are supported prefixes
+        #     Property keys are specified in `prefix:property` format, for example
+        #     `core:hadoop.tmp.dir`. The following are supported prefixes
         #     and their mappings:
         #
         #     * capacity-scheduler: `capacity-scheduler.xml`
@@ -428,6 +541,9 @@ module Google
         #
         #     For more information, see
         #     [Cluster properties](https://cloud.google.com/dataproc/docs/concepts/cluster-properties).
+        # @!attribute [rw] optional_components
+        #   @return [Array<Google::Cloud::Dataproc::V1beta2::Component>]
+        #     The set of optional components to activate on the cluster.
         class SoftwareConfig; end
 
         # Contains cluster daemon metrics, such as HDFS and YARN stats.
@@ -456,11 +572,10 @@ module Google
         # @!attribute [rw] request_id
         #   @return [String]
         #     Optional. A unique id used to identify the request. If the server
-        #     receives two
-        #     {Google::Cloud::Dataproc::V1beta2::CreateClusterRequest CreateClusterRequest}
-        #     requests  with the same id, then the second request will be ignored and the
-        #     first {Google::Longrunning::Operation} created
-        #     and stored in the backend is returned.
+        #     receives two {Google::Cloud::Dataproc::V1beta2::CreateClusterRequest CreateClusterRequest} requests  with the same
+        #     id, then the second request will be ignored and the
+        #     first {Google::Longrunning::Operation} created and stored in the backend
+        #     is returned.
         #
         #     It is recommended to always set this value to a
         #     [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
@@ -550,15 +665,18 @@ module Google
         #     <td>config.lifecycle_config.idle_delete_ttl</td><td>Update Idle TTL
         #     duration</td>
         #     </tr>
+        #     <tr>
+        #     <td>config.autoscaling_config.policy_uri</td><td>Use, stop using, or change
+        #     autoscaling policies</td>
+        #     </tr>
         #     </table>
         # @!attribute [rw] request_id
         #   @return [String]
         #     Optional. A unique id used to identify the request. If the server
-        #     receives two
-        #     {Google::Cloud::Dataproc::V1beta2::UpdateClusterRequest UpdateClusterRequest}
-        #     requests  with the same id, then the second request will be ignored and the
-        #     first {Google::Longrunning::Operation} created
-        #     and stored in the backend is returned.
+        #     receives two {Google::Cloud::Dataproc::V1beta2::UpdateClusterRequest UpdateClusterRequest} requests  with the same
+        #     id, then the second request will be ignored and the
+        #     first {Google::Longrunning::Operation} created and stored in the
+        #     backend is returned.
         #
         #     It is recommended to always set this value to a
         #     [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
@@ -585,11 +703,10 @@ module Google
         # @!attribute [rw] request_id
         #   @return [String]
         #     Optional. A unique id used to identify the request. If the server
-        #     receives two
-        #     {Google::Cloud::Dataproc::V1beta2::DeleteClusterRequest DeleteClusterRequest}
-        #     requests  with the same id, then the second request will be ignored and the
-        #     first {Google::Longrunning::Operation} created
-        #     and stored in the backend is returned.
+        #     receives two {Google::Cloud::Dataproc::V1beta2::DeleteClusterRequest DeleteClusterRequest} requests  with the same
+        #     id, then the second request will be ignored and the
+        #     first {Google::Longrunning::Operation} created and stored in the
+        #     backend is returned.
         #
         #     It is recommended to always set this value to a
         #     [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
@@ -679,6 +796,33 @@ module Google
         #     The output report is a plain text file with a summary of collected
         #     diagnostics.
         class DiagnoseClusterResults; end
+
+        # Reservation Affinity for consuming Zonal reservation.
+        # @!attribute [rw] consume_reservation_type
+        #   @return [Google::Cloud::Dataproc::V1beta2::ReservationAffinity::Type]
+        #     Optional. Type of reservation to consume
+        # @!attribute [rw] key
+        #   @return [String]
+        #     Optional. Corresponds to the label key of reservation resource.
+        # @!attribute [rw] values
+        #   @return [Array<String>]
+        #     Optional. Corresponds to the label values of reservation resource.
+        class ReservationAffinity
+          # Indicates whether to consume capacity from an reservation or not.
+          module Type
+            TYPE_UNSPECIFIED = 0
+
+            # Do not consume from any allocated capacity.
+            NO_RESERVATION = 1
+
+            # Consume any reservation available.
+            ANY_RESERVATION = 2
+
+            # Must consume from a specific reservation. Must specify key value fields
+            # for specifying the reservations.
+            SPECIFIC_RESERVATION = 3
+          end
+        end
       end
     end
   end
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/jobs.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/jobs.rb
index 39ed03985..852ae5aa2 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/jobs.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/jobs.rb
@@ -289,6 +289,38 @@ module Google
         #     Optional. The runtime log config for job execution.
         class PigJob; end
 
+        # A Cloud Dataproc job for running
+        # [Apache SparkR](https://spark.apache.org/docs/latest/sparkr.html)
+        # applications on YARN.
+        # @!attribute [rw] main_r_file_uri
+        #   @return [String]
+        #     Required. The HCFS URI of the main R file to use as the driver.
+        #     Must be a .R file.
+        # @!attribute [rw] args
+        #   @return [Array<String>]
+        #     Optional. The arguments to pass to the driver.  Do not include arguments,
+        #     such as `--conf`, that can be set as job properties, since a collision may
+        #     occur that causes an incorrect job submission.
+        # @!attribute [rw] file_uris
+        #   @return [Array<String>]
+        #     Optional. HCFS URIs of files to be copied to the working directory of
+        #     R drivers and distributed tasks. Useful for naively parallel tasks.
+        # @!attribute [rw] archive_uris
+        #   @return [Array<String>]
+        #     Optional. HCFS URIs of archives to be extracted in the working directory of
+        #     Spark drivers and tasks. Supported file types:
+        #     .jar, .tar, .tar.gz, .tgz, and .zip.
+        # @!attribute [rw] properties
+        #   @return [Hash{String => String}]
+        #     Optional. A mapping of property names to values, used to configure SparkR.
+        #     Properties that conflict with values set by the Cloud Dataproc API may be
+        #     overwritten. Can include properties set in
+        #     /etc/spark/conf/spark-defaults.conf and classes in user code.
+        # @!attribute [rw] logging_config
+        #   @return [Google::Cloud::Dataproc::V1beta2::LoggingConfig]
+        #     Optional. The runtime log config for job execution.
+        class SparkRJob; end
+
         # Cloud Dataproc job config.
         # @!attribute [rw] cluster_name
         #   @return [String]
@@ -386,11 +418,12 @@ module Google
         #     belongs to.
         # @!attribute [rw] job_id
         #   @return [String]
-        #     Optional. The job ID, which must be unique within the project. The job ID
-        #     is generated by the server upon job submission or provided by the user as a
-        #     means to perform retries without creating duplicate jobs. The ID must
-        #     contain only letters (a-z, A-Z), numbers (0-9), underscores (_), or
-        #     hyphens (-). The maximum length is 100 characters.
+        #     Optional. The job ID, which must be unique within the project.
+        #
+        #     The ID must contain only letters (a-z, A-Z), numbers (0-9),
+        #     underscores (_), or hyphens (-). The maximum length is 100 characters.
+        #
+        #     If not specified by the caller, the job ID will be provided by the server.
         class JobReference; end
 
         # A YARN application created by a job. Application information is a subset of
@@ -472,6 +505,9 @@ module Google
         # @!attribute [rw] pig_job
         #   @return [Google::Cloud::Dataproc::V1beta2::PigJob]
         #     Job is a Pig job.
+        # @!attribute [rw] spark_r_job
+        #   @return [Google::Cloud::Dataproc::V1beta2::SparkRJob]
+        #     Job is a SparkR job.
         # @!attribute [rw] spark_sql_job
         #   @return [Google::Cloud::Dataproc::V1beta2::SparkSqlJob]
         #     Job is a SparkSql job.
@@ -548,10 +584,9 @@ module Google
         # @!attribute [rw] request_id
         #   @return [String]
         #     Optional. A unique id used to identify the request. If the server
-        #     receives two
-        #     {Google::Cloud::Dataproc::V1beta2::SubmitJobRequest SubmitJobRequest} requests
-        #     with the same id, then the second request will be ignored and the first
-        #     {Google::Cloud::Dataproc::V1beta2::Job Job} created and stored in the backend
+        #     receives two {Google::Cloud::Dataproc::V1beta2::SubmitJobRequest SubmitJobRequest} requests  with the same
+        #     id, then the second request will be ignored and the
+        #     first {Google::Cloud::Dataproc::V1beta2::Job Job} created and stored in the backend
         #     is returned.
         #
         #     It is recommended to always set this value to a
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/workflow_templates.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/workflow_templates.rb
index 9d04f7be6..c3bf72b7d 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/workflow_templates.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/doc/google/cloud/dataproc/v1beta2/workflow_templates.rb
@@ -25,6 +25,8 @@ module Google
         #     The id must contain only letters (a-z, A-Z), numbers (0-9),
         #     underscores (_), and hyphens (-). Cannot begin or end with underscore
         #     or hyphen. Must consist of between 3 and 50 characters.
+        #
+        #     .
         # @!attribute [rw] name
         #   @return [String]
         #     Output only. The "resource name" of the template, as described
@@ -136,8 +138,8 @@ module Google
         #
         #     The step id is used as prefix for job id, as job
         #     `goog-dataproc-workflow-step-id` label, and in
-        #     {Google::Cloud::Dataproc::V1beta2::OrderedJob#prerequisite_step_ids prerequisiteStepIds}
-        #     field from other steps.
+        #     {Google::Cloud::Dataproc::V1beta2::OrderedJob#prerequisite_step_ids prerequisiteStepIds} field from other
+        #     steps.
         #
         #     The id must contain only letters (a-z, A-Z), numbers (0-9),
         #     underscores (_), and hyphens (-). Cannot begin or end with underscore
@@ -205,10 +207,10 @@ module Google
         #     A field is allowed to appear in at most one parameter's list of field
         #     paths.
         #
-        #     A field path is similar in syntax to a
-        #     {Google::Protobuf::FieldMask}. For example, a
-        #     field path that references the zone field of a workflow template's cluster
-        #     selector would be specified as `placement.clusterSelector.zone`.
+        #     A field path is similar in syntax to a {Google::Protobuf::FieldMask}.
+        #     For example, a field path that references the zone field of a workflow
+        #     template's cluster selector would be specified as
+        #     `placement.clusterSelector.zone`.
         #
         #     Also, field paths can reference fields using the following syntax:
         #
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/job_controller_client.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/job_controller_client.rb
index c75d5eb66..a04eaed09 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/job_controller_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/job_controller_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/cloud/dataproc/v1beta2/jobs_pb"
 require "google/cloud/dataproc/v1beta2/credentials"
+require "google/cloud/dataproc/version"
 
 module Google
   module Cloud
@@ -129,7 +130,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-dataproc'].version.version
+            package_version = Google::Cloud::Dataproc::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
@@ -217,10 +218,9 @@ module Google
           #   can also be provided.
           # @param request_id [String]
           #   Optional. A unique id used to identify the request. If the server
-          #   receives two
-          #   {Google::Cloud::Dataproc::V1beta2::SubmitJobRequest SubmitJobRequest} requests
-          #   with the same id, then the second request will be ignored and the first
-          #   {Google::Cloud::Dataproc::V1beta2::Job Job} created and stored in the backend
+          #   receives two {Google::Cloud::Dataproc::V1beta2::SubmitJobRequest SubmitJobRequest} requests  with the same
+          #   id, then the second request will be ignored and the
+          #   first {Google::Cloud::Dataproc::V1beta2::Job Job} created and stored in the backend
           #   is returned.
           #
           #   It is recommended to always set this value to a
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/jobs_pb.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/jobs_pb.rb
index 097e8bc68..e493d598e 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/jobs_pb.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/jobs_pb.rb
@@ -91,6 +91,14 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :query_list, :message, 2, "google.cloud.dataproc.v1beta2.QueryList"
     end
   end
+  add_message "google.cloud.dataproc.v1beta2.SparkRJob" do
+    optional :main_r_file_uri, :string, 1
+    repeated :args, :string, 2
+    repeated :file_uris, :string, 3
+    repeated :archive_uris, :string, 4
+    map :properties, :string, :string, 5
+    optional :logging_config, :message, 6, "google.cloud.dataproc.v1beta2.LoggingConfig"
+  end
   add_message "google.cloud.dataproc.v1beta2.JobPlacement" do
     optional :cluster_name, :string, 1
     optional :cluster_uuid, :string, 2
@@ -158,6 +166,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :pyspark_job, :message, 5, "google.cloud.dataproc.v1beta2.PySparkJob"
       optional :hive_job, :message, 6, "google.cloud.dataproc.v1beta2.HiveJob"
       optional :pig_job, :message, 7, "google.cloud.dataproc.v1beta2.PigJob"
+      optional :spark_r_job, :message, 21, "google.cloud.dataproc.v1beta2.SparkRJob"
       optional :spark_sql_job, :message, 12, "google.cloud.dataproc.v1beta2.SparkSqlJob"
     end
   end
@@ -225,6 +234,7 @@ module Google
         HiveJob = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.HiveJob").msgclass
         SparkSqlJob = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.SparkSqlJob").msgclass
         PigJob = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.PigJob").msgclass
+        SparkRJob = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.SparkRJob").msgclass
         JobPlacement = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.JobPlacement").msgclass
         JobStatus = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.JobStatus").msgclass
         JobStatus::State = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.JobStatus.State").enummodule
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/jobs_services_pb.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/jobs_services_pb.rb
index 0aebadf7b..d3df70a85 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/jobs_services_pb.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/jobs_services_pb.rb
@@ -1,7 +1,7 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
 # Source: google/cloud/dataproc/v1beta2/jobs.proto for package 'google.cloud.dataproc.v1beta2'
 # Original file comments:
-# Copyright 2018 Google LLC.
+# Copyright 2019 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/shared_pb.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/shared_pb.rb
index 2a52b2e63..bf4778826 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/shared_pb.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/shared_pb.rb
@@ -6,12 +6,24 @@ require 'google/protobuf'
 
 require 'google/api/annotations_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
+  add_enum "google.cloud.dataproc.v1beta2.Component" do
+    value :COMPONENT_UNSPECIFIED, 0
+    value :ANACONDA, 5
+    value :DRUID, 9
+    value :HIVE_WEBHCAT, 3
+    value :JUPYTER, 1
+    value :KERBEROS, 7
+    value :PRESTO, 6
+    value :ZEPPELIN, 4
+    value :ZOOKEEPER, 8
+  end
 end
 
 module Google
   module Cloud
     module Dataproc
       module V1beta2
+        Component = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dataproc.v1beta2.Component").enummodule
       end
     end
   end
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/workflow_template_service_client.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/workflow_template_service_client.rb
index c4052c4eb..d962ac31d 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/workflow_template_service_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/workflow_template_service_client.rb
@@ -29,6 +29,7 @@ require "google/longrunning/operations_client"
 
 require "google/cloud/dataproc/v1beta2/workflow_templates_pb"
 require "google/cloud/dataproc/v1beta2/credentials"
+require "google/cloud/dataproc/version"
 
 module Google
   module Cloud
@@ -181,7 +182,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-dataproc'].version.version
+            package_version = Google::Cloud::Dataproc::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
@@ -477,8 +478,7 @@ module Google
           # Instantiates a template and begins execution.
           #
           # This method is equivalent to executing the sequence
-          # {Google::Cloud::Dataproc::V1beta2::WorkflowTemplateService::CreateWorkflowTemplate CreateWorkflowTemplate},
-          # {Google::Cloud::Dataproc::V1beta2::WorkflowTemplateService::InstantiateWorkflowTemplate InstantiateWorkflowTemplate},
+          # {Google::Cloud::Dataproc::V1beta2::WorkflowTemplateService::CreateWorkflowTemplate CreateWorkflowTemplate}, {Google::Cloud::Dataproc::V1beta2::WorkflowTemplateService::InstantiateWorkflowTemplate InstantiateWorkflowTemplate},
           # {Google::Cloud::Dataproc::V1beta2::WorkflowTemplateService::DeleteWorkflowTemplate DeleteWorkflowTemplate}.
           #
           # The returned Operation can be used to track execution of
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/workflow_templates_services_pb.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/workflow_templates_services_pb.rb
index afa6b231e..ea2988b8d 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/workflow_templates_services_pb.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/workflow_templates_services_pb.rb
@@ -1,7 +1,7 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
 # Source: google/cloud/dataproc/v1beta2/workflow_templates.proto for package 'google.cloud.dataproc.v1beta2'
 # Original file comments:
-# Copyright 2018 Google LLC.
+# Copyright 2019 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,8 +65,7 @@ module Google
             # Instantiates a template and begins execution.
             #
             # This method is equivalent to executing the sequence
-            # [CreateWorkflowTemplate][google.cloud.dataproc.v1beta2.WorkflowTemplateService.CreateWorkflowTemplate],
-            # [InstantiateWorkflowTemplate][google.cloud.dataproc.v1beta2.WorkflowTemplateService.InstantiateWorkflowTemplate],
+            # [CreateWorkflowTemplate][google.cloud.dataproc.v1beta2.WorkflowTemplateService.CreateWorkflowTemplate], [InstantiateWorkflowTemplate][google.cloud.dataproc.v1beta2.WorkflowTemplateService.InstantiateWorkflowTemplate],
             # [DeleteWorkflowTemplate][google.cloud.dataproc.v1beta2.WorkflowTemplateService.DeleteWorkflowTemplate].
             #
             # The returned Operation can be used to track execution of
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/version.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/version.rb
new file mode 100644
index 000000000..0a4b2a1aa
--- /dev/null
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/version.rb
@@ -0,0 +1,22 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Dataproc
+      VERSION = "0.3.1".freeze
+    end
+  end
+end
diff --git a/google-cloud-dataproc/synth.metadata b/google-cloud-dataproc/synth.metadata
index 86e56de8e..f01b34ec9 100644
--- a/google-cloud-dataproc/synth.metadata
+++ b/google-cloud-dataproc/synth.metadata
@@ -1,26 +1,26 @@
 {
-  "updateTime": "2019-04-25T10:41:16.263325Z",
+  "updateTime": "2019-06-04T19:26:57.216831Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.17.0",
-        "dockerImage": "googleapis/artman@sha256:c58f4ec3838eb4e0718eb1bccc6512bd6850feaa85a360a9e38f6f848ec73bc2"
+        "version": "0.23.0",
+        "dockerImage": "googleapis/artman@sha256:846102ebf7ea2239162deea69f64940443b4147f7c2e68d64b332416f74211ba"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "25cbfd4a5386742f5968d69bd276a0436d23bd97",
-        "internalRef": "245137805"
+        "sha": "0026f4b890ed9e2388fb0573c0727defa6f5b82e",
+        "internalRef": "251265049"
       }
     },
     {
       "template": {
         "name": "ruby_library",
         "origin": "synthtool.gcp",
-        "version": "2019.4.10"
+        "version": "2019.5.2"
       }
     }
   ],
diff --git a/google-cloud-dataproc/synth.py b/google-cloud-dataproc/synth.py
index 8d27ef972..079d317cb 100644
--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -46,6 +46,15 @@ s.copy(v1beta2 / 'lib/google/cloud/dataproc/v1beta2.rb')
 s.copy(v1beta2 / 'acceptance/google/cloud/dataproc/v1beta2')
 s.copy(v1beta2 / 'test/google/cloud/dataproc/v1beta2')
 
+# Use v1beta2 version of dataproc.rb because it includes services not found in
+# v1. Need to change the default version back to v1.
+s.copy(v1beta2 / 'lib/google/cloud/dataproc.rb')
+s.replace(
+    'lib/google/cloud/dataproc.rb',
+    ':v1beta2',
+    ':v1'
+)
+
 # Copy common templates
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
@@ -100,12 +109,20 @@ s.replace(
     'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
+# https://github.com/googleapis/gapic-generator/issues/2492
+s.replace(
+    [
+        'lib/google/cloud/dataproc.rb',
+        'lib/google/cloud/dataproc/v*.rb'
+    ],
+    'module WorkflowTemplate\n',
+    'module WorkflowTemplateService\n'
+)
 s.replace(
     'lib/google/cloud/dataproc.rb',
     'WorkflowTemplate\\.new',
     'WorkflowTemplateService.new'
 )
-
 s.replace(
     [
         'lib/google/cloud/dataproc/v*/workflow_template_service_client.rb',
@@ -114,15 +131,26 @@ s.replace(
     'WorkflowTemplate\\.new\\(version:',
     'WorkflowTemplateService.new(version:'
 )
-
-# https://github.com/googleapis/gapic-generator/issues/2492
 s.replace(
     [
         'lib/google/cloud/dataproc.rb',
         'lib/google/cloud/dataproc/v*.rb'
     ],
-    'module WorkflowTemplate\n',
-    'module WorkflowTemplateService\n'
+    'module AutoscalingPolicy\n',
+    'module AutoscalingPolicyService\n'
+)
+s.replace(
+    'lib/google/cloud/dataproc.rb',
+    'AutoscalingPolicy\\.new',
+    'AutoscalingPolicyService.new'
+)
+s.replace(
+    [
+        'lib/google/cloud/dataproc/v*/autoscaling_policy_service_client.rb',
+        'test/google/cloud/dataproc/v*/autoscaling_policy_service_client_test.rb'
+    ],
+    'AutoscalingPolicy\\.new\\(version:',
+    'AutoscalingPolicyService.new(version:'
 )
 
 # https://github.com/googleapis/gapic-generator/issues/2232
@@ -142,3 +170,26 @@ s.replace(
     'README.md\n',
     'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
+
+# https://github.com/googleapis/google-cloud-ruby/issues/3058
+s.replace(
+    'google-cloud-dataproc.gemspec',
+    '\nGem::Specification.new do',
+    'require File.expand_path("../lib/google/cloud/dataproc/version", __FILE__)\n\nGem::Specification.new do'
+)
+s.replace(
+    'google-cloud-dataproc.gemspec',
+    '(gem.version\s+=\s+).\d+.\d+.\d.*$',
+    '\\1Google::Cloud::Dataproc::VERSION'
+)
+for version in ['v1', 'v1beta2']:
+    s.replace(
+        f'lib/google/cloud/dataproc/{version}/*_client.rb',
+        f'(require \".*credentials\"\n)\n',
+        f'\\1require "google/cloud/dataproc/version"\n\n'
+    )
+    s.replace(
+        f'lib/google/cloud/dataproc/{version}/*_client.rb',
+        'Gem.loaded_specs\[.*\]\.version\.version',
+        'Google::Cloud::Dataproc::VERSION'
+    )
diff --git a/google-cloud-dataproc/test/google/cloud/dataproc/v1/cluster_controller_client_test.rb b/google-cloud-dataproc/test/google/cloud/dataproc/v1/cluster_controller_client_test.rb
index 4701072f5..429f123d5 100644
--- a/google-cloud-dataproc/test/google/cloud/dataproc/v1/cluster_controller_client_test.rb
+++ b/google-cloud-dataproc/test/google/cloud/dataproc/v1/cluster_controller_client_test.rb
@@ -196,7 +196,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
           client = Google::Cloud::Dataproc::ClusterController.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_cluster(
               project_id,
               region,
@@ -355,7 +355,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
           client = Google::Cloud::Dataproc::ClusterController.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_cluster(
               project_id,
               region,
@@ -493,7 +493,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
           client = Google::Cloud::Dataproc::ClusterController.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_cluster(
               project_id,
               region,
@@ -593,7 +593,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
           client = Google::Cloud::Dataproc::ClusterController.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_cluster(
               project_id,
               region,
@@ -673,7 +673,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
           client = Google::Cloud::Dataproc::ClusterController.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_clusters(project_id, region)
           end
 
@@ -805,7 +805,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
           client = Google::Cloud::Dataproc::ClusterController.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.diagnose_cluster(
               project_id,
               region,
diff --git a/google-cloud-dataproc/test/google/cloud/dataproc/v1/job_controller_client_test.rb b/google-cloud-dataproc/test/google/cloud/dataproc/v1/job_controller_client_test.rb
index 8fbc84826..a1377008d 100644
--- a/google-cloud-dataproc/test/google/cloud/dataproc/v1/job_controller_client_test.rb
+++ b/google-cloud-dataproc/test/google/cloud/dataproc/v1/job_controller_client_test.rb
@@ -152,7 +152,7 @@ describe Google::Cloud::Dataproc::V1::JobControllerClient do
           client = Google::Cloud::Dataproc::JobController.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.submit_job(
               project_id,
               region,
@@ -252,7 +252,7 @@ describe Google::Cloud::Dataproc::V1::JobControllerClient do
           client = Google::Cloud::Dataproc::JobController.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_job(
               project_id,
               region,
@@ -332,7 +332,7 @@ describe Google::Cloud::Dataproc::V1::JobControllerClient do
           client = Google::Cloud::Dataproc::JobController.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_jobs(project_id, region)
           end
 
@@ -440,7 +440,7 @@ describe Google::Cloud::Dataproc::V1::JobControllerClient do
           client = Google::Cloud::Dataproc::JobController.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_job(
               project_id,
               region,
@@ -542,7 +542,7 @@ describe Google::Cloud::Dataproc::V1::JobControllerClient do
           client = Google::Cloud::Dataproc::JobController.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.cancel_job(
               project_id,
               region,
@@ -631,7 +631,7 @@ describe Google::Cloud::Dataproc::V1::JobControllerClient do
           client = Google::Cloud::Dataproc::JobController.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_job(
               project_id,
               region,
diff --git a/google-cloud-dataproc/test/google/cloud/dataproc/v1/workflow_template_service_client_test.rb b/google-cloud-dataproc/test/google/cloud/dataproc/v1/workflow_template_service_client_test.rb
index 3d122c3c8..92af1819d 100644
--- a/google-cloud-dataproc/test/google/cloud/dataproc/v1/workflow_template_service_client_test.rb
+++ b/google-cloud-dataproc/test/google/cloud/dataproc/v1/workflow_template_service_client_test.rb
@@ -141,7 +141,7 @@ describe Google::Cloud::Dataproc::V1::WorkflowTemplateServiceClient do
           client = Google::Cloud::Dataproc::WorkflowTemplateService.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_workflow_template(formatted_parent, template)
           end
 
@@ -221,7 +221,7 @@ describe Google::Cloud::Dataproc::V1::WorkflowTemplateServiceClient do
           client = Google::Cloud::Dataproc::WorkflowTemplateService.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_workflow_template(formatted_name)
           end
 
@@ -333,7 +333,7 @@ describe Google::Cloud::Dataproc::V1::WorkflowTemplateServiceClient do
           client = Google::Cloud::Dataproc::WorkflowTemplateService.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.instantiate_workflow_template(formatted_name)
           end
 
@@ -451,7 +451,7 @@ describe Google::Cloud::Dataproc::V1::WorkflowTemplateServiceClient do
           client = Google::Cloud::Dataproc::WorkflowTemplateService.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.instantiate_inline_workflow_template(formatted_parent, template)
           end
 
@@ -531,7 +531,7 @@ describe Google::Cloud::Dataproc::V1::WorkflowTemplateServiceClient do
           client = Google::Cloud::Dataproc::WorkflowTemplateService.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_workflow_template(template)
           end
 
@@ -603,7 +603,7 @@ describe Google::Cloud::Dataproc::V1::WorkflowTemplateServiceClient do
           client = Google::Cloud::Dataproc::WorkflowTemplateService.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_workflow_templates(formatted_parent)
           end
 
@@ -672,7 +672,7 @@ describe Google::Cloud::Dataproc::V1::WorkflowTemplateServiceClient do
           client = Google::Cloud::Dataproc::WorkflowTemplateService.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_workflow_template(formatted_name)
           end
 
diff --git a/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/autoscaling_policy_service_client_test.rb b/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/autoscaling_policy_service_client_test.rb
new file mode 100644
index 000000000..0367b7cf2
--- /dev/null
+++ b/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/autoscaling_policy_service_client_test.rb
@@ -0,0 +1,439 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "minitest/autorun"
+require "minitest/spec"
+
+require "google/gax"
+
+require "google/cloud/dataproc"
+require "google/cloud/dataproc/v1beta2/autoscaling_policy_service_client"
+require "google/cloud/dataproc/v1beta2/autoscaling_policies_services_pb"
+
+class CustomTestError_v1beta2 < StandardError; end
+
+# Mock for the GRPC::ClientStub class.
+class MockGrpcClientStub_v1beta2
+
+  # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
+  # @param mock_method [Proc] The method that is being mocked.
+  def initialize(expected_symbol, mock_method)
+    @expected_symbol = expected_symbol
+    @mock_method = mock_method
+  end
+
+  # This overrides the Object#method method to return the mocked method when the mocked method
+  # is being requested. For methods that aren't being tested, this method returns a proc that
+  # will raise an error when called. This is to assure that only the mocked grpc method is being
+  # called.
+  #
+  # @param symbol [Symbol] The symbol of the method being requested.
+  # @return [Proc] The proc of the requested method. If the requested method is not being mocked
+  #   the proc returned will raise when called.
+  def method(symbol)
+    return @mock_method if symbol == @expected_symbol
+
+    # The requested method is not being tested, raise if it called.
+    proc do
+      raise "The method #{symbol} was unexpectedly called during the " \
+        "test for #{@expected_symbol}."
+    end
+  end
+end
+
+class MockAutoscalingPolicyServiceCredentials_v1beta2 < Google::Cloud::Dataproc::V1beta2::Credentials
+  def initialize(method_name)
+    @method_name = method_name
+  end
+
+  def updater_proc
+    proc do
+      raise "The method `#{@method_name}` was trying to make a grpc request. This should not " \
+          "happen since the grpc layer is being mocked."
+    end
+  end
+end
+
+describe Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient do
+
+  describe 'create_autoscaling_policy' do
+    custom_error = CustomTestError_v1beta2.new "Custom test error for Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient#create_autoscaling_policy."
+
+    it 'invokes create_autoscaling_policy without error' do
+      # Create request parameters
+      formatted_parent = Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient.region_path("[PROJECT]", "[REGION]")
+      policy = {}
+
+      # Create expected grpc response
+      id = "id3355"
+      name = "name3373707"
+      expected_response = { id: id, name: name }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Dataproc::V1beta2::CreateAutoscalingPolicyRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        assert_equal(Google::Gax::to_proto(policy, Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy), request.policy)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1beta2.new(:create_autoscaling_policy, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockAutoscalingPolicyServiceCredentials_v1beta2.new("create_autoscaling_policy")
+
+      Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Dataproc::V1beta2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+
+          # Call method
+          response = client.create_autoscaling_policy(formatted_parent, policy)
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.create_autoscaling_policy(formatted_parent, policy) do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes create_autoscaling_policy with error' do
+      # Create request parameters
+      formatted_parent = Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient.region_path("[PROJECT]", "[REGION]")
+      policy = {}
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Dataproc::V1beta2::CreateAutoscalingPolicyRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        assert_equal(Google::Gax::to_proto(policy, Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy), request.policy)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1beta2.new(:create_autoscaling_policy, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockAutoscalingPolicyServiceCredentials_v1beta2.new("create_autoscaling_policy")
+
+      Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Dataproc::V1beta2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
+            client.create_autoscaling_policy(formatted_parent, policy)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'update_autoscaling_policy' do
+    custom_error = CustomTestError_v1beta2.new "Custom test error for Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient#update_autoscaling_policy."
+
+    it 'invokes update_autoscaling_policy without error' do
+      # Create request parameters
+      policy = {}
+
+      # Create expected grpc response
+      id = "id3355"
+      name = "name3373707"
+      expected_response = { id: id, name: name }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Dataproc::V1beta2::UpdateAutoscalingPolicyRequest, request)
+        assert_equal(Google::Gax::to_proto(policy, Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy), request.policy)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1beta2.new(:update_autoscaling_policy, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockAutoscalingPolicyServiceCredentials_v1beta2.new("update_autoscaling_policy")
+
+      Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Dataproc::V1beta2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+
+          # Call method
+          response = client.update_autoscaling_policy(policy)
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.update_autoscaling_policy(policy) do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes update_autoscaling_policy with error' do
+      # Create request parameters
+      policy = {}
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Dataproc::V1beta2::UpdateAutoscalingPolicyRequest, request)
+        assert_equal(Google::Gax::to_proto(policy, Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy), request.policy)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1beta2.new(:update_autoscaling_policy, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockAutoscalingPolicyServiceCredentials_v1beta2.new("update_autoscaling_policy")
+
+      Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Dataproc::V1beta2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
+            client.update_autoscaling_policy(policy)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'get_autoscaling_policy' do
+    custom_error = CustomTestError_v1beta2.new "Custom test error for Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient#get_autoscaling_policy."
+
+    it 'invokes get_autoscaling_policy without error' do
+      # Create request parameters
+      formatted_name = Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient.autoscaling_policy_path("[PROJECT]", "[REGION]", "[AUTOSCALING_POLICY]")
+
+      # Create expected grpc response
+      id = "id3355"
+      name_2 = "name2-1052831874"
+      expected_response = { id: id, name: name_2 }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Dataproc::V1beta2::AutoscalingPolicy)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Dataproc::V1beta2::GetAutoscalingPolicyRequest, request)
+        assert_equal(formatted_name, request.name)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1beta2.new(:get_autoscaling_policy, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockAutoscalingPolicyServiceCredentials_v1beta2.new("get_autoscaling_policy")
+
+      Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Dataproc::V1beta2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+
+          # Call method
+          response = client.get_autoscaling_policy(formatted_name)
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.get_autoscaling_policy(formatted_name) do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes get_autoscaling_policy with error' do
+      # Create request parameters
+      formatted_name = Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient.autoscaling_policy_path("[PROJECT]", "[REGION]", "[AUTOSCALING_POLICY]")
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Dataproc::V1beta2::GetAutoscalingPolicyRequest, request)
+        assert_equal(formatted_name, request.name)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1beta2.new(:get_autoscaling_policy, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockAutoscalingPolicyServiceCredentials_v1beta2.new("get_autoscaling_policy")
+
+      Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Dataproc::V1beta2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
+            client.get_autoscaling_policy(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'list_autoscaling_policies' do
+    custom_error = CustomTestError_v1beta2.new "Custom test error for Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient#list_autoscaling_policies."
+
+    it 'invokes list_autoscaling_policies without error' do
+      # Create request parameters
+      formatted_parent = Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient.region_path("[PROJECT]", "[REGION]")
+
+      # Create expected grpc response
+      next_page_token = ""
+      policies_element = {}
+      policies = [policies_element]
+      expected_response = { next_page_token: next_page_token, policies: policies }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Dataproc::V1beta2::ListAutoscalingPoliciesResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Dataproc::V1beta2::ListAutoscalingPoliciesRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1beta2.new(:list_autoscaling_policies, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockAutoscalingPolicyServiceCredentials_v1beta2.new("list_autoscaling_policies")
+
+      Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Dataproc::V1beta2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+
+          # Call method
+          response = client.list_autoscaling_policies(formatted_parent)
+
+          # Verify the response
+          assert(response.instance_of?(Google::Gax::PagedEnumerable))
+          assert_equal(expected_response, response.page.response)
+          assert_nil(response.next_page)
+          assert_equal(expected_response.policies.to_a, response.to_a)
+        end
+      end
+    end
+
+    it 'invokes list_autoscaling_policies with error' do
+      # Create request parameters
+      formatted_parent = Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient.region_path("[PROJECT]", "[REGION]")
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Dataproc::V1beta2::ListAutoscalingPoliciesRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1beta2.new(:list_autoscaling_policies, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockAutoscalingPolicyServiceCredentials_v1beta2.new("list_autoscaling_policies")
+
+      Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Dataproc::V1beta2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
+            client.list_autoscaling_policies(formatted_parent)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'delete_autoscaling_policy' do
+    custom_error = CustomTestError_v1beta2.new "Custom test error for Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient#delete_autoscaling_policy."
+
+    it 'invokes delete_autoscaling_policy without error' do
+      # Create request parameters
+      formatted_name = Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient.autoscaling_policy_path("[PROJECT]", "[REGION]", "[AUTOSCALING_POLICY]")
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Dataproc::V1beta2::DeleteAutoscalingPolicyRequest, request)
+        assert_equal(formatted_name, request.name)
+        OpenStruct.new(execute: nil)
+      end
+      mock_stub = MockGrpcClientStub_v1beta2.new(:delete_autoscaling_policy, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockAutoscalingPolicyServiceCredentials_v1beta2.new("delete_autoscaling_policy")
+
+      Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Dataproc::V1beta2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+
+          # Call method
+          response = client.delete_autoscaling_policy(formatted_name)
+
+          # Verify the response
+          assert_nil(response)
+
+          # Call method with block
+          client.delete_autoscaling_policy(formatted_name) do |response, operation|
+            # Verify the response
+            assert_nil(response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes delete_autoscaling_policy with error' do
+      # Create request parameters
+      formatted_name = Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient.autoscaling_policy_path("[PROJECT]", "[REGION]", "[AUTOSCALING_POLICY]")
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Dataproc::V1beta2::DeleteAutoscalingPolicyRequest, request)
+        assert_equal(formatted_name, request.name)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1beta2.new(:delete_autoscaling_policy, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockAutoscalingPolicyServiceCredentials_v1beta2.new("delete_autoscaling_policy")
+
+      Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Dataproc::V1beta2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Dataproc::AutoscalingPolicyService.new(version: :v1beta2)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
+            client.delete_autoscaling_policy(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+end
\ No newline at end of file
diff --git a/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/cluster_controller_client_test.rb b/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/cluster_controller_client_test.rb
index ee50c2e5c..8599bf047 100644
--- a/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/cluster_controller_client_test.rb
+++ b/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/cluster_controller_client_test.rb
@@ -196,7 +196,7 @@ describe Google::Cloud::Dataproc::V1beta2::ClusterControllerClient do
           client = Google::Cloud::Dataproc::ClusterController.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.create_cluster(
               project_id,
               region,
@@ -355,7 +355,7 @@ describe Google::Cloud::Dataproc::V1beta2::ClusterControllerClient do
           client = Google::Cloud::Dataproc::ClusterController.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.update_cluster(
               project_id,
               region,
@@ -493,7 +493,7 @@ describe Google::Cloud::Dataproc::V1beta2::ClusterControllerClient do
           client = Google::Cloud::Dataproc::ClusterController.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.delete_cluster(
               project_id,
               region,
@@ -593,7 +593,7 @@ describe Google::Cloud::Dataproc::V1beta2::ClusterControllerClient do
           client = Google::Cloud::Dataproc::ClusterController.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.get_cluster(
               project_id,
               region,
@@ -673,7 +673,7 @@ describe Google::Cloud::Dataproc::V1beta2::ClusterControllerClient do
           client = Google::Cloud::Dataproc::ClusterController.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.list_clusters(project_id, region)
           end
 
@@ -805,7 +805,7 @@ describe Google::Cloud::Dataproc::V1beta2::ClusterControllerClient do
           client = Google::Cloud::Dataproc::ClusterController.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.diagnose_cluster(
               project_id,
               region,
diff --git a/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/job_controller_client_test.rb b/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/job_controller_client_test.rb
index d0a394ccf..b097521e3 100644
--- a/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/job_controller_client_test.rb
+++ b/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/job_controller_client_test.rb
@@ -154,7 +154,7 @@ describe Google::Cloud::Dataproc::V1beta2::JobControllerClient do
           client = Google::Cloud::Dataproc::JobController.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.submit_job(
               project_id,
               region,
@@ -256,7 +256,7 @@ describe Google::Cloud::Dataproc::V1beta2::JobControllerClient do
           client = Google::Cloud::Dataproc::JobController.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.get_job(
               project_id,
               region,
@@ -336,7 +336,7 @@ describe Google::Cloud::Dataproc::V1beta2::JobControllerClient do
           client = Google::Cloud::Dataproc::JobController.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.list_jobs(project_id, region)
           end
 
@@ -446,7 +446,7 @@ describe Google::Cloud::Dataproc::V1beta2::JobControllerClient do
           client = Google::Cloud::Dataproc::JobController.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.update_job(
               project_id,
               region,
@@ -550,7 +550,7 @@ describe Google::Cloud::Dataproc::V1beta2::JobControllerClient do
           client = Google::Cloud::Dataproc::JobController.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.cancel_job(
               project_id,
               region,
@@ -639,7 +639,7 @@ describe Google::Cloud::Dataproc::V1beta2::JobControllerClient do
           client = Google::Cloud::Dataproc::JobController.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.delete_job(
               project_id,
               region,
diff --git a/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/workflow_template_service_client_test.rb b/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/workflow_template_service_client_test.rb
index 9f0c9897a..9cf2f6394 100644
--- a/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/workflow_template_service_client_test.rb
+++ b/google-cloud-dataproc/test/google/cloud/dataproc/v1beta2/workflow_template_service_client_test.rb
@@ -141,7 +141,7 @@ describe Google::Cloud::Dataproc::V1beta2::WorkflowTemplateServiceClient do
           client = Google::Cloud::Dataproc::WorkflowTemplateService.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.create_workflow_template(formatted_parent, template)
           end
 
@@ -221,7 +221,7 @@ describe Google::Cloud::Dataproc::V1beta2::WorkflowTemplateServiceClient do
           client = Google::Cloud::Dataproc::WorkflowTemplateService.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.get_workflow_template(formatted_name)
           end
 
@@ -333,7 +333,7 @@ describe Google::Cloud::Dataproc::V1beta2::WorkflowTemplateServiceClient do
           client = Google::Cloud::Dataproc::WorkflowTemplateService.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.instantiate_workflow_template(formatted_name)
           end
 
@@ -451,7 +451,7 @@ describe Google::Cloud::Dataproc::V1beta2::WorkflowTemplateServiceClient do
           client = Google::Cloud::Dataproc::WorkflowTemplateService.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.instantiate_inline_workflow_template(formatted_parent, template)
           end
 
@@ -531,7 +531,7 @@ describe Google::Cloud::Dataproc::V1beta2::WorkflowTemplateServiceClient do
           client = Google::Cloud::Dataproc::WorkflowTemplateService.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.update_workflow_template(template)
           end
 
@@ -603,7 +603,7 @@ describe Google::Cloud::Dataproc::V1beta2::WorkflowTemplateServiceClient do
           client = Google::Cloud::Dataproc::WorkflowTemplateService.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.list_workflow_templates(formatted_parent)
           end
 
@@ -672,7 +672,7 @@ describe Google::Cloud::Dataproc::V1beta2::WorkflowTemplateServiceClient do
           client = Google::Cloud::Dataproc::WorkflowTemplateService.new(version: :v1beta2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta2 do
             client.delete_workflow_template(formatted_name)
           end
 

```

</details>

This pull request was generated using releasetool.