### PR TITLE
Release google-cloud-firestore 0.26.0

### DIFF
--- a/google-cloud-firestore/CHANGELOG.md
+++ b/google-cloud-firestore/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+### 0.26.0 / 2019-06-13
+
+BREAKING CHANGE: The default return value of Client#transaction has been
+changed to the return value of the yielded block. Pass commit_response: true
+for the previous default behavior of returning the CommitResponse.
+
+* Add commit_response to Client#transaction
+* Add Collection Group queries
+* Add CollectionReference#list_documents
+* Enable grpc.service_config_disable_resolution
+* Use VERSION constant in GAPIC client
+
 ### 0.25.1 / 2019-04-29
 
 * Add AUTHENTICATION.md guide.

--- a/google-cloud-firestore/lib/google/cloud/firestore/version.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Firestore
-      VERSION = "0.25.1".freeze
+      VERSION = "0.26.0".freeze
     end
   end
 end


### PR DESCRIPTION
BREAKING CHANGE: The default return value of Client#transaction has been
changed to the return value of the yielded block. Pass commit_response: true
for the previous default behavior of returning the CommitResponse.

* Add commit_response to Client#transaction
* Add Collection Group queries
* Add CollectionReference#list_documents
* Enable grpc.service_config_disable_resolution
* Use VERSION constant in GAPIC client

<details><summary>Commits since previous release</summary><pre><code>commit c3f100da4536930396d0816303f696bdfaafddb8
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 11 13:35:45 2019 -0700

    prepare repo-metadata.json for docuploader (#3444)

commit cd52f3f1b9c805e5ef1f3dc2c231db2cd0928cb5
Author: Chris Smith <quartzmo@gmail.com>
Date:   Mon Jun 10 12:14:38 2019 -0600

    feat(firestore): add CollectionReference#list_documents
    
    
    [fixes #2828, pr #3447]

commit efb80c87489098075b6da5e186f573940afcbfd7
Author: Mike Moore <mike@blowmage.com>
Date:   Wed Jun 5 12:10:16 2019 -0600

    config: Disable gRPC Service Config
    
    [pr #3443]

commit ea562c18e376f461f529bd5b535931af5593e4a1
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 4 10:14:49 2019 -0700

    add version.rb and remove Gem.loaded_specs (#3391)

commit fe59f8084c727c8e8067fb0204f7647049d75614
Author: Chris Smith <quartzmo@gmail.com>
Date:   Tue Jun 4 09:01:18 2019 -0600

    feat(firestore): add commit_response to Client#transaction
    
    
    BREAKING CHANGE: The default return value of Client#transaction has been
    changed to the return value of the yielded block. Pass commit_response: true
    for the previous default behavior of returning the CommitResponse.
    
    [fixes #3388, pr #3430]

commit 9d7566152ec7d6ba02c053dda066589e7f641548
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed May 29 20:17:25 2019 -0700

    Fix unit tests to check for both custom and wrapper exception types (#3427)

commit f5ab8268c864e9956a7016c020a8e4b01965686a
Author: Chris Smith <quartzmo@gmail.com>
Date:   Wed May 29 10:58:02 2019 -0600

    feat(firestore): add Collection Group queries
    
    
    [pr #3416]

commit 22624f250e3d955433526f1a7836eca23f3d5cc7
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Fri May 10 11:18:49 2019 -0700

    Update generated google-cloud-firestore files (#3360)
    
    * Revert error retry configuration.

commit 9871e9daa0d1f0e7cda149b4b79b2268dbd543b9
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Wed May 8 10:22:36 2019 -0700

    Update generated google-cloud-firestore files (#3314)
    
    * Update error retry configuration.
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-firestore/.repo-metadata.json b/google-cloud-firestore/.repo-metadata.json
new file mode 100644
index 000000000..0ba6db7b4
--- /dev/null
+++ b/google-cloud-firestore/.repo-metadata.json
@@ -0,0 +1,5 @@
+{
+    "name": "firestore",
+    "language": "ruby",
+    "distribution_name": "google-cloud-firestore"
+}
diff --git a/google-cloud-firestore/acceptance/firestore/collection_test.rb b/google-cloud-firestore/acceptance/firestore/collection_test.rb
index f19f4d31f..dd0ab8cf0 100644
--- a/google-cloud-firestore/acceptance/firestore/collection_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/collection_test.rb
@@ -41,4 +41,18 @@ describe "Collection", :firestore_acceptance do
 
     doc_snp[:foo].must_equal "hello world"
   end
+
+  it "lists its documents" do
+    rand_col = firestore.col "#{root_path}/query/#{SecureRandom.hex(4)}"
+    rand_col.add({foo: "bar"})
+    rand_col.add({bar: "foo"})
+    docs = rand_col.list_documents
+
+    docs.must_be_kind_of Array
+    docs.size.must_be :>, 1
+    docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+
+    docs_max_1 = rand_col.list_documents max: 1
+    docs_max_1.size.must_equal 1
+  end
 end
diff --git a/google-cloud-firestore/acceptance/firestore/query_test.rb b/google-cloud-firestore/acceptance/firestore/query_test.rb
index eda4c7432..96515a015 100644
--- a/google-cloud-firestore/acceptance/firestore/query_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/query_test.rb
@@ -190,4 +190,101 @@ describe "Query", :firestore_acceptance do
     results.map(&:document_id).must_equal ["doc1", "doc2"]
     results.map { |doc| doc[:foo] }.must_equal ["a", "b"]
   end
+
+  describe "Collection Group" do
+    it "queries a collection group" do
+      collection_group = "b-#{SecureRandom.hex(4)}"
+      doc_paths = [
+          "abc/123/#{collection_group}/cg-doc1",
+          "abc/123/#{collection_group}/cg-doc2",
+          "#{collection_group}/cg-doc3",
+          "#{collection_group}/cg-doc4",
+          "def/456/#{collection_group}/cg-doc5",
+          "#{collection_group}/virtual-doc/nested-coll/not-cg-doc",
+          "x#{collection_group}/not-cg-doc",
+          "#{collection_group}x/not-cg-doc",
+          "abc/123/#{collection_group}x/not-cg-doc",
+          "abc/123/x#{collection_group}/not-cg-doc",
+          "abc/#{collection_group}"
+      ]
+      firestore.batch do |b|
+        doc_paths.each do |doc_path|
+          doc_ref = firestore.document doc_path
+          b.set doc_ref, {x: 1}
+        end
+      end
+
+      query = firestore.collection_group collection_group
+      snapshots = query.get
+      snapshots.map(&:document_id).must_equal ["cg-doc1", "cg-doc2", "cg-doc3", "cg-doc4", "cg-doc5"]
+    end
+
+    it "queries a collection group with start_at and end_at" do
+      collection_group = "b-#{SecureRandom.hex(4)}"
+      doc_paths = [
+        "a/a/#{collection_group}/cg-doc1",
+        "a/b/a/b/#{collection_group}/cg-doc2",
+        "a/b/#{collection_group}/cg-doc3",
+        "a/b/c/d/#{collection_group}/cg-doc4",
+        "a/c/#{collection_group}/cg-doc5",
+        "#{collection_group}/cg-doc6",
+        "a/b/nope/nope"
+      ]
+      firestore.batch do |b|
+        doc_paths.each do |doc_path|
+          doc_ref = firestore.document doc_path
+          b.set doc_ref, {x: 1}
+        end
+      end
+
+      query = firestore.collection_group(collection_group)
+        .order_by("__name__")
+        .start_at(firestore.document("a/b"))
+        .end_at(firestore.document("a/b0"))
+
+      snapshots = query.get
+      snapshots.map(&:document_id).must_equal ["cg-doc2", "cg-doc3", "cg-doc4"]
+
+      query = firestore.collection_group(collection_group)
+        .order_by("__name__")
+        .start_after(firestore.document("a/b"))
+        .end_before(firestore.document("a/b/#{collection_group}/cg-doc3"))
+      snapshots = query.get
+      snapshots.map(&:document_id).must_equal ["cg-doc2"]
+    end
+
+    it "queries a collection group with filters" do
+      collection_group = "b-#{SecureRandom.hex(4)}"
+      doc_paths = [
+        "a/a/#{collection_group}/cg-doc1",
+        "a/b/a/b/#{collection_group}/cg-doc2",
+        "a/b/#{collection_group}/cg-doc3",
+        "a/b/c/d/#{collection_group}/cg-doc4",
+        "a/c/#{collection_group}/cg-doc5",
+        "#{collection_group}/cg-doc6",
+        "a/b/nope/nope"
+      ]
+      firestore.batch do |b|
+        doc_paths.each do |doc_path|
+          doc_ref = firestore.document doc_path
+          b.set doc_ref, {x: 1}
+        end
+      end
+
+      query = firestore.collection_group(collection_group)
+        .where("__name__", ">=", firestore.document("a/b"))
+        .where("__name__", "<=", firestore.document("a/b0"))
+
+      snapshots = query.get
+      snapshots.map(&:document_id).must_equal ["cg-doc2", "cg-doc3", "cg-doc4"]
+
+      query = firestore.collection_group(collection_group)
+        .where("__name__", ">", firestore.document("a/b"))
+        .where(
+          "__name__", "<", firestore.document("a/b/#{collection_group}/cg-doc3")
+        )
+      snapshots = query.get
+      snapshots.map(&:document_id).must_equal ["cg-doc2"]
+    end
+  end
 end
diff --git a/google-cloud-firestore/acceptance/firestore/transaction_test.rb b/google-cloud-firestore/acceptance/firestore/transaction_test.rb
index 4a63d32fe..f93da60d2 100644
--- a/google-cloud-firestore/acceptance/firestore/transaction_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/transaction_test.rb
@@ -19,10 +19,23 @@ describe "Transaction", :firestore_acceptance do
     rand_tx_col = firestore.col "#{root_path}/tx/#{SecureRandom.hex(4)}"
     doc_ref = rand_tx_col.doc
 
-    firestore.transaction do |tx|
+    doc_snp = firestore.transaction do |tx|
+      tx.get doc_ref
+    end
+    doc_snp.wont_be :exists?
+  end
+
+  it "returns CommitResponse when commit_response option is true" do
+    rand_tx_col = firestore.col "#{root_path}/tx/#{SecureRandom.hex(4)}"
+    doc_ref = rand_tx_col.doc
+
+    resp = firestore.transaction commit_response: true do |tx|
       doc_snp = tx.get doc_ref
       doc_snp.wont_be :exists?
     end
+
+    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    resp.commit_time.must_be_kind_of Time
   end
 
   it "has get with query" do
@@ -32,21 +45,22 @@ describe "Transaction", :firestore_acceptance do
 
     query = rand_query_col.select "foo"
 
-    firestore.transaction do |tx|
-      results = tx.get query
-      results.map(&:document_id).must_equal ["doc1", "doc2"]
-      results.map { |doc| doc[:foo] }.must_equal ["a", "b"]
+    results = firestore.transaction do |tx|
+      tx.get(query).to_a # all results must be retrieved inside tx
     end
+    results.map(&:document_id).must_equal ["doc1", "doc2"]
+    results.map { |doc| doc[:foo] }.must_equal ["a", "b"]
   end
 
   it "has set method" do
     rand_tx_col = firestore.col "#{root_path}/tx/#{SecureRandom.hex(4)}"
     doc_ref = rand_tx_col.doc
 
-    firestore.transaction do |tx|
+    resp = firestore.transaction do |tx|
       tx.set doc_ref, foo: "bar"
     end
 
+    resp.must_be :nil?
     doc_ref.get[:foo].must_equal "bar"
   end
 
@@ -55,10 +69,11 @@ describe "Transaction", :firestore_acceptance do
     doc_ref = rand_tx_col.doc
     doc_ref.create foo: "bar"
 
-    firestore.transaction do |tx|
+    resp = firestore.transaction do |tx|
       tx.update doc_ref, foo: "baz"
     end
 
+    resp.must_be :nil?
     doc_ref.get[:foo].must_equal "baz"
   end
 
@@ -79,10 +94,11 @@ describe "Transaction", :firestore_acceptance do
     doc_ref = rand_tx_col.doc
     doc_ref.create({foo: "bar"})
 
-    firestore.transaction do |tx|
+    resp = firestore.transaction do |tx|
       tx.delete doc_ref
     end
 
+    resp.must_be :nil?
     doc_ref.get.wont_be :exists?
   end
 end
diff --git a/google-cloud-firestore/lib/google/cloud/firestore/client.rb b/google-cloud-firestore/lib/google/cloud/firestore/client.rb
index f34afcdd3..e3f73838a 100644
--- a/google-cloud-firestore/lib/google/cloud/firestore/client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/client.rb
@@ -139,6 +139,46 @@ module Google
         end
         alias collection col
 
+        ##
+        # Creates and returns a new Query that includes all documents in the
+        # database that are contained in a collection or subcollection with the
+        # given collection_id.
+        #
+        # @param [String] collection_id Identifies the collections to query
+        #   over. Every collection or subcollection with this ID as the last
+        #   segment of its path will be included. Cannot contain a slash (`/`).
+        #
+        # @return [Query] The created Query.
+        #
+        # @example
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #
+        #   # Get the cities collection group query
+        #   query = firestore.col_group "cities"
+        #
+        #   query.get do |city|
+        #     puts "#{city.document_id} has #{city[:population]} residents."
+        #   end
+        #
+        def col_group collection_id
+          if collection_id.include? "/"
+            raise ArgumentError, "Invalid collection_id: '#{collection_id}', " \
+              "must not contain '/'."
+          end
+          query = Google::Firestore::V1::StructuredQuery.new(
+            from: [
+              Google::Firestore::V1::StructuredQuery::CollectionSelector.new(
+                collection_id: collection_id, all_descendants: true
+              )
+            ]
+          )
+
+          Query.start query, service.documents_path, self
+        end
+        alias collection_group col_group
+
         ##
         # Retrieves a document reference.
         #
@@ -555,12 +595,19 @@ module Google
         #
         # @param [Integer] max_retries The maximum number of retries for
         #   transactions failed due to errors. Default is 5. Optional.
+        # @param [Boolean] commit_response When `true`, the return value from
+        #   this method will be a `Google::Cloud::Firestore::CommitResponse`
+        #   object with a `commit_time` attribute. Otherwise, the return
+        #   value from this method will be the return value of the provided
+        #   yield block. Default is `false`. Optional.
         #
         # @yield [transaction] The block for reading data and making changes.
         # @yieldparam [Transaction] transaction The transaction object for
         #   making changes.
         #
-        # @return [CommitResponse] The response from committing the changes.
+        # @return [Object, CommitResponse] The return value of the provided
+        #   yield block, or if `commit_response` is provided and true, the
+        #   `CommitResponse` object from the commit operation.
         #
         # @example
         #   require "google/cloud/firestore"
@@ -578,14 +625,16 @@ module Google
         #     tx.delete("cities/LA")
         #   end
         #
-        def transaction max_retries: nil
+        def transaction max_retries: nil, commit_response: nil
           max_retries = 5 unless max_retries.is_a? Integer
           backoff = { current: 0, delay: 1.0, max: max_retries, mod: 1.3 }
 
           transaction = Transaction.from_client self
           begin
-            yield transaction
-            transaction.commit
+            transaction_return = yield transaction
+            commit_return = transaction.commit
+            # Conditional return value, depending on truthy commit_response
+            commit_response ? commit_return : transaction_return
           rescue Google::Cloud::UnavailableError => err
             # Re-raise if retried more than the max
             raise err if backoff[:current] > backoff[:max]
@@ -618,6 +667,14 @@ module Google
 
         # @!endgroup
 
+        # @private
+        def list_documents parent, collection_id, token: nil, max: nil
+          ensure_service!
+          grpc = service.list_documents \
+            parent, collection_id, token: token, max: max
+          DocumentReference::List.from_grpc grpc, service, parent, collection_id
+        end
+
         protected
 
         ##
diff --git a/google-cloud-firestore/lib/google/cloud/firestore/collection_reference.rb b/google-cloud-firestore/lib/google/cloud/firestore/collection_reference.rb
index 66e5c1ab9..d6ad0dd33 100644
--- a/google-cloud-firestore/lib/google/cloud/firestore/collection_reference.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/collection_reference.rb
@@ -25,7 +25,7 @@ module Google
       ##
       # # CollectionReference
       #
-      # A collection reference object ise used for adding documents, getting
+      # A collection reference object is used for adding documents, getting
       # document references, and querying for documents (See {Query}).
       #
       # @example
@@ -126,6 +126,39 @@ module Google
         end
         alias document doc
 
+        ##
+        # Retrieves a list of document references for the documents in this
+        # collection.
+        #
+        # The document references returned may include references to "missing
+        # documents", i.e. document locations that have no document present but
+        # which contain subcollections with documents. Attempting to read such a
+        # document reference (e.g. via {DocumentReference#get}) will return
+        # a {DocumentSnapshot} whose `exists?` method returns false.
+        #
+        # @param [String] token A previously-returned page token representing
+        #   part of the larger set of results to view.
+        # @param [Integer] max Maximum number of results to return.
+        #
+        # @return [Array<DocumentReference>] An array of document references.
+        #
+        # @example
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #
+        #   col = firestore.col "cities"
+        #
+        #   col.list_documents.each do |doc_ref|
+        #     puts doc_ref.document_id
+        #   end
+        #
+        def list_documents token: nil, max: nil
+          ensure_client!
+          client.list_documents \
+            parent_path, collection_id, token: token, max: max
+        end
+
         ##
         # The document reference or database the collection reference belongs
         # to. If the collection is a root collection, it will return the client
diff --git a/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb b/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
index 61c0277b8..ca079eeff 100644
--- a/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
@@ -17,6 +17,7 @@ require "google/cloud/firestore/v1"
 require "google/cloud/firestore/document_snapshot"
 require "google/cloud/firestore/collection_reference"
 require "google/cloud/firestore/document_listener"
+require "google/cloud/firestore/document_reference/list"
 
 module Google
   module Cloud
diff --git a/google-cloud-firestore/lib/google/cloud/firestore/document_reference/list.rb b/google-cloud-firestore/lib/google/cloud/firestore/document_reference/list.rb
new file mode 100644
index 000000000..cb81392b5
--- /dev/null
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_reference/list.rb
@@ -0,0 +1,191 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "delegate"
+
+module Google
+  module Cloud
+    module Firestore
+      class DocumentReference
+        ##
+        # DocumentReference::List is a special case Array with additional
+        # values.
+        #
+        # @example
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #
+        #   col = firestore.col "cities"
+        #
+        #   doc_refs = col.list_documents
+        #
+        #   doc_refs.each do |doc_ref|
+        #     puts doc_ref.document_id
+        #   end
+        #
+        class List < DelegateClass(::Array)
+          ##
+          # If not empty, indicates that there are more records that match
+          # the request and this value should be passed to continue.
+          attr_accessor :token
+
+          ##
+          # @private Create a new DocumentReference::List with an array of
+          # DocumentReference instances.
+          def initialize arr = []
+            super arr
+          end
+
+          ##
+          # Whether there is a next page of document references.
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/firestore"
+          #
+          #   firestore = Google::Cloud::Firestore.new
+          #   col = firestore.col "cities"
+          #
+          #   doc_refs = col.list_documents
+          #   if doc_refs.next?
+          #     next_documents = doc_refs.next
+          #   end
+          def next?
+            !token.nil?
+          end
+
+          ##
+          # Retrieve the next page of document references.
+          #
+          # @return [DocumentReference::List]
+          #
+          # @example
+          #   require "google/cloud/firestore"
+          #
+          #   firestore = Google::Cloud::Firestore.new
+          #   col = firestore.col "cities"
+          #
+          #   doc_refs = col.list_documents
+          #   if doc_refs.next?
+          #     next_documents = doc_refs.next
+          #   end
+          def next
+            return nil unless next?
+            ensure_service!
+            options = { token: token, max: @max }
+            grpc = @service.list_documents @parent, @collection_id, options
+            self.class.from_grpc grpc, @service, @parent, @collection_id, @max
+          end
+
+          ##
+          # Retrieves remaining results by repeatedly invoking {#next} until
+          # {#next?} returns `false`. Calls the given block once for each
+          # result, which is passed as the argument to the block.
+          #
+          # An Enumerator is returned if no block is given.
+          #
+          # This method will make repeated API calls until all remaining results
+          # are retrieved. (Unlike `#each`, for example, which merely iterates
+          # over the results returned by a single API call.) Use with caution.
+          #
+          # @param [Integer] request_limit The upper limit of API requests to
+          #   make to load all document references. Default is no limit.
+          # @yield [document] The block for accessing each document.
+          # @yieldparam [DocumentReference] document The document reference
+          #   object.
+          #
+          # @return [Enumerator]
+          #
+          # @example Iterating each document reference by passing a block:
+          #   require "google/cloud/firestore"
+          #
+          #   firestore = Google::Cloud::Firestore.new
+          #   col = firestore.col "cities"
+          #
+          #   doc_refs = col.list_documents
+          #   doc_refs.all do |doc_ref|
+          #     puts doc_ref.document_id
+          #   end
+          #
+          # @example Using the enumerator by not passing a block:
+          #   require "google/cloud/firestore"
+          #
+          #   firestore = Google::Cloud::Firestore.new
+          #   col = firestore.col "cities"
+          #
+          #   doc_refs = col.list_documents
+          #   all_document_ids = doc_refs.all.map do |doc_ref|
+          #     doc_ref.document_id
+          #   end
+          #
+          # @example Limit the number of API calls made:
+          #   require "google/cloud/firestore"
+          #
+          #   firestore = Google::Cloud::Firestore.new
+          #   col = firestore.col "cities"
+          #
+          #   doc_refs = col.list_documents
+          #   doc_refs.all(request_limit: 10) do |doc_ref|
+          #     puts doc_ref.document_id
+          #   end
+          #
+          def all request_limit: nil
+            request_limit = request_limit.to_i if request_limit
+            unless block_given?
+              return enum_for :all, request_limit: request_limit
+            end
+            results = self
+            loop do
+              results.each { |r| yield r }
+              if request_limit
+                request_limit -= 1
+                break if request_limit < 0
+              end
+              break unless results.next?
+              results = results.next
+            end
+          end
+
+          ##
+          # @private New DocumentReference::List from a
+          # Google::Firestore::V1::ListDocumentsResponse object.
+          def self.from_grpc grpc, service, parent, collection_id, max = nil
+            documents = List.new(Array(grpc.documents).map do |document|
+              DocumentReference.from_path document.name, service
+            end)
+            documents.instance_variable_set :@parent, parent
+            documents.instance_variable_set :@collection_id, collection_id
+            token = grpc.next_page_token
+            token = nil if token == "".freeze
+            documents.instance_variable_set :@token, token
+            documents.instance_variable_set :@service, service
+            documents.instance_variable_set :@max, max
+            documents
+          end
+
+          protected
+
+          ##
+          # Raise an error unless an active service is available.
+          def ensure_service!
+            raise "Must have active connection" unless @service
+          end
+        end
+      end
+    end
+  end
+end
diff --git a/google-cloud-firestore/lib/google/cloud/firestore/query.rb b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
index 8ff0e2cfd..122b25b2e 100644
--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -63,7 +63,7 @@ module Google
         attr_accessor :parent_path
 
         ##
-        # @private The Google::Firestore::V1::Query object.
+        # @private The Google::Firestore::V1::StructuredQuery object.
         attr_accessor :query
 
         ##
diff --git a/google-cloud-firestore/lib/google/cloud/firestore/service.rb b/google-cloud-firestore/lib/google/cloud/firestore/service.rb
index c2131867f..0d9ff9e33 100644
--- a/google-cloud-firestore/lib/google/cloud/firestore/service.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/service.rb
@@ -41,7 +41,11 @@ module Google
 
         def channel
           require "grpc"
-          GRPC::Core::Channel.new host, nil, chan_creds
+          GRPC::Core::Channel.new host, chan_args, chan_creds
+        end
+
+        def chan_args
+          { "grpc.service_config_disable_resolution" => 1 }
         end
 
         def chan_creds
@@ -81,6 +85,26 @@ module Google
           end
         end
 
+        ##
+        # Returns a list of DocumentReferences that are directly nested under
+        # the given collection. Fetches all documents from the server, but
+        # provides an empty field mask to avoid unnecessary data transfer. Sets
+        # the showMissing flag to true to support full document traversal. If
+        # there are too many documents, recommendation will be not to call this
+        # method.
+        def list_documents parent, collection_id, token: nil, max: nil
+          mask = { field_paths: [] }
+          call_options = nil
+          call_options = Google::Gax::CallOptions.new page_token: token if token
+          execute do
+            paged_enum = firestore.list_documents \
+              parent, collection_id, mask: mask, show_missing: true,
+                                     page_size: max, options: call_options
+
+            paged_enum.page.response
+          end
+        end
+
         def list_collections parent, transaction: nil
           list_args = {}
           if transaction.is_a? String
diff --git a/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb b/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
index 8dd2846f2..ce8413a85 100644
--- a/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
@@ -604,6 +604,7 @@ module Google
 
         ##
         # @private commit the transaction
+        # @return [CommitResponse] The response from committing the changes.
         def commit
           ensure_not_closed!
 
diff --git a/google-cloud-firestore/lib/google/cloud/firestore/v1/firestore_client.rb b/google-cloud-firestore/lib/google/cloud/firestore/v1/firestore_client.rb
index cea91b008..3aef53db1 100644
--- a/google-cloud-firestore/lib/google/cloud/firestore/v1/firestore_client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1/firestore_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/firestore/v1/firestore_pb"
 require "google/cloud/firestore/v1/credentials"
+require "google/cloud/firestore/version"
 
 module Google
   module Cloud
@@ -223,7 +224,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-firestore'].version.version
+            package_version = Google::Cloud::Firestore::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/firestore_client.rb b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/firestore_client.rb
index 0067ecf56..f7821d44e 100644
--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/firestore_client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/firestore_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/firestore/v1beta1/firestore_pb"
 require "google/cloud/firestore/v1beta1/credentials"
+require "google/cloud/firestore/version"
 
 module Google
   module Cloud
@@ -223,7 +224,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-firestore'].version.version
+            package_version = Google::Cloud::Firestore::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-firestore/support/doctest_helper.rb b/google-cloud-firestore/support/doctest_helper.rb
index c20ffcef8..c2e436af5 100644
--- a/google-cloud-firestore/support/doctest_helper.rb
+++ b/google-cloud-firestore/support/doctest_helper.rb
@@ -134,6 +134,14 @@ YARD::Doctest.configure do |doctest|
   doctest.skip "Google::Cloud::Firestore::Client#collections"
   doctest.skip "Google::Cloud::Firestore::Client#list_collections"
 
+  doctest.before "Google::Cloud::Firestore::Client#col_group" do
+    mock_firestore do |mock|
+      mock.expect :run_query, run_query_resp, run_query_args
+    end
+  end
+  # Skip aliased methods
+  doctest.skip "Google::Cloud::Firestore::Client#collection_group"
+
   doctest.before "Google::Cloud::Firestore::Client#docs" do
     mock_firestore do |mock|
       mock.expect :run_query, run_query_resp, run_query_args
@@ -315,6 +323,12 @@ YARD::Doctest.configure do |doctest|
   doctest.skip "Google::Cloud::Firestore::CollectionReference#get_documents"
   doctest.skip "Google::Cloud::Firestore::CollectionReference#find"
 
+  doctest.before "Google::Cloud::Firestore::CollectionReference#list_documents" do
+    mock_firestore do |mock|
+      mock.expect :list_documents, documents_resp, list_documents_args
+    end
+  end
+
   doctest.before "Google::Cloud::Firestore::DocumentReference#cols" do
     mock_firestore do |mock|
       mock.expect :list_collection_ids, list_collection_resp, list_collection_args
@@ -354,6 +368,12 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Firestore::DocumentReference::List" do
+    mock_firestore do |mock|
+      mock.expect :list_documents, documents_resp, list_documents_args
+    end
+  end
+
   doctest.before "Google::Cloud::Firestore::DocumentSnapshot" do
     mock_firestore do |mock|
       mock.expect :batch_get_documents, batch_get_resp, batch_get_args
@@ -387,6 +407,11 @@ YARD::Doctest.configure do |doctest|
 end
 
 # Fixture helpers
+
+def paged_enum_struct response
+  OpenStruct.new page: OpenStruct.new(response: response)
+end
+
 def commit_args
   [String, Array, Hash]
 end
@@ -419,12 +444,8 @@ def run_query_resp_obj doc, data
   Google::Firestore::V1::RunQueryResponse.new(
     transaction: "tx123",
     read_time: Google::Cloud::Firestore::Convert.time_to_timestamp(Time.now),
-    document: Google::Firestore::V1::Document.new(
-      name: "projects/my-project-id/databases/(default)/documents/#{doc}",
-      fields: Google::Cloud::Firestore::Convert.hash_to_fields(data),
-      create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(Time.now),
-      update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(Time.now)
-    ))
+    document: document_gapi(doc: doc, fields: Google::Cloud::Firestore::Convert.hash_to_fields(data))
+  )
 end
 
 def run_query_args
@@ -466,14 +487,35 @@ end
 def batch_get_resp_obj doc, data
   Google::Firestore::V1::BatchGetDocumentsResponse.new(
     read_time: Google::Cloud::Firestore::Convert.time_to_timestamp(Time.now),
-    found: Google::Firestore::V1::Document.new(
-      name: "projects/my-project-id/databases/(default)/documents/#{doc}",
-      fields: Google::Cloud::Firestore::Convert.hash_to_fields(data),
-      create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(Time.now),
-      update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(Time.now)
-    ))
+    found: document_gapi(doc: doc, fields: Google::Cloud::Firestore::Convert.hash_to_fields(data))
+  )
 end
 
 def batch_get_args
   [String, Array, Hash]
 end
+
+def list_documents_args
+  [
+    "projects/my-project-id/databases/(default)/documents",
+    "cities",
+    { mask: {field_paths: []}, show_missing: true, page_size: nil, options: nil }
+  ]
+end
+
+def document_gapi doc: "my-document", fields: {}
+  Google::Firestore::V1::Document.new(
+    name: "projects/my-project-id/databases/(default)/documents/#{doc}",
+    fields: fields,
+    create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(Time.now),
+    update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(Time.now)
+  )
+end
+
+def documents_resp token: nil
+  response = Google::Firestore::V1::ListDocumentsResponse.new(
+    documents: [document_gapi]
+  )
+  response.next_page_token = token if token
+  paged_enum_struct response
+end
diff --git a/google-cloud-firestore/synth.metadata b/google-cloud-firestore/synth.metadata
index 2191e22c2..e52e72fce 100644
--- a/google-cloud-firestore/synth.metadata
+++ b/google-cloud-firestore/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-04-23T10:41:05.616192Z",
+  "updateTime": "2019-05-30T00:41:27.484340Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.17.0",
-        "dockerImage": "googleapis/artman@sha256:c58f4ec3838eb4e0718eb1bccc6512bd6850feaa85a360a9e38f6f848ec73bc2"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "547e19e7df398e9290e8e3674d7351efc500f9b0",
-        "internalRef": "244712781"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     }
   ],
diff --git a/google-cloud-firestore/synth.py b/google-cloud-firestore/synth.py
index 0b9413efe..f97b0cab1 100644
--- a/google-cloud-firestore/synth.py
+++ b/google-cloud-firestore/synth.py
@@ -111,3 +111,24 @@ s.replace(
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
 )
+
+# https://github.com/googleapis/google-cloud-ruby/issues/3058
+for version in ['v1', 'v1beta1']:
+    s.replace(
+        f'lib/google/cloud/firestore/{version}/*_client.rb',
+        f'(require \".*credentials\"\n)\n',
+        f'\\1require "google/cloud/firestore/version"\n\n'
+    )
+    s.replace(
+        f'lib/google/cloud/firestore/{version}/*_client.rb',
+        'Gem.loaded_specs\[.*\]\.version\.version',
+        'Google::Cloud::Firestore::VERSION'
+    )
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1', 'v1beta1']:
+    s.replace(
+        f'test/google/cloud/firestore/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )
diff --git a/google-cloud-firestore/test/google/cloud/firestore/client/col_group_test.rb b/google-cloud-firestore/test/google/cloud/firestore/client/col_group_test.rb
new file mode 100644
index 000000000..85f7de3d2
--- /dev/null
+++ b/google-cloud-firestore/test/google/cloud/firestore/client/col_group_test.rb
@@ -0,0 +1,51 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Firestore::Client, :col_group, :mock_firestore do
+  let(:collection_id) { "my-collection-id" }
+  let(:collection_id_bad) { "a/b/my-collection-id" }
+
+  it "creates a collection group query" do
+    query = firestore.col_group(collection_id).where "foo", "==", "bar"
+
+    query.must_be_kind_of Google::Cloud::Firestore::Query
+    query_gapi = query.query
+    query_gapi.must_be_kind_of Google::Firestore::V1::StructuredQuery
+    query_gapi.from.size.must_equal 1
+    query_gapi.from.first.must_be_kind_of Google::Firestore::V1::StructuredQuery::CollectionSelector
+    query_gapi.from.first.all_descendants.must_equal true
+    query_gapi.from.first.collection_id.must_equal collection_id
+  end
+
+  it "creates a collection group query using collection_group alias" do
+    query = firestore.collection_group(collection_id).where "foo", "==", "bar"
+
+    query.must_be_kind_of Google::Cloud::Firestore::Query
+    query_gapi = query.query
+    query_gapi.must_be_kind_of Google::Firestore::V1::StructuredQuery
+    query_gapi.from.size.must_equal 1
+    query_gapi.from.first.must_be_kind_of Google::Firestore::V1::StructuredQuery::CollectionSelector
+    query_gapi.from.first.all_descendants.must_equal true
+    query_gapi.from.first.collection_id.must_equal collection_id
+  end
+
+  it "raises when collection_id contains a forward slash" do
+    error = expect do
+      firestore.col_group collection_id_bad
+    end.must_raise ArgumentError
+    error.message.must_equal "Invalid collection_id: 'a/b/my-collection-id', must not contain '/'."
+  end
+end
diff --git a/google-cloud-firestore/test/google/cloud/firestore/client/transaction_test.rb b/google-cloud-firestore/test/google/cloud/firestore/client/transaction_test.rb
index 5d5e912c9..26910ea30 100644
--- a/google-cloud-firestore/test/google/cloud/firestore/client/transaction_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/client/transaction_test.rb
@@ -190,7 +190,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
     firestore_mock.expect :begin_transaction, begin_tx_resp, [database_path, options_: transaction_opt, options: default_options]
     firestore_mock.expect :commit, write_commit_resp, [database_path, create_writes, transaction: transaction_id, options: default_options]
 
-    resp = firestore.transaction do |tx|
+    resp = firestore.transaction commit_response: true do |tx|
       tx.create(document_path, { name: "Mike" })
     end
 
@@ -203,7 +203,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
     firestore_mock.expect :commit, write_commit_resp, [database_path, create_writes, transaction: transaction_id, options: default_options]
 
     doc = firestore.doc document_path
-    resp = firestore.transaction do |tx|
+    resp = firestore.transaction commit_response: true do |tx|
       tx.create(doc, { name: "Mike" })
     end
 
@@ -224,7 +224,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
     firestore_mock.expect :begin_transaction, begin_tx_resp, [database_path, options_: transaction_opt, options: default_options]
     firestore_mock.expect :commit, write_commit_resp, [database_path, set_writes, transaction: transaction_id, options: default_options]
 
-    resp = firestore.transaction do |tx|
+    resp = firestore.transaction commit_response: true do |tx|
       tx.set(document_path, { name: "Mike" })
     end
 
@@ -237,7 +237,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
     firestore_mock.expect :commit, write_commit_resp, [database_path, set_writes, transaction: transaction_id, options: default_options]
 
     doc = firestore.doc document_path
-    resp = firestore.transaction do |tx|
+    resp = firestore.transaction commit_response: true do |tx|
       tx.set(doc, { name: "Mike" })
     end
 
@@ -258,7 +258,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
     firestore_mock.expect :begin_transaction, begin_tx_resp, [database_path, options_: transaction_opt, options: default_options]
     firestore_mock.expect :commit, write_commit_resp, [database_path, update_writes, transaction: transaction_id, options: default_options]
 
-    resp = firestore.transaction do |tx|
+    resp = firestore.transaction commit_response: true do |tx|
       tx.update(document_path, { name: "Mike" })
     end
 
@@ -271,7 +271,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
     firestore_mock.expect :commit, write_commit_resp, [database_path, update_writes, transaction: transaction_id, options: default_options]
 
     doc = firestore.doc document_path
-    resp = firestore.transaction do |tx|
+    resp = firestore.transaction commit_response: true do |tx|
       tx.update(doc, { name: "Mike" })
     end
 
@@ -292,7 +292,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
     firestore_mock.expect :begin_transaction, begin_tx_resp, [database_path, options_: transaction_opt, options: default_options]
     firestore_mock.expect :commit, write_commit_resp, [database_path, delete_writes, transaction: transaction_id, options: default_options]
 
-    resp = firestore.transaction do |tx|
+    resp = firestore.transaction commit_response: true do |tx|
       tx.delete document_path
     end
 
@@ -305,7 +305,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
     firestore_mock.expect :commit, write_commit_resp, [database_path, delete_writes, transaction: transaction_id, options: default_options]
 
     doc = firestore.doc document_path
-    resp = firestore.transaction do |tx|
+    resp = firestore.transaction commit_response: true do |tx|
       tx.delete doc
     end
 
@@ -313,11 +313,29 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
     resp.commit_time.must_equal commit_time
   end
 
-  it "returns nil when no work is done in the transaction" do
+  it "returns nil when the transaction is empty and commit_response is false or nil" do
+    resp = firestore.transaction do |tx|
+      # no op
+    end
+
+    resp.must_be :nil?
+  end
+
+  it "returns the user-provided return value from the transaction when commit_response is false or nil" do
     resp = firestore.transaction do |tx|
       # no op
+      "my-return-value"
     end
 
+    resp.must_equal "my-return-value"
+  end
+
+  it "returns commit_time nil when no work is done in the transaction with commit_response: true" do
+    resp = firestore.transaction commit_response: true do |tx|
+      "my-return-value"
+    end
+
+    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
     resp.commit_time.must_be :nil?
   end
 
@@ -326,7 +344,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
     firestore_mock.expect :begin_transaction, begin_tx_resp, [database_path, options_: transaction_opt, options: default_options]
     firestore_mock.expect :commit, write_commit_resp, [database_path, all_writes, transaction: transaction_id, options: default_options]
 
-    resp = firestore.transaction do |tx|
+    resp = firestore.transaction commit_response: true do |tx|
       tx.create(document_path, { name: "Mike" })
       tx.set(document_path, { name: "Mike" })
       tx.update(document_path, { name: "Mike" })
@@ -345,7 +363,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
     doc_ref = firestore.doc document_path
     doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
-    resp = firestore.transaction do |tx|
+    resp = firestore.transaction commit_response: true do |tx|
       tx.create(doc_ref, { name: "Mike" })
       tx.set(doc_ref, { name: "Mike" })
       tx.update(doc_ref, { name: "Mike" })
@@ -362,7 +380,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
 
     outside_transaction_obj = nil
 
-    resp = firestore.transaction do |tx|
+    resp = firestore.transaction commit_response: true do |tx|
       tx.wont_be :closed?
       tx.firestore.must_equal firestore
 
diff --git a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/list_documents_test.rb b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/list_documents_test.rb
new file mode 100644
index 000000000..a9df7c3e9
--- /dev/null
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/list_documents_test.rb
@@ -0,0 +1,182 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Firestore::CollectionReference, :list_documents, :mock_firestore do
+  let(:collection_id) { "messages" }
+  let(:collection_path) { "users/mike/#{collection_id}" }
+  let(:collection) { Google::Cloud::Firestore::CollectionReference.from_path "projects/#{project}/databases/(default)/documents/#{collection_path}", firestore }
+
+  it "lists documents" do
+    num_documents = 3
+
+    list_res = OpenStruct.new(page: OpenStruct.new(response: list_documents_gapi(num_documents)))
+
+    firestore_mock.expect :list_documents, list_res, list_documents_args
+
+    documents = collection.list_documents
+
+    firestore_mock.verify
+
+    documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    documents.size.must_equal num_documents
+  end
+
+  it "paginates documents" do
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: list_documents_gapi(3, "next_page_token")))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: list_documents_gapi(2)))
+
+    firestore_mock.expect :list_documents, first_list_res, list_documents_args
+    firestore_mock.expect :list_documents, second_list_res, list_documents_args(options: token_options("next_page_token"))
+
+    first_documents = collection.list_documents
+    second_documents = collection.list_documents token: first_documents.token
+
+    firestore_mock.verify
+
+    first_documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    first_documents.count.must_equal 3
+    first_documents.token.wont_be :nil?
+    first_documents.token.must_equal "next_page_token"
+
+    second_documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    second_documents.count.must_equal 2
+    second_documents.token.must_be :nil?
+  end
+
+  it "paginates documents using next? and next" do
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: list_documents_gapi(3, "next_page_token")))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: list_documents_gapi(2)))
+
+    firestore_mock.expect :list_documents, first_list_res, list_documents_args
+    firestore_mock.expect :list_documents, second_list_res, list_documents_args(options: token_options("next_page_token"))
+
+    first_documents = collection.list_documents
+    second_documents = first_documents.next
+
+    firestore_mock.verify
+
+    first_documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    first_documents.count.must_equal 3
+    first_documents.next?.must_equal true #must_be :next?
+
+    second_documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    second_documents.count.must_equal 2
+    second_documents.next?.must_equal false #wont_be :next?
+  end
+
+  it "paginates documents using all" do
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: list_documents_gapi(3, "next_page_token")))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: list_documents_gapi(2)))
+
+    firestore_mock.expect :list_documents, first_list_res, list_documents_args
+    firestore_mock.expect :list_documents, second_list_res, list_documents_args(options: token_options("next_page_token"))
+
+    all_documents = collection.list_documents.all.to_a
+
+    firestore_mock.verify
+
+    all_documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    all_documents.count.must_equal 5
+  end
+
+  it "paginates documents using all using Enumerator" do
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: list_documents_gapi(3, "next_page_token")))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: list_documents_gapi(3, "second_page_token")))
+
+    firestore_mock.expect :list_documents, first_list_res, list_documents_args
+    firestore_mock.expect :list_documents, second_list_res, list_documents_args(options: token_options("next_page_token"))
+
+    all_documents = collection.list_documents.all.take(5)
+
+    firestore_mock.verify
+
+    all_documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    all_documents.count.must_equal 5
+  end
+
+  it "paginates documents using all with request_limit set" do
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: list_documents_gapi(3, "next_page_token")))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: list_documents_gapi(3, "second_page_token")))
+
+    firestore_mock.expect :list_documents, first_list_res, list_documents_args
+    firestore_mock.expect :list_documents, second_list_res, list_documents_args(options: token_options("next_page_token"))
+
+    all_documents = collection.list_documents.all(request_limit: 1).to_a
+
+    firestore_mock.verify
+
+    all_documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    all_documents.count.must_equal 6
+  end
+
+  it "paginates documents with max set" do
+    list_res = OpenStruct.new(page: OpenStruct.new(response: list_documents_gapi(3, "next_page_token")))
+
+    firestore_mock.expect :list_documents, list_res, list_documents_args(page_size: 3)
+
+    documents = collection.list_documents max: 3
+
+    firestore_mock.verify
+
+    documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    documents.count.must_equal 3
+    documents.token.wont_be :nil?
+    documents.token.must_equal "next_page_token"
+  end
+
+  it "paginates documents without max set" do
+    list_res = OpenStruct.new(page: OpenStruct.new(response: list_documents_gapi(3, "next_page_token")))
+
+    firestore_mock.expect :list_documents, list_res, list_documents_args
+
+    documents = collection.list_documents
+
+    firestore_mock.verify
+
+    documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    documents.count.must_equal 3
+    documents.token.wont_be :nil?
+    documents.token.must_equal "next_page_token"
+  end
+
+  def document_gapi
+    Google::Firestore::V1::Document.new(
+      name: "projects/#{project}/databases/(default)/documents/my-document",
+      fields: {},
+      create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(Time.now),
+      update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(Time.now)
+    )
+  end
+
+  def list_documents_gapi count = 2, token = nil
+    Google::Firestore::V1::ListDocumentsResponse.new(
+      documents: count.times.map { document_gapi },
+      next_page_token: token
+    )
+  end
+
+  def paged_enum_struct response
+    OpenStruct.new page: OpenStruct.new(response: response)
+  end
+
+  def token_options token
+    Google::Gax::CallOptions.new(page_token: token)
+  end
+
+  def list_documents_args page_size: nil, options: nil
+    ["projects/projectID/databases/(default)/documents/users/mike", "messages", {mask: {field_paths: []}, show_missing: true, page_size: page_size, options: options}]
+  end
+end
diff --git a/google-cloud-firestore/test/google/cloud/firestore/v1/firestore_client_test.rb b/google-cloud-firestore/test/google/cloud/firestore/v1/firestore_client_test.rb
index 4fcc3c79f..abeac7516 100644
--- a/google-cloud-firestore/test/google/cloud/firestore/v1/firestore_client_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/v1/firestore_client_test.rb
@@ -130,7 +130,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_document(formatted_name)
           end
 
@@ -206,7 +206,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_documents(formatted_parent, collection_id)
           end
 
@@ -302,7 +302,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_document(
               formatted_parent,
               collection_id,
@@ -385,7 +385,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_document(document, update_mask)
           end
 
@@ -454,7 +454,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_document(formatted_name)
           end
 
@@ -527,7 +527,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.batch_get_documents(formatted_database, documents)
           end
 
@@ -601,7 +601,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.begin_transaction(formatted_database)
           end
 
@@ -684,7 +684,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.commit(formatted_database, writes)
           end
 
@@ -757,7 +757,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.rollback(formatted_database, transaction)
           end
 
@@ -826,7 +826,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.run_query(formatted_parent)
           end
 
@@ -899,7 +899,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.write([request])
           end
 
@@ -970,7 +970,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.listen([request])
           end
 
@@ -1042,7 +1042,7 @@ describe Google::Cloud::Firestore::V1::FirestoreClient do
           client = Google::Cloud::Firestore::V1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_collection_ids(formatted_parent)
           end
 
diff --git a/google-cloud-firestore/test/google/cloud/firestore/v1beta1/firestore_client_test.rb b/google-cloud-firestore/test/google/cloud/firestore/v1beta1/firestore_client_test.rb
index 97fc5ded3..2a396da05 100644
--- a/google-cloud-firestore/test/google/cloud/firestore/v1beta1/firestore_client_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/v1beta1/firestore_client_test.rb
@@ -130,7 +130,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.get_document(formatted_name)
           end
 
@@ -206,7 +206,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.list_documents(formatted_parent, collection_id)
           end
 
@@ -302,7 +302,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.create_document(
               formatted_parent,
               collection_id,
@@ -385,7 +385,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.update_document(document, update_mask)
           end
 
@@ -454,7 +454,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.delete_document(formatted_name)
           end
 
@@ -527,7 +527,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.batch_get_documents(formatted_database, documents)
           end
 
@@ -601,7 +601,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.begin_transaction(formatted_database)
           end
 
@@ -684,7 +684,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.commit(formatted_database, writes)
           end
 
@@ -757,7 +757,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.rollback(formatted_database, transaction)
           end
 
@@ -826,7 +826,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.run_query(formatted_parent)
           end
 
@@ -899,7 +899,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.write([request])
           end
 
@@ -970,7 +970,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.listen([request])
           end
 
@@ -1042,7 +1042,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           client = Google::Cloud::Firestore::V1beta1.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1beta1 do
             client.list_collection_ids(formatted_parent)
           end
 

```

</details>

This pull request was generated using releasetool.