### PR TITLE
Explicitly require run_asset_discovery_response_pb in security_center

### DIFF
--- a/google-cloud-security_center/lib/google/cloud/security_center/v1/security_center_client.rb
+++ b/google-cloud-security_center/lib/google/cloud/security_center/v1/security_center_client.rb
@@ -28,6 +28,7 @@ require "google/gax/operation"
 require "google/longrunning/operations_client"
 
 require "google/cloud/security_center/v1/securitycenter_service_pb"
+require "google/cloud/security_center/v1/run_asset_discovery_response_pb"
 require "google/cloud/security_center/v1/credentials"
 require "google/cloud/security_center/version"
 

--- a/google-cloud-security_center/synth.metadata
+++ b/google-cloud-security_center/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-30T00:28:53.080931Z",
+  "updateTime": "2019-06-17T17:55:35.784983Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.21.0",
-        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
+        "version": "0.26.0",
+        "dockerImage": "googleapis/artman@sha256:6db0735b0d3beec5b887153a2a7c7411fc7bb53f73f6f389a822096bd14a3a15"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
-        "internalRef": "250569499"
+        "sha": "7b58b37559f6a5337c4c564518e9573d742df225",
+        "internalRef": "253322136"
       }
     },
     {

--- a/google-cloud-security_center/synth.py
+++ b/google-cloud-security_center/synth.py
@@ -174,3 +174,11 @@ for version in ['v1']:
         'err = assert_raises Google::Gax::GaxError do',
         f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
     )
+
+# Deal with weirdness where RunAssetDiscoveryResponse is defined in a separate
+# file that doesn't get required properly.
+s.replace(
+    'lib/google/cloud/security_center/v1/security_center_client.rb',
+    '\nrequire "google/cloud/security_center/v1/securitycenter_service_pb"\n',
+    '\nrequire "google/cloud/security_center/v1/securitycenter_service_pb"\nrequire "google/cloud/security_center/v1/run_asset_discovery_response_pb"\n'
+)


### PR DESCRIPTION
I think this will solve the flakiness in the security_center tests.

The protos for security_center include a weird orphan proto (`RunAssetDiscoveryResponse`) defined in a separate proto file (`lib/google/cloud/security_center/v1/run_asset_discovery_response_pb`). This file is not required properly at the point where it is needed (in `security_center_client.rb`) with the result that it is possible for a NameError to happen depending on the order in which calls are made and files are required. This PR puts in a synth hack to ensure the file is required at the appropriate place.