### PR TITLE
Release google-cloud-monitoring 0.29.5

### DIFF
--- a/google-cloud-monitoring/CHANGELOG.md
+++ b/google-cloud-monitoring/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 0.29.5 / 2019-06-11
+
+* Add documentation for MetricDescriptor#launch_stage and
+  MonitoredResourceDescriptor#launch_stage
+* Deprecate MetricDescriptor:: MetricDescriptorMetadata#launch_stage
+* Add VERSION constant
+
 ### 0.29.4 / 2019-04-29
 
 * Add AUTHENTICATION.md guide.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/version.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Monitoring
-      VERSION = "0.29.4".freeze
+      VERSION = "0.29.5".freeze
     end
   end
 end


### PR DESCRIPTION
* Add documentation for MetricDescriptor#launch_stage and
  MonitoredResourceDescriptor#launch_stage
* Deprecate MetricDescriptor:: MetricDescriptorMetadata#launch_stage
* Add VERSION constant

<details><summary>Commits since previous release</summary><pre><code>commit c3f100da4536930396d0816303f696bdfaafddb8
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 11 13:35:45 2019 -0700

    prepare repo-metadata.json for docuploader (#3444)

commit ea562c18e376f461f529bd5b535931af5593e4a1
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 4 10:14:49 2019 -0700

    add version.rb and remove Gem.loaded_specs (#3391)

commit 9d7566152ec7d6ba02c053dda066589e7f641548
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed May 29 20:17:25 2019 -0700

    Fix unit tests to check for both custom and wrapper exception types (#3427)

commit 4aeb0e913035b39176ca190a9f109e3bf97bb2ce
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Mon May 13 09:15:11 2019 -0700

    Update generated google-cloud-monitoring files (#3381)
    
    * Add documentation for MetricDescriptor#launch_stage.
    * Deprecate MetricDescriptor:: MetricDescriptorMetadata#launch_stage
    * Add documentation for MonitoredResourceDescriptor#launch_stage

commit 8da171e4573c961c2b392540a396ec4d84d8c1d2
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Fri May 10 11:44:29 2019 -0700

    Update generated google-cloud-monitoring files (#3364)
    
    * Revert error retry configuration.

commit 5c1b9da4a4eafa30547e486472cf14c4b8358092
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Wed May 8 10:48:40 2019 -0700

    Update generated google-cloud-monitoring files (#3318)
    
    * Update error retry configuration.
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-monitoring/.repo-metadata.json b/google-cloud-monitoring/.repo-metadata.json
index 99b7b31a8..a9d8357cb 100644
--- a/google-cloud-monitoring/.repo-metadata.json
+++ b/google-cloud-monitoring/.repo-metadata.json
@@ -1,6 +1,8 @@
 {
-  "distribution_name": "google-cloud-monitoring",
-  "module_name": "Monitoring",
-  "module_name_credentials": "Monitoring::V3",
-  "env_var_prefix": "MONITORING"
-}
\ No newline at end of file
+    "name": "monitoring",
+    "language": "ruby",
+    "distribution_name": "google-cloud-monitoring",
+    "module_name": "Monitoring",
+    "module_name_credentials": "Monitoring::V3",
+    "env_var_prefix": "MONITORING"
+}
diff --git a/google-cloud-monitoring/google-cloud-monitoring.gemspec b/google-cloud-monitoring/google-cloud-monitoring.gemspec
index 83bf8774e..3dea10481 100644
--- a/google-cloud-monitoring/google-cloud-monitoring.gemspec
+++ b/google-cloud-monitoring/google-cloud-monitoring.gemspec
@@ -1,9 +1,10 @@
 # -*- ruby -*-
 # encoding: utf-8
+require File.expand_path("../lib/google/cloud/monitoring/version", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-monitoring"
-  gem.version       = "0.29.4"
+  gem.version       = Google::Cloud::Monitoring::VERSION
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/alert_policy_service_client.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/alert_policy_service_client.rb
index faf5bddf3..93605d56d 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/alert_policy_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/alert_policy_service_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/monitoring/v3/alert_service_pb"
 require "google/cloud/monitoring/v3/credentials"
+require "google/cloud/monitoring/version"
 
 module Google
   module Cloud
@@ -191,7 +192,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-monitoring'].version.version
+            package_version = Google::Cloud::Monitoring::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb
index 8a9b87f86..7dc15e19c 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb
@@ -126,10 +126,14 @@ module Google
     # @!attribute [rw] metadata
     #   @return [Google::Api::MetricDescriptor::MetricDescriptorMetadata]
     #     Optional. Metadata which can be used to guide usage of the metric.
+    # @!attribute [rw] launch_stage
+    #   @return [Google::Api::LaunchStage]
+    #     Optional. The launch stage of the metric definition.
     class MetricDescriptor
       # Additional annotations that can be used to guide the usage of a metric.
       # @!attribute [rw] launch_stage
       #   @return [Google::Api::LaunchStage]
+      #     Deprecated. Please use the MetricDescriptor.launch_stage instead.
       #     The launch stage of the metric definition.
       # @!attribute [rw] sample_period
       #   @return [Google::Protobuf::Duration]
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/monitored_resource.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/monitored_resource.rb
index cd61531a7..ff94669f0 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/monitored_resource.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/monitored_resource.rb
@@ -52,6 +52,9 @@ module Google
     #     Required. A set of labels used to describe instances of this monitored
     #     resource type. For example, an individual Google Cloud SQL database is
     #     identified by values for the labels `"database_id"` and `"zone"`.
+    # @!attribute [rw] launch_stage
+    #   @return [Google::Api::LaunchStage]
+    #     Optional. The launch stage of the monitored resource definition.
     class MonitoredResourceDescriptor; end
 
     # An object representing a resource that can be used for monitoring, logging,
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb
index dba9b8d3a..443b944cd 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/monitoring/v3/group_service_pb"
 require "google/cloud/monitoring/v3/credentials"
+require "google/cloud/monitoring/version"
 
 module Google
   module Cloud
@@ -179,7 +180,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-monitoring'].version.version
+            package_version = Google::Cloud::Monitoring::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb
index 983e888c9..f889d87b0 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/monitoring/v3/metric_service_pb"
 require "google/cloud/monitoring/v3/credentials"
+require "google/cloud/monitoring/version"
 
 module Google
   module Cloud
@@ -190,7 +191,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-monitoring'].version.version
+            package_version = Google::Cloud::Monitoring::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/notification_channel_service_client.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/notification_channel_service_client.rb
index 94a00ffec..1629a8a86 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/notification_channel_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/notification_channel_service_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/monitoring/v3/notification_service_pb"
 require "google/cloud/monitoring/v3/credentials"
+require "google/cloud/monitoring/version"
 
 module Google
   module Cloud
@@ -186,7 +187,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-monitoring'].version.version
+            package_version = Google::Cloud::Monitoring::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/uptime_check_service_client.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/uptime_check_service_client.rb
index a5e946904..353315a0b 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/uptime_check_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/uptime_check_service_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/monitoring/v3/uptime_service_pb"
 require "google/cloud/monitoring/v3/credentials"
+require "google/cloud/monitoring/version"
 
 module Google
   module Cloud
@@ -175,7 +176,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-monitoring'].version.version
+            package_version = Google::Cloud::Monitoring::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/version.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/version.rb
new file mode 100644
index 000000000..17f26dce4
--- /dev/null
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/version.rb
@@ -0,0 +1,22 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Monitoring
+      VERSION = "0.29.4".freeze
+    end
+  end
+end
diff --git a/google-cloud-monitoring/synth.metadata b/google-cloud-monitoring/synth.metadata
index c2e5a4e91..edf95fc11 100644
--- a/google-cloud-monitoring/synth.metadata
+++ b/google-cloud-monitoring/synth.metadata
@@ -1,26 +1,26 @@
 {
-  "updateTime": "2019-04-25T10:43:56.222722Z",
+  "updateTime": "2019-05-30T00:36:25.067893Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.17.0",
-        "dockerImage": "googleapis/artman@sha256:c58f4ec3838eb4e0718eb1bccc6512bd6850feaa85a360a9e38f6f848ec73bc2"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "25cbfd4a5386742f5968d69bd276a0436d23bd97",
-        "internalRef": "245137805"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {
       "template": {
         "name": "ruby_library",
         "origin": "synthtool.gcp",
-        "version": "2019.4.10"
+        "version": "2019.5.2"
       }
     }
   ],
diff --git a/google-cloud-monitoring/synth.py b/google-cloud-monitoring/synth.py
index 8b0ac1828..4c74b07d0 100644
--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -109,3 +109,33 @@ s.replace(
     'README.md\n',
     'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
+
+# https://github.com/googleapis/google-cloud-ruby/issues/3058
+s.replace(
+    'google-cloud-monitoring.gemspec',
+    '\nGem::Specification.new do',
+    'require File.expand_path("../lib/google/cloud/monitoring/version", __FILE__)\n\nGem::Specification.new do'
+)
+s.replace(
+    'google-cloud-monitoring.gemspec',
+    '(gem.version\s+=\s+).\d+.\d+.\d.*$',
+    '\\1Google::Cloud::Monitoring::VERSION'
+)
+s.replace(
+    'lib/google/cloud/monitoring/v3/*_client.rb',
+    '(require \".*credentials\"\n)\n',
+    '\\1require "google/cloud/monitoring/version"\n\n'
+)
+s.replace(
+    'lib/google/cloud/monitoring/v3/*_client.rb',
+    'Gem.loaded_specs\[.*\]\.version\.version',
+    'Google::Cloud::Monitoring::VERSION'
+)
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v3']:
+    s.replace(
+        f'test/google/cloud/monitoring/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )
diff --git a/google-cloud-monitoring/test/google/cloud/monitoring/v3/alert_policy_service_client_test.rb b/google-cloud-monitoring/test/google/cloud/monitoring/v3/alert_policy_service_client_test.rb
index be2f8ac00..a760e56e1 100644
--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/alert_policy_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/alert_policy_service_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Monitoring::V3::AlertPolicyServiceClient do
           client = Google::Cloud::Monitoring::AlertPolicy.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_alert_policies(formatted_name)
           end
 
@@ -203,7 +203,7 @@ describe Google::Cloud::Monitoring::V3::AlertPolicyServiceClient do
           client = Google::Cloud::Monitoring::AlertPolicy.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.get_alert_policy(formatted_name)
           end
 
@@ -282,7 +282,7 @@ describe Google::Cloud::Monitoring::V3::AlertPolicyServiceClient do
           client = Google::Cloud::Monitoring::AlertPolicy.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.create_alert_policy(formatted_name, alert_policy)
           end
 
@@ -351,7 +351,7 @@ describe Google::Cloud::Monitoring::V3::AlertPolicyServiceClient do
           client = Google::Cloud::Monitoring::AlertPolicy.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.delete_alert_policy(formatted_name)
           end
 
@@ -426,7 +426,7 @@ describe Google::Cloud::Monitoring::V3::AlertPolicyServiceClient do
           client = Google::Cloud::Monitoring::AlertPolicy.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.update_alert_policy(alert_policy)
           end
 
diff --git a/google-cloud-monitoring/test/google/cloud/monitoring/v3/group_service_client_test.rb b/google-cloud-monitoring/test/google/cloud/monitoring/v3/group_service_client_test.rb
index 921cdabc6..5bc87ecf1 100644
--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/group_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/group_service_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
           client = Google::Cloud::Monitoring::Group.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_groups(formatted_name)
           end
 
@@ -212,7 +212,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
           client = Google::Cloud::Monitoring::Group.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.get_group(formatted_name)
           end
 
@@ -300,7 +300,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
           client = Google::Cloud::Monitoring::Group.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.create_group(formatted_name, group)
           end
 
@@ -384,7 +384,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
           client = Google::Cloud::Monitoring::Group.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.update_group(group)
           end
 
@@ -453,7 +453,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
           client = Google::Cloud::Monitoring::Group.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.delete_group(formatted_name)
           end
 
@@ -530,7 +530,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
           client = Google::Cloud::Monitoring::Group.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_group_members(formatted_name)
           end
 
diff --git a/google-cloud-monitoring/test/google/cloud/monitoring/v3/metric_service_client_test.rb b/google-cloud-monitoring/test/google/cloud/monitoring/v3/metric_service_client_test.rb
index 1ad888555..335bb029b 100644
--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/metric_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/metric_service_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_monitored_resource_descriptors(formatted_name)
           end
 
@@ -210,7 +210,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.get_monitored_resource_descriptor(formatted_name)
           end
 
@@ -282,7 +282,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_metric_descriptors(formatted_name)
           end
 
@@ -366,7 +366,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.get_metric_descriptor(formatted_name)
           end
 
@@ -454,7 +454,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.create_metric_descriptor(formatted_name, metric_descriptor)
           end
 
@@ -523,7 +523,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.delete_metric_descriptor(formatted_name)
           end
 
@@ -612,7 +612,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_time_series(
               formatted_name,
               filter,
@@ -696,7 +696,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           client = Google::Cloud::Monitoring::Metric.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.create_time_series(formatted_name, time_series)
           end
 
diff --git a/google-cloud-monitoring/test/google/cloud/monitoring/v3/notification_channel_service_client_test.rb b/google-cloud-monitoring/test/google/cloud/monitoring/v3/notification_channel_service_client_test.rb
index d3118b878..8d8a96a5e 100644
--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/notification_channel_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/notification_channel_service_client_test.rb
@@ -128,7 +128,7 @@ describe Google::Cloud::Monitoring::V3::NotificationChannelServiceClient do
           client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_notification_channel_descriptors(formatted_name)
           end
 
@@ -210,7 +210,7 @@ describe Google::Cloud::Monitoring::V3::NotificationChannelServiceClient do
           client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.get_notification_channel_descriptor(formatted_name)
           end
 
@@ -282,7 +282,7 @@ describe Google::Cloud::Monitoring::V3::NotificationChannelServiceClient do
           client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_notification_channels(formatted_name)
           end
 
@@ -364,7 +364,7 @@ describe Google::Cloud::Monitoring::V3::NotificationChannelServiceClient do
           client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.get_notification_channel(formatted_name)
           end
 
@@ -450,7 +450,7 @@ describe Google::Cloud::Monitoring::V3::NotificationChannelServiceClient do
           client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.create_notification_channel(formatted_name, notification_channel)
           end
 
@@ -532,7 +532,7 @@ describe Google::Cloud::Monitoring::V3::NotificationChannelServiceClient do
           client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.update_notification_channel(notification_channel)
           end
 
@@ -601,7 +601,7 @@ describe Google::Cloud::Monitoring::V3::NotificationChannelServiceClient do
           client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.delete_notification_channel(formatted_name)
           end
 
diff --git a/google-cloud-monitoring/test/google/cloud/monitoring/v3/uptime_check_service_client_test.rb b/google-cloud-monitoring/test/google/cloud/monitoring/v3/uptime_check_service_client_test.rb
index 1d0622a3a..ad9a8b90f 100644
--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/uptime_check_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/uptime_check_service_client_test.rb
@@ -133,7 +133,7 @@ describe Google::Cloud::Monitoring::V3::UptimeCheckServiceClient do
           client = Google::Cloud::Monitoring::UptimeCheck.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_uptime_check_configs(formatted_parent)
           end
 
@@ -213,7 +213,7 @@ describe Google::Cloud::Monitoring::V3::UptimeCheckServiceClient do
           client = Google::Cloud::Monitoring::UptimeCheck.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.get_uptime_check_config(formatted_name)
           end
 
@@ -297,7 +297,7 @@ describe Google::Cloud::Monitoring::V3::UptimeCheckServiceClient do
           client = Google::Cloud::Monitoring::UptimeCheck.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.create_uptime_check_config(formatted_parent, uptime_check_config)
           end
 
@@ -377,7 +377,7 @@ describe Google::Cloud::Monitoring::V3::UptimeCheckServiceClient do
           client = Google::Cloud::Monitoring::UptimeCheck.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.update_uptime_check_config(uptime_check_config)
           end
 
@@ -446,7 +446,7 @@ describe Google::Cloud::Monitoring::V3::UptimeCheckServiceClient do
           client = Google::Cloud::Monitoring::UptimeCheck.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.delete_uptime_check_config(formatted_name)
           end
 
@@ -508,7 +508,7 @@ describe Google::Cloud::Monitoring::V3::UptimeCheckServiceClient do
           client = Google::Cloud::Monitoring::UptimeCheck.new(version: :v3)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v3 do
             client.list_uptime_check_ips
           end
 

```

</details>

This pull request was generated using releasetool.