### PR TITLE
Release google-cloud-error_reporting 0.31.5

### DIFF
--- a/google-cloud-error_reporting/CHANGELOG.md
+++ b/google-cloud-error_reporting/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.31.5 / 2019-06-11
+
+* Use VERSION constant in GAPIC client
+
 ### 0.31.4 / 2019-04-29
 
 * Add AUTHENTICATION.md guide.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module ErrorReporting
-      VERSION = "0.31.4".freeze
+      VERSION = "0.31.5".freeze
     end
   end
 end


### PR DESCRIPTION
* Use VERSION constant in GAPIC client

<details><summary>Commits since previous release</summary><pre><code>commit c3f100da4536930396d0816303f696bdfaafddb8
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 11 13:35:45 2019 -0700

    prepare repo-metadata.json for docuploader (#3444)

commit ea562c18e376f461f529bd5b535931af5593e4a1
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 4 10:14:49 2019 -0700

    add version.rb and remove Gem.loaded_specs (#3391)

commit e112cd86bb9c276c5127e3143d40c7ffe1b4f3e5
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Fri May 10 10:41:07 2019 -0700

    Update generated google-cloud-error_reporting files (#3359)
    
    * Revert error retry configuration.

commit 8a6e589df773cad1e6907668e8f8983fdc98a7a8
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Wed May 8 10:21:51 2019 -0700

    Update generated google-cloud-error_reporting files (#3313)
    
    * Update error retry configuration.
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-error_reporting/.repo-metadata.json b/google-cloud-error_reporting/.repo-metadata.json
new file mode 100644
index 000000000..b4b5aa3cd
--- /dev/null
+++ b/google-cloud-error_reporting/.repo-metadata.json
@@ -0,0 +1,5 @@
+{
+    "name": "clouderrorreporting",
+    "language": "ruby",
+    "distribution_name": "google-cloud-error_reporting"
+}
diff --git a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb
index 6cdb65c69..e3fcbe3d6 100644
--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/devtools/clouderrorreporting/v1beta1/error_group_service_pb"
 require "google/cloud/error_reporting/v1beta1/credentials"
+require "google/cloud/error_reporting/version"
 
 module Google
   module Cloud
@@ -137,7 +138,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-error_reporting'].version.version
+            package_version = Google::Cloud::ErrorReporting::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb
index 20b0dabae..8244a20cf 100644
--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/devtools/clouderrorreporting/v1beta1/error_stats_service_pb"
 require "google/cloud/error_reporting/v1beta1/credentials"
+require "google/cloud/error_reporting/version"
 
 module Google
   module Cloud
@@ -149,7 +150,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-error_reporting'].version.version
+            package_version = Google::Cloud::ErrorReporting::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb
index f8a0319f3..8a090b398 100644
--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/devtools/clouderrorreporting/v1beta1/report_errors_service_pb"
 require "google/cloud/error_reporting/v1beta1/credentials"
+require "google/cloud/error_reporting/version"
 
 module Google
   module Cloud
@@ -135,7 +136,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-error_reporting'].version.version
+            package_version = Google::Cloud::ErrorReporting::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-error_reporting/synth.metadata b/google-cloud-error_reporting/synth.metadata
index cdff0fd96..dd0869a83 100644
--- a/google-cloud-error_reporting/synth.metadata
+++ b/google-cloud-error_reporting/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-04-21T10:39:30.224916Z",
+  "updateTime": "2019-05-10T10:39:52.813406Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.16.26",
-        "dockerImage": "googleapis/artman@sha256:314eae2a40f6f7822db77365cf5f45bd513d628ae17773fd0473f460e7c2a665"
+        "version": "0.19.0",
+        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "3369c803f56d52662ea3792076deb8545183bdb0",
-        "internalRef": "244282812"
+        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
+        "internalRef": "247530843"
       }
     }
   ],
diff --git a/google-cloud-error_reporting/synth.py b/google-cloud-error_reporting/synth.py
index c9bbcff4b..a1d0d284f 100644
--- a/google-cloud-error_reporting/synth.py
+++ b/google-cloud-error_reporting/synth.py
@@ -58,3 +58,15 @@ s.replace(
     'lib/**/*.rb',
     '\\A(((#[^\n]*)?\n)*# (Copyright \\d+|Generated by the protocol buffer compiler)[^\n]+\n(#[^\n]*\n)*\n)([^\n])',
     '\\1\n\\6')
+
+# https://github.com/googleapis/google-cloud-ruby/issues/3058
+s.replace(
+    'lib/google/cloud/error_reporting/v1beta1/*_client.rb',
+    '(require \".*credentials\"\n)\n',
+    '\\1require "google/cloud/error_reporting/version"\n\n'
+)
+s.replace(
+    'lib/google/cloud/error_reporting/v1beta1/*_client.rb',
+    'Gem.loaded_specs\[.*\]\.version\.version',
+    'Google::Cloud::ErrorReporting::VERSION'
+)

```

</details>

This pull request was generated using releasetool.