### PR TITLE
Release google-cloud-webrisk 0.1.2

### DIFF
--- a/google-cloud-webrisk/CHANGELOG.md
+++ b/google-cloud-webrisk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.1.2 / 2019-06-11
+
+* Add VERSION constant
+
 ### 0.1.1 / 2019-04-29
 
 * Add AUTHENTICATION.md guide.

--- a/google-cloud-webrisk/lib/google/cloud/webrisk/version.rb
+++ b/google-cloud-webrisk/lib/google/cloud/webrisk/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Webrisk
-      VERSION = "0.1.1".freeze
+      VERSION = "0.1.2".freeze
     end
   end
 end


### PR DESCRIPTION
* Add VERSION constant

<details><summary>Commits since previous release</summary><pre><code>commit c3f100da4536930396d0816303f696bdfaafddb8
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 11 13:35:45 2019 -0700

    prepare repo-metadata.json for docuploader (#3444)

commit 18355418748d3fac1d6e8699ae158e578bbf9f24
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Thu Jun 6 14:26:54 2019 -0700

    test(webrisk): Update generated tests
    
    
    [pr #3439]

commit ea562c18e376f461f529bd5b535931af5593e4a1
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 4 10:14:49 2019 -0700

    add version.rb and remove Gem.loaded_specs (#3391)

commit 2eb3abf6350663a58aca1e0a232c62cf2fa0c0fe
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Fri May 10 13:49:36 2019 -0700

    Update generated google-cloud-webrisk files (#3378)
    
    * Revert error retry configuration.

commit a11f541f755f76ce5414783d1496cff3aa58a964
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Wed May 8 11:39:54 2019 -0700

    Re-generate google-cloud-webrisk files. (#3332)
    
    * Update error retry configuration.
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-webrisk/.repo-metadata.json b/google-cloud-webrisk/.repo-metadata.json
index 8b83f9e60..1b898483e 100644
--- a/google-cloud-webrisk/.repo-metadata.json
+++ b/google-cloud-webrisk/.repo-metadata.json
@@ -1,6 +1,8 @@
 {
-  "distribution_name": "google-cloud-webrisk",
-  "module_name": "Webrisk",
-  "module_name_credentials": "Webrisk::V1beta1",
-  "env_var_prefix": "WEBRISK"
-}
\ No newline at end of file
+    "name": "webrisk",
+    "language": "ruby",
+    "distribution_name": "google-cloud-webrisk",
+    "module_name": "Webrisk",
+    "module_name_credentials": "Webrisk::V1beta1",
+    "env_var_prefix": "WEBRISK"
+}
diff --git a/google-cloud-webrisk/google-cloud-webrisk.gemspec b/google-cloud-webrisk/google-cloud-webrisk.gemspec
index 739421b8c..22119b8c2 100644
--- a/google-cloud-webrisk/google-cloud-webrisk.gemspec
+++ b/google-cloud-webrisk/google-cloud-webrisk.gemspec
@@ -1,9 +1,10 @@
 # -*- ruby -*-
 # encoding: utf-8
+require File.expand_path("../lib/google/cloud/webrisk/version", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-webrisk"
-  gem.version       = "0.1.1"
+  gem.version       = Google::Cloud::Webrisk::VERSION
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
diff --git a/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1/web_risk_service_v1_beta1_client.rb b/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1/web_risk_service_v1_beta1_client.rb
index a17dd68d8..f268e03a7 100644
--- a/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1/web_risk_service_v1_beta1_client.rb
+++ b/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1/web_risk_service_v1_beta1_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/cloud/webrisk/v1beta1/webrisk_pb"
 require "google/cloud/webrisk/v1beta1/credentials"
+require "google/cloud/webrisk/version"
 
 module Google
   module Cloud
@@ -121,7 +122,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-webrisk'].version.version
+            package_version = Google::Cloud::Webrisk::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-webrisk/lib/google/cloud/webrisk/version.rb b/google-cloud-webrisk/lib/google/cloud/webrisk/version.rb
new file mode 100644
index 000000000..13b4cd55e
--- /dev/null
+++ b/google-cloud-webrisk/lib/google/cloud/webrisk/version.rb
@@ -0,0 +1,22 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Webrisk
+      VERSION = "0.1.1".freeze
+    end
+  end
+end
diff --git a/google-cloud-webrisk/synth.metadata b/google-cloud-webrisk/synth.metadata
index 879917398..5e2d6ad87 100644
--- a/google-cloud-webrisk/synth.metadata
+++ b/google-cloud-webrisk/synth.metadata
@@ -1,26 +1,26 @@
 {
-  "updateTime": "2019-04-25T10:48:46.888431Z",
+  "updateTime": "2019-06-04T19:33:40.470247Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.17.0",
-        "dockerImage": "googleapis/artman@sha256:c58f4ec3838eb4e0718eb1bccc6512bd6850feaa85a360a9e38f6f848ec73bc2"
+        "version": "0.23.0",
+        "dockerImage": "googleapis/artman@sha256:846102ebf7ea2239162deea69f64940443b4147f7c2e68d64b332416f74211ba"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "25cbfd4a5386742f5968d69bd276a0436d23bd97",
-        "internalRef": "245137805"
+        "sha": "0026f4b890ed9e2388fb0573c0727defa6f5b82e",
+        "internalRef": "251265049"
       }
     },
     {
       "template": {
         "name": "ruby_library",
         "origin": "synthtool.gcp",
-        "version": "2019.4.10"
+        "version": "2019.5.2"
       }
     }
   ],
diff --git a/google-cloud-webrisk/synth.py b/google-cloud-webrisk/synth.py
index 492187530..bd84d1a8a 100644
--- a/google-cloud-webrisk/synth.py
+++ b/google-cloud-webrisk/synth.py
@@ -86,3 +86,25 @@ s.replace(
     'README.md\n',
     'README.md\nAUTHENTICATION.md\nLICENSE\n'
 )
+
+# https://github.com/googleapis/google-cloud-ruby/issues/3058
+s.replace(
+    'google-cloud-webrisk.gemspec',
+    '\nGem::Specification.new do',
+    'require File.expand_path("../lib/google/cloud/webrisk/version", __FILE__)\n\nGem::Specification.new do'
+)
+s.replace(
+    'google-cloud-webrisk.gemspec',
+    '(gem.version\s+=\s+).\d+.\d+.\d.*$',
+    '\\1Google::Cloud::Webrisk::VERSION'
+)
+s.replace(
+    'lib/google/cloud/webrisk/v1beta1/*_client.rb',
+    '(require \".*credentials\"\n)\n',
+    '\\1require "google/cloud/webrisk/version"\n\n'
+)
+s.replace(
+    'lib/google/cloud/webrisk/v1beta1/*_client.rb',
+    'Gem.loaded_specs\[.*\]\.version\.version',
+    'Google::Cloud::Webrisk::VERSION'
+)
diff --git a/google-cloud-webrisk/test/google/cloud/webrisk/v1beta1/web_risk_service_v1_beta1_client_test.rb b/google-cloud-webrisk/test/google/cloud/webrisk/v1beta1/web_risk_service_v1_beta1_client_test.rb
index 8ec09e36d..0c431fb35 100644
--- a/google-cloud-webrisk/test/google/cloud/webrisk/v1beta1/web_risk_service_v1_beta1_client_test.rb
+++ b/google-cloud-webrisk/test/google/cloud/webrisk/v1beta1/web_risk_service_v1_beta1_client_test.rb
@@ -134,7 +134,7 @@ describe Google::Cloud::Webrisk::V1beta1::WebRiskServiceV1Beta1Client do
           client = Google::Cloud::Webrisk.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.compute_threat_list_diff(threat_type, constraints)
           end
 
@@ -211,7 +211,7 @@ describe Google::Cloud::Webrisk::V1beta1::WebRiskServiceV1Beta1Client do
           client = Google::Cloud::Webrisk.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.search_uris(uri, threat_types)
           end
 
@@ -274,7 +274,7 @@ describe Google::Cloud::Webrisk::V1beta1::WebRiskServiceV1Beta1Client do
           client = Google::Cloud::Webrisk.new(version: :v1beta1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.search_hashes
           end
 

```

</details>

This pull request was generated using releasetool.