### PR TITLE
Release google-cloud-logging 1.6.4

### DIFF
--- a/google-cloud-logging/CHANGELOG.md
+++ b/google-cloud-logging/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 1.6.4 / 2019-06-11
+
+* Add documentation for MetricDescriptor#launch_stage and
+  MonitoredResourceDescriptor#launch_stage.
+* Deprecate MetricDescriptor:: MetricDescriptorMetadata#launch_stage
+* Use VERSION constant in GAPIC client
+
 ### 1.6.3 / 2019-04-29
 
 * Add AUTHENTICATION.md guide.

--- a/google-cloud-logging/lib/google/cloud/logging/version.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Logging
-      VERSION = "1.6.3".freeze
+      VERSION = "1.6.4".freeze
     end
   end
 end


### PR DESCRIPTION
* Add documentation for MetricDescriptor#launch_stage and
  MonitoredResourceDescriptor#launch_stage.
* Deprecate MetricDescriptor:: MetricDescriptorMetadata#launch_stage
* Use VERSION constant in GAPIC client

<details><summary>Commits since previous release</summary><pre><code>commit c3f100da4536930396d0816303f696bdfaafddb8
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 11 13:35:45 2019 -0700

    prepare repo-metadata.json for docuploader (#3444)

commit ea562c18e376f461f529bd5b535931af5593e4a1
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 4 10:14:49 2019 -0700

    add version.rb and remove Gem.loaded_specs (#3391)

commit cabf126e2a85b131c988779bc9f40bd6861a1cbb
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Mon May 13 09:13:26 2019 -0700

    [CHANGE ME] Re-generated google-cloud-logging to pick up changes in the API or client library generator. (#3380)
    
    * Add documentation for MetricDescriptor#launch_stage.
    * Deprecate MetricDescriptor:: MetricDescriptorMetadata#launch_stage
    * Add documentation for MonitoredResourceDescriptor#launch_stage

commit b72ad586d6b6473512f5d472b515a98713a4218e
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Fri May 10 11:43:57 2019 -0700

    Update generated google-cloud-logging files (#3363)
    
    * Revert error retry configuration.

commit 23860da23ef6e940c116e8040d11747bbab653d1
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Wed May 8 10:48:03 2019 -0700

    Update generated google-cloud-logging files (#3317)
    
    * Update error retry configuration.
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-logging/.repo-metadata.json b/google-cloud-logging/.repo-metadata.json
new file mode 100644
index 000000000..ab743ab02
--- /dev/null
+++ b/google-cloud-logging/.repo-metadata.json
@@ -0,0 +1,5 @@
+{
+    "name": "logging",
+    "language": "ruby",
+    "distribution_name": "google-cloud-logging"
+}
diff --git a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
index c3ac76774..1a4326dc6 100644
--- a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/logging/v2/logging_config_pb"
 require "google/cloud/logging/v2/credentials"
+require "google/cloud/logging/version"
 
 module Google
   module Cloud
@@ -187,7 +188,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-logging'].version.version
+            package_version = Google::Cloud::Logging::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb
index 3b67113fd..ae1cfe7e3 100644
--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb
@@ -126,10 +126,14 @@ module Google
     # @!attribute [rw] metadata
     #   @return [Google::Api::MetricDescriptor::MetricDescriptorMetadata]
     #     Optional. Metadata which can be used to guide usage of the metric.
+    # @!attribute [rw] launch_stage
+    #   @return [Google::Api::LaunchStage]
+    #     Optional. The launch stage of the metric definition.
     class MetricDescriptor
       # Additional annotations that can be used to guide the usage of a metric.
       # @!attribute [rw] launch_stage
       #   @return [Google::Api::LaunchStage]
+      #     Deprecated. Please use the MetricDescriptor.launch_stage instead.
       #     The launch stage of the metric definition.
       # @!attribute [rw] sample_period
       #   @return [Google::Protobuf::Duration]
diff --git a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/monitored_resource.rb b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/monitored_resource.rb
index cd61531a7..ff94669f0 100644
--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/monitored_resource.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/monitored_resource.rb
@@ -52,6 +52,9 @@ module Google
     #     Required. A set of labels used to describe instances of this monitored
     #     resource type. For example, an individual Google Cloud SQL database is
     #     identified by values for the labels `"database_id"` and `"zone"`.
+    # @!attribute [rw] launch_stage
+    #   @return [Google::Api::LaunchStage]
+    #     Optional. The launch stage of the monitored resource definition.
     class MonitoredResourceDescriptor; end
 
     # An object representing a resource that can be used for monitoring, logging,
diff --git a/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb b/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb
index 31e993b21..08bf8ab1d 100644
--- a/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/logging/v2/logging_pb"
 require "google/cloud/logging/v2/credentials"
+require "google/cloud/logging/version"
 
 module Google
   module Cloud
@@ -185,7 +186,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-logging'].version.version
+            package_version = Google::Cloud::Logging::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb b/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb
index dac1174dc..87267dca1 100644
--- a/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/logging/v2/logging_metrics_pb"
 require "google/cloud/logging/v2/credentials"
+require "google/cloud/logging/version"
 
 module Google
   module Cloud
@@ -165,7 +166,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-logging'].version.version
+            package_version = Google::Cloud::Logging::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-logging/synth.metadata b/google-cloud-logging/synth.metadata
index ee6db8c57..92dc1555b 100644
--- a/google-cloud-logging/synth.metadata
+++ b/google-cloud-logging/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-04-27T10:43:34.421393Z",
+  "updateTime": "2019-05-11T10:39:37.629382Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.17.1",
-        "dockerImage": "googleapis/artman@sha256:a40ca4dd4ef031c0ded4df4909ffdf7b3f20d29b23e682ef991eb60ba0ca6025"
+        "version": "0.19.0",
+        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "808110e242c682d7ac2bab6d9c49fc3bf72d7604",
-        "internalRef": "245313728"
+        "sha": "32b08107fa1710f46287c17d5bb2016e443ed3ba",
+        "internalRef": "247684466"
       }
     }
   ],
diff --git a/google-cloud-logging/synth.py b/google-cloud-logging/synth.py
index b500bce3c..0a17f94b9 100644
--- a/google-cloud-logging/synth.py
+++ b/google-cloud-logging/synth.py
@@ -88,3 +88,15 @@ s.replace(
     'lib/**/*.rb',
     '\\A(((#[^\n]*)?\n)*# (Copyright \\d+|Generated by the protocol buffer compiler)[^\n]+\n(#[^\n]*\n)*\n)([^\n])',
     '\\1\n\\6')
+
+# https://github.com/googleapis/google-cloud-ruby/issues/3058
+s.replace(
+    'lib/google/cloud/logging/v2/*_client.rb',
+    '(require \".*credentials\"\n)\n',
+    '\\1require "google/cloud/logging/version"\n\n'
+)
+s.replace(
+    'lib/google/cloud/logging/v2/*_client.rb',
+    'Gem.loaded_specs\[.*\]\.version\.version',
+    'Google::Cloud::Logging::VERSION'
+)

```

</details>

This pull request was generated using releasetool.