### PR TITLE
Release google-cloud-spanner 1.9.2

### DIFF
--- a/google-cloud-spanner/CHANGELOG.md
+++ b/google-cloud-spanner/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+### 1.9.2 / 2019-06-13
+
+* Update IAM:
+  * Deprecate Policy#version
+  * Add Binding#condition
+  * Add Google::Type::Expr
+  * Update documentation
+* Update retry configuration
+* Use VERSION constant in GAPIC client
+
 ### 1.9.1 / 2019-04-30
 
 * Fix Spanner session limit bug.

--- a/google-cloud-spanner/lib/google/cloud/spanner/version.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Spanner
-      VERSION = "1.9.1".freeze
+      VERSION = "1.9.2".freeze
     end
   end
 end


### PR DESCRIPTION
* Update IAM:
  * Deprecate Policy#version
  * Add Binding#condition
  * Add Google::Type::Expr
  * Update documentation
* Update retry configuration
* Use VERSION constant in GAPIC client

<details><summary>Commits since previous release</summary><pre><code>commit c3f100da4536930396d0816303f696bdfaafddb8
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 11 13:35:45 2019 -0700

    prepare repo-metadata.json for docuploader (#3444)

commit ea562c18e376f461f529bd5b535931af5593e4a1
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 4 10:14:49 2019 -0700

    add version.rb and remove Gem.loaded_specs (#3391)

commit 9d7566152ec7d6ba02c053dda066589e7f641548
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed May 29 20:17:25 2019 -0700

    Fix unit tests to check for both custom and wrapper exception types (#3427)

commit 8b3928fb63b99621d9fcbb165e640f2bc4703103
Author: Mike Moore <mike@blowmage.com>
Date:   Tue May 14 16:05:18 2019 -0600

     Resolve BigDecimal deprecation warnings (#3393)
    
    * Resolve Spanner BigDecimal deprecation warning
    * Resolve Pub/Sub BigDecimal deprecation warning

commit 532afe6ae8d73dd026be29aaf95958e8de29ea21
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Fri May 10 12:49:46 2019 -0700

    Update generated google-cloud-spanner files (#3371)
    
    * Revert error retry configuration.

commit 599d18cefe2c00b12980b4ba1fc5b6f7ecb2db0f
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Wed May 8 10:53:44 2019 -0700

    Update generated google-cloud-spanner files (#3324)
    
    * Update error retry configuration.

commit 499c99b0ab1496a91a4b0d475cb632a9b0722c0f
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Tue May 7 12:46:44 2019 -0700

    Update generated google-cloud-spanner files (#3297)
    
    * Update IAM:
      * Deprecate Policy#version
      * Add Binding#condition
      * Add Google::Type::Expr
      * Update documentation

commit 24fe5aba3e7f46af28fbd85d0ffb4ffda7685177
Author: Yoshi Automation Bot <44816363+yoshi-automation@users.noreply.github.com>
Date:   Mon May 6 08:35:39 2019 -0700

    Update generated google-cloud-spanner files (#3289)
    
    * Update retry configuration.
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-spanner/.repo-metadata.json b/google-cloud-spanner/.repo-metadata.json
new file mode 100644
index 000000000..eb9098bfb
--- /dev/null
+++ b/google-cloud-spanner/.repo-metadata.json
@@ -0,0 +1,5 @@
+{
+    "name": "spanner",
+    "language": "ruby",
+    "distribution_name": "google-cloud-spanner"
+}
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
index 92b8e8124..23880f2a7 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
@@ -29,6 +29,7 @@ require "google/longrunning/operations_client"
 
 require "google/spanner/admin/database/v1/spanner_database_admin_pb"
 require "google/cloud/spanner/admin/database/v1/credentials"
+require "google/cloud/spanner/version"
 
 module Google
   module Cloud
@@ -188,7 +189,7 @@ module Google
                   updater_proc = credentials.updater_proc
                 end
 
-                package_version = Gem.loaded_specs['google-cloud-spanner'].version.version
+                package_version = Google::Cloud::Spanner::VERSION
 
                 google_api_client = "gl-ruby/#{RUBY_VERSION}"
                 google_api_client << " #{lib_name}/#{lib_version}" if lib_name
@@ -645,8 +646,7 @@ module Google
               #
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being specified.
-              #   `resource` is usually specified as a path. For example, a Project
-              #   resource is specified as `projects/{project}`.
+              #   See the operation documentation for the appropriate value for this field.
               # @param policy [Google::Iam::V1::Policy | Hash]
               #   REQUIRED: The complete policy to be applied to the `resource`. The size of
               #   the policy is limited to a few 10s of KB. An empty policy is a
@@ -693,8 +693,7 @@ module Google
               #
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being requested.
-              #   `resource` is usually specified as a path. For example, a Project
-              #   resource is specified as `projects/{project}`.
+              #   See the operation documentation for the appropriate value for this field.
               # @param options [Google::Gax::CallOptions]
               #   Overrides the default settings for this call, e.g, timeout,
               #   retries, etc.
@@ -730,8 +729,7 @@ module Google
               #
               # @param resource [String]
               #   REQUIRED: The resource for which the policy detail is being requested.
-              #   `resource` is usually specified as a path. For example, a Project
-              #   resource is specified as `projects/{project}`.
+              #   See the operation documentation for the appropriate value for this field.
               # @param permissions [Array<String>]
               #   The set of permissions to check for the `resource`. Permissions with
               #   wildcards (such as '*' or 'storage.*') are not allowed. For more
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/iam_policy.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/iam_policy.rb
index 6b1f10d61..d3abef3b1 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/iam_policy.rb
@@ -20,8 +20,7 @@ module Google
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being specified.
-      #     `resource` is usually specified as a path. For example, a Project
-      #     resource is specified as `projects/{project}`.
+      #     See the operation documentation for the appropriate value for this field.
       # @!attribute [rw] policy
       #   @return [Google::Iam::V1::Policy]
       #     REQUIRED: The complete policy to be applied to the `resource`. The size of
@@ -34,16 +33,14 @@ module Google
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
-      #     `resource` is usually specified as a path. For example, a Project
-      #     resource is specified as `projects/{project}`.
+      #     See the operation documentation for the appropriate value for this field.
       class GetIamPolicyRequest; end
 
       # Request message for `TestIamPermissions` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy detail is being requested.
-      #     `resource` is usually specified as a path. For example, a Project
-      #     resource is specified as `projects/{project}`.
+      #     See the operation documentation for the appropriate value for this field.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
       #     The set of permissions to check for the `resource`. Permissions with
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
index bf7194481..8dfa03345 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
@@ -20,12 +20,12 @@ module Google
       # specify access control policies for Cloud Platform resources.
       #
       #
-      # A `Policy` consists of a list of `bindings`. A `Binding` binds a list of
+      # A `Policy` consists of a list of `bindings`. A `binding` binds a list of
       # `members` to a `role`, where the members can be user accounts, Google groups,
       # Google domains, and service accounts. A `role` is a named list of permissions
       # defined by IAM.
       #
-      # **Example**
+      # **JSON Example**
       #
       #     {
       #       "bindings": [
@@ -35,7 +35,7 @@ module Google
       #             "user:mike@example.com",
       #             "group:admins@example.com",
       #             "domain:google.com",
-      #             "serviceAccount:my-other-app@appspot.gserviceaccount.com",
+      #             "serviceAccount:my-other-app@appspot.gserviceaccount.com"
       #           ]
       #         },
       #         {
@@ -45,15 +45,28 @@ module Google
       #       ]
       #     }
       #
-      # For a description of IAM and its features, see the
-      # [IAM developer's guide](https://cloud.google.com/iam).
+      # **YAML Example**
+      #
+      #     bindings:
+      # * members:
+      #   * user:mike@example.com
+      #     * group:admins@example.com
+      #       * domain:google.com
+      #       * serviceAccount:my-other-app@appspot.gserviceaccount.com
+      #         role: roles/owner
+      #       * members:
+      #       * user:sean@example.com
+      #         role: roles/viewer
+      #
+      #
+      #     For a description of IAM and its features, see the
+      #     [IAM developer's guide](https://cloud.google.com/iam/docs).
       # @!attribute [rw] version
       #   @return [Integer]
-      #     Version of the `Policy`. The default version is 0.
+      #     Deprecated.
       # @!attribute [rw] bindings
       #   @return [Array<Google::Iam::V1::Binding>]
       #     Associates a list of `members` to a `role`.
-      #     Multiple `bindings` must not be specified for the same `role`.
       #     `bindings` with no members will result in an error.
       # @!attribute [rw] etag
       #   @return [String]
@@ -74,7 +87,6 @@ module Google
       #   @return [String]
       #     Role that is assigned to `members`.
       #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
-      #     Required
       # @!attribute [rw] members
       #   @return [Array<String>]
       #     Specifies the identities requesting access for a Cloud Platform resource.
@@ -87,7 +99,7 @@ module Google
       #       who is authenticated with a Google account or a service account.
       #
       #     * `user:{emailid}`: An email address that represents a specific Google
-      #       account. For example, `alice@gmail.com` or `joe@example.com`.
+      #       account. For example, `alice@gmail.com` .
       #
       #
       #     * `serviceAccount:{emailid}`: An email address that represents a service
@@ -96,8 +108,15 @@ module Google
       #     * `group:{emailid}`: An email address that represents a Google group.
       #       For example, `admins@example.com`.
       #
-      #     * `domain:{domain}`: A Google Apps domain name that represents all the
+      #
+      #     * `domain:{domain}`: The G Suite domain (primary) that represents all the
       #       users of that domain. For example, `google.com` or `example.com`.
+      # @!attribute [rw] condition
+      #   @return [Google::Type::Expr]
+      #     The condition that is associated with this binding.
+      #     NOTE: An unsatisfied condition will not allow user access via current
+      #     binding. Different bindings, including their conditions, are examined
+      #     independently.
       class Binding; end
     end
   end
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/type/expr.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/type/expr.rb
new file mode 100644
index 000000000..4f1a812bd
--- /dev/null
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/type/expr.rb
@@ -0,0 +1,45 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Type
+    # Represents an expression text. Example:
+    #
+    #     title: "User account presence"
+    #     description: "Determines whether the request has a user account"
+    #     expression: "size(request.user) > 0"
+    # @!attribute [rw] expression
+    #   @return [String]
+    #     Textual representation of an expression in
+    #     Common Expression Language syntax.
+    #
+    #     The application context of the containing message determines which
+    #     well-known feature set of CEL is supported.
+    # @!attribute [rw] title
+    #   @return [String]
+    #     An optional title for the expression, i.e. a short string describing
+    #     its purpose. This can be used e.g. in UIs which allow to enter the
+    #     expression.
+    # @!attribute [rw] description
+    #   @return [String]
+    #     An optional description of the expression. This is a longer text which
+    #     describes the expression, e.g. when hovered over it in a UI.
+    # @!attribute [rw] location
+    #   @return [String]
+    #     An optional string indicating the location of the expression for error
+    #     reporting, e.g. a file name and a position in the file.
+    class Expr; end
+  end
+end
\ No newline at end of file
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/iam_policy.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/iam_policy.rb
index 6b1f10d61..d3abef3b1 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/iam_policy.rb
@@ -20,8 +20,7 @@ module Google
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being specified.
-      #     `resource` is usually specified as a path. For example, a Project
-      #     resource is specified as `projects/{project}`.
+      #     See the operation documentation for the appropriate value for this field.
       # @!attribute [rw] policy
       #   @return [Google::Iam::V1::Policy]
       #     REQUIRED: The complete policy to be applied to the `resource`. The size of
@@ -34,16 +33,14 @@ module Google
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
-      #     `resource` is usually specified as a path. For example, a Project
-      #     resource is specified as `projects/{project}`.
+      #     See the operation documentation for the appropriate value for this field.
       class GetIamPolicyRequest; end
 
       # Request message for `TestIamPermissions` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy detail is being requested.
-      #     `resource` is usually specified as a path. For example, a Project
-      #     resource is specified as `projects/{project}`.
+      #     See the operation documentation for the appropriate value for this field.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
       #     The set of permissions to check for the `resource`. Permissions with
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
index bf7194481..8dfa03345 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
@@ -20,12 +20,12 @@ module Google
       # specify access control policies for Cloud Platform resources.
       #
       #
-      # A `Policy` consists of a list of `bindings`. A `Binding` binds a list of
+      # A `Policy` consists of a list of `bindings`. A `binding` binds a list of
       # `members` to a `role`, where the members can be user accounts, Google groups,
       # Google domains, and service accounts. A `role` is a named list of permissions
       # defined by IAM.
       #
-      # **Example**
+      # **JSON Example**
       #
       #     {
       #       "bindings": [
@@ -35,7 +35,7 @@ module Google
       #             "user:mike@example.com",
       #             "group:admins@example.com",
       #             "domain:google.com",
-      #             "serviceAccount:my-other-app@appspot.gserviceaccount.com",
+      #             "serviceAccount:my-other-app@appspot.gserviceaccount.com"
       #           ]
       #         },
       #         {
@@ -45,15 +45,28 @@ module Google
       #       ]
       #     }
       #
-      # For a description of IAM and its features, see the
-      # [IAM developer's guide](https://cloud.google.com/iam).
+      # **YAML Example**
+      #
+      #     bindings:
+      # * members:
+      #   * user:mike@example.com
+      #     * group:admins@example.com
+      #       * domain:google.com
+      #       * serviceAccount:my-other-app@appspot.gserviceaccount.com
+      #         role: roles/owner
+      #       * members:
+      #       * user:sean@example.com
+      #         role: roles/viewer
+      #
+      #
+      #     For a description of IAM and its features, see the
+      #     [IAM developer's guide](https://cloud.google.com/iam/docs).
       # @!attribute [rw] version
       #   @return [Integer]
-      #     Version of the `Policy`. The default version is 0.
+      #     Deprecated.
       # @!attribute [rw] bindings
       #   @return [Array<Google::Iam::V1::Binding>]
       #     Associates a list of `members` to a `role`.
-      #     Multiple `bindings` must not be specified for the same `role`.
       #     `bindings` with no members will result in an error.
       # @!attribute [rw] etag
       #   @return [String]
@@ -74,7 +87,6 @@ module Google
       #   @return [String]
       #     Role that is assigned to `members`.
       #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
-      #     Required
       # @!attribute [rw] members
       #   @return [Array<String>]
       #     Specifies the identities requesting access for a Cloud Platform resource.
@@ -87,7 +99,7 @@ module Google
       #       who is authenticated with a Google account or a service account.
       #
       #     * `user:{emailid}`: An email address that represents a specific Google
-      #       account. For example, `alice@gmail.com` or `joe@example.com`.
+      #       account. For example, `alice@gmail.com` .
       #
       #
       #     * `serviceAccount:{emailid}`: An email address that represents a service
@@ -96,8 +108,15 @@ module Google
       #     * `group:{emailid}`: An email address that represents a Google group.
       #       For example, `admins@example.com`.
       #
-      #     * `domain:{domain}`: A Google Apps domain name that represents all the
+      #
+      #     * `domain:{domain}`: The G Suite domain (primary) that represents all the
       #       users of that domain. For example, `google.com` or `example.com`.
+      # @!attribute [rw] condition
+      #   @return [Google::Type::Expr]
+      #     The condition that is associated with this binding.
+      #     NOTE: An unsatisfied condition will not allow user access via current
+      #     binding. Different bindings, including their conditions, are examined
+      #     independently.
       class Binding; end
     end
   end
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/type/expr.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/type/expr.rb
new file mode 100644
index 000000000..4f1a812bd
--- /dev/null
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/type/expr.rb
@@ -0,0 +1,45 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Type
+    # Represents an expression text. Example:
+    #
+    #     title: "User account presence"
+    #     description: "Determines whether the request has a user account"
+    #     expression: "size(request.user) > 0"
+    # @!attribute [rw] expression
+    #   @return [String]
+    #     Textual representation of an expression in
+    #     Common Expression Language syntax.
+    #
+    #     The application context of the containing message determines which
+    #     well-known feature set of CEL is supported.
+    # @!attribute [rw] title
+    #   @return [String]
+    #     An optional title for the expression, i.e. a short string describing
+    #     its purpose. This can be used e.g. in UIs which allow to enter the
+    #     expression.
+    # @!attribute [rw] description
+    #   @return [String]
+    #     An optional description of the expression. This is a longer text which
+    #     describes the expression, e.g. when hovered over it in a UI.
+    # @!attribute [rw] location
+    #   @return [String]
+    #     An optional string indicating the location of the expression for error
+    #     reporting, e.g. a file name and a position in the file.
+    class Expr; end
+  end
+end
\ No newline at end of file
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
index 4dab12cd3..99f01e2b0 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
@@ -29,6 +29,7 @@ require "google/longrunning/operations_client"
 
 require "google/spanner/admin/instance/v1/spanner_instance_admin_pb"
 require "google/cloud/spanner/admin/instance/v1/credentials"
+require "google/cloud/spanner/version"
 
 module Google
   module Cloud
@@ -221,7 +222,7 @@ module Google
                   updater_proc = credentials.updater_proc
                 end
 
-                package_version = Gem.loaded_specs['google-cloud-spanner'].version.version
+                package_version = Google::Cloud::Spanner::VERSION
 
                 google_api_client = "gl-ruby/#{RUBY_VERSION}"
                 google_api_client << " #{lib_name}/#{lib_version}" if lib_name
@@ -823,8 +824,7 @@ module Google
               #
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being specified.
-              #   `resource` is usually specified as a path. For example, a Project
-              #   resource is specified as `projects/{project}`.
+              #   See the operation documentation for the appropriate value for this field.
               # @param policy [Google::Iam::V1::Policy | Hash]
               #   REQUIRED: The complete policy to be applied to the `resource`. The size of
               #   the policy is limited to a few 10s of KB. An empty policy is a
@@ -871,8 +871,7 @@ module Google
               #
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being requested.
-              #   `resource` is usually specified as a path. For example, a Project
-              #   resource is specified as `projects/{project}`.
+              #   See the operation documentation for the appropriate value for this field.
               # @param options [Google::Gax::CallOptions]
               #   Overrides the default settings for this call, e.g, timeout,
               #   retries, etc.
@@ -908,8 +907,7 @@ module Google
               #
               # @param resource [String]
               #   REQUIRED: The resource for which the policy detail is being requested.
-              #   `resource` is usually specified as a path. For example, a Project
-              #   resource is specified as `projects/{project}`.
+              #   See the operation documentation for the appropriate value for this field.
               # @param permissions [Array<String>]
               #   The set of permissions to check for the `resource`. Permissions with
               #   wildcards (such as '*' or 'storage.*') are not allowed. For more
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
index 75c41f6fc..046138bfd 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
@@ -27,6 +27,7 @@ require "google/gax"
 
 require "google/spanner/v1/spanner_pb"
 require "google/cloud/spanner/v1/credentials"
+require "google/cloud/spanner/version"
 
 module Google
   module Cloud
@@ -173,7 +174,7 @@ module Google
               updater_proc = credentials.updater_proc
             end
 
-            package_version = Gem.loaded_specs['google-cloud-spanner'].version.version
+            package_version = Google::Cloud::Spanner::VERSION
 
             google_api_client = "gl-ruby/#{RUBY_VERSION}"
             google_api_client << " #{lib_name}/#{lib_version}" if lib_name
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json
index 4b938e13f..b0b56f361 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json
@@ -3,7 +3,6 @@
     "google.spanner.v1.Spanner": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": [],
diff --git a/google-cloud-spanner/synth.metadata b/google-cloud-spanner/synth.metadata
index 35350a949..d761d994d 100644
--- a/google-cloud-spanner/synth.metadata
+++ b/google-cloud-spanner/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-04-23T10:44:16.476603Z",
+  "updateTime": "2019-05-30T00:26:05.978698Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.17.0",
-        "dockerImage": "googleapis/artman@sha256:c58f4ec3838eb4e0718eb1bccc6512bd6850feaa85a360a9e38f6f848ec73bc2"
+        "version": "0.21.0",
+        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "547e19e7df398e9290e8e3674d7351efc500f9b0",
-        "internalRef": "244712781"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     }
   ],
diff --git a/google-cloud-spanner/synth.py b/google-cloud-spanner/synth.py
index 6ce711076..80f8b892f 100644
--- a/google-cloud-spanner/synth.py
+++ b/google-cloud-spanner/synth.py
@@ -163,3 +163,53 @@ s.replace(
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
 )
+
+# https://github.com/googleapis/google-cloud-ruby/issues/3058
+s.replace(
+    'lib/google/cloud/spanner/admin/database/v1/*_admin_client.rb',
+    '(require \".*credentials\"\n)\n',
+    '\\1require "google/cloud/spanner/version"\n\n'
+)
+s.replace(
+    'lib/google/cloud/spanner/admin/database/v1/*_admin_client.rb',
+    'Gem.loaded_specs\[.*\]\.version\.version',
+    'Google::Cloud::Spanner::VERSION'
+)
+s.replace(
+    'lib/google/cloud/spanner/admin/instance/v1/*_admin_client.rb',
+    '(require \".*credentials\"\n)\n',
+    '\\1require "google/cloud/spanner/version"\n\n'
+)
+s.replace(
+    'lib/google/cloud/spanner/admin/instance/v1/*_admin_client.rb',
+    'Gem.loaded_specs\[.*\]\.version\.version',
+    'Google::Cloud::Spanner::VERSION'
+)
+s.replace(
+    'lib/google/cloud/spanner/v1/spanner_client.rb',
+    '(require \".*credentials\"\n)\n',
+    '\\1require "google/cloud/spanner/version"\n\n'
+)
+s.replace(
+    'lib/google/cloud/spanner/v1/spanner_client.rb',
+    'Gem.loaded_specs\[.*\]\.version\.version',
+    'Google::Cloud::Spanner::VERSION'
+)
+
+# Exception tests have to check for both custom errors and retry wrapper errors
+for version in ['v1']:
+    s.replace(
+        f'test/google/cloud/spanner/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )
+    s.replace(
+        f'test/google/cloud/spanner/admin/database/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )
+    s.replace(
+        f'test/google/cloud/spanner/admin/instance/{version}/*_client_test.rb',
+        'err = assert_raises Google::Gax::GaxError do',
+        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
+    )
diff --git a/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb b/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb
index 108cbde86..61d646efc 100644
--- a/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb
@@ -129,7 +129,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_databases(formatted_parent)
           end
 
@@ -248,7 +248,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_database(formatted_parent, create_statement)
           end
 
@@ -322,7 +322,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_database(formatted_name)
           end
 
@@ -440,7 +440,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_database_ddl(formatted_database, statements)
           end
 
@@ -509,7 +509,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.drop_database(formatted_database)
           end
 
@@ -582,7 +582,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_database_ddl(formatted_database)
           end
 
@@ -661,7 +661,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_iam_policy(formatted_resource, policy)
           end
 
@@ -736,7 +736,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_iam_policy(formatted_resource)
           end
 
@@ -813,7 +813,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.test_iam_permissions(formatted_resource, permissions)
           end
 
diff --git a/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb b/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb
index 99447cc61..5dfa1e07d 100644
--- a/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb
@@ -129,7 +129,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_instance_configs(formatted_parent)
           end
 
@@ -204,7 +204,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_instance_config(formatted_name)
           end
 
@@ -276,7 +276,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_instances(formatted_parent)
           end
 
@@ -358,7 +358,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_instance(formatted_name)
           end
 
@@ -499,7 +499,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_instance(
               formatted_parent,
               instance_id,
@@ -630,7 +630,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.update_instance(instance, field_mask)
           end
 
@@ -699,7 +699,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_instance(formatted_name)
           end
 
@@ -778,7 +778,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.set_iam_policy(formatted_resource, policy)
           end
 
@@ -853,7 +853,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_iam_policy(formatted_resource)
           end
 
@@ -930,7 +930,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.test_iam_permissions(formatted_resource, permissions)
           end
 
diff --git a/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb b/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
index ce89baa1d..f6c2c198b 100644
--- a/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
@@ -54,7 +54,7 @@ describe Google::Cloud::Spanner::Convert, :number_to_duration, :mock_spanner do
   end
 
   it "converts a BigDecimal" do
-    number = BigDecimal.new "643383279502884.1971693993751058209749445923078164062"
+    number = BigDecimal "643383279502884.1971693993751058209749445923078164062"
     duration = Google::Cloud::Spanner::Convert.number_to_duration number
     duration.must_be_kind_of Google::Protobuf::Duration
     duration.seconds.must_equal 643383279502884
@@ -62,7 +62,7 @@ describe Google::Cloud::Spanner::Convert, :number_to_duration, :mock_spanner do
   end
 
   it "converts a negative BigDecimal" do
-    number = BigDecimal.new "-643383279502884.1971693993751058209749445923078164062"
+    number = BigDecimal "-643383279502884.1971693993751058209749445923078164062"
     duration = Google::Cloud::Spanner::Convert.number_to_duration number
     duration.must_be_kind_of Google::Protobuf::Duration
     # This should really be -643383279502884, but BigDecimal is doing something here...
diff --git a/google-cloud-spanner/test/google/cloud/spanner/v1/spanner_client_test.rb b/google-cloud-spanner/test/google/cloud/spanner/v1/spanner_client_test.rb
index 23e9f2c1c..3508a8f35 100644
--- a/google-cloud-spanner/test/google/cloud/spanner/v1/spanner_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/v1/spanner_client_test.rb
@@ -130,7 +130,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.create_session(formatted_database)
           end
 
@@ -204,7 +204,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_session(formatted_name)
           end
 
@@ -276,7 +276,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.list_sessions(formatted_database)
           end
 
@@ -345,7 +345,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.delete_session(formatted_name)
           end
 
@@ -422,7 +422,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.execute_sql(formatted_session, sql)
           end
 
@@ -495,7 +495,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.execute_streaming_sql(formatted_session, sql)
           end
 
@@ -596,7 +596,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.execute_batch_dml(
               formatted_session,
               transaction,
@@ -696,7 +696,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.read(
               formatted_session,
               table,
@@ -787,7 +787,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.streaming_read(
               formatted_session,
               table,
@@ -870,7 +870,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.begin_transaction(formatted_session, options_)
           end
 
@@ -953,7 +953,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.commit(formatted_session, mutations)
           end
 
@@ -1026,7 +1026,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.rollback(formatted_session, transaction_id)
           end
 
@@ -1103,7 +1103,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.partition_query(formatted_session, sql)
           end
 
@@ -1192,7 +1192,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          err = assert_raises Google::Gax::GaxError do
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.partition_read(
               formatted_session,
               table,

```

</details>

This pull request was generated using releasetool.