### PR TITLE
Release google-cloud-text_to_speech 0.3.1

### DIFF
--- a/google-cloud-text_to_speech/CHANGELOG.md
+++ b/google-cloud-text_to_speech/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.3.1 / 2019-06-11
+
+* Add VERSION constant
+
 ### 0.3.0 / 2019-04-29
 
 * Add V1beta1 client.

--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/version.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module TextToSpeech
-      VERSION = "0.3.0".freeze
+      VERSION = "0.3.1".freeze
     end
   end
 end


### PR DESCRIPTION
* Add VERSION constant

<details><summary>Commits since previous release</summary><pre><code>commit c3f100da4536930396d0816303f696bdfaafddb8
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 11 13:35:45 2019 -0700

    prepare repo-metadata.json for docuploader (#3444)

commit 00fca66f6fdbaccfd38d2dca8c5e89b010d8c0ad
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Fri Jun 7 10:00:12 2019 -0700

    test(test_to_speech): update generated tests
    
    
    [pr #3437]

commit ea562c18e376f461f529bd5b535931af5593e4a1
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 4 10:14:49 2019 -0700

    add version.rb and remove Gem.loaded_specs (#3391)

commit 9dc361fabb595257e5ce3b43a0b01bf8e44d1bae
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Fri May 10 12:52:36 2019 -0700

    Update generated google-cloud-text_to_speech files (#3374)
    
    * Revert error retry configuration.

commit 35bfdcd4fbf80e0594be9b3fc2053b513b52ce8c
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Wed May 8 10:59:36 2019 -0700

    Update generated google-cloud-text_to_speech files (#3328)
    
    * Update error retry configuration.
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-text_to_speech/.repo-metadata.json b/google-cloud-text_to_speech/.repo-metadata.json
index 5b3e621cc..d90866676 100644
--- a/google-cloud-text_to_speech/.repo-metadata.json
+++ b/google-cloud-text_to_speech/.repo-metadata.json
@@ -1,6 +1,8 @@
 {
-  "distribution_name": "google-cloud-text_to_speech",
-  "module_name": "TextToSpeech",
-  "module_name_credentials": "TextToSpeech::V1",
-  "env_var_prefix": "TEXTTOSPEECH"
-}
\ No newline at end of file
+    "name": "texttospeech",
+    "language": "ruby",
+    "distribution_name": "google-cloud-text_to_speech",
+    "module_name": "TextToSpeech",
+    "module_name_credentials": "TextToSpeech::V1",
+    "env_var_prefix": "TEXTTOSPEECH"
+}
diff --git a/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec b/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
index 6c8fc7d2a..1ae9275e4 100644
--- a/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
+++ b/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
@@ -1,9 +1,10 @@
 # -*- ruby -*-
 # encoding: utf-8
+require File.expand_path("../lib/google/cloud/text_to_speech/version", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-text_to_speech"
-  gem.version       = "0.3.0"
+  gem.version       = Google::Cloud::TextToSpeech::VERSION
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
diff --git a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1/text_to_speech_client.rb b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1/text_to_speech_client.rb
index e096d7187..cddd31e0f 100644
--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1/text_to_speech_client.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1/text_to_speech_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/cloud/texttospeech/v1/cloud_tts_pb"
 require "google/cloud/text_to_speech/v1/credentials"
+require "google/cloud/text_to_speech/version"
 
 module Google
   module Cloud
@@ -120,7 +121,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-text_to_speech'].version.version
+            package_version = Google::Cloud::TextToSpeech::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1/text_to_speech_client.rb b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1/text_to_speech_client.rb
index eda9d7c2d..cf9c4816a 100644
--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1/text_to_speech_client.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1/text_to_speech_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/cloud/texttospeech/v1beta1/cloud_tts_pb"
 require "google/cloud/text_to_speech/v1beta1/credentials"
+require "google/cloud/text_to_speech/version"
 
 module Google
   module Cloud
@@ -120,7 +121,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-text_to_speech'].version.version
+            package_version = Google::Cloud::TextToSpeech::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/version.rb b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/version.rb
new file mode 100644
index 000000000..f92adc6b7
--- /dev/null
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/version.rb
@@ -0,0 +1,22 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module TextToSpeech
+      VERSION = "0.3.0".freeze
+    end
+  end
+end
diff --git a/google-cloud-text_to_speech/synth.metadata b/google-cloud-text_to_speech/synth.metadata
index 96a813185..561eb5060 100644
--- a/google-cloud-text_to_speech/synth.metadata
+++ b/google-cloud-text_to_speech/synth.metadata
@@ -1,26 +1,26 @@
 {
-  "updateTime": "2019-04-25T10:47:31.518108Z",
+  "updateTime": "2019-06-04T19:32:25.297729Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.17.0",
-        "dockerImage": "googleapis/artman@sha256:c58f4ec3838eb4e0718eb1bccc6512bd6850feaa85a360a9e38f6f848ec73bc2"
+        "version": "0.23.0",
+        "dockerImage": "googleapis/artman@sha256:846102ebf7ea2239162deea69f64940443b4147f7c2e68d64b332416f74211ba"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "25cbfd4a5386742f5968d69bd276a0436d23bd97",
-        "internalRef": "245137805"
+        "sha": "0026f4b890ed9e2388fb0573c0727defa6f5b82e",
+        "internalRef": "251265049"
       }
     },
     {
       "template": {
         "name": "ruby_library",
         "origin": "synthtool.gcp",
-        "version": "2019.4.10"
+        "version": "2019.5.2"
       }
     }
   ],
diff --git a/google-cloud-text_to_speech/synth.py b/google-cloud-text_to_speech/synth.py
index e9f2424fb..2c5304e3b 100644
--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -96,3 +96,26 @@ s.replace(
     'README.md\n',
     'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
+
+# https://github.com/googleapis/google-cloud-ruby/issues/3058
+s.replace(
+    'google-cloud-text_to_speech.gemspec',
+    '\nGem::Specification.new do',
+    'require File.expand_path("../lib/google/cloud/text_to_speech/version", __FILE__)\n\nGem::Specification.new do'
+)
+s.replace(
+    'google-cloud-text_to_speech.gemspec',
+    '(gem.version\s+=\s+).\d+.\d+.\d.*$',
+    '\\1Google::Cloud::TextToSpeech::VERSION'
+)
+for version in ['v1', 'v1beta1']:
+    s.replace(
+        f'lib/google/cloud/text_to_speech/{version}/*_client.rb',
+        f'(require \".*credentials\"\n)\n',
+        f'\\1require "google/cloud/text_to_speech/version"\n\n'
+    )
+    s.replace(
+        f'lib/google/cloud/text_to_speech/{version}/*_client.rb',
+        'Gem.loaded_specs\[.*\]\.version\.version',
+        'Google::Cloud::TextToSpeech::VERSION'
+    )
diff --git a/google-cloud-text_to_speech/test/google/cloud/text_to_speech/v1/text_to_speech_client_test.rb b/google-cloud-text_to_speech/test/google/cloud/text_to_speech/v1/text_to_speech_client_test.rb
index b367e59fe..5d3422bdb 100644
--- a/google-cloud-text_to_speech/test/google/cloud/text_to_speech/v1/text_to_speech_client_test.rb
+++ b/google-cloud-text_to_speech/test/google/cloud/text_to_speech/v1/text_to_speech_client_test.rb
@@ -119,7 +119,7 @@ describe Google::Cloud::TextToSpeech::V1::TextToSpeechClient do
           client = Google::Cloud::TextToSpeech.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_voices
           end
 
@@ -209,7 +209,7 @@ describe Google::Cloud::TextToSpeech::V1::TextToSpeechClient do
           client = Google::Cloud::TextToSpeech.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.synthesize_speech(
               input,
               voice,
diff --git a/google-cloud-text_to_speech/test/google/cloud/text_to_speech/v1beta1/text_to_speech_client_test.rb b/google-cloud-text_to_speech/test/google/cloud/text_to_speech/v1beta1/text_to_speech_client_test.rb
index 3b36c1a67..4fd2a1887 100644
--- a/google-cloud-text_to_speech/test/google/cloud/text_to_speech/v1beta1/text_to_speech_client_test.rb
+++ b/google-cloud-text_to_speech/test/google/cloud/text_to_speech/v1beta1/text_to_speech_client_test.rb
@@ -119,7 +119,7 @@ describe Google::Cloud::TextToSpeech::V1beta1::TextToSpeechClient do
           client = Google::Cloud::TextToSpeech.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.list_voices
           end
 
@@ -209,7 +209,7 @@ describe Google::Cloud::TextToSpeech::V1beta1::TextToSpeechClient do
           client = Google::Cloud::TextToSpeech.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.synthesize_speech(
               input,
               voice,

```

</details>

This pull request was generated using releasetool.