### PR TITLE
Release stackdriver 0.15.4

### DIFF
--- a/stackdriver/CHANGELOG.md
+++ b/stackdriver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.15.4 / 2019-06-13
+
+* Fix Logging example in INSTRUMENTATION_CONFIGURATION.md
+
 ### 0.15.3 / 2018-09-20
 
 * Update documentation.

--- a/stackdriver/lib/stackdriver/version.rb
+++ b/stackdriver/lib/stackdriver/version.rb
@@ -14,5 +14,5 @@
 
 
 module Stackdriver
-  VERSION = "0.15.3".freeze
+  VERSION = "0.15.4".freeze
 end


### PR DESCRIPTION
* Fix Logging example in INSTRUMENTATION_CONFIGURATION.md

<details><summary>Commits since previous release</summary><pre><code>commit c3f100da4536930396d0816303f696bdfaafddb8
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 11 13:35:45 2019 -0700

    prepare repo-metadata.json for docuploader (#3444)

commit 32341c358f71cc832439c0a4710669ad9de5e5bc
Author: Chris Smith <quartzmo@gmail.com>
Date:   Thu Feb 14 11:54:58 2019 -0700

    Update rubocop to 0.64.0 (#2927)
    
    Update rubocop in all gemspecs.
    Update rubocop in synth.py.
    Set TargetRubyVersion: 2.2 in google-cloud-irm/.rubocop.yml and
    google-cloud-talent/.rubocop.yml.

commit 1c12fe5682a67d67cc186371d1d17f12acd99321
Author: Mike Moore <mike@blowmage.com>
Date:   Fri Jan 4 17:07:35 2019 -0700

    Upgrade Rubocop to 0.61 (#2743)

commit bca5849755beba081827495509c3dfca364aaf0c
Author: Chris Smith <quartzmo@gmail.com>
Date:   Thu Dec 13 14:21:34 2018 -0700

    Update .rubocop.yml in all gems (#2721)
    
    Set TargetRubyVersion to 2.2
    
    [fixes #2718]

commit 4fa168fa68ce06bcabbcab5594047a4517f9bc9a
Author: Mike Moore <mike@blowmage.com>
Date:   Wed Dec 12 15:59:53 2018 -0700

    Fix Logging sample code (#2722)
    
    The example configuration was incorrectly using google_cloud.

commit f7a5c442199863759f18259075c13f1e3ee7a672
Author: Chris Smith <quartzmo@gmail.com>
Date:   Tue Oct 16 15:36:19 2018 -0600

    Upgrade Rubocop to 0.59.2 (#2525)
    
    * Update rubocop Lint/RescueWithoutErrorClass to new name.
    * Disable Layout/EmptyLineAfterGuardClause cop where failing
    * Disable Naming/UncommunicativeMethodParamName cop where failing
    * Locally disable MultipleComparison cop where failing
    * Remove blank line from bigtable/instance.rb
    * Fix code alignment in core/config.rb
    * Fix rubocop errors in debugger
    * Fix rubocop errors in spanner
    * Remove require 'thread' statements
    
    [closes #2136]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/stackdriver/.repo-metadata.json b/stackdriver/.repo-metadata.json
new file mode 100644
index 000000000..bcd6c400c
--- /dev/null
+++ b/stackdriver/.repo-metadata.json
@@ -0,0 +1,5 @@
+{
+    "name": "stackdriver",
+    "language": "ruby",
+    "distribution_name": "stackdriver"
+}
diff --git a/stackdriver/.rubocop.yml b/stackdriver/.rubocop.yml
index e5e69c331..fec1ca691 100644
--- a/stackdriver/.rubocop.yml
+++ b/stackdriver/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
     - "Rakefile"
     - "lib/legacy_stackdriver.rb"
     - "test/**/*"
+  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
diff --git a/stackdriver/INSTRUMENTATION_CONFIGURATION.md b/stackdriver/INSTRUMENTATION_CONFIGURATION.md
index e7c1847f2..0e00905db 100644
--- a/stackdriver/INSTRUMENTATION_CONFIGURATION.md
+++ b/stackdriver/INSTRUMENTATION_CONFIGURATION.md
@@ -53,7 +53,7 @@ end
 Google::Cloud::Logging.configure do |config|
   config.project_id = "error-reporting-project"
   config.log_name = "my-app-log"
-  config.google_cloud.labels = {
+  config.labels = {
     "my-static-label" => "static-label-value",
     "my-dynamic-label" => ->(rack_env) { rack_env["HTTP_X_MY_HEADER"] }
   }
diff --git a/stackdriver/stackdriver.gemspec b/stackdriver/stackdriver.gemspec
index 4464c205f..66c300593 100644
--- a/stackdriver/stackdriver.gemspec
+++ b/stackdriver/stackdriver.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.6"

```

</details>

This pull request was generated using releasetool.