### PR TITLE
Release google-cloud-datastore 1.5.3

### DIFF
--- a/google-cloud-datastore/CHANGELOG.md
+++ b/google-cloud-datastore/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.5.3 / 2019-06-12
+
+* Enable grpc.service_config_disable_resolution
+* Use VERSION constant in GAPIC client
+
 ### 1.5.2 / 2019-04-29
 
 * Add AUTHENTICATION.md guide.

--- a/google-cloud-datastore/lib/google/cloud/datastore/version.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Datastore
-      VERSION = "1.5.2".freeze
+      VERSION = "1.5.3".freeze
     end
   end
 end


### PR DESCRIPTION
* Enable grpc.service_config_disable_resolution
* Use VERSION constant in GAPIC client

<details><summary>Commits since previous release</summary><pre><code>commit c3f100da4536930396d0816303f696bdfaafddb8
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 11 13:35:45 2019 -0700

    prepare repo-metadata.json for docuploader (#3444)

commit efb80c87489098075b6da5e186f573940afcbfd7
Author: Mike Moore <mike@blowmage.com>
Date:   Wed Jun 5 12:10:16 2019 -0600

    config: Disable gRPC Service Config
    
    [pr #3443]

commit ea562c18e376f461f529bd5b535931af5593e4a1
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 4 10:14:49 2019 -0700

    add version.rb and remove Gem.loaded_specs (#3391)

commit 19df0d592009605b5211dbbf9c36b120a3056dec
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Fri May 10 10:38:36 2019 -0700

    Update generated google-cloud-datastore files (#3355)
    
    * Revert error retry configuration.

commit 989cd7885b82d72106d4d2f48c633725a20ed473
Author: Graham Paye <paye@google.com>
Date:   Thu May 9 11:38:46 2019 -0700

    datastore - use version.rb in place of Gem.loaded_specs (#3344)

commit 80c98a52e5e46cf70c27e6327c5e30258765fbbc
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Wed May 8 10:46:02 2019 -0700

    Update generated google-cloud-datastore files (#3309)
    
    * Update error retry configuration.
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-datastore/.repo-metadata.json b/google-cloud-datastore/.repo-metadata.json
new file mode 100644
index 000000000..e1bbb2576
--- /dev/null
+++ b/google-cloud-datastore/.repo-metadata.json
@@ -0,0 +1,5 @@
+{
+    "name": "datastore",
+    "language": "ruby",
+    "distribution_name": "google-cloud-datastore"
+}
diff --git a/google-cloud-datastore/lib/google/cloud/datastore/service.rb b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
index 05ac739e2..d2cc65c83 100644
--- a/google-cloud-datastore/lib/google/cloud/datastore/service.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
@@ -41,7 +41,11 @@ module Google
 
         def channel
           require "grpc"
-          GRPC::Core::Channel.new host, nil, chan_creds
+          GRPC::Core::Channel.new host, chan_args, chan_creds
+        end
+
+        def chan_args
+          { "grpc.service_config_disable_resolution" => 1 }
         end
 
         def chan_creds
diff --git a/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb b/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb
index 7676bfdce..e8b6cfe4a 100644
--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/datastore/v1/datastore_pb"
 require "google/cloud/datastore/v1/credentials"
+require "google/cloud/datastore/version"
 
 module Google
   module Cloud
@@ -126,7 +127,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-datastore'].version.version
+            package_version = Google::Cloud::Datastore::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-datastore/synth.metadata b/google-cloud-datastore/synth.metadata
index d8f6009fe..355565d27 100644
--- a/google-cloud-datastore/synth.metadata
+++ b/google-cloud-datastore/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-03-28T10:40:11.361531Z",
+  "updateTime": "2019-05-10T10:38:52.873324Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.16.20",
-        "dockerImage": "googleapis/artman@sha256:e3c054a2fb85a12481c722af616c7fb6f1d02d862248385eecbec3e4240ebd1e"
+        "version": "0.19.0",
+        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "6a84b3267b0a95e922608b9891219075047eee29",
-        "internalRef": "240640999"
+        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
+        "internalRef": "247530843"
       }
     }
   ],
diff --git a/google-cloud-datastore/synth.py b/google-cloud-datastore/synth.py
index d30a6ab7c..d7baedd4e 100644
--- a/google-cloud-datastore/synth.py
+++ b/google-cloud-datastore/synth.py
@@ -50,3 +50,15 @@ s.replace(
     'lib/**/*.rb',
     '\\A(((#[^\n]*)?\n)*# (Copyright \\d+|Generated by the protocol buffer compiler)[^\n]+\n(#[^\n]*\n)*\n)([^\n])',
     '\\1\n\\6')
+
+# https://github.com/googleapis/google-cloud-ruby/issues/3058
+s.replace(
+    'lib/google/cloud/datastore/v1/*_client.rb',
+    '(require \".*credentials\"\n)\n',
+    '\\1require "google/cloud/datastore/version"\n\n'
+)
+s.replace(
+    'lib/google/cloud/datastore/v1/*_client.rb',
+    'Gem.loaded_specs\[.*\]\.version\.version',
+    'Google::Cloud::Datastore::VERSION'
+)

```

</details>

This pull request was generated using releasetool.