### PR TITLE
Release google-cloud-dialogflow 0.4.0

### DIFF
--- a/google-cloud-dialogflow/CHANGELOG.md
+++ b/google-cloud-dialogflow/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 0.4.0 / 2019-06-12
+
+* Add SpeechModelVariant
+* Add InputAudioConfig#model_variant
+* Add Intent::Message::Platform::GOOGLE_HANGOUTS
+* Add VERSION constant
+
 ### 0.3.0 / 2019-04-29
 
 * Client changes:

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/version.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Dialogflow
-      VERSION = "0.3.0".freeze
+      VERSION = "0.4.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add SpeechModelVariant
* Add InputAudioConfig#model_variant
* Add Intent::Message::Platform::GOOGLE_HANGOUTS
* Add VERSION constant

<details><summary>Commits since previous release</summary><pre><code>commit c3f100da4536930396d0816303f696bdfaafddb8
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 11 13:35:45 2019 -0700

    prepare repo-metadata.json for docuploader (#3444)

commit ea562c18e376f461f529bd5b535931af5593e4a1
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 4 10:14:49 2019 -0700

    add version.rb and remove Gem.loaded_specs (#3391)

commit 9d7566152ec7d6ba02c053dda066589e7f641548
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed May 29 20:17:25 2019 -0700

    Fix unit tests to check for both custom and wrapper exception types (#3427)

commit 9f81c12eb48e49f0c177bdde3195b84266918c52
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Fri May 24 10:50:31 2019 -0700

    feat(dialogflow): add Intent::Message::Platform::GOOGLE_HANGOUTS

commit 98a39016ed4606ec556561423df4e08afe154a8f
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Fri May 10 10:39:43 2019 -0700

    Update generated google-cloud-dialogflow files (#3357)
    
    * Revert error retry configuration.

commit 2fb379182d65f836f7f1f48c997f672b6a02da8b
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Wed May 8 10:18:50 2019 -0700

    Update generated google-cloud-dialogflow files (#3311)
    
    * Update error retry configuration.

commit 8dd19fe90cdb6713a02eabfa88cc86bea5e46a2a
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Fri May 3 09:32:18 2019 -0700

    Update generated google-cloud-dialogflow files (#3274)
    
    * Add SpeechModelVariant.
    * Add InputAudioConfig#model_variant.
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-dialogflow/.repo-metadata.json b/google-cloud-dialogflow/.repo-metadata.json
index 5fa08178a..80376f9ee 100644
--- a/google-cloud-dialogflow/.repo-metadata.json
+++ b/google-cloud-dialogflow/.repo-metadata.json
@@ -1,6 +1,8 @@
 {
-  "distribution_name": "google-cloud-dialogflow",
-  "module_name": "Dialogflow",
-  "module_name_credentials": "Dialogflow::V2",
-  "env_var_prefix": "DIALOGFLOW"
-}
\ No newline at end of file
+    "name": "dialogflow",
+    "language": "ruby",
+    "distribution_name": "google-cloud-dialogflow",
+    "module_name": "Dialogflow",
+    "module_name_credentials": "Dialogflow::V2",
+    "env_var_prefix": "DIALOGFLOW"
+}
diff --git a/google-cloud-dialogflow/google-cloud-dialogflow.gemspec b/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
index 47d0b3315..9b1f1bea2 100644
--- a/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
+++ b/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
@@ -1,9 +1,10 @@
 # -*- ruby -*-
 # encoding: utf-8
+require File.expand_path("../lib/google/cloud/dialogflow/version", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dialogflow"
-  gem.version       = "0.3.0"
+  gem.version       = Google::Cloud::Dialogflow::VERSION
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agent_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agent_pb.rb
index c769b4610..ee80fc853 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agent_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agent_pb.rb
@@ -5,7 +5,6 @@
 require 'google/protobuf'
 
 require 'google/api/annotations_pb'
-require 'google/api/resource_pb'
 require 'google/longrunning/operations_pb'
 require 'google/protobuf/empty_pb'
 require 'google/protobuf/field_mask_pb'
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agents_client.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agents_client.rb
index 95f632f07..dcc87e984 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agents_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agents_client.rb
@@ -29,6 +29,7 @@ require "google/longrunning/operations_client"
 
 require "google/cloud/dialogflow/v2/agent_pb"
 require "google/cloud/dialogflow/v2/credentials"
+require "google/cloud/dialogflow/version"
 
 module Google
   module Cloud
@@ -188,7 +189,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-dialogflow'].version.version
+            package_version = Google::Cloud::Dialogflow::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/audio_config_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/audio_config_pb.rb
index 29da4784f..680e5bef6 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/audio_config_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/audio_config_pb.rb
@@ -6,6 +6,13 @@ require 'google/protobuf'
 
 require 'google/api/annotations_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
+  add_message "google.cloud.dialogflow.v2.InputAudioConfig" do
+    optional :audio_encoding, :enum, 1, "google.cloud.dialogflow.v2.AudioEncoding"
+    optional :sample_rate_hertz, :int32, 2
+    optional :language_code, :string, 3
+    repeated :phrase_hints, :string, 4
+    optional :model_variant, :enum, 10, "google.cloud.dialogflow.v2.SpeechModelVariant"
+  end
   add_message "google.cloud.dialogflow.v2.VoiceSelectionParams" do
     optional :name, :string, 1
     optional :ssml_gender, :enum, 2, "google.cloud.dialogflow.v2.SsmlVoiceGender"
@@ -22,6 +29,22 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :sample_rate_hertz, :int32, 2
     optional :synthesize_speech_config, :message, 3, "google.cloud.dialogflow.v2.SynthesizeSpeechConfig"
   end
+  add_enum "google.cloud.dialogflow.v2.AudioEncoding" do
+    value :AUDIO_ENCODING_UNSPECIFIED, 0
+    value :AUDIO_ENCODING_LINEAR_16, 1
+    value :AUDIO_ENCODING_FLAC, 2
+    value :AUDIO_ENCODING_MULAW, 3
+    value :AUDIO_ENCODING_AMR, 4
+    value :AUDIO_ENCODING_AMR_WB, 5
+    value :AUDIO_ENCODING_OGG_OPUS, 6
+    value :AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE, 7
+  end
+  add_enum "google.cloud.dialogflow.v2.SpeechModelVariant" do
+    value :SPEECH_MODEL_VARIANT_UNSPECIFIED, 0
+    value :USE_BEST_AVAILABLE, 1
+    value :USE_STANDARD, 2
+    value :USE_ENHANCED, 3
+  end
   add_enum "google.cloud.dialogflow.v2.SsmlVoiceGender" do
     value :SSML_VOICE_GENDER_UNSPECIFIED, 0
     value :SSML_VOICE_GENDER_MALE, 1
@@ -40,9 +63,12 @@ module Google
   module Cloud
     module Dialogflow
       module V2
+        InputAudioConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.InputAudioConfig").msgclass
         VoiceSelectionParams = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.VoiceSelectionParams").msgclass
         SynthesizeSpeechConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.SynthesizeSpeechConfig").msgclass
         OutputAudioConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.OutputAudioConfig").msgclass
+        AudioEncoding = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.AudioEncoding").enummodule
+        SpeechModelVariant = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.SpeechModelVariant").enummodule
         SsmlVoiceGender = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.SsmlVoiceGender").enummodule
         OutputAudioEncoding = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.OutputAudioEncoding").enummodule
       end
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/context_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/context_pb.rb
index e3252ca53..6d29b8718 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/context_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/context_pb.rb
@@ -5,7 +5,6 @@
 require 'google/protobuf'
 
 require 'google/api/annotations_pb'
-require 'google/api/resource_pb'
 require 'google/protobuf/empty_pb'
 require 'google/protobuf/field_mask_pb'
 require 'google/protobuf/struct_pb'
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/contexts_client.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/contexts_client.rb
index 584fb78cc..f56dc712b 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/contexts_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/contexts_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/cloud/dialogflow/v2/context_pb"
 require "google/cloud/dialogflow/v2/credentials"
+require "google/cloud/dialogflow/version"
 
 module Google
   module Cloud
@@ -183,7 +184,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-dialogflow'].version.version
+            package_version = Google::Cloud::Dialogflow::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/audio_config.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/audio_config.rb
index aca28a178..ce8ee97c5 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/audio_config.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/audio_config.rb
@@ -17,6 +17,37 @@ module Google
   module Cloud
     module Dialogflow
       module V2
+        # Instructs the speech recognizer how to process the audio content.
+        # @!attribute [rw] audio_encoding
+        #   @return [Google::Cloud::Dialogflow::V2::AudioEncoding]
+        #     Required. Audio encoding of the audio content to process.
+        # @!attribute [rw] sample_rate_hertz
+        #   @return [Integer]
+        #     Required. Sample rate (in Hertz) of the audio content sent in the query.
+        #     Refer to
+        #     [Cloud Speech API
+        #     documentation](https://cloud.google.com/speech-to-text/docs/basics) for
+        #     more details.
+        # @!attribute [rw] language_code
+        #   @return [String]
+        #     Required. The language of the supplied audio. Dialogflow does not do
+        #     translations. See [Language
+        #     Support](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     for a list of the currently supported language codes. Note that queries in
+        #     the same session do not necessarily need to specify the same language.
+        # @!attribute [rw] phrase_hints
+        #   @return [Array<String>]
+        #     Optional. The collection of phrase hints which are used to boost accuracy
+        #     of speech recognition.
+        #     Refer to
+        #     [Cloud Speech API
+        #     documentation](https://cloud.google.com/speech-to-text/docs/basics#phrase-hints)
+        #     for more details.
+        # @!attribute [rw] model_variant
+        #   @return [Google::Cloud::Dialogflow::V2::SpeechModelVariant]
+        #     Optional. Which variant of the {Google::Cloud::Dialogflow::V2::InputAudioConfig#model Speech model} to use.
+        class InputAudioConfig; end
+
         # Description of which voice to use for speech synthesis.
         # @!attribute [rw] name
         #   @return [String]
@@ -63,7 +94,7 @@ module Google
         #     Optional. The desired voice of the synthesized audio.
         class SynthesizeSpeechConfig; end
 
-        # Instructs the speech synthesizer how to generate the output audio content.
+        # Instructs the speech synthesizer on how to generate the output audio content.
         # @!attribute [rw] audio_encoding
         #   @return [Google::Cloud::Dialogflow::V2::OutputAudioEncoding]
         #     Required. Audio encoding of the synthesized audio content.
@@ -79,6 +110,55 @@ module Google
         #     Optional. Configuration of how speech should be synthesized.
         class OutputAudioConfig; end
 
+        # Audio encoding of the audio content sent in the conversational query request.
+        # Refer to the
+        # [Cloud Speech API
+        # documentation](https://cloud.google.com/speech-to-text/docs/basics) for more
+        # details.
+        module AudioEncoding
+          # Not specified.
+          AUDIO_ENCODING_UNSPECIFIED = 0
+
+          # Uncompressed 16-bit signed little-endian samples (Linear PCM).
+          AUDIO_ENCODING_LINEAR_16 = 1
+
+          # [`FLAC`](https://xiph.org/flac/documentation.html) (Free Lossless Audio
+          # Codec) is the recommended encoding because it is lossless (therefore
+          # recognition is not compromised) and requires only about half the
+          # bandwidth of `LINEAR16`. `FLAC` stream encoding supports 16-bit and
+          # 24-bit samples, however, not all fields in `STREAMINFO` are supported.
+          AUDIO_ENCODING_FLAC = 2
+
+          # 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
+          AUDIO_ENCODING_MULAW = 3
+
+          # Adaptive Multi-Rate Narrowband codec. `sample_rate_hertz` must be 8000.
+          AUDIO_ENCODING_AMR = 4
+
+          # Adaptive Multi-Rate Wideband codec. `sample_rate_hertz` must be 16000.
+          AUDIO_ENCODING_AMR_WB = 5
+
+          # Opus encoded audio frames in Ogg container
+          # ([OggOpus](https://wiki.xiph.org/OggOpus)).
+          # `sample_rate_hertz` must be 16000.
+          AUDIO_ENCODING_OGG_OPUS = 6
+
+          # Although the use of lossy encodings is not recommended, if a very low
+          # bitrate encoding is required, `OGG_OPUS` is highly preferred over
+          # Speex encoding. The [Speex](https://speex.org/) encoding supported by
+          # Dialogflow API has a header byte in each block, as in MIME type
+          # `audio/x-speex-with-header-byte`.
+          # It is a variant of the RTP Speex encoding defined in
+          # [RFC 5574](https://tools.ietf.org/html/rfc5574).
+          # The stream is a sequence of blocks, one block per RTP packet. Each block
+          # starts with a byte containing the length of the block, in bytes, followed
+          # by one or more frames of Speex data, padded to an integral number of
+          # bytes (octets) as specified in RFC 5574. In other words, each RTP header
+          # is replaced with a single byte containing the block length. Only Speex
+          # wideband is supported. `sample_rate_hertz` must be 16000.
+          AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE = 7
+        end
+
         # Audio encoding of the output audio format in Text-To-Speech.
         module OutputAudioEncoding
           # Not specified.
@@ -98,6 +178,49 @@ module Google
           OUTPUT_AUDIO_ENCODING_OGG_OPUS = 3
         end
 
+        # Variant of the specified {Google::Cloud::Dialogflow::V2::InputAudioConfig#model Speech model} to use.
+        #
+        # See the [Cloud Speech
+        # documentation](https://cloud.google.com/speech-to-text/docs/enhanced-models)
+        # for which models have different variants. For example, the "phone_call" model
+        # has both a standard and an enhanced variant. When you use an enhanced model,
+        # you will generally receive higher quality results than for a standard model.
+        module SpeechModelVariant
+          # No model variant specified. In this case Dialogflow defaults to
+          # USE_BEST_AVAILABLE.
+          SPEECH_MODEL_VARIANT_UNSPECIFIED = 0
+
+          # Use the best available variant of the [Speech
+          # model][InputAudioConfig.model] that the caller is eligible for.
+          #
+          # Please see the [Dialogflow
+          # docs](https://cloud.google.com/dialogflow-enterprise/docs/data-logging) for
+          # how to make your project eligible for enhanced models.
+          USE_BEST_AVAILABLE = 1
+
+          # Use standard model variant even if an enhanced model is available.  See the
+          # [Cloud Speech
+          # documentation](https://cloud.google.com/speech-to-text/docs/enhanced-models)
+          # for details about enhanced models.
+          USE_STANDARD = 2
+
+          # Use an enhanced model variant:
+          #
+          # * If an enhanced variant does not exist for the given
+          #   {Google::Cloud::Dialogflow::V2::InputAudioConfig#model model} and request language, Dialogflow falls
+          #   back to the standard variant.
+          #
+          #   The [Cloud Speech
+          #   documentation](https://cloud.google.com/speech-to-text/docs/enhanced-models)
+          #   describes which models have enhanced variants.
+          #
+          # * If the API caller isn't eligible for enhanced models, Dialogflow returns
+          #   an error. Please see the [Dialogflow
+          #   docs](https://cloud.google.com/dialogflow-enterprise/docs/data-logging)
+          #   for how to make your project eligible.
+          USE_ENHANCED = 3
+        end
+
         # Gender of the voice as described in
         # [SSML voice element](https://www.w3.org/TR/speech-synthesis11/#edef_voice).
         module SsmlVoiceGender
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/intent.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/intent.rb
index 4fd5e760d..d13e049e5 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/intent.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/intent.rb
@@ -86,8 +86,8 @@ module Google
         #     `Response` field in the Dialogflow console.
         # @!attribute [rw] default_response_platforms
         #   @return [Array<Google::Cloud::Dialogflow::V2::Intent::Message::Platform>]
-        #     Optional. The list of platforms for which the first response will be
-        #     taken from among the messages assigned to the DEFAULT_PLATFORM.
+        #     Optional. The list of platforms for which the first responses will be
+        #     copied from the messages in PLATFORM_UNSPECIFIED (i.e. default platform).
         # @!attribute [rw] root_followup_intent_name
         #   @return [String]
         #     Read-only. The unique identifier of the root intent in the chain of
@@ -539,6 +539,9 @@ module Google
               #   }
               # }</pre>
               ACTIONS_ON_GOOGLE = 8
+
+              # Google Hangouts.
+              GOOGLE_HANGOUTS = 11
             end
           end
 
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/session.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/session.rb
index 26b4f2c94..059058c86 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/session.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/session.rb
@@ -131,12 +131,14 @@ module Google
         # @!attribute [rw] query_text
         #   @return [String]
         #     The original conversational query text:
+        #
         #     * If natural language text was provided as input, `query_text` contains
         #       a copy of the input.
         #     * If natural language speech audio was provided as input, `query_text`
         #       contains the speech recognition result. If speech recognizer produced
         #       multiple alternatives, a particular one is picked.
-        #     * If an event was provided as input, `query_text` is not set.
+        #     * If automatic spell correction is enabled, `query_text` will contain the
+        #       corrected user input.
         # @!attribute [rw] language_code
         #   @return [String]
         #     The language that was triggered during intent detection.
@@ -163,6 +165,7 @@ module Google
         # @!attribute [rw] all_required_params_present
         #   @return [true, false]
         #     This field is set to:
+        #
         #     * `false` if the matched intent has required parameters and not all of
         #       the required parameter values have been collected.
         #     * `true` if all required parameter values have been collected, or if the
@@ -374,34 +377,6 @@ module Google
           end
         end
 
-        # Instructs the speech recognizer how to process the audio content.
-        # @!attribute [rw] audio_encoding
-        #   @return [Google::Cloud::Dialogflow::V2::AudioEncoding]
-        #     Required. Audio encoding of the audio content to process.
-        # @!attribute [rw] sample_rate_hertz
-        #   @return [Integer]
-        #     Required. Sample rate (in Hertz) of the audio content sent in the query.
-        #     Refer to
-        #     [Cloud Speech API
-        #     documentation](https://cloud.google.com/speech-to-text/docs/basics) for
-        #     more details.
-        # @!attribute [rw] language_code
-        #   @return [String]
-        #     Required. The language of the supplied audio. Dialogflow does not do
-        #     translations. See [Language
-        #     Support](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
-        #     for a list of the currently supported language codes. Note that queries in
-        #     the same session do not necessarily need to specify the same language.
-        # @!attribute [rw] phrase_hints
-        #   @return [Array<String>]
-        #     Optional. The collection of phrase hints which are used to boost accuracy
-        #     of speech recognition.
-        #     Refer to
-        #     [Cloud Speech API
-        #     documentation](https://cloud.google.com/speech-to-text/docs/basics#phrase-hints)
-        #     for more details.
-        class InputAudioConfig; end
-
         # Represents the natural language text to be processed.
         # @!attribute [rw] text
         #   @return [String]
@@ -460,55 +435,6 @@ module Google
         #     A non-negative number in the [0, +inf) range, which represents the absolute
         #     magnitude of sentiment, regardless of score (positive or negative).
         class Sentiment; end
-
-        # Audio encoding of the audio content sent in the conversational query request.
-        # Refer to the
-        # [Cloud Speech API
-        # documentation](https://cloud.google.com/speech-to-text/docs/basics) for more
-        # details.
-        module AudioEncoding
-          # Not specified.
-          AUDIO_ENCODING_UNSPECIFIED = 0
-
-          # Uncompressed 16-bit signed little-endian samples (Linear PCM).
-          AUDIO_ENCODING_LINEAR_16 = 1
-
-          # [`FLAC`](https://xiph.org/flac/documentation.html) (Free Lossless Audio
-          # Codec) is the recommended encoding because it is lossless (therefore
-          # recognition is not compromised) and requires only about half the
-          # bandwidth of `LINEAR16`. `FLAC` stream encoding supports 16-bit and
-          # 24-bit samples, however, not all fields in `STREAMINFO` are supported.
-          AUDIO_ENCODING_FLAC = 2
-
-          # 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
-          AUDIO_ENCODING_MULAW = 3
-
-          # Adaptive Multi-Rate Narrowband codec. `sample_rate_hertz` must be 8000.
-          AUDIO_ENCODING_AMR = 4
-
-          # Adaptive Multi-Rate Wideband codec. `sample_rate_hertz` must be 16000.
-          AUDIO_ENCODING_AMR_WB = 5
-
-          # Opus encoded audio frames in Ogg container
-          # ([OggOpus](https://wiki.xiph.org/OggOpus)).
-          # `sample_rate_hertz` must be 16000.
-          AUDIO_ENCODING_OGG_OPUS = 6
-
-          # Although the use of lossy encodings is not recommended, if a very low
-          # bitrate encoding is required, `OGG_OPUS` is highly preferred over
-          # Speex encoding. The [Speex](https://speex.org/) encoding supported by
-          # Dialogflow API has a header byte in each block, as in MIME type
-          # `audio/x-speex-with-header-byte`.
-          # It is a variant of the RTP Speex encoding defined in
-          # [RFC 5574](https://tools.ietf.org/html/rfc5574).
-          # The stream is a sequence of blocks, one block per RTP packet. Each block
-          # starts with a byte containing the length of the block, in bytes, followed
-          # by one or more frames of Speex data, padded to an integral number of
-          # bytes (octets) as specified in RFC 5574. In other words, each RTP header
-          # is replaced with a single byte containing the block length. Only Speex
-          # wideband is supported. `sample_rate_hertz` must be 16000.
-          AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE = 7
-        end
       end
     end
   end
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_type_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_type_pb.rb
index a68cf350a..cc7395ff4 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_type_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_type_pb.rb
@@ -5,7 +5,6 @@
 require 'google/protobuf'
 
 require 'google/api/annotations_pb'
-require 'google/api/resource_pb'
 require 'google/longrunning/operations_pb'
 require 'google/protobuf/empty_pb'
 require 'google/protobuf/field_mask_pb'
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_types_client.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_types_client.rb
index 7bde2010b..a9a923d31 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_types_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_types_client.rb
@@ -29,6 +29,7 @@ require "google/longrunning/operations_client"
 
 require "google/cloud/dialogflow/v2/entity_type_pb"
 require "google/cloud/dialogflow/v2/credentials"
+require "google/cloud/dialogflow/version"
 
 module Google
   module Cloud
@@ -205,7 +206,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-dialogflow'].version.version
+            package_version = Google::Cloud::Dialogflow::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intent_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intent_pb.rb
index ccc406905..b9851557f 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intent_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intent_pb.rb
@@ -5,7 +5,6 @@
 require 'google/protobuf'
 
 require 'google/api/annotations_pb'
-require 'google/api/resource_pb'
 require 'google/cloud/dialogflow/v2/context_pb'
 require 'google/longrunning/operations_pb'
 require 'google/protobuf/duration_pb'
@@ -162,6 +161,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     value :LINE, 6
     value :VIBER, 7
     value :ACTIONS_ON_GOOGLE, 8
+    value :GOOGLE_HANGOUTS, 11
   end
   add_message "google.cloud.dialogflow.v2.Intent.FollowupIntentInfo" do
     optional :followup_intent_name, :string, 1
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intents_client.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intents_client.rb
index 7e807db13..51f862f7c 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intents_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intents_client.rb
@@ -29,6 +29,7 @@ require "google/longrunning/operations_client"
 
 require "google/cloud/dialogflow/v2/intent_pb"
 require "google/cloud/dialogflow/v2/credentials"
+require "google/cloud/dialogflow/version"
 
 module Google
   module Cloud
@@ -226,7 +227,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-dialogflow'].version.version
+            package_version = Google::Cloud::Dialogflow::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_type_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_type_pb.rb
index 76dcb40af..83bf3ab94 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_type_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_type_pb.rb
@@ -5,7 +5,6 @@
 require 'google/protobuf'
 
 require 'google/api/annotations_pb'
-require 'google/api/resource_pb'
 require 'google/cloud/dialogflow/v2/entity_type_pb'
 require 'google/protobuf/empty_pb'
 require 'google/protobuf/field_mask_pb'
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_types_client.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_types_client.rb
index 272ba95dd..5024072c2 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_types_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_types_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/cloud/dialogflow/v2/session_entity_type_pb"
 require "google/cloud/dialogflow/v2/credentials"
+require "google/cloud/dialogflow/version"
 
 module Google
   module Cloud
@@ -178,7 +179,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-dialogflow'].version.version
+            package_version = Google::Cloud::Dialogflow::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_pb.rb
index ee53ac025..576d05baa 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_pb.rb
@@ -5,7 +5,6 @@
 require 'google/protobuf'
 
 require 'google/api/annotations_pb'
-require 'google/api/resource_pb'
 require 'google/cloud/dialogflow/v2/audio_config_pb'
 require 'google/cloud/dialogflow/v2/context_pb'
 require 'google/cloud/dialogflow/v2/intent_pb'
@@ -88,12 +87,6 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     value :TRANSCRIPT, 1
     value :END_OF_SINGLE_UTTERANCE, 2
   end
-  add_message "google.cloud.dialogflow.v2.InputAudioConfig" do
-    optional :audio_encoding, :enum, 1, "google.cloud.dialogflow.v2.AudioEncoding"
-    optional :sample_rate_hertz, :int32, 2
-    optional :language_code, :string, 3
-    repeated :phrase_hints, :string, 4
-  end
   add_message "google.cloud.dialogflow.v2.TextInput" do
     optional :text, :string, 1
     optional :language_code, :string, 2
@@ -113,16 +106,6 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :score, :float, 1
     optional :magnitude, :float, 2
   end
-  add_enum "google.cloud.dialogflow.v2.AudioEncoding" do
-    value :AUDIO_ENCODING_UNSPECIFIED, 0
-    value :AUDIO_ENCODING_LINEAR_16, 1
-    value :AUDIO_ENCODING_FLAC, 2
-    value :AUDIO_ENCODING_MULAW, 3
-    value :AUDIO_ENCODING_AMR, 4
-    value :AUDIO_ENCODING_AMR_WB, 5
-    value :AUDIO_ENCODING_OGG_OPUS, 6
-    value :AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE, 7
-  end
 end
 
 module Google
@@ -138,13 +121,11 @@ module Google
         StreamingDetectIntentResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.StreamingDetectIntentResponse").msgclass
         StreamingRecognitionResult = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.StreamingRecognitionResult").msgclass
         StreamingRecognitionResult::MessageType = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.StreamingRecognitionResult.MessageType").enummodule
-        InputAudioConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.InputAudioConfig").msgclass
         TextInput = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.TextInput").msgclass
         EventInput = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.EventInput").msgclass
         SentimentAnalysisRequestConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.SentimentAnalysisRequestConfig").msgclass
         SentimentAnalysisResult = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.SentimentAnalysisResult").msgclass
         Sentiment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.Sentiment").msgclass
-        AudioEncoding = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.AudioEncoding").enummodule
       end
     end
   end
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/sessions_client.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/sessions_client.rb
index a40ab3e0b..a54bd32bc 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/sessions_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/sessions_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/cloud/dialogflow/v2/session_pb"
 require "google/cloud/dialogflow/v2/credentials"
+require "google/cloud/dialogflow/version"
 
 module Google
   module Cloud
@@ -141,7 +142,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-dialogflow'].version.version
+            package_version = Google::Cloud::Dialogflow::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/version.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/version.rb
new file mode 100644
index 000000000..5e30c70d7
--- /dev/null
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/version.rb
@@ -0,0 +1,22 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Dialogflow
+      VERSION = "0.3.0".freeze
+    end
+  end
+end
diff --git a/google-cloud-dialogflow/synth.metadata b/google-cloud-dialogflow/synth.metadata
index e0c62f01d..c6110b04a 100644
--- a/google-cloud-dialogflow/synth.metadata
+++ b/google-cloud-dialogflow/synth.metadata
@@ -1,26 +1,26 @@
 {
-  "updateTime": "2019-04-25T10:41:48.943723Z",
+  "updateTime": "2019-05-30T00:43:51.837253Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.17.0",
-        "dockerImage": "googleapis/artman@sha256:c58f4ec3838eb4e0718eb1bccc6512bd6850feaa85a360a9e38f6f848ec73bc2"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "25cbfd4a5386742f5968d69bd276a0436d23bd97",
-        "internalRef": "245137805"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {
       "template": {
         "name": "ruby_library",
         "origin": "synthtool.gcp",
-        "version": "2019.4.10"
+        "version": "2019.5.2"
       }
     }
   ],
diff --git a/google-cloud-dialogflow/synth.py b/google-cloud-dialogflow/synth.py
index d5dc54e64..f6c9a553a 100644
--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -107,3 +107,33 @@ s.replace(
     'README.md\n',
     'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
+
+# https://github.com/googleapis/google-cloud-ruby/issues/3058
+s.replace(
+    'google-cloud-dialogflow.gemspec',
+    '\nGem::Specification.new do',
+    'require File.expand_path("../lib/google/cloud/dialogflow/version", __FILE__)\n\nGem::Specification.new do'
+)
+s.replace(
+    'google-cloud-dialogflow.gemspec',
+    '(gem.version\s+=\s+).\d+.\d+.\d.*$',
+    '\\1Google::Cloud::Dialogflow::VERSION'
+)
+s.replace(
+    'lib/google/cloud/dialogflow/v2/*_client.rb',
+    '(require \".*credentials\"\n)\n',
+    '\\1require "google/cloud/dialogflow/version"\n\n'
+)
+s.replace(
+    'lib/google/cloud/dialogflow/v2/*_client.rb',
+    'Gem.loaded_specs\[.*\]\.version\.version',
+    'Google::Cloud::Dialogflow::VERSION'
+)
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v2']:
+    s.replace(
+        f'test/google/cloud/dialogflow/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )
diff --git a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/agents_client_test.rb b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/agents_client_test.rb
index 9381f1ad5..bf3d5d1b2 100644
--- a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/agents_client_test.rb
+++ b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/agents_client_test.rb
@@ -147,7 +147,7 @@ describe Google::Cloud::Dialogflow::V2::AgentsClient do
           client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_agent(formatted_parent)
           end
 
@@ -219,7 +219,7 @@ describe Google::Cloud::Dialogflow::V2::AgentsClient do
           client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.search_agents(formatted_parent)
           end
 
@@ -331,7 +331,7 @@ describe Google::Cloud::Dialogflow::V2::AgentsClient do
           client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.train_agent(formatted_parent)
           end
 
@@ -444,7 +444,7 @@ describe Google::Cloud::Dialogflow::V2::AgentsClient do
           client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.export_agent(formatted_parent)
           end
 
@@ -556,7 +556,7 @@ describe Google::Cloud::Dialogflow::V2::AgentsClient do
           client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.import_agent(formatted_parent)
           end
 
@@ -668,7 +668,7 @@ describe Google::Cloud::Dialogflow::V2::AgentsClient do
           client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.restore_agent(formatted_parent)
           end
 
diff --git a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/contexts_client_test.rb b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/contexts_client_test.rb
index 052a17006..738b73a0e 100644
--- a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/contexts_client_test.rb
+++ b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/contexts_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Dialogflow::V2::ContextsClient do
           client = Google::Cloud::Dialogflow::Contexts.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_contexts(formatted_parent)
           end
 
@@ -203,7 +203,7 @@ describe Google::Cloud::Dialogflow::V2::ContextsClient do
           client = Google::Cloud::Dialogflow::Contexts.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_context(formatted_name)
           end
 
@@ -282,7 +282,7 @@ describe Google::Cloud::Dialogflow::V2::ContextsClient do
           client = Google::Cloud::Dialogflow::Contexts.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_context(formatted_parent, context)
           end
 
@@ -357,7 +357,7 @@ describe Google::Cloud::Dialogflow::V2::ContextsClient do
           client = Google::Cloud::Dialogflow::Contexts.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_context(context)
           end
 
@@ -426,7 +426,7 @@ describe Google::Cloud::Dialogflow::V2::ContextsClient do
           client = Google::Cloud::Dialogflow::Contexts.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_context(formatted_name)
           end
 
@@ -495,7 +495,7 @@ describe Google::Cloud::Dialogflow::V2::ContextsClient do
           client = Google::Cloud::Dialogflow::Contexts.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_all_contexts(formatted_parent)
           end
 
diff --git a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/entity_types_client_test.rb b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/entity_types_client_test.rb
index 10f1e74ca..a669b5d9b 100644
--- a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/entity_types_client_test.rb
+++ b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/entity_types_client_test.rb
@@ -129,7 +129,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_entity_types(formatted_parent)
           end
 
@@ -204,7 +204,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_entity_type(formatted_name)
           end
 
@@ -283,7 +283,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_entity_type(formatted_parent, entity_type)
           end
 
@@ -358,7 +358,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_entity_type(entity_type)
           end
 
@@ -427,7 +427,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_entity_type(formatted_name)
           end
 
@@ -539,7 +539,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.batch_update_entity_types(formatted_parent)
           end
 
@@ -657,7 +657,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.batch_delete_entity_types(formatted_parent, entity_type_names)
           end
 
@@ -784,7 +784,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.batch_create_entities(formatted_parent, entities)
           end
 
@@ -911,7 +911,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.batch_update_entities(formatted_parent, entities)
           end
 
@@ -1029,7 +1029,7 @@ describe Google::Cloud::Dialogflow::V2::EntityTypesClient do
           client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.batch_delete_entities(formatted_parent, entity_values)
           end
 
diff --git a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/intents_client_test.rb b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/intents_client_test.rb
index c2b778e42..85e299c5d 100644
--- a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/intents_client_test.rb
+++ b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/intents_client_test.rb
@@ -129,7 +129,7 @@ describe Google::Cloud::Dialogflow::V2::IntentsClient do
           client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_intents(formatted_parent)
           end
 
@@ -221,7 +221,7 @@ describe Google::Cloud::Dialogflow::V2::IntentsClient do
           client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_intent(formatted_name)
           end
 
@@ -317,7 +317,7 @@ describe Google::Cloud::Dialogflow::V2::IntentsClient do
           client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_intent(formatted_parent, intent)
           end
 
@@ -413,7 +413,7 @@ describe Google::Cloud::Dialogflow::V2::IntentsClient do
           client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_intent(intent, language_code)
           end
 
@@ -482,7 +482,7 @@ describe Google::Cloud::Dialogflow::V2::IntentsClient do
           client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_intent(formatted_name)
           end
 
@@ -600,7 +600,7 @@ describe Google::Cloud::Dialogflow::V2::IntentsClient do
           client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.batch_update_intents(formatted_parent, language_code)
           end
 
@@ -727,7 +727,7 @@ describe Google::Cloud::Dialogflow::V2::IntentsClient do
           client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.batch_delete_intents(formatted_parent, intents)
           end
 
diff --git a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/session_entity_types_client_test.rb b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/session_entity_types_client_test.rb
index e67260f10..afff28b4c 100644
--- a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/session_entity_types_client_test.rb
+++ b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/session_entity_types_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Dialogflow::V2::SessionEntityTypesClient do
           client = Google::Cloud::Dialogflow::SessionEntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.list_session_entity_types(formatted_parent)
           end
 
@@ -202,7 +202,7 @@ describe Google::Cloud::Dialogflow::V2::SessionEntityTypesClient do
           client = Google::Cloud::Dialogflow::SessionEntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.get_session_entity_type(formatted_name)
           end
 
@@ -280,7 +280,7 @@ describe Google::Cloud::Dialogflow::V2::SessionEntityTypesClient do
           client = Google::Cloud::Dialogflow::SessionEntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.create_session_entity_type(formatted_parent, session_entity_type)
           end
 
@@ -354,7 +354,7 @@ describe Google::Cloud::Dialogflow::V2::SessionEntityTypesClient do
           client = Google::Cloud::Dialogflow::SessionEntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.update_session_entity_type(session_entity_type)
           end
 
@@ -423,7 +423,7 @@ describe Google::Cloud::Dialogflow::V2::SessionEntityTypesClient do
           client = Google::Cloud::Dialogflow::SessionEntityTypes.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.delete_session_entity_type(formatted_name)
           end
 
diff --git a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/sessions_client_test.rb b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/sessions_client_test.rb
index 013d94a7b..73b8b78cf 100644
--- a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/sessions_client_test.rb
+++ b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/sessions_client_test.rb
@@ -135,7 +135,7 @@ describe Google::Cloud::Dialogflow::V2::SessionsClient do
           client = Google::Cloud::Dialogflow::Sessions.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.detect_intent(formatted_session, query_input)
           end
 
@@ -212,7 +212,7 @@ describe Google::Cloud::Dialogflow::V2::SessionsClient do
           client = Google::Cloud::Dialogflow::Sessions.new(version: :v2)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
             client.streaming_detect_intent([request])
           end
 

```

</details>

This pull request was generated using releasetool.