### PR TITLE
test(webrisk): add TargetRubyVersion: 2.2 to .rubocop.yml

### DIFF
--- a/google-cloud-webrisk/.rubocop.yml
+++ b/google-cloud-webrisk/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.2
   Exclude:
     - "google-cloud-webrisk.gemspec"
     - "lib/google/**/*"


### PR DESCRIPTION
In Ruby 2.4, this change fixes:

```
Running RuboCop...
Inspecting 1 file
C

Offenses:

Gemfile:1:1: C: Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
source "https://rubygems.org"
^

1 file inspected, 1 offense detected
RuboCop failed!
rake aborted!
```