### PR TITLE
Release google-cloud-speech 0.35.0

### DIFF
--- a/google-cloud-speech/CHANGELOG.md
+++ b/google-cloud-speech/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+### 0.35.0 / 2019-06-11
+
+* Update documentation for SpeechContext phrases
+* Add RecognitionConfig#metadata (RecognitionMetadata)
+* Add StreamingRecognitionResult#result_end_time
+* Add StreamingRecognitionResult#language_code
+* Add VERSION constant
+
 ### 0.34.1 / 2019-04-29
 
 * Add AUTHENTICATION.md guide.

--- a/google-cloud-speech/lib/google/cloud/speech/version.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Speech
-      VERSION = "0.34.1".freeze
+      VERSION = "0.35.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Update documentation for SpeechContext phrases
* Add RecognitionConfig#metadata (RecognitionMetadata)
* Add StreamingRecognitionResult#result_end_time
* Add StreamingRecognitionResult#language_code
* Add VERSION constant

<details><summary>Commits since previous release</summary><pre><code>commit c3f100da4536930396d0816303f696bdfaafddb8
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 11 13:35:45 2019 -0700

    prepare repo-metadata.json for docuploader (#3444)

commit 797546b4805d35f00c4f6ce67e30df674d702142
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Thu Jun 6 14:30:25 2019 -0700

    docs(speech): Update SpeechContext phrases description
    
    
    [pr #3441]

commit ea562c18e376f461f529bd5b535931af5593e4a1
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 4 10:14:49 2019 -0700

    add version.rb and remove Gem.loaded_specs (#3391)

commit 9d7566152ec7d6ba02c053dda066589e7f641548
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed May 29 20:17:25 2019 -0700

    Fix unit tests to check for both custom and wrapper exception types (#3427)

commit f1b52924ae02e38fceffd1464c68e778d0369e19
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Fri May 24 13:37:05 2019 -0700

    [CHANGE ME] Re-generated google-cloud-speech to pick up changes in the API or client library generator. (#3409)

commit 23350bc27364849e586482780115b28700d06684
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Tue May 14 08:12:10 2019 -0700

    Update generated google-cloud-speech files (#3385)
    
    * Add RecognitionConfig#metadata (RecognitionMetadata)
    * Add StreamingRecognitionResult#result_end_time
    * Add StreamingRecognitionResult#language_code

commit ef7a9dc46dc8c025c71975b5ecf6e41fb973a51c
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Fri May 10 12:50:23 2019 -0700

    Update generated google-cloud-speech files (#3372)
    
    * Revert error retry configuration.

commit 9539f2db362a29400cc9d1b9f6e4bf31c9d41a20
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Wed May 8 10:57:48 2019 -0700

    Update generated google-cloud-speech files (#3325)
    
    * Update error retry configuration.
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-speech/.repo-metadata.json b/google-cloud-speech/.repo-metadata.json
index 20f550387..56d53401c 100644
--- a/google-cloud-speech/.repo-metadata.json
+++ b/google-cloud-speech/.repo-metadata.json
@@ -1,6 +1,8 @@
 {
-  "distribution_name": "google-cloud-speech",
-  "module_name": "Speech",
-  "module_name_credentials": "Speech::V1",
-  "env_var_prefix": "SPEECH"
-}
\ No newline at end of file
+    "name": "speech",
+    "language": "ruby",
+    "distribution_name": "google-cloud-speech",
+    "module_name": "Speech",
+    "module_name_credentials": "Speech::V1",
+    "env_var_prefix": "SPEECH"
+}
diff --git a/google-cloud-speech/google-cloud-speech.gemspec b/google-cloud-speech/google-cloud-speech.gemspec
index 0e2ccc0e0..7b74ea134 100644
--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -1,9 +1,10 @@
 # -*- ruby -*-
 # encoding: utf-8
+require File.expand_path("../lib/google/cloud/speech/version", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-speech"
-  gem.version       = "0.34.1"
+  gem.version       = Google::Cloud::Speech::VERSION
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
diff --git a/google-cloud-speech/lib/google/cloud/speech/v1/cloud_speech_pb.rb b/google-cloud-speech/lib/google/cloud/speech/v1/cloud_speech_pb.rb
index c4b4f5af3..837c43d54 100644
--- a/google-cloud-speech/lib/google/cloud/speech/v1/cloud_speech_pb.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/cloud_speech_pb.rb
@@ -6,9 +6,7 @@ require 'google/protobuf'
 
 require 'google/api/annotations_pb'
 require 'google/longrunning/operations_pb'
-require 'google/protobuf/any_pb'
 require 'google/protobuf/duration_pb'
-require 'google/protobuf/empty_pb'
 require 'google/protobuf/timestamp_pb'
 require 'google/rpc/status_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
@@ -42,6 +40,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     repeated :speech_contexts, :message, 6, "google.cloud.speech.v1.SpeechContext"
     optional :enable_word_time_offsets, :bool, 8
     optional :enable_automatic_punctuation, :bool, 11
+    optional :metadata, :message, 9, "google.cloud.speech.v1.RecognitionMetadata"
     optional :model, :string, 13
     optional :use_enhanced, :bool, 14
   end
@@ -55,6 +54,47 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     value :OGG_OPUS, 6
     value :SPEEX_WITH_HEADER_BYTE, 7
   end
+  add_message "google.cloud.speech.v1.RecognitionMetadata" do
+    optional :interaction_type, :enum, 1, "google.cloud.speech.v1.RecognitionMetadata.InteractionType"
+    optional :industry_naics_code_of_audio, :uint32, 3
+    optional :microphone_distance, :enum, 4, "google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance"
+    optional :original_media_type, :enum, 5, "google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType"
+    optional :recording_device_type, :enum, 6, "google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType"
+    optional :recording_device_name, :string, 7
+    optional :original_mime_type, :string, 8
+    optional :audio_topic, :string, 10
+  end
+  add_enum "google.cloud.speech.v1.RecognitionMetadata.InteractionType" do
+    value :INTERACTION_TYPE_UNSPECIFIED, 0
+    value :DISCUSSION, 1
+    value :PRESENTATION, 2
+    value :PHONE_CALL, 3
+    value :VOICEMAIL, 4
+    value :PROFESSIONALLY_PRODUCED, 5
+    value :VOICE_SEARCH, 6
+    value :VOICE_COMMAND, 7
+    value :DICTATION, 8
+  end
+  add_enum "google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance" do
+    value :MICROPHONE_DISTANCE_UNSPECIFIED, 0
+    value :NEARFIELD, 1
+    value :MIDFIELD, 2
+    value :FARFIELD, 3
+  end
+  add_enum "google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType" do
+    value :ORIGINAL_MEDIA_TYPE_UNSPECIFIED, 0
+    value :AUDIO, 1
+    value :VIDEO, 2
+  end
+  add_enum "google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType" do
+    value :RECORDING_DEVICE_TYPE_UNSPECIFIED, 0
+    value :SMARTPHONE, 1
+    value :PC, 2
+    value :PHONE_LINE, 3
+    value :VEHICLE, 4
+    value :OTHER_OUTDOOR_DEVICE, 5
+    value :OTHER_INDOOR_DEVICE, 6
+  end
   add_message "google.cloud.speech.v1.SpeechContext" do
     repeated :phrases, :string, 1
   end
@@ -88,7 +128,9 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     repeated :alternatives, :message, 1, "google.cloud.speech.v1.SpeechRecognitionAlternative"
     optional :is_final, :bool, 2
     optional :stability, :float, 3
+    optional :result_end_time, :message, 4, "google.protobuf.Duration"
     optional :channel_tag, :int32, 5
+    optional :language_code, :string, 6
   end
   add_message "google.cloud.speech.v1.SpeechRecognitionResult" do
     repeated :alternatives, :message, 1, "google.cloud.speech.v1.SpeechRecognitionAlternative"
@@ -116,6 +158,11 @@ module Google
         StreamingRecognitionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.speech.v1.StreamingRecognitionConfig").msgclass
         RecognitionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.speech.v1.RecognitionConfig").msgclass
         RecognitionConfig::AudioEncoding = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.speech.v1.RecognitionConfig.AudioEncoding").enummodule
+        RecognitionMetadata = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.speech.v1.RecognitionMetadata").msgclass
+        RecognitionMetadata::InteractionType = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.speech.v1.RecognitionMetadata.InteractionType").enummodule
+        RecognitionMetadata::MicrophoneDistance = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance").enummodule
+        RecognitionMetadata::OriginalMediaType = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType").enummodule
+        RecognitionMetadata::RecordingDeviceType = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType").enummodule
         SpeechContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.speech.v1.SpeechContext").msgclass
         RecognitionAudio = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.speech.v1.RecognitionAudio").msgclass
         RecognizeResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.speech.v1.RecognizeResponse").msgclass
diff --git a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb
index ad1c6b512..35c2ab5f7 100644
--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb
@@ -165,6 +165,9 @@ module Google
         #     Note: This is currently offered as an experimental service, complimentary
         #     to all users. In the future this may be exclusively available as a
         #     premium feature.
+        # @!attribute [rw] metadata
+        #   @return [Google::Cloud::Speech::V1::RecognitionMetadata]
+        #     *Optional* Metadata regarding this request.
         # @!attribute [rw] model
         #   @return [String]
         #     *Optional* Which model to select for the given request. Select the model
@@ -284,6 +287,133 @@ module Google
           end
         end
 
+        # Description of audio data to be recognized.
+        # @!attribute [rw] interaction_type
+        #   @return [Google::Cloud::Speech::V1::RecognitionMetadata::InteractionType]
+        #     The use case most closely describing the audio content to be recognized.
+        # @!attribute [rw] industry_naics_code_of_audio
+        #   @return [Integer]
+        #     The industry vertical to which this speech recognition request most
+        #     closely applies. This is most indicative of the topics contained
+        #     in the audio.  Use the 6-digit NAICS code to identify the industry
+        #     vertical - see https://www.naics.com/search/.
+        # @!attribute [rw] microphone_distance
+        #   @return [Google::Cloud::Speech::V1::RecognitionMetadata::MicrophoneDistance]
+        #     The audio type that most closely describes the audio being recognized.
+        # @!attribute [rw] original_media_type
+        #   @return [Google::Cloud::Speech::V1::RecognitionMetadata::OriginalMediaType]
+        #     The original media the speech was recorded on.
+        # @!attribute [rw] recording_device_type
+        #   @return [Google::Cloud::Speech::V1::RecognitionMetadata::RecordingDeviceType]
+        #     The type of device the speech was recorded with.
+        # @!attribute [rw] recording_device_name
+        #   @return [String]
+        #     The device used to make the recording.  Examples 'Nexus 5X' or
+        #     'Polycom SoundStation IP 6000' or 'POTS' or 'VoIP' or
+        #     'Cardioid Microphone'.
+        # @!attribute [rw] original_mime_type
+        #   @return [String]
+        #     Mime type of the original audio file.  For example `audio/m4a`,
+        #     `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
+        #     A list of possible audio mime types is maintained at
+        #     http://www.iana.org/assignments/media-types/media-types.xhtml#audio
+        # @!attribute [rw] audio_topic
+        #   @return [String]
+        #     Description of the content. Eg. "Recordings of federal supreme court
+        #     hearings from 2012".
+        class RecognitionMetadata
+          # Use case categories that the audio recognition request can be described
+          # by.
+          module InteractionType
+            # Use case is either unknown or is something other than one of the other
+            # values below.
+            INTERACTION_TYPE_UNSPECIFIED = 0
+
+            # Multiple people in a conversation or discussion. For example in a
+            # meeting with two or more people actively participating. Typically
+            # all the primary people speaking would be in the same room (if not,
+            # see PHONE_CALL)
+            DISCUSSION = 1
+
+            # One or more persons lecturing or presenting to others, mostly
+            # uninterrupted.
+            PRESENTATION = 2
+
+            # A phone-call or video-conference in which two or more people, who are
+            # not in the same room, are actively participating.
+            PHONE_CALL = 3
+
+            # A recorded message intended for another person to listen to.
+            VOICEMAIL = 4
+
+            # Professionally produced audio (eg. TV Show, Podcast).
+            PROFESSIONALLY_PRODUCED = 5
+
+            # Transcribe spoken questions and queries into text.
+            VOICE_SEARCH = 6
+
+            # Transcribe voice commands, such as for controlling a device.
+            VOICE_COMMAND = 7
+
+            # Transcribe speech to text to create a written document, such as a
+            # text-message, email or report.
+            DICTATION = 8
+          end
+
+          # Enumerates the types of capture settings describing an audio file.
+          module MicrophoneDistance
+            # Audio type is not known.
+            MICROPHONE_DISTANCE_UNSPECIFIED = 0
+
+            # The audio was captured from a closely placed microphone. Eg. phone,
+            # dictaphone, or handheld microphone. Generally if there speaker is within
+            # 1 meter of the microphone.
+            NEARFIELD = 1
+
+            # The speaker if within 3 meters of the microphone.
+            MIDFIELD = 2
+
+            # The speaker is more than 3 meters away from the microphone.
+            FARFIELD = 3
+          end
+
+          # The original media the speech was recorded on.
+          module OriginalMediaType
+            # Unknown original media type.
+            ORIGINAL_MEDIA_TYPE_UNSPECIFIED = 0
+
+            # The speech data is an audio recording.
+            AUDIO = 1
+
+            # The speech data originally recorded on a video.
+            VIDEO = 2
+          end
+
+          # The type of device the speech was recorded with.
+          module RecordingDeviceType
+            # The recording device is unknown.
+            RECORDING_DEVICE_TYPE_UNSPECIFIED = 0
+
+            # Speech was recorded on a smartphone.
+            SMARTPHONE = 1
+
+            # Speech was recorded using a personal computer or tablet.
+            PC = 2
+
+            # Speech was recorded over a phone line.
+            PHONE_LINE = 3
+
+            # Speech was recorded in a vehicle.
+            VEHICLE = 4
+
+            # Speech was recorded outdoors.
+            OTHER_OUTDOOR_DEVICE = 5
+
+            # Speech was recorded indoors.
+            OTHER_INDOOR_DEVICE = 6
+          end
+        end
+
         # Provides "hints" to the speech recognizer to favor specific words and phrases
         # in the results.
         # @!attribute [rw] phrases
@@ -453,11 +583,21 @@ module Google
         #     (completely unstable) to 1.0 (completely stable).
         #     This field is only provided for interim results (`is_final=false`).
         #     The default of 0.0 is a sentinel value indicating `stability` was not set.
+        # @!attribute [rw] result_end_time
+        #   @return [Google::Protobuf::Duration]
+        #     Output only. Time offset of the end of this result relative to the
+        #     beginning of the audio.
         # @!attribute [rw] channel_tag
         #   @return [Integer]
         #     For multi-channel audio, this is the channel number corresponding to the
         #     recognized result for the audio from that channel.
         #     For audio_channel_count = N, its output values can range from '1' to 'N'.
+        # @!attribute [rw] language_code
+        #   @return [String]
+        #     Output only. The
+        #     [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag of the
+        #     language in this result. This language code was detected to have the most
+        #     likelihood of being spoken in the audio.
         class StreamingRecognitionResult; end
 
         # A speech recognition result corresponding to a portion of the audio.
diff --git a/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb b/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb
index d57c59b8c..75b4f0759 100644
--- a/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb
@@ -29,6 +29,7 @@ require "google/longrunning/operations_client"
 
 require "google/cloud/speech/v1/cloud_speech_pb"
 require "google/cloud/speech/v1/credentials"
+require "google/cloud/speech/version"
 
 module Google
   module Cloud
@@ -136,7 +137,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-speech'].version.version
+            package_version = Google::Cloud::Speech::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/cloud_speech_pb.rb b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/cloud_speech_pb.rb
index ab44bdf91..73a69ef71 100644
--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/cloud_speech_pb.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/cloud_speech_pb.rb
@@ -59,6 +59,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     value :AMR_WB, 5
     value :OGG_OPUS, 6
     value :SPEEX_WITH_HEADER_BYTE, 7
+    value :MP3, 8
   end
   add_message "google.cloud.speech.v1p1beta1.RecognitionMetadata" do
     optional :interaction_type, :enum, 1, "google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType"
@@ -104,6 +105,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   end
   add_message "google.cloud.speech.v1p1beta1.SpeechContext" do
     repeated :phrases, :string, 1
+    optional :boost, :float, 4
   end
   add_message "google.cloud.speech.v1p1beta1.RecognitionAudio" do
     oneof :audio_source do
diff --git a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/cloud/speech/v1p1beta1/cloud_speech.rb b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/cloud/speech/v1p1beta1/cloud_speech.rb
index 2030bf01d..9b546cd52 100644
--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/cloud/speech/v1p1beta1/cloud_speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/cloud/speech/v1p1beta1/cloud_speech.rb
@@ -321,6 +321,11 @@ module Google
             # is replaced with a single byte containing the block length. Only Speex
             # wideband is supported. `sample_rate_hertz` must be 16000.
             SPEEX_WITH_HEADER_BYTE = 7
+
+            # MP3 audio. Support all standard MP3 bitrates (which range from 32-320
+            # kbps). When using this encoding, `sample_rate_hertz` can be optionally
+            # unset if not known.
+            MP3 = 8
           end
         end
 
@@ -465,6 +470,22 @@ module Google
         #     specific commands are typically spoken by the user. This can also be used
         #     to add additional words to the vocabulary of the recognizer. See
         #     [usage limits](https://cloud.google.com/speech-to-text/quotas#content).
+        #
+        #     List items can also be set to classes for groups of words that represent
+        #     common concepts that occur in natural language. For example, rather than
+        #     providing phrase hints for every month of the year, using the $MONTH class
+        #     improves the likelihood of correctly transcribing audio that includes
+        #     months.
+        # @!attribute [rw] boost
+        #   @return [Float]
+        #     Hint Boost. Positive value will increase the probability that a specific
+        #     phrase will be recognized over other similar sounding phrases. The higher
+        #     the boost, the higher the chance of false positive recognition as well.
+        #     Negative boost values would correspond to anti-biasing. Anti-biasing is not
+        #     enabled, so negative boost will simply be ignored. Though `boost` can
+        #     accept a wide range of positive values, most use cases are best served with
+        #     values between 0 and 20. We recommend using a binary search approach to
+        #     finding the optimal value for your use case.
         class SpeechContext; end
 
         # Contains audio data in the encoding specified in the `RecognitionConfig`.
diff --git a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/speech_client.rb b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/speech_client.rb
index e367817db..9030eb0c2 100644
--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/speech_client.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/speech_client.rb
@@ -29,6 +29,7 @@ require "google/longrunning/operations_client"
 
 require "google/cloud/speech/v1p1beta1/cloud_speech_pb"
 require "google/cloud/speech/v1p1beta1/credentials"
+require "google/cloud/speech/version"
 
 module Google
   module Cloud
@@ -136,7 +137,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-speech'].version.version
+            package_version = Google::Cloud::Speech::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-speech/lib/google/cloud/speech/version.rb b/google-cloud-speech/lib/google/cloud/speech/version.rb
new file mode 100644
index 000000000..66e2b51bb
--- /dev/null
+++ b/google-cloud-speech/lib/google/cloud/speech/version.rb
@@ -0,0 +1,22 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Speech
+      VERSION = "0.34.1".freeze
+    end
+  end
+end
diff --git a/google-cloud-speech/synth.metadata b/google-cloud-speech/synth.metadata
index c3d9eee89..43e997c63 100644
--- a/google-cloud-speech/synth.metadata
+++ b/google-cloud-speech/synth.metadata
@@ -1,26 +1,26 @@
 {
-  "updateTime": "2019-04-25T10:46:26.986013Z",
+  "updateTime": "2019-06-05T10:41:16.900630Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.17.0",
-        "dockerImage": "googleapis/artman@sha256:c58f4ec3838eb4e0718eb1bccc6512bd6850feaa85a360a9e38f6f848ec73bc2"
+        "version": "0.23.1",
+        "dockerImage": "googleapis/artman@sha256:9d5cae1454da64ac3a87028f8ef486b04889e351c83bb95e83b8fab3959faed0"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "25cbfd4a5386742f5968d69bd276a0436d23bd97",
-        "internalRef": "245137805"
+        "sha": "4f3516a6f96dac182973a3573ff5117e8e4f76c7",
+        "internalRef": "251559960"
       }
     },
     {
       "template": {
         "name": "ruby_library",
         "origin": "synthtool.gcp",
-        "version": "2019.4.10"
+        "version": "2019.5.2"
       }
     }
   ],
diff --git a/google-cloud-speech/synth.py b/google-cloud-speech/synth.py
index 2248a8d0b..16f27ef64 100644
--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -187,3 +187,34 @@ s.replace(
     'gem.add_development_dependency "rubocop".*$',
     'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
+
+# https://github.com/googleapis/google-cloud-ruby/issues/3058
+s.replace(
+    'google-cloud-speech.gemspec',
+    '\nGem::Specification.new do',
+    'require File.expand_path("../lib/google/cloud/speech/version", __FILE__)\n\nGem::Specification.new do'
+)
+s.replace(
+    'google-cloud-speech.gemspec',
+    '(gem.version\s+=\s+).\d+.\d+.\d.*$',
+    '\\1Google::Cloud::Speech::VERSION'
+)
+for version in ['v1', 'v1p1beta1']:
+    s.replace(
+        f'lib/google/cloud/speech/{version}/*_client.rb',
+        f'(require \".*credentials\"\n)\n',
+        f'\\1require "google/cloud/speech/version"\n\n'
+    )
+    s.replace(
+        f'lib/google/cloud/speech/{version}/*_client.rb',
+        'Gem.loaded_specs\[.*\]\.version\.version',
+        'Google::Cloud::Speech::VERSION'
+    )
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1', 'v1p1beta1']:
+    s.replace(
+        f'test/google/cloud/speech/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )
diff --git a/google-cloud-speech/test/google/cloud/speech/v1/speech_client_test.rb b/google-cloud-speech/test/google/cloud/speech/v1/speech_client_test.rb
index f1f14d6ea..f255835bb 100644
--- a/google-cloud-speech/test/google/cloud/speech/v1/speech_client_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/v1/speech_client_test.rb
@@ -150,7 +150,7 @@ describe Google::Cloud::Speech::V1::SpeechClient do
           client = Google::Cloud::Speech.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.recognize(config, audio)
           end
 
@@ -292,7 +292,7 @@ describe Google::Cloud::Speech::V1::SpeechClient do
           client = Google::Cloud::Speech.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.long_running_recognize(config, audio)
           end
 
diff --git a/google-cloud-speech/test/google/cloud/speech/v1p1beta1/speech_client_test.rb b/google-cloud-speech/test/google/cloud/speech/v1p1beta1/speech_client_test.rb
index 976844143..4799b8a71 100644
--- a/google-cloud-speech/test/google/cloud/speech/v1p1beta1/speech_client_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/v1p1beta1/speech_client_test.rb
@@ -150,7 +150,7 @@ describe Google::Cloud::Speech::V1p1beta1::SpeechClient do
           client = Google::Cloud::Speech.new(version: :v1p1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p1beta1 do
             client.recognize(config, audio)
           end
 
@@ -292,7 +292,7 @@ describe Google::Cloud::Speech::V1p1beta1::SpeechClient do
           client = Google::Cloud::Speech.new(version: :v1p1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1p1beta1 do
             client.long_running_recognize(config, audio)
           end
 

```

</details>

This pull request was generated using releasetool.