### PR TITLE
Release google-cloud-trace 0.34.3

### DIFF
--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.34.3 / 2019-06-11
+
+* Accept Numeric in Google::Cloud::Trace::Utils.time_to_grpc
+* Add VERSION constant
+
 ### 0.34.2 / 2019-04-29
 
 * Add AUTHENTICATION.md guide.

--- a/google-cloud-trace/lib/google/cloud/trace/version.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Trace
-      VERSION = "0.34.2".freeze
+      VERSION = "0.34.3".freeze
     end
   end
 end


### PR DESCRIPTION
* Accept Numeric in Google::Cloud::Trace::Utils.time_to_grpc
* Add VERSION constant

<details><summary>Commits since previous release</summary><pre><code>commit c3f100da4536930396d0816303f696bdfaafddb8
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 11 13:35:45 2019 -0700

    prepare repo-metadata.json for docuploader (#3444)

commit ea562c18e376f461f529bd5b535931af5593e4a1
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 4 10:14:49 2019 -0700

    add version.rb and remove Gem.loaded_specs (#3391)

commit b662ef12ebdd1a0a6072e23aac254cc15116f460
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Fri May 10 12:53:13 2019 -0700

    Update generated google-cloud-trace files (#3375)
    
    * Revert error retry configuration.

commit 029570ee5955c424bd3ec075ac6496d0c1e5bdbb
Author: Mike Moore <mike@blowmage.com>
Date:   Wed May 8 17:08:43 2019 -0600

    Fix trace test (#3336)
    
    The test was failing on Ruby 2.3, due to how truncate was used.
    ArgumentError: wrong number of arguments (given 1, expected 0)

commit 281f6d1130f55ee94caa1a2f586f5e147178e0a2
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Wed May 8 11:38:10 2019 -0700

    Re-generate google-cloud-trace files (#3329)
    
    * Update error retry configuration.

commit fc4a13b181488437f5cfed15624d15c8860d3a64
Author: seph <github@directionless.org>
Date:   Tue May 7 16:02:39 2019 -0400

    Allow Numeric values for Time (#3300)
    
    * Accept Numeric in Google::Cloud::Trace::Utils.time_to_grpc
    
    [fixes #3299]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-trace/.repo-metadata.json b/google-cloud-trace/.repo-metadata.json
new file mode 100644
index 000000000..05f70ad85
--- /dev/null
+++ b/google-cloud-trace/.repo-metadata.json
@@ -0,0 +1,5 @@
+{
+    "name": "cloudtrace",
+    "language": "ruby",
+    "distribution_name": "google-cloud-trace"
+}
diff --git a/google-cloud-trace/lib/google/cloud/trace/utils.rb b/google-cloud-trace/lib/google/cloud/trace/utils.rb
index bf04e823a..2e9c64235 100644
--- a/google-cloud-trace/lib/google/cloud/trace/utils.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/utils.rb
@@ -29,6 +29,13 @@ module Google
         #
         def self.time_to_grpc time
           return nil if time.nil?
+
+          # sometimes this gets called with time as a float or
+          # int. Coerce into a time object, and move on.
+          time = Time.at(time) if time.is_a? Numeric
+
+          raise ArgumentError unless time.is_a? Time
+
           Google::Protobuf::Timestamp.new seconds: time.to_i,
                                           nanos: time.nsec
         end
diff --git a/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client.rb b/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client.rb
index 590dccf50..b5c9d273c 100644
--- a/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/devtools/cloudtrace/v1/trace_pb"
 require "google/cloud/trace/v1/credentials"
+require "google/cloud/trace/version"
 
 module Google
   module Cloud
@@ -135,7 +136,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-trace'].version.version
+            package_version = Google::Cloud::Trace::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-trace/lib/google/cloud/trace/v2/trace_service_client.rb b/google-cloud-trace/lib/google/cloud/trace/v2/trace_service_client.rb
index b851a6c18..37dfb98de 100644
--- a/google-cloud-trace/lib/google/cloud/trace/v2/trace_service_client.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/trace_service_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/devtools/cloudtrace/v2/tracing_pb"
 require "google/cloud/trace/v2/credentials"
+require "google/cloud/trace/version"
 
 module Google
   module Cloud
@@ -159,7 +160,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-trace'].version.version
+            package_version = Google::Cloud::Trace::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-trace/synth.metadata b/google-cloud-trace/synth.metadata
index 105e916ba..d954817ff 100644
--- a/google-cloud-trace/synth.metadata
+++ b/google-cloud-trace/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-04-21T10:43:57.801363Z",
+  "updateTime": "2019-05-10T10:45:20.657398Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.16.26",
-        "dockerImage": "googleapis/artman@sha256:314eae2a40f6f7822db77365cf5f45bd513d628ae17773fd0473f460e7c2a665"
+        "version": "0.19.0",
+        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "3369c803f56d52662ea3792076deb8545183bdb0",
-        "internalRef": "244282812"
+        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
+        "internalRef": "247530843"
       }
     }
   ],
diff --git a/google-cloud-trace/synth.py b/google-cloud-trace/synth.py
index 223b21700..3270ee876 100644
--- a/google-cloud-trace/synth.py
+++ b/google-cloud-trace/synth.py
@@ -91,3 +91,16 @@ s.replace(
     'lib/**/*.rb',
     '\\A(((#[^\n]*)?\n)*# (Copyright \\d+|Generated by the protocol buffer compiler)[^\n]+\n(#[^\n]*\n)*\n)([^\n])',
     '\\1\n\\6')
+
+# https://github.com/googleapis/google-cloud-ruby/issues/3058
+for version in ['v1', 'v2']:
+    s.replace(
+        f'lib/google/cloud/trace/{version}/*_client.rb',
+        f'(require \".*credentials\"\n)\n',
+        f'\\1require "google/cloud/trace/version"\n\n'
+    )
+    s.replace(
+        f'lib/google/cloud/trace/{version}/*_client.rb',
+        'Gem.loaded_specs\[.*\]\.version\.version',
+        'Google::Cloud::Trace::VERSION'
+    )
diff --git a/google-cloud-trace/test/google/cloud/trace/utils_test.rb b/google-cloud-trace/test/google/cloud/trace/utils_test.rb
index 5c0c573bb..1e6e5c6e0 100644
--- a/google-cloud-trace/test/google/cloud/trace/utils_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/utils_test.rb
@@ -23,11 +23,33 @@ describe Google::Cloud::Trace::Utils do
   let(:time_obj) {
     Time.at(secs, Rational(nsecs, 1000))
   }
+  let(:time_float) {
+    secs + nsecs.to_f / 1000000000
+  }
+
+    it "accepts nil" do
+    Google::Cloud::Trace::Utils.time_to_grpc(nil).must_be_nil
+  end
 
   it "converts time objects to proto objects" do
     Google::Cloud::Trace::Utils.time_to_grpc(time_obj).must_equal time_proto
   end
 
+  it "converts float objects to proto objects" do
+    # Float math is imprecise, so we're faking a sorta-equal
+    result = Google::Cloud::Trace::Utils.time_to_grpc(time_float)
+    result.seconds.must_equal secs
+    result.nanos.must_be_close_to nsecs, 1000
+  end
+
+  it "converts int objects to proto objects" do
+    Google::Cloud::Trace::Utils.time_to_grpc(secs).must_equal Google::Protobuf::Timestamp.new seconds: secs
+  end
+
+  it "raises when called with a string" do
+    proc { Google::Cloud::Trace::Utils.time_to_grpc("test")}.must_raise ArgumentError
+  end
+
   it "converts proto objects to time objects" do
     Google::Cloud::Trace::Utils.grpc_to_time(time_proto).must_equal time_obj
   end

```

</details>

This pull request was generated using releasetool.