### PR TITLE
Release google-cloud-kms 1.1.0

### DIFF
--- a/google-cloud-kms/CHANGELOG.md
+++ b/google-cloud-kms/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Release History
 
+### 1.1.0 / 2019-06-17
+
+* KeyManagementServiceClient  changes:
+  * Added methods
+    * create_import_job
+    * get_import_job
+    * list_import_jobs
+    * import_crypto_key_version
+  * Argument changes
+    * Add filter and order_by arguments to:
+      * list_key_rings
+      * list_crypto_keys
+      * list_crypto_key_versions
+    * Add skip_initial_version_creation argument to create_crypto_key
+* CryptoKeyVersion changes:
+  * Add CryptoKeyVersionAlgorithm constants:
+    * RSA_SIGN_PSS_4096_SHA512
+    * RSA_SIGN_PKCS1_4096_SHA512
+    * RSA_DECRYPT_OAEP_4096_SHA512
+  * Add CryptoKeyVersionState constants:
+    * PENDING_IMPORT
+    * IMPORT_FAILED
+* Add import_job_path helper method
+* Update documentation
+
 ### 1.0.2 / 2019-06-11
 
 * Update IAM Policy documentation.

--- a/google-cloud-kms/lib/google/cloud/kms/version.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Kms
-      VERSION = "1.0.2".freeze
+      VERSION = "1.1.0".freeze
     end
   end
 end


### PR DESCRIPTION
* KeyManagementServiceClient  changes:
  * Added methods
    * create_import_job
    * get_import_job
    * list_import_jobs
    * import_crypto_key_version
  * Argument changes
    * Add filter and order_by arguments to:
      * list_key_rings
      * list_crypto_keys
      * list_crypto_key_versions
    * Add skip_initial_version_creation argument to create_crypto_key
* CryptoKeyVersion changes:
  * Add CryptoKeyVersionAlgorithm constants:
    * RSA_SIGN_PSS_4096_SHA512
    * RSA_SIGN_PKCS1_4096_SHA512
    * RSA_DECRYPT_OAEP_4096_SHA512
  * Add CryptoKeyVersionState constants:
    * PENDING_IMPORT
    * IMPORT_FAILED
* Add import_job_path helper method
* Update documentation

<details><summary>Commits since previous release</summary><pre><code>commit 1ba4286d48e517fed0b989bb630ca4b2b1762e72
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jun 17 08:18:48 2019 -0700

    feat(kms): add ImportJob methods
    
    * KeyManagementServiceClient  changes:
      * Added methods
        * create_import_job
        * get_import_job
        * list_import_jobs
        * import_crypto_key_version
      * Argument changes
        * Add filter and order_by arguments to:
          * list_key_rings
          * list_crypto_keys
          * list_crypto_key_versions
        * Add skip_initial_version_creation argument to create_crypto_key
    * CryptoKeyVersion changes:
      * Add CryptoKeyVersionAlgorithm constants:
        * RSA_SIGN_PSS_4096_SHA512
        * RSA_SIGN_PKCS1_4096_SHA512
        * RSA_DECRYPT_OAEP_4096_SHA512
      * Add CryptoKeyVersionState constants:
        * PENDING_IMPORT
        * IMPORT_FAILED
    * Add import_job_path helper method
    * Update documentation.
    
    [pr #3490]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-kms/lib/google/cloud/kms/v1/credentials.rb b/google-cloud-kms/lib/google/cloud/kms/v1/credentials.rb
index 481d441f8..091304cf5 100644
--- a/google-cloud-kms/lib/google/cloud/kms/v1/credentials.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/credentials.rb
@@ -21,7 +21,8 @@ module Google
       module V1
         class Credentials < Google::Auth::Credentials
           SCOPE = [
-            "https://www.googleapis.com/auth/cloud-platform"
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloudkms"
           ].freeze
           PATH_ENV_VARS = %w(KMS_CREDENTIALS
                              KMS_KEYFILE
diff --git a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/cloud/kms/v1/resources.rb b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/cloud/kms/v1/resources.rb
index 6f0436d05..b6169441f 100644
--- a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/cloud/kms/v1/resources.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/cloud/kms/v1/resources.rb
@@ -17,153 +17,125 @@ module Google
   module Cloud
     module Kms
       module V1
-        # A {Google::Cloud::Kms::V1::KeyRing KeyRing} is a toplevel logical grouping of
-        # {Google::Cloud::Kms::V1::CryptoKey CryptoKeys}.
+        # A {Google::Cloud::Kms::V1::KeyRing KeyRing} is a toplevel logical grouping of {Google::Cloud::Kms::V1::CryptoKey CryptoKeys}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Output only. The resource name for the
-        #     {Google::Cloud::Kms::V1::KeyRing KeyRing} in the format
+        #     Output only. The resource name for the {Google::Cloud::Kms::V1::KeyRing KeyRing} in the format
         #     `projects/*/locations/*/keyRings/*`.
         # @!attribute [rw] create_time
         #   @return [Google::Protobuf::Timestamp]
-        #     Output only. The time at which this {Google::Cloud::Kms::V1::KeyRing KeyRing}
-        #     was created.
+        #     Output only. The time at which this {Google::Cloud::Kms::V1::KeyRing KeyRing} was created.
         class KeyRing; end
 
-        # A {Google::Cloud::Kms::V1::CryptoKey CryptoKey} represents a logical key that
-        # can be used for cryptographic operations.
+        # A {Google::Cloud::Kms::V1::CryptoKey CryptoKey} represents a logical key that can be used for cryptographic
+        # operations.
         #
-        # A {Google::Cloud::Kms::V1::CryptoKey CryptoKey} is made up of one or more
-        # {Google::Cloud::Kms::V1::CryptoKeyVersion versions}, which represent the actual
-        # key material used in cryptographic operations.
+        # A {Google::Cloud::Kms::V1::CryptoKey CryptoKey} is made up of one or more {Google::Cloud::Kms::V1::CryptoKeyVersion versions}, which
+        # represent the actual key material used in cryptographic operations.
         # @!attribute [rw] name
         #   @return [String]
-        #     Output only. The resource name for this
-        #     {Google::Cloud::Kms::V1::CryptoKey CryptoKey} in the format
+        #     Output only. The resource name for this {Google::Cloud::Kms::V1::CryptoKey CryptoKey} in the format
         #     `projects/*/locations/*/keyRings/*/cryptoKeys/*`.
         # @!attribute [rw] primary
         #   @return [Google::Cloud::Kms::V1::CryptoKeyVersion]
-        #     Output only. A copy of the "primary"
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} that will be used
-        #     by {Google::Cloud::Kms::V1::KeyManagementService::Encrypt Encrypt} when this
-        #     {Google::Cloud::Kms::V1::CryptoKey CryptoKey} is given in
-        #     {Google::Cloud::Kms::V1::EncryptRequest#name EncryptRequest#name}.
+        #     Output only. A copy of the "primary" {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} that will be used
+        #     by {Google::Cloud::Kms::V1::KeyManagementService::Encrypt Encrypt} when this {Google::Cloud::Kms::V1::CryptoKey CryptoKey} is given
+        #     in {Google::Cloud::Kms::V1::EncryptRequest#name EncryptRequest#name}.
         #
-        #     The {Google::Cloud::Kms::V1::CryptoKey CryptoKey}'s primary version can be
-        #     updated via
+        #     The {Google::Cloud::Kms::V1::CryptoKey CryptoKey}'s primary version can be updated via
         #     {Google::Cloud::Kms::V1::KeyManagementService::UpdateCryptoKeyPrimaryVersion UpdateCryptoKeyPrimaryVersion}.
         #
         #     All keys with {Google::Cloud::Kms::V1::CryptoKey#purpose purpose}
-        #     {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ENCRYPT_DECRYPT ENCRYPT_DECRYPT}
-        #     have a primary. For other keys, this field will be omitted.
+        #     {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ENCRYPT_DECRYPT ENCRYPT_DECRYPT} have a
+        #     primary. For other keys, this field will be omitted.
         # @!attribute [rw] purpose
         #   @return [Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose]
         #     The immutable purpose of this {Google::Cloud::Kms::V1::CryptoKey CryptoKey}.
         # @!attribute [rw] create_time
         #   @return [Google::Protobuf::Timestamp]
-        #     Output only. The time at which this
-        #     {Google::Cloud::Kms::V1::CryptoKey CryptoKey} was created.
+        #     Output only. The time at which this {Google::Cloud::Kms::V1::CryptoKey CryptoKey} was created.
         # @!attribute [rw] next_rotation_time
         #   @return [Google::Protobuf::Timestamp]
-        #     At {Google::Cloud::Kms::V1::CryptoKey#next_rotation_time next_rotation_time},
-        #     the Key Management Service will automatically:
+        #     At {Google::Cloud::Kms::V1::CryptoKey#next_rotation_time next_rotation_time}, the Key Management Service will automatically:
         #
         #     1. Create a new version of this {Google::Cloud::Kms::V1::CryptoKey CryptoKey}.
         #     2. Mark the new version as primary.
         #
         #     Key rotations performed manually via
-        #     {Google::Cloud::Kms::V1::KeyManagementService::CreateCryptoKeyVersion CreateCryptoKeyVersion}
-        #     and
+        #     {Google::Cloud::Kms::V1::KeyManagementService::CreateCryptoKeyVersion CreateCryptoKeyVersion} and
         #     {Google::Cloud::Kms::V1::KeyManagementService::UpdateCryptoKeyPrimaryVersion UpdateCryptoKeyPrimaryVersion}
-        #     do not affect
-        #     {Google::Cloud::Kms::V1::CryptoKey#next_rotation_time next_rotation_time}.
+        #     do not affect {Google::Cloud::Kms::V1::CryptoKey#next_rotation_time next_rotation_time}.
         #
         #     Keys with {Google::Cloud::Kms::V1::CryptoKey#purpose purpose}
-        #     {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ENCRYPT_DECRYPT ENCRYPT_DECRYPT}
-        #     support automatic rotation. For other keys, this field must be omitted.
+        #     {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ENCRYPT_DECRYPT ENCRYPT_DECRYPT} support
+        #     automatic rotation. For other keys, this field must be omitted.
         # @!attribute [rw] rotation_period
         #   @return [Google::Protobuf::Duration]
-        #     {Google::Cloud::Kms::V1::CryptoKey#next_rotation_time next_rotation_time}
-        #     will be advanced by this period when the service automatically rotates a
-        #     key. Must be at least one day.
+        #     {Google::Cloud::Kms::V1::CryptoKey#next_rotation_time next_rotation_time} will be advanced by this period when the service
+        #     automatically rotates a key. Must be at least one day.
         #
-        #     If {Google::Cloud::Kms::V1::CryptoKey#rotation_period rotation_period} is
-        #     set,
-        #     {Google::Cloud::Kms::V1::CryptoKey#next_rotation_time next_rotation_time}
-        #     must also be set.
+        #     If {Google::Cloud::Kms::V1::CryptoKey#rotation_period rotation_period} is set, {Google::Cloud::Kms::V1::CryptoKey#next_rotation_time next_rotation_time} must also be set.
         #
         #     Keys with {Google::Cloud::Kms::V1::CryptoKey#purpose purpose}
-        #     {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ENCRYPT_DECRYPT ENCRYPT_DECRYPT}
-        #     support automatic rotation. For other keys, this field must be omitted.
+        #     {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ENCRYPT_DECRYPT ENCRYPT_DECRYPT} support
+        #     automatic rotation. For other keys, this field must be omitted.
         # @!attribute [rw] version_template
         #   @return [Google::Cloud::Kms::V1::CryptoKeyVersionTemplate]
-        #     A template describing settings for new
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} instances. The
-        #     properties of new {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}
-        #     instances created by either
-        #     {Google::Cloud::Kms::V1::KeyManagementService::CreateCryptoKeyVersion CreateCryptoKeyVersion}
-        #     or auto-rotation are controlled by this template.
+        #     A template describing settings for new {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} instances.
+        #     The properties of new {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} instances created by either
+        #     {Google::Cloud::Kms::V1::KeyManagementService::CreateCryptoKeyVersion CreateCryptoKeyVersion} or
+        #     auto-rotation are controlled by this template.
         # @!attribute [rw] labels
         #   @return [Hash{String => String}]
         #     Labels with user-defined metadata. For more information, see
         #     [Labeling Keys](https://cloud.google.com/kms/docs/labeling-keys).
         class CryptoKey
-          # {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose CryptoKeyPurpose}
-          # describes the cryptographic capabilities of a
-          # {Google::Cloud::Kms::V1::CryptoKey CryptoKey}. A given key can only be used
-          # for the operations allowed by its purpose.
+          # {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose CryptoKeyPurpose} describes the cryptographic capabilities of a
+          # {Google::Cloud::Kms::V1::CryptoKey CryptoKey}. A given key can only be used for the operations allowed by
+          # its purpose. For more information, see
+          # [Key purposes](https://cloud.google.com/kms/docs/algorithms#key_purposes).
           module CryptoKeyPurpose
             # Not specified.
             CRYPTO_KEY_PURPOSE_UNSPECIFIED = 0
 
-            # {Google::Cloud::Kms::V1::CryptoKey CryptoKeys} with this purpose may be used
-            # with {Google::Cloud::Kms::V1::KeyManagementService::Encrypt Encrypt} and
+            # {Google::Cloud::Kms::V1::CryptoKey CryptoKeys} with this purpose may be used with
+            # {Google::Cloud::Kms::V1::KeyManagementService::Encrypt Encrypt} and
             # {Google::Cloud::Kms::V1::KeyManagementService::Decrypt Decrypt}.
             ENCRYPT_DECRYPT = 1
 
-            # {Google::Cloud::Kms::V1::CryptoKey CryptoKeys} with this purpose may be used
-            # with
-            # {Google::Cloud::Kms::V1::KeyManagementService::AsymmetricSign AsymmetricSign}
-            # and
+            # {Google::Cloud::Kms::V1::CryptoKey CryptoKeys} with this purpose may be used with
+            # {Google::Cloud::Kms::V1::KeyManagementService::AsymmetricSign AsymmetricSign} and
             # {Google::Cloud::Kms::V1::KeyManagementService::GetPublicKey GetPublicKey}.
             ASYMMETRIC_SIGN = 5
 
-            # {Google::Cloud::Kms::V1::CryptoKey CryptoKeys} with this purpose may be used
-            # with
-            # {Google::Cloud::Kms::V1::KeyManagementService::AsymmetricDecrypt AsymmetricDecrypt}
-            # and
+            # {Google::Cloud::Kms::V1::CryptoKey CryptoKeys} with this purpose may be used with
+            # {Google::Cloud::Kms::V1::KeyManagementService::AsymmetricDecrypt AsymmetricDecrypt} and
             # {Google::Cloud::Kms::V1::KeyManagementService::GetPublicKey GetPublicKey}.
             ASYMMETRIC_DECRYPT = 6
           end
         end
 
-        # A {Google::Cloud::Kms::V1::CryptoKeyVersionTemplate CryptoKeyVersionTemplate}
-        # specifies the properties to use when creating a new
-        # {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}, either manually
-        # with
-        # {Google::Cloud::Kms::V1::KeyManagementService::CreateCryptoKeyVersion CreateCryptoKeyVersion}
-        # or automatically as a result of auto-rotation.
+        # A {Google::Cloud::Kms::V1::CryptoKeyVersionTemplate CryptoKeyVersionTemplate} specifies the properties to use when creating
+        # a new {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}, either manually with
+        # {Google::Cloud::Kms::V1::KeyManagementService::CreateCryptoKeyVersion CreateCryptoKeyVersion} or
+        # automatically as a result of auto-rotation.
         # @!attribute [rw] protection_level
         #   @return [Google::Cloud::Kms::V1::ProtectionLevel]
-        #     {Google::Cloud::Kms::V1::ProtectionLevel ProtectionLevel} to use when creating
-        #     a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} based on this
-        #     template. Immutable. Defaults to
-        #     {Google::Cloud::Kms::V1::ProtectionLevel::SOFTWARE SOFTWARE}.
+        #     {Google::Cloud::Kms::V1::ProtectionLevel ProtectionLevel} to use when creating a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} based on
+        #     this template. Immutable. Defaults to {Google::Cloud::Kms::V1::ProtectionLevel::SOFTWARE SOFTWARE}.
         # @!attribute [rw] algorithm
         #   @return [Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionAlgorithm]
-        #     Required.
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionAlgorithm Algorithm}
-        #     to use when creating a
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} based on this
-        #     template.
+        #     Required. {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionAlgorithm Algorithm} to use
+        #     when creating a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} based on this template.
         #
         #     For backwards compatibility, GOOGLE_SYMMETRIC_ENCRYPTION is implied if both
-        #     this field is omitted and
-        #     {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose} is
+        #     this field is omitted and {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose} is
         #     {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ENCRYPT_DECRYPT ENCRYPT_DECRYPT}.
         class CryptoKeyVersionTemplate; end
 
-        # Contains an HSM-generated attestation about a key operation.
+        # Contains an HSM-generated attestation about a key operation. For more
+        # information, see [Verifying attestations]
+        # (https://cloud.google.com/kms/docs/attest-key).
         # @!attribute [rw] format
         #   @return [Google::Cloud::Kms::V1::KeyOperationAttestation::AttestationFormat]
         #     Output only. The format of the attestation data.
@@ -172,8 +144,9 @@ module Google
         #     Output only. The attestation data provided by the HSM when the key
         #     operation was performed.
         class KeyOperationAttestation
-          # Attestion formats provided by the HSM.
+          # Attestation formats provided by the HSM.
           module AttestationFormat
+            # Not specified.
             ATTESTATION_FORMAT_UNSPECIFIED = 0
 
             # Cavium HSM attestation compressed with gzip. Note that this format is
@@ -181,84 +154,83 @@ module Google
             CAVIUM_V1_COMPRESSED = 3
 
             # Cavium HSM attestation V2 compressed with gzip. This is a new format
-            # Introduced in Cavium's version 3.2-08
+            # introduced in Cavium's version 3.2-08.
             CAVIUM_V2_COMPRESSED = 4
           end
         end
 
-        # A {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} represents an
-        # individual cryptographic key, and the associated key material.
+        # A {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} represents an individual cryptographic key, and the
+        # associated key material.
         #
-        # An
-        # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::ENABLED ENABLED}
-        # version can be used for cryptographic operations.
+        # An {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::ENABLED ENABLED} version can be
+        # used for cryptographic operations.
         #
         # For security reasons, the raw cryptographic key material represented by a
-        # {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} can never be viewed
-        # or exported. It can only be used to encrypt, decrypt, or sign data when an
-        # authorized user or application invokes Cloud KMS.
+        # {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} can never be viewed or exported. It can only be used to
+        # encrypt, decrypt, or sign data when an authorized user or application invokes
+        # Cloud KMS.
         # @!attribute [rw] name
         #   @return [String]
-        #     Output only. The resource name for this
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} in the format
+        #     Output only. The resource name for this {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} in the format
         #     `projects/*/locations/*/keyRings/*/cryptoKeys/*/cryptoKeyVersions/*`.
         # @!attribute [rw] state
         #   @return [Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState]
-        #     The current state of the
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}.
+        #     The current state of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}.
         # @!attribute [rw] protection_level
         #   @return [Google::Cloud::Kms::V1::ProtectionLevel]
-        #     Output only. The {Google::Cloud::Kms::V1::ProtectionLevel ProtectionLevel}
-        #     describing how crypto operations are performed with this
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}.
+        #     Output only. The {Google::Cloud::Kms::V1::ProtectionLevel ProtectionLevel} describing how crypto operations are
+        #     performed with this {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}.
         # @!attribute [rw] algorithm
         #   @return [Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionAlgorithm]
-        #     Output only. The
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionAlgorithm CryptoKeyVersionAlgorithm}
-        #     that this {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}
-        #     supports.
+        #     Output only. The {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionAlgorithm CryptoKeyVersionAlgorithm} that this
+        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} supports.
         # @!attribute [rw] attestation
         #   @return [Google::Cloud::Kms::V1::KeyOperationAttestation]
         #     Output only. Statement that was generated and signed by the HSM at key
         #     creation time. Use this statement to verify attributes of the key as stored
         #     on the HSM, independently of Google. Only provided for key versions with
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion#protection_level protection_level}
-        #     {Google::Cloud::Kms::V1::ProtectionLevel::HSM HSM}.
+        #     {Google::Cloud::Kms::V1::CryptoKeyVersion#protection_level protection_level} {Google::Cloud::Kms::V1::ProtectionLevel::HSM HSM}.
         # @!attribute [rw] create_time
         #   @return [Google::Protobuf::Timestamp]
-        #     Output only. The time at which this
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} was created.
+        #     Output only. The time at which this {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} was created.
         # @!attribute [rw] generate_time
         #   @return [Google::Protobuf::Timestamp]
-        #     Output only. The time this
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}'s key material was
+        #     Output only. The time this {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}'s key material was
         #     generated.
         # @!attribute [rw] destroy_time
         #   @return [Google::Protobuf::Timestamp]
-        #     Output only. The time this
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}'s key material is
-        #     scheduled for destruction. Only present if
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion#state state} is
+        #     Output only. The time this {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}'s key material is scheduled
+        #     for destruction. Only present if {Google::Cloud::Kms::V1::CryptoKeyVersion#state state} is
         #     {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::DESTROY_SCHEDULED DESTROY_SCHEDULED}.
         # @!attribute [rw] destroy_event_time
         #   @return [Google::Protobuf::Timestamp]
         #     Output only. The time this CryptoKeyVersion's key material was
-        #     destroyed. Only present if
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion#state state} is
+        #     destroyed. Only present if {Google::Cloud::Kms::V1::CryptoKeyVersion#state state} is
         #     {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::DESTROYED DESTROYED}.
+        # @!attribute [rw] import_job
+        #   @return [String]
+        #     Output only. The name of the {Google::Cloud::Kms::V1::ImportJob ImportJob} used to import this
+        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}. Only present if the underlying key material was
+        #     imported.
+        # @!attribute [rw] import_time
+        #   @return [Google::Protobuf::Timestamp]
+        #     Output only. The time at which this {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}'s key material
+        #     was imported.
+        # @!attribute [rw] import_failure_reason
+        #   @return [String]
+        #     Output only. The root cause of an import failure. Only present if
+        #     {Google::Cloud::Kms::V1::CryptoKeyVersion#state state} is
+        #     {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::IMPORT_FAILED IMPORT_FAILED}.
         class CryptoKeyVersion
-          # The algorithm of the
-          # {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}, indicating what
+          # The algorithm of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}, indicating what
           # parameters must be used for each cryptographic operation.
           #
           # The
           # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionAlgorithm::GOOGLE_SYMMETRIC_ENCRYPTION GOOGLE_SYMMETRIC_ENCRYPTION}
-          # algorithm is usable with
-          # {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose}
+          # algorithm is usable with {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose}
           # {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ENCRYPT_DECRYPT ENCRYPT_DECRYPT}.
           #
-          # Algorithms beginning with "RSA_SIGN_" are usable with
-          # {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose}
+          # Algorithms beginning with "RSA_SIGN_" are usable with {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose}
           # {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ASYMMETRIC_SIGN ASYMMETRIC_SIGN}.
           #
           # The fields in the name after "RSA_SIGN_" correspond to the following
@@ -276,12 +248,14 @@ module Google
           # The fields in the name after "RSA_DECRYPT_" correspond to the following
           # parameters: padding algorithm, modulus bit length, and digest algorithm.
           #
-          # Algorithms beginning with "EC_SIGN_" are usable with
-          # {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose}
+          # Algorithms beginning with "EC_SIGN_" are usable with {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose}
           # {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ASYMMETRIC_SIGN ASYMMETRIC_SIGN}.
           #
           # The fields in the name after "EC_SIGN_" correspond to the following
           # parameters: elliptic curve, digest algorithm.
+          #
+          # For more information, see [Key purposes and algorithms]
+          # (https://cloud.google.com/kms/docs/algorithms).
           module CryptoKeyVersionAlgorithm
             # Not specified.
             CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED = 0
@@ -298,6 +272,9 @@ module Google
             # RSASSA-PSS 4096 bit key with a SHA256 digest.
             RSA_SIGN_PSS_4096_SHA256 = 4
 
+            # RSASSA-PSS 4096 bit key with a SHA512 digest.
+            RSA_SIGN_PSS_4096_SHA512 = 15
+
             # RSASSA-PKCS1-v1_5 with a 2048 bit key and a SHA256 digest.
             RSA_SIGN_PKCS1_2048_SHA256 = 5
 
@@ -307,6 +284,9 @@ module Google
             # RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA256 digest.
             RSA_SIGN_PKCS1_4096_SHA256 = 7
 
+            # RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA512 digest.
+            RSA_SIGN_PKCS1_4096_SHA512 = 16
+
             # RSAES-OAEP 2048 bit key with a SHA256 digest.
             RSA_DECRYPT_OAEP_2048_SHA256 = 8
 
@@ -316,6 +296,9 @@ module Google
             # RSAES-OAEP 4096 bit key with a SHA256 digest.
             RSA_DECRYPT_OAEP_4096_SHA256 = 10
 
+            # RSAES-OAEP 4096 bit key with a SHA512 digest.
+            RSA_DECRYPT_OAEP_4096_SHA512 = 17
+
             # ECDSA on the NIST P-256 curve with a SHA256 digest.
             EC_SIGN_P256_SHA256 = 12
 
@@ -323,26 +306,21 @@ module Google
             EC_SIGN_P384_SHA384 = 13
           end
 
-          # The state of a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion},
-          # indicating if it can be used.
+          # The state of a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}, indicating if it can be used.
           module CryptoKeyVersionState
             # Not specified.
             CRYPTO_KEY_VERSION_STATE_UNSPECIFIED = 0
 
             # This version is still being generated. It may not be used, enabled,
             # disabled, or destroyed yet. Cloud KMS will automatically mark this
-            # version
-            # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::ENABLED ENABLED}
-            # as soon as the version is ready.
+            # version {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::ENABLED ENABLED} as soon as the version is ready.
             PENDING_GENERATION = 5
 
             # This version may be used for cryptographic operations.
             ENABLED = 1
 
             # This version may not be used, but the key material is still available,
-            # and the version can be placed back into the
-            # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::ENABLED ENABLED}
-            # state.
+            # and the version can be placed back into the {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::ENABLED ENABLED} state.
             DISABLED = 2
 
             # This version is destroyed, and the key material is no longer stored.
@@ -352,34 +330,37 @@ module Google
             # This version is scheduled for destruction, and will be destroyed soon.
             # Call
             # {Google::Cloud::Kms::V1::KeyManagementService::RestoreCryptoKeyVersion RestoreCryptoKeyVersion}
-            # to put it back into the
-            # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::DISABLED DISABLED}
-            # state.
+            # to put it back into the {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::DISABLED DISABLED} state.
             DESTROY_SCHEDULED = 4
+
+            # This version is still being imported. It may not be used, enabled,
+            # disabled, or destroyed yet. Cloud KMS will automatically mark this
+            # version {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::ENABLED ENABLED} as soon as the version is ready.
+            PENDING_IMPORT = 6
+
+            # This version was not imported successfully. It may not be used, enabled,
+            # disabled, or destroyed. The submitted key material has been discarded.
+            # Additional details can be found in
+            # {Google::Cloud::Kms::V1::CryptoKeyVersion#import_failure_reason CryptoKeyVersion#import_failure_reason}.
+            IMPORT_FAILED = 7
           end
 
-          # A view for {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}s.
-          # Controls the level of detail returned for
-          # {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions} in
-          # {Google::Cloud::Kms::V1::KeyManagementService::ListCryptoKeyVersions KeyManagementService::ListCryptoKeyVersions}
-          # and
+          # A view for {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}s. Controls the level of detail returned
+          # for {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions} in
+          # {Google::Cloud::Kms::V1::KeyManagementService::ListCryptoKeyVersions KeyManagementService::ListCryptoKeyVersions} and
           # {Google::Cloud::Kms::V1::KeyManagementService::ListCryptoKeys KeyManagementService::ListCryptoKeys}.
           module CryptoKeyVersionView
-            # Default view for each
-            # {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}. Does not
-            # include the
-            # {Google::Cloud::Kms::V1::CryptoKeyVersion#attestation attestation} field.
+            # Default view for each {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}. Does not include
+            # the {Google::Cloud::Kms::V1::CryptoKeyVersion#attestation attestation} field.
             CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED = 0
 
-            # Provides all fields in each
-            # {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}, including the
+            # Provides all fields in each {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}, including the
             # {Google::Cloud::Kms::V1::CryptoKeyVersion#attestation attestation}.
             FULL = 1
           end
         end
 
-        # The public key for a given
-        # {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}. Obtained via
+        # The public key for a given {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}. Obtained via
         # {Google::Cloud::Kms::V1::KeyManagementService::GetPublicKey GetPublicKey}.
         # @!attribute [rw] pem
         #   @return [String]
@@ -390,13 +371,141 @@ module Google
         #     (https://tools.ietf.org/html/rfc7468#section-13).
         # @!attribute [rw] algorithm
         #   @return [Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionAlgorithm]
-        #     The
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionAlgorithm Algorithm}
-        #     associated with this key.
+        #     The {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionAlgorithm Algorithm} associated
+        #     with this key.
         class PublicKey; end
 
-        # {Google::Cloud::Kms::V1::ProtectionLevel ProtectionLevel} specifies how
-        # cryptographic operations are performed.
+        # An {Google::Cloud::Kms::V1::ImportJob ImportJob} can be used to create {Google::Cloud::Kms::V1::CryptoKey CryptoKeys} and
+        # {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions} using pre-existing key material,
+        # generated outside of Cloud KMS.
+        #
+        # When an {Google::Cloud::Kms::V1::ImportJob ImportJob} is created, Cloud KMS will generate a "wrapping key",
+        # which is a public/private key pair. You use the wrapping key to encrypt (also
+        # known as wrap) the pre-existing key material to protect it during the import
+        # process. The nature of the wrapping key depends on the choice of
+        # {Google::Cloud::Kms::V1::ImportJob#import_method import_method}. When the wrapping key generation
+        # is complete, the {Google::Cloud::Kms::V1::ImportJob#state state} will be set to
+        # {Google::Cloud::Kms::V1::ImportJob::ImportJobState::ACTIVE ACTIVE} and the {Google::Cloud::Kms::V1::ImportJob#public_key public_key}
+        # can be fetched. The fetched public key can then be used to wrap your
+        # pre-existing key material.
+        #
+        # Once the key material is wrapped, it can be imported into a new
+        # {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} in an existing {Google::Cloud::Kms::V1::CryptoKey CryptoKey} by calling
+        # {Google::Cloud::Kms::V1::KeyManagementService::ImportCryptoKeyVersion ImportCryptoKeyVersion}.
+        # Multiple {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions} can be imported with a single
+        # {Google::Cloud::Kms::V1::ImportJob ImportJob}. Cloud KMS uses the private key portion of the wrapping key to
+        # unwrap the key material. Only Cloud KMS has access to the private key.
+        #
+        # An {Google::Cloud::Kms::V1::ImportJob ImportJob} expires 3 days after it is created. Once expired, Cloud KMS
+        # will no longer be able to import or unwrap any key material that was wrapped
+        # with the {Google::Cloud::Kms::V1::ImportJob ImportJob}'s public key.
+        #
+        # For more information, see
+        # [Importing a key](https://cloud.google.com/kms/docs/importing-a-key).
+        # @!attribute [rw] name
+        #   @return [String]
+        #     Output only. The resource name for this {Google::Cloud::Kms::V1::ImportJob ImportJob} in the format
+        #     `projects/*/locations/*/keyRings/*/importJobs/*`.
+        # @!attribute [rw] import_method
+        #   @return [Google::Cloud::Kms::V1::ImportJob::ImportMethod]
+        #     Required and immutable. The wrapping method to be used for incoming
+        #     key material.
+        # @!attribute [rw] protection_level
+        #   @return [Google::Cloud::Kms::V1::ProtectionLevel]
+        #     Required and immutable. The protection level of the {Google::Cloud::Kms::V1::ImportJob ImportJob}. This
+        #     must match the
+        #     {Google::Cloud::Kms::V1::CryptoKeyVersionTemplate#protection_level protection_level} of the
+        #     {Google::Cloud::Kms::V1::CryptoKey#version_template version_template} on the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} you
+        #     attempt to import into.
+        # @!attribute [rw] create_time
+        #   @return [Google::Protobuf::Timestamp]
+        #     Output only. The time at which this {Google::Cloud::Kms::V1::ImportJob ImportJob} was created.
+        # @!attribute [rw] generate_time
+        #   @return [Google::Protobuf::Timestamp]
+        #     Output only. The time this {Google::Cloud::Kms::V1::ImportJob ImportJob}'s key material was generated.
+        # @!attribute [rw] expire_time
+        #   @return [Google::Protobuf::Timestamp]
+        #     Output only. The time at which this {Google::Cloud::Kms::V1::ImportJob ImportJob} is scheduled for
+        #     expiration and can no longer be used to import key material.
+        # @!attribute [rw] expire_event_time
+        #   @return [Google::Protobuf::Timestamp]
+        #     Output only. The time this {Google::Cloud::Kms::V1::ImportJob ImportJob} expired. Only present if
+        #     {Google::Cloud::Kms::V1::ImportJob#state state} is {Google::Cloud::Kms::V1::ImportJob::ImportJobState::EXPIRED EXPIRED}.
+        # @!attribute [rw] state
+        #   @return [Google::Cloud::Kms::V1::ImportJob::ImportJobState]
+        #     Output only. The current state of the {Google::Cloud::Kms::V1::ImportJob ImportJob}, indicating if it can
+        #     be used.
+        # @!attribute [rw] public_key
+        #   @return [Google::Cloud::Kms::V1::ImportJob::WrappingPublicKey]
+        #     Output only. The public key with which to wrap key material prior to
+        #     import. Only returned if {Google::Cloud::Kms::V1::ImportJob#state state} is
+        #     {Google::Cloud::Kms::V1::ImportJob::ImportJobState::ACTIVE ACTIVE}.
+        # @!attribute [rw] attestation
+        #   @return [Google::Cloud::Kms::V1::KeyOperationAttestation]
+        #     Output only. Statement that was generated and signed by the key creator
+        #     (for example, an HSM) at key creation time. Use this statement to verify
+        #     attributes of the key as stored on the HSM, independently of Google.
+        #     Only present if the chosen {Google::Cloud::Kms::V1::ImportJob::ImportMethod ImportMethod} is one with a protection
+        #     level of {Google::Cloud::Kms::V1::ProtectionLevel::HSM HSM}.
+        class ImportJob
+          # The public key component of the wrapping key. For details of the type of
+          # key this public key corresponds to, see the {Google::Cloud::Kms::V1::ImportJob::ImportMethod ImportMethod}.
+          # @!attribute [rw] pem
+          #   @return [String]
+          #     The public key, encoded in PEM format. For more information, see the [RFC
+          #     7468](https://tools.ietf.org/html/rfc7468) sections for [General
+          #     Considerations](https://tools.ietf.org/html/rfc7468#section-2) and
+          #     [Textual Encoding of Subject Public Key Info]
+          #     (https://tools.ietf.org/html/rfc7468#section-13).
+          class WrappingPublicKey; end
+
+          # The state of the {Google::Cloud::Kms::V1::ImportJob ImportJob}, indicating if it can be used.
+          module ImportJobState
+            # Not specified.
+            IMPORT_JOB_STATE_UNSPECIFIED = 0
+
+            # The wrapping key for this job is still being generated. It may not be
+            # used. Cloud KMS will automatically mark this job as
+            # {Google::Cloud::Kms::V1::ImportJob::ImportJobState::ACTIVE ACTIVE} as soon as the wrapping key is generated.
+            PENDING_GENERATION = 1
+
+            # This job may be used in
+            # {Google::Cloud::Kms::V1::KeyManagementService::CreateCryptoKey CreateCryptoKey} and
+            # {Google::Cloud::Kms::V1::KeyManagementService::CreateCryptoKeyVersion CreateCryptoKeyVersion}
+            # requests.
+            ACTIVE = 2
+
+            # This job can no longer be used and may not leave this state once entered.
+            EXPIRED = 3
+          end
+
+          # {Google::Cloud::Kms::V1::ImportJob::ImportMethod ImportMethod} describes the key wrapping method chosen for this
+          # {Google::Cloud::Kms::V1::ImportJob ImportJob}.
+          module ImportMethod
+            # Not specified.
+            IMPORT_METHOD_UNSPECIFIED = 0
+
+            # This ImportMethod represents the CKM_RSA_AES_KEY_WRAP key wrapping
+            # scheme defined in the PKCS #11 standard. In summary, this involves
+            # wrapping the raw key with an ephemeral AES key, and wrapping the
+            # ephemeral AES key with a 3072 bit RSA key. For more details, see
+            # [RSA AES key wrap
+            # mechanism](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908).
+            RSA_OAEP_3072_SHA1_AES_256 = 1
+
+            # This ImportMethod represents the CKM_RSA_AES_KEY_WRAP key wrapping
+            # scheme defined in the PKCS #11 standard. In summary, this involves
+            # wrapping the raw key with an ephemeral AES key, and wrapping the
+            # ephemeral AES key with a 4096 bit RSA key. For more details, see
+            # [RSA AES key wrap
+            # mechanism](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908).
+            RSA_OAEP_4096_SHA1_AES_256 = 2
+          end
+        end
+
+        # {Google::Cloud::Kms::V1::ProtectionLevel ProtectionLevel} specifies how cryptographic operations are performed.
+        # For more information, see [Protection levels]
+        # (https://cloud.google.com/kms/docs/algorithms#protection_levels).
         module ProtectionLevel
           # Not specified.
           PROTECTION_LEVEL_UNSPECIFIED = 0
diff --git a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/cloud/kms/v1/service.rb b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/cloud/kms/v1/service.rb
index 82b164d0d..b305be9b8 100644
--- a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/cloud/kms/v1/service.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/cloud/kms/v1/service.rb
@@ -17,42 +17,41 @@ module Google
   module Cloud
     module Kms
       module V1
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::ListKeyRings KeyManagementService::ListKeyRings}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::ListKeyRings KeyManagementService::ListKeyRings}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the location associated with the
-        #     {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format
-        #     `projects/*/locations/*`.
+        #     {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format `projects/*/locations/*`.
         # @!attribute [rw] page_size
         #   @return [Integer]
-        #     Optional limit on the number of {Google::Cloud::Kms::V1::KeyRing KeyRings} to
-        #     include in the response.  Further {Google::Cloud::Kms::V1::KeyRing KeyRings}
-        #     can subsequently be obtained by including the
-        #     {Google::Cloud::Kms::V1::ListKeyRingsResponse#next_page_token ListKeyRingsResponse#next_page_token}
-        #     in a subsequent request.  If unspecified, the server will pick an
-        #     appropriate default.
+        #     Optional limit on the number of {Google::Cloud::Kms::V1::KeyRing KeyRings} to include in the
+        #     response.  Further {Google::Cloud::Kms::V1::KeyRing KeyRings} can subsequently be obtained by
+        #     including the {Google::Cloud::Kms::V1::ListKeyRingsResponse#next_page_token ListKeyRingsResponse#next_page_token} in a subsequent
+        #     request.  If unspecified, the server will pick an appropriate default.
         # @!attribute [rw] page_token
         #   @return [String]
         #     Optional pagination token, returned earlier via
         #     {Google::Cloud::Kms::V1::ListKeyRingsResponse#next_page_token ListKeyRingsResponse#next_page_token}.
+        # @!attribute [rw] filter
+        #   @return [String]
+        #     Optional. Only include resources that match the filter in the response.
+        # @!attribute [rw] order_by
+        #   @return [String]
+        #     Optional. Specify how the results should be sorted. If not specified, the
+        #     results will be sorted in the default order.
         class ListKeyRingsRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::ListCryptoKeys KeyManagementService::ListCryptoKeys}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::ListCryptoKeys KeyManagementService::ListCryptoKeys}.
         # @!attribute [rw] parent
         #   @return [String]
-        #     Required. The resource name of the {Google::Cloud::Kms::V1::KeyRing KeyRing}
-        #     to list, in the format `projects/*/locations/*/keyRings/*`.
+        #     Required. The resource name of the {Google::Cloud::Kms::V1::KeyRing KeyRing} to list, in the format
+        #     `projects/*/locations/*/keyRings/*`.
         # @!attribute [rw] page_size
         #   @return [Integer]
-        #     Optional limit on the number of {Google::Cloud::Kms::V1::CryptoKey CryptoKeys}
-        #     to include in the response.  Further
-        #     {Google::Cloud::Kms::V1::CryptoKey CryptoKeys} can subsequently be obtained by
-        #     including the
-        #     {Google::Cloud::Kms::V1::ListCryptoKeysResponse#next_page_token ListCryptoKeysResponse#next_page_token}
-        #     in a subsequent request.  If unspecified, the server will pick an
-        #     appropriate default.
+        #     Optional limit on the number of {Google::Cloud::Kms::V1::CryptoKey CryptoKeys} to include in the
+        #     response.  Further {Google::Cloud::Kms::V1::CryptoKey CryptoKeys} can subsequently be obtained by
+        #     including the {Google::Cloud::Kms::V1::ListCryptoKeysResponse#next_page_token ListCryptoKeysResponse#next_page_token} in a subsequent
+        #     request.  If unspecified, the server will pick an appropriate default.
         # @!attribute [rw] page_token
         #   @return [String]
         #     Optional pagination token, returned earlier via
@@ -60,24 +59,27 @@ module Google
         # @!attribute [rw] version_view
         #   @return [Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionView]
         #     The fields of the primary version to include in the response.
+        # @!attribute [rw] filter
+        #   @return [String]
+        #     Optional. Only include resources that match the filter in the response.
+        # @!attribute [rw] order_by
+        #   @return [String]
+        #     Optional. Specify how the results should be sorted. If not specified, the
+        #     results will be sorted in the default order.
         class ListCryptoKeysRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::ListCryptoKeyVersions KeyManagementService::ListCryptoKeyVersions}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::ListCryptoKeyVersions KeyManagementService::ListCryptoKeyVersions}.
         # @!attribute [rw] parent
         #   @return [String]
-        #     Required. The resource name of the
-        #     {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to list, in the format
+        #     Required. The resource name of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to list, in the format
         #     `projects/*/locations/*/keyRings/*/cryptoKeys/*`.
         # @!attribute [rw] page_size
         #   @return [Integer]
-        #     Optional limit on the number of
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions} to include in the
-        #     response. Further {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions}
-        #     can subsequently be obtained by including the
-        #     {Google::Cloud::Kms::V1::ListCryptoKeyVersionsResponse#next_page_token ListCryptoKeyVersionsResponse#next_page_token}
-        #     in a subsequent request. If unspecified, the server will pick an
-        #     appropriate default.
+        #     Optional limit on the number of {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions} to
+        #     include in the response. Further {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions} can
+        #     subsequently be obtained by including the
+        #     {Google::Cloud::Kms::V1::ListCryptoKeyVersionsResponse#next_page_token ListCryptoKeyVersionsResponse#next_page_token} in a subsequent request.
+        #     If unspecified, the server will pick an appropriate default.
         # @!attribute [rw] page_token
         #   @return [String]
         #     Optional pagination token, returned earlier via
@@ -85,96 +87,129 @@ module Google
         # @!attribute [rw] view
         #   @return [Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionView]
         #     The fields to include in the response.
+        # @!attribute [rw] filter
+        #   @return [String]
+        #     Optional. Only include resources that match the filter in the response.
+        # @!attribute [rw] order_by
+        #   @return [String]
+        #     Optional. Specify how the results should be sorted. If not specified, the
+        #     results will be sorted in the default order.
         class ListCryptoKeyVersionsRequest; end
 
-        # Response message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::ListKeyRings KeyManagementService::ListKeyRings}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::ListImportJobs KeyManagementService::ListImportJobs}.
+        # @!attribute [rw] parent
+        #   @return [String]
+        #     Required. The resource name of the {Google::Cloud::Kms::V1::KeyRing KeyRing} to list, in the format
+        #     `projects/*/locations/*/keyRings/*`.
+        # @!attribute [rw] page_size
+        #   @return [Integer]
+        #     Optional limit on the number of {Google::Cloud::Kms::V1::ImportJob ImportJobs} to include in the
+        #     response. Further {Google::Cloud::Kms::V1::ImportJob ImportJobs} can subsequently be obtained by
+        #     including the {Google::Cloud::Kms::V1::ListImportJobsResponse#next_page_token ListImportJobsResponse#next_page_token} in a subsequent
+        #     request. If unspecified, the server will pick an appropriate default.
+        # @!attribute [rw] page_token
+        #   @return [String]
+        #     Optional pagination token, returned earlier via
+        #     {Google::Cloud::Kms::V1::ListImportJobsResponse#next_page_token ListImportJobsResponse#next_page_token}.
+        # @!attribute [rw] filter
+        #   @return [String]
+        #     Optional. Only include resources that match the filter in the response.
+        # @!attribute [rw] order_by
+        #   @return [String]
+        #     Optional. Specify how the results should be sorted. If not specified, the
+        #     results will be sorted in the default order.
+        class ListImportJobsRequest; end
+
+        # Response message for {Google::Cloud::Kms::V1::KeyManagementService::ListKeyRings KeyManagementService::ListKeyRings}.
         # @!attribute [rw] key_rings
         #   @return [Array<Google::Cloud::Kms::V1::KeyRing>]
         #     The list of {Google::Cloud::Kms::V1::KeyRing KeyRings}.
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     A token to retrieve next page of results. Pass this value in
-        #     {Google::Cloud::Kms::V1::ListKeyRingsRequest#page_token ListKeyRingsRequest#page_token}
-        #     to retrieve the next page of results.
+        #     {Google::Cloud::Kms::V1::ListKeyRingsRequest#page_token ListKeyRingsRequest#page_token} to retrieve the next page of results.
         # @!attribute [rw] total_size
         #   @return [Integer]
-        #     The total number of {Google::Cloud::Kms::V1::KeyRing KeyRings} that matched
-        #     the query.
+        #     The total number of {Google::Cloud::Kms::V1::KeyRing KeyRings} that matched the query.
         class ListKeyRingsResponse; end
 
-        # Response message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::ListCryptoKeys KeyManagementService::ListCryptoKeys}.
+        # Response message for {Google::Cloud::Kms::V1::KeyManagementService::ListCryptoKeys KeyManagementService::ListCryptoKeys}.
         # @!attribute [rw] crypto_keys
         #   @return [Array<Google::Cloud::Kms::V1::CryptoKey>]
         #     The list of {Google::Cloud::Kms::V1::CryptoKey CryptoKeys}.
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     A token to retrieve next page of results. Pass this value in
-        #     {Google::Cloud::Kms::V1::ListCryptoKeysRequest#page_token ListCryptoKeysRequest#page_token}
-        #     to retrieve the next page of results.
+        #     {Google::Cloud::Kms::V1::ListCryptoKeysRequest#page_token ListCryptoKeysRequest#page_token} to retrieve the next page of results.
         # @!attribute [rw] total_size
         #   @return [Integer]
-        #     The total number of {Google::Cloud::Kms::V1::CryptoKey CryptoKeys} that
-        #     matched the query.
+        #     The total number of {Google::Cloud::Kms::V1::CryptoKey CryptoKeys} that matched the query.
         class ListCryptoKeysResponse; end
 
-        # Response message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::ListCryptoKeyVersions KeyManagementService::ListCryptoKeyVersions}.
+        # Response message for {Google::Cloud::Kms::V1::KeyManagementService::ListCryptoKeyVersions KeyManagementService::ListCryptoKeyVersions}.
         # @!attribute [rw] crypto_key_versions
         #   @return [Array<Google::Cloud::Kms::V1::CryptoKeyVersion>]
         #     The list of {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions}.
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     A token to retrieve next page of results. Pass this value in
-        #     {Google::Cloud::Kms::V1::ListCryptoKeyVersionsRequest#page_token ListCryptoKeyVersionsRequest#page_token}
-        #     to retrieve the next page of results.
+        #     {Google::Cloud::Kms::V1::ListCryptoKeyVersionsRequest#page_token ListCryptoKeyVersionsRequest#page_token} to retrieve the next page of
+        #     results.
         # @!attribute [rw] total_size
         #   @return [Integer]
-        #     The total number of
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions} that matched the
+        #     The total number of {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions} that matched the
         #     query.
         class ListCryptoKeyVersionsResponse; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::GetKeyRing KeyManagementService::GetKeyRing}.
+        # Response message for {Google::Cloud::Kms::V1::KeyManagementService::ListImportJobs KeyManagementService::ListImportJobs}.
+        # @!attribute [rw] import_jobs
+        #   @return [Array<Google::Cloud::Kms::V1::ImportJob>]
+        #     The list of {Google::Cloud::Kms::V1::ImportJob ImportJobs}.
+        # @!attribute [rw] next_page_token
+        #   @return [String]
+        #     A token to retrieve next page of results. Pass this value in
+        #     {Google::Cloud::Kms::V1::ListImportJobsRequest#page_token ListImportJobsRequest#page_token} to retrieve the next page of results.
+        # @!attribute [rw] total_size
+        #   @return [Integer]
+        #     The total number of {Google::Cloud::Kms::V1::ImportJob ImportJobs} that matched the query.
+        class ListImportJobsResponse; end
+
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::GetKeyRing KeyManagementService::GetKeyRing}.
         # @!attribute [rw] name
         #   @return [String]
-        #     The {Google::Cloud::Kms::V1::KeyRing#name name} of the
-        #     {Google::Cloud::Kms::V1::KeyRing KeyRing} to get.
+        #     The {Google::Cloud::Kms::V1::KeyRing#name name} of the {Google::Cloud::Kms::V1::KeyRing KeyRing} to get.
         class GetKeyRingRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::GetCryptoKey KeyManagementService::GetCryptoKey}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::GetCryptoKey KeyManagementService::GetCryptoKey}.
         # @!attribute [rw] name
         #   @return [String]
-        #     The {Google::Cloud::Kms::V1::CryptoKey#name name} of the
-        #     {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to get.
+        #     The {Google::Cloud::Kms::V1::CryptoKey#name name} of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to get.
         class GetCryptoKeyRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::GetCryptoKeyVersion KeyManagementService::GetCryptoKeyVersion}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::GetCryptoKeyVersion KeyManagementService::GetCryptoKeyVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     The {Google::Cloud::Kms::V1::CryptoKeyVersion#name name} of the
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to get.
+        #     The {Google::Cloud::Kms::V1::CryptoKeyVersion#name name} of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to get.
         class GetCryptoKeyVersionRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::GetPublicKey KeyManagementService::GetPublicKey}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::GetPublicKey KeyManagementService::GetPublicKey}.
         # @!attribute [rw] name
         #   @return [String]
-        #     The {Google::Cloud::Kms::V1::CryptoKeyVersion#name name} of the
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} public key to get.
+        #     The {Google::Cloud::Kms::V1::CryptoKeyVersion#name name} of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} public key to
+        #     get.
         class GetPublicKeyRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::CreateKeyRing KeyManagementService::CreateKeyRing}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::GetImportJob KeyManagementService::GetImportJob}.
+        # @!attribute [rw] name
+        #   @return [String]
+        #     The {Google::Cloud::Kms::V1::ImportJob#name name} of the {Google::Cloud::Kms::V1::ImportJob ImportJob} to get.
+        class GetImportJobRequest; end
+
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::CreateKeyRing KeyManagementService::CreateKeyRing}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the location associated with the
-        #     {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format
-        #     `projects/*/locations/*`.
+        #     {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format `projects/*/locations/*`.
         # @!attribute [rw] key_ring_id
         #   @return [String]
         #     Required. It must be unique within a location and match the regular
@@ -184,12 +219,11 @@ module Google
         #     A {Google::Cloud::Kms::V1::KeyRing KeyRing} with initial field values.
         class CreateKeyRingRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::CreateCryptoKey KeyManagementService::CreateCryptoKey}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::CreateCryptoKey KeyManagementService::CreateCryptoKey}.
         # @!attribute [rw] parent
         #   @return [String]
-        #     Required. The {Google::Cloud::Kms::V1::KeyRing#name name} of the KeyRing
-        #     associated with the {Google::Cloud::Kms::V1::CryptoKey CryptoKeys}.
+        #     Required. The {Google::Cloud::Kms::V1::KeyRing#name name} of the KeyRing associated with the
+        #     {Google::Cloud::Kms::V1::CryptoKey CryptoKeys}.
         # @!attribute [rw] crypto_key_id
         #   @return [String]
         #     Required. It must be unique within a KeyRing and match the regular
@@ -197,23 +231,77 @@ module Google
         # @!attribute [rw] crypto_key
         #   @return [Google::Cloud::Kms::V1::CryptoKey]
         #     A {Google::Cloud::Kms::V1::CryptoKey CryptoKey} with initial field values.
+        # @!attribute [rw] skip_initial_version_creation
+        #   @return [true, false]
+        #     If set to true, the request will create a {Google::Cloud::Kms::V1::CryptoKey CryptoKey} without any
+        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions}. You must manually call
+        #     {Google::Cloud::Kms::V1::KeyManagementService::CreateCryptoKeyVersion CreateCryptoKeyVersion} or
+        #     {Google::Cloud::Kms::V1::KeyManagementService::ImportCryptoKeyVersion ImportCryptoKeyVersion}
+        #     before you can use this {Google::Cloud::Kms::V1::CryptoKey CryptoKey}.
         class CreateCryptoKeyRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::CreateCryptoKeyVersion KeyManagementService::CreateCryptoKeyVersion}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::CreateCryptoKeyVersion KeyManagementService::CreateCryptoKeyVersion}.
         # @!attribute [rw] parent
         #   @return [String]
-        #     Required. The {Google::Cloud::Kms::V1::CryptoKey#name name} of the
-        #     {Google::Cloud::Kms::V1::CryptoKey CryptoKey} associated with the
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions}.
+        #     Required. The {Google::Cloud::Kms::V1::CryptoKey#name name} of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} associated with
+        #     the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions}.
         # @!attribute [rw] crypto_key_version
         #   @return [Google::Cloud::Kms::V1::CryptoKeyVersion]
-        #     A {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} with initial
-        #     field values.
+        #     A {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} with initial field values.
         class CreateCryptoKeyVersionRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::UpdateCryptoKey KeyManagementService::UpdateCryptoKey}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::ImportCryptoKeyVersion KeyManagementService::ImportCryptoKeyVersion}.
+        # @!attribute [rw] parent
+        #   @return [String]
+        #     Required. The {Google::Cloud::Kms::V1::CryptoKey#name name} of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to
+        #     be imported into.
+        # @!attribute [rw] algorithm
+        #   @return [Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionAlgorithm]
+        #     Required. The {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionAlgorithm algorithm} of
+        #     the key being imported. This does not need to match the
+        #     {Google::Cloud::Kms::V1::CryptoKey#version_template version_template} of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} this
+        #     version imports into.
+        # @!attribute [rw] import_job
+        #   @return [String]
+        #     Required. The {Google::Cloud::Kms::V1::ImportJob#name name} of the {Google::Cloud::Kms::V1::ImportJob ImportJob} that was used to
+        #     wrap this key material.
+        # @!attribute [rw] rsa_aes_wrapped_key
+        #   @return [String]
+        #     Wrapped key material produced with
+        #     {Google::Cloud::Kms::V1::ImportJob::ImportMethod::RSA_OAEP_3072_SHA1_AES_256 RSA_OAEP_3072_SHA1_AES_256}
+        #     or
+        #     {Google::Cloud::Kms::V1::ImportJob::ImportMethod::RSA_OAEP_4096_SHA1_AES_256 RSA_OAEP_4096_SHA1_AES_256}.
+        #
+        #     This field contains the concatenation of two wrapped keys:
+        #     <ol>
+        #       <li>An ephemeral AES-256 wrapping key wrapped with the
+        #           {Google::Cloud::Kms::V1::ImportJob#public_key public_key} using RSAES-OAEP with SHA-1,
+        #           MGF1 with SHA-1, and an empty label.
+        #       </li>
+        #       <li>The key to be imported, wrapped with the ephemeral AES-256 key
+        #           using AES-KWP (RFC 5649).
+        #       </li>
+        #     </ol>
+        #
+        #     This format is the same as the format produced by PKCS#11 mechanism
+        #     CKM_RSA_AES_KEY_WRAP.
+        class ImportCryptoKeyVersionRequest; end
+
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::CreateImportJob KeyManagementService::CreateImportJob}.
+        # @!attribute [rw] parent
+        #   @return [String]
+        #     Required. The {Google::Cloud::Kms::V1::KeyRing#name name} of the {Google::Cloud::Kms::V1::KeyRing KeyRing} associated with the
+        #     {Google::Cloud::Kms::V1::ImportJob ImportJobs}.
+        # @!attribute [rw] import_job_id
+        #   @return [String]
+        #     Required. It must be unique within a KeyRing and match the regular
+        #     expression `[a-zA-Z0-9_-]{1,63}`
+        # @!attribute [rw] import_job
+        #   @return [Google::Cloud::Kms::V1::ImportJob]
+        #     Required. An {Google::Cloud::Kms::V1::ImportJob ImportJob} with initial field values.
+        class CreateImportJobRequest; end
+
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::UpdateCryptoKey KeyManagementService::UpdateCryptoKey}.
         # @!attribute [rw] crypto_key
         #   @return [Google::Cloud::Kms::V1::CryptoKey]
         #     {Google::Cloud::Kms::V1::CryptoKey CryptoKey} with updated values.
@@ -222,61 +310,51 @@ module Google
         #     Required list of fields to be updated in this request.
         class UpdateCryptoKeyRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::UpdateCryptoKeyVersion KeyManagementService::UpdateCryptoKeyVersion}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::UpdateCryptoKeyVersion KeyManagementService::UpdateCryptoKeyVersion}.
         # @!attribute [rw] crypto_key_version
         #   @return [Google::Cloud::Kms::V1::CryptoKeyVersion]
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} with updated
-        #     values.
+        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} with updated values.
         # @!attribute [rw] update_mask
         #   @return [Google::Protobuf::FieldMask]
         #     Required list of fields to be updated in this request.
         class UpdateCryptoKeyVersionRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::Encrypt KeyManagementService::Encrypt}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::Encrypt KeyManagementService::Encrypt}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the
-        #     {Google::Cloud::Kms::V1::CryptoKey CryptoKey} or
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use for
-        #     encryption.
+        #     Required. The resource name of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} or {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}
+        #     to use for encryption.
         #
-        #     If a {Google::Cloud::Kms::V1::CryptoKey CryptoKey} is specified, the server
-        #     will use its {Google::Cloud::Kms::V1::CryptoKey#primary primary version}.
+        #     If a {Google::Cloud::Kms::V1::CryptoKey CryptoKey} is specified, the server will use its
+        #     {Google::Cloud::Kms::V1::CryptoKey#primary primary version}.
         # @!attribute [rw] plaintext
         #   @return [String]
         #     Required. The data to encrypt. Must be no larger than 64KiB.
         #
         #     The maximum size depends on the key version's
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersionTemplate#protection_level protection_level}.
-        #     For {Google::Cloud::Kms::V1::ProtectionLevel::SOFTWARE SOFTWARE} keys, the
-        #     plaintext must be no larger than 64KiB. For
-        #     {Google::Cloud::Kms::V1::ProtectionLevel::HSM HSM} keys, the combined length of
-        #     the plaintext and additional_authenticated_data fields must be no larger
-        #     than 8KiB.
+        #     {Google::Cloud::Kms::V1::CryptoKeyVersionTemplate#protection_level protection_level}. For
+        #     {Google::Cloud::Kms::V1::ProtectionLevel::SOFTWARE SOFTWARE} keys, the plaintext must be no larger
+        #     than 64KiB. For {Google::Cloud::Kms::V1::ProtectionLevel::HSM HSM} keys, the combined length of the
+        #     plaintext and additional_authenticated_data fields must be no larger than
+        #     8KiB.
         # @!attribute [rw] additional_authenticated_data
         #   @return [String]
         #     Optional data that, if specified, must also be provided during decryption
-        #     through
-        #     {Google::Cloud::Kms::V1::DecryptRequest#additional_authenticated_data DecryptRequest#additional_authenticated_data}.
+        #     through {Google::Cloud::Kms::V1::DecryptRequest#additional_authenticated_data DecryptRequest#additional_authenticated_data}.
         #
         #     The maximum size depends on the key version's
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersionTemplate#protection_level protection_level}.
-        #     For {Google::Cloud::Kms::V1::ProtectionLevel::SOFTWARE SOFTWARE} keys, the AAD
-        #     must be no larger than 64KiB. For
-        #     {Google::Cloud::Kms::V1::ProtectionLevel::HSM HSM} keys, the combined length of
-        #     the plaintext and additional_authenticated_data fields must be no larger
-        #     than 8KiB.
+        #     {Google::Cloud::Kms::V1::CryptoKeyVersionTemplate#protection_level protection_level}. For
+        #     {Google::Cloud::Kms::V1::ProtectionLevel::SOFTWARE SOFTWARE} keys, the AAD must be no larger than
+        #     64KiB. For {Google::Cloud::Kms::V1::ProtectionLevel::HSM HSM} keys, the combined length of the
+        #     plaintext and additional_authenticated_data fields must be no larger than
+        #     8KiB.
         class EncryptRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::Decrypt KeyManagementService::Decrypt}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::Decrypt KeyManagementService::Decrypt}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the
-        #     {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to use for decryption. The
-        #     server will choose the appropriate version.
+        #     Required. The resource name of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to use for decryption.
+        #     The server will choose the appropriate version.
         # @!attribute [rw] ciphertext
         #   @return [String]
         #     Required. The encrypted data originally returned in
@@ -287,13 +365,10 @@ module Google
         #     {Google::Cloud::Kms::V1::EncryptRequest#additional_authenticated_data EncryptRequest#additional_authenticated_data}.
         class DecryptRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::AsymmetricSign KeyManagementService::AsymmetricSign}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::AsymmetricSign KeyManagementService::AsymmetricSign}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use for
-        #     signing.
+        #     Required. The resource name of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use for signing.
         # @!attribute [rw] digest
         #   @return [Google::Cloud::Kms::V1::Digest]
         #     Required. The digest of the data to sign. The digest must be produced with
@@ -301,80 +376,63 @@ module Google
         #     {Google::Cloud::Kms::V1::CryptoKeyVersion#algorithm algorithm}.
         class AsymmetricSignRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::AsymmetricDecrypt KeyManagementService::AsymmetricDecrypt}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::AsymmetricDecrypt KeyManagementService::AsymmetricDecrypt}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use for
+        #     Required. The resource name of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use for
         #     decryption.
         # @!attribute [rw] ciphertext
         #   @return [String]
-        #     Required. The data encrypted with the named
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}'s public key using
-        #     OAEP.
+        #     Required. The data encrypted with the named {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}'s public
+        #     key using OAEP.
         class AsymmetricDecryptRequest; end
 
-        # Response message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::Decrypt KeyManagementService::Decrypt}.
+        # Response message for {Google::Cloud::Kms::V1::KeyManagementService::Decrypt KeyManagementService::Decrypt}.
         # @!attribute [rw] plaintext
         #   @return [String]
-        #     The decrypted data originally supplied in
-        #     {Google::Cloud::Kms::V1::EncryptRequest#plaintext EncryptRequest#plaintext}.
+        #     The decrypted data originally supplied in {Google::Cloud::Kms::V1::EncryptRequest#plaintext EncryptRequest#plaintext}.
         class DecryptResponse; end
 
-        # Response message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::Encrypt KeyManagementService::Encrypt}.
+        # Response message for {Google::Cloud::Kms::V1::KeyManagementService::Encrypt KeyManagementService::Encrypt}.
         # @!attribute [rw] name
         #   @return [String]
-        #     The resource name of the
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} used in
-        #     encryption.
+        #     The resource name of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} used in encryption.
         # @!attribute [rw] ciphertext
         #   @return [String]
         #     The encrypted data.
         class EncryptResponse; end
 
-        # Response message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::AsymmetricSign KeyManagementService::AsymmetricSign}.
+        # Response message for {Google::Cloud::Kms::V1::KeyManagementService::AsymmetricSign KeyManagementService::AsymmetricSign}.
         # @!attribute [rw] signature
         #   @return [String]
         #     The created signature.
         class AsymmetricSignResponse; end
 
-        # Response message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::AsymmetricDecrypt KeyManagementService::AsymmetricDecrypt}.
+        # Response message for {Google::Cloud::Kms::V1::KeyManagementService::AsymmetricDecrypt KeyManagementService::AsymmetricDecrypt}.
         # @!attribute [rw] plaintext
         #   @return [String]
         #     The decrypted data originally encrypted with the matching public key.
         class AsymmetricDecryptResponse; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::UpdateCryptoKeyPrimaryVersion KeyManagementService::UpdateCryptoKeyPrimaryVersion}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::UpdateCryptoKeyPrimaryVersion KeyManagementService::UpdateCryptoKeyPrimaryVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     The resource name of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to
-        #     update.
+        #     The resource name of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to update.
         # @!attribute [rw] crypto_key_version_id
         #   @return [String]
-        #     The id of the child
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use as primary.
+        #     The id of the child {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use as primary.
         class UpdateCryptoKeyPrimaryVersionRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::DestroyCryptoKeyVersion KeyManagementService::DestroyCryptoKeyVersion}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::DestroyCryptoKeyVersion KeyManagementService::DestroyCryptoKeyVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     The resource name of the
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to destroy.
+        #     The resource name of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to destroy.
         class DestroyCryptoKeyVersionRequest; end
 
-        # Request message for
-        # {Google::Cloud::Kms::V1::KeyManagementService::RestoreCryptoKeyVersion KeyManagementService::RestoreCryptoKeyVersion}.
+        # Request message for {Google::Cloud::Kms::V1::KeyManagementService::RestoreCryptoKeyVersion KeyManagementService::RestoreCryptoKeyVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     The resource name of the
-        #     {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to restore.
+        #     The resource name of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to restore.
         class RestoreCryptoKeyVersionRequest; end
 
         # A {Google::Cloud::Kms::V1::Digest Digest} holds a cryptographic message digest.
@@ -389,14 +447,12 @@ module Google
         #     A message digest produced with the SHA-512 algorithm.
         class Digest; end
 
-        # Cloud KMS metadata for the given
-        # {Google::Cloud::Location::Location}.
+        # Cloud KMS metadata for the given {Google::Cloud::Location::Location}.
         # @!attribute [rw] hsm_available
         #   @return [true, false]
         #     Indicates whether {Google::Cloud::Kms::V1::CryptoKey CryptoKeys} with
         #     {Google::Cloud::Kms::V1::CryptoKeyVersionTemplate#protection_level protection_level}
-        #     {Google::Cloud::Kms::V1::ProtectionLevel::HSM HSM} can be created in this
-        #     location.
+        #     {Google::Cloud::Kms::V1::ProtectionLevel::HSM HSM} can be created in this location.
         class LocationMetadata; end
       end
     end
diff --git a/google-cloud-kms/lib/google/cloud/kms/v1/helpers.rb b/google-cloud-kms/lib/google/cloud/kms/v1/helpers.rb
index c176e4feb..7bf3262b6 100644
--- a/google-cloud-kms/lib/google/cloud/kms/v1/helpers.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/helpers.rb
@@ -47,6 +47,16 @@
             self.class.crypto_key_version_path project, location, key_ring, crypto_key, crypto_key_version
           end
           
+          # Alias for Google::Cloud::Kms::V1::KeyManagementServiceClient.import_job_path.
+          # @param project [String]
+          # @param location [String]
+          # @param key_ring [String]
+          # @param import_job [String]
+          # @return [String]
+          def import_job_path project, location, key_ring, import_job
+            self.class.import_job_path project, location, key_ring, import_job
+          end
+          
           # Alias for Google::Cloud::Kms::V1::KeyManagementServiceClient.key_ring_path.
           # @param project [String]
           # @param location [String]
diff --git a/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client.rb b/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client.rb
index f278a06ab..3db4a5ac8 100644
--- a/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client.rb
@@ -70,6 +70,10 @@ module Google
               "page_token",
               "next_page_token",
               "key_rings"),
+            "list_import_jobs" => Google::Gax::PageDescriptor.new(
+              "page_token",
+              "next_page_token",
+              "import_jobs"),
             "list_crypto_keys" => Google::Gax::PageDescriptor.new(
               "page_token",
               "next_page_token",
@@ -85,7 +89,8 @@ module Google
           # The scopes needed to make gRPC calls to all of the methods defined in
           # this service.
           ALL_SCOPES = [
-            "https://www.googleapis.com/auth/cloud-platform"
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloudkms"
           ].freeze
 
 
@@ -107,6 +112,12 @@ module Google
 
           private_constant :CRYPTO_KEY_VERSION_PATH_TEMPLATE
 
+          IMPORT_JOB_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+            "projects/{project}/locations/{location}/keyRings/{key_ring}/importJobs/{import_job}"
+          )
+
+          private_constant :IMPORT_JOB_PATH_TEMPLATE
+
           KEY_RING_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
             "projects/{project}/locations/{location}/keyRings/{key_ring}"
           )
@@ -166,6 +177,21 @@ module Google
             )
           end
 
+          # Returns a fully-qualified import_job resource name string.
+          # @param project [String]
+          # @param location [String]
+          # @param key_ring [String]
+          # @param import_job [String]
+          # @return [String]
+          def self.import_job_path project, location, key_ring, import_job
+            IMPORT_JOB_PATH_TEMPLATE.render(
+              :"project" => project,
+              :"location" => location,
+              :"key_ring" => key_ring,
+              :"import_job" => import_job
+            )
+          end
+
           # Returns a fully-qualified key_ring resource name string.
           # @param project [String]
           # @param location [String]
@@ -312,6 +338,14 @@ module Google
                 {'parent' => request.parent}
               end
             )
+            @list_import_jobs = Google::Gax.create_api_call(
+              @key_management_service_stub.method(:list_import_jobs),
+              defaults["list_import_jobs"],
+              exception_transformer: exception_transformer,
+              params_extractor: proc do |request|
+                {'parent' => request.parent}
+              end
+            )
             @list_crypto_keys = Google::Gax.create_api_call(
               @key_management_service_stub.method(:list_crypto_keys),
               defaults["list_crypto_keys"],
@@ -336,6 +370,14 @@ module Google
                 {'name' => request.name}
               end
             )
+            @get_import_job = Google::Gax.create_api_call(
+              @key_management_service_stub.method(:get_import_job),
+              defaults["get_import_job"],
+              exception_transformer: exception_transformer,
+              params_extractor: proc do |request|
+                {'name' => request.name}
+              end
+            )
             @get_crypto_key = Google::Gax.create_api_call(
               @key_management_service_stub.method(:get_crypto_key),
               defaults["get_crypto_key"],
@@ -360,6 +402,14 @@ module Google
                 {'parent' => request.parent}
               end
             )
+            @create_import_job = Google::Gax.create_api_call(
+              @key_management_service_stub.method(:create_import_job),
+              defaults["create_import_job"],
+              exception_transformer: exception_transformer,
+              params_extractor: proc do |request|
+                {'parent' => request.parent}
+              end
+            )
             @create_crypto_key = Google::Gax.create_api_call(
               @key_management_service_stub.method(:create_crypto_key),
               defaults["create_crypto_key"],
@@ -376,6 +426,14 @@ module Google
                 {'parent' => request.parent}
               end
             )
+            @import_crypto_key_version = Google::Gax.create_api_call(
+              @key_management_service_stub.method(:import_crypto_key_version),
+              defaults["import_crypto_key_version"],
+              exception_transformer: exception_transformer,
+              params_extractor: proc do |request|
+                {'parent' => request.parent}
+              end
+            )
             @update_crypto_key = Google::Gax.create_api_call(
               @key_management_service_stub.method(:update_crypto_key),
               defaults["update_crypto_key"],
@@ -488,14 +546,18 @@ module Google
           #
           # @param parent [String]
           #   Required. The resource name of the location associated with the
-          #   {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format
-          #   `projects/*/locations/*`.
+          #   {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format `projects/*/locations/*`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
           #   parameter does not affect the return value. If page streaming is
           #   performed per-page, this determines the maximum number of
           #   resources in a page.
+          # @param filter [String]
+          #   Optional. Only include resources that match the filter in the response.
+          # @param order_by [String]
+          #   Optional. Specify how the results should be sorted. If not specified, the
+          #   results will be sorted in the default order.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -530,21 +592,89 @@ module Google
           def list_key_rings \
               parent,
               page_size: nil,
+              filter: nil,
+              order_by: nil,
               options: nil,
               &block
             req = {
               parent: parent,
-              page_size: page_size
+              page_size: page_size,
+              filter: filter,
+              order_by: order_by
             }.delete_if { |_, v| v.nil? }
             req = Google::Gax::to_proto(req, Google::Cloud::Kms::V1::ListKeyRingsRequest)
             @list_key_rings.call(req, options, &block)
           end
 
+          # Lists {Google::Cloud::Kms::V1::ImportJob ImportJobs}.
+          #
+          # @param parent [String]
+          #   Required. The resource name of the {Google::Cloud::Kms::V1::KeyRing KeyRing} to list, in the format
+          #   `projects/*/locations/*/keyRings/*`.
+          # @param page_size [Integer]
+          #   The maximum number of resources contained in the underlying API
+          #   response. If page streaming is performed per-resource, this
+          #   parameter does not affect the return value. If page streaming is
+          #   performed per-page, this determines the maximum number of
+          #   resources in a page.
+          # @param filter [String]
+          #   Optional. Only include resources that match the filter in the response.
+          # @param order_by [String]
+          #   Optional. Specify how the results should be sorted. If not specified, the
+          #   results will be sorted in the default order.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @yield [result, operation] Access the result along with the RPC operation
+          # @yieldparam result [Google::Gax::PagedEnumerable<Google::Cloud::Kms::V1::ImportJob>]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
+          # @return [Google::Gax::PagedEnumerable<Google::Cloud::Kms::V1::ImportJob>]
+          #   An enumerable of Google::Cloud::Kms::V1::ImportJob instances.
+          #   See Google::Gax::PagedEnumerable documentation for other
+          #   operations such as per-page iteration or access to the response
+          #   object.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/kms"
+          #
+          #   key_management_client = Google::Cloud::Kms.new(version: :v1)
+          #   formatted_parent = Google::Cloud::Kms::V1::KeyManagementServiceClient.key_ring_path("[PROJECT]", "[LOCATION]", "[KEY_RING]")
+          #
+          #   # Iterate over all results.
+          #   key_management_client.list_import_jobs(formatted_parent).each do |element|
+          #     # Process element.
+          #   end
+          #
+          #   # Or iterate over results one page at a time.
+          #   key_management_client.list_import_jobs(formatted_parent).each_page do |page|
+          #     # Process each page at a time.
+          #     page.each do |element|
+          #       # Process element.
+          #     end
+          #   end
+
+          def list_import_jobs \
+              parent,
+              page_size: nil,
+              filter: nil,
+              order_by: nil,
+              options: nil,
+              &block
+            req = {
+              parent: parent,
+              page_size: page_size,
+              filter: filter,
+              order_by: order_by
+            }.delete_if { |_, v| v.nil? }
+            req = Google::Gax::to_proto(req, Google::Cloud::Kms::V1::ListImportJobsRequest)
+            @list_import_jobs.call(req, options, &block)
+          end
+
           # Lists {Google::Cloud::Kms::V1::CryptoKey CryptoKeys}.
           #
           # @param parent [String]
-          #   Required. The resource name of the {Google::Cloud::Kms::V1::KeyRing KeyRing}
-          #   to list, in the format `projects/*/locations/*/keyRings/*`.
+          #   Required. The resource name of the {Google::Cloud::Kms::V1::KeyRing KeyRing} to list, in the format
+          #   `projects/*/locations/*/keyRings/*`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -553,6 +683,11 @@ module Google
           #   resources in a page.
           # @param version_view [Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionView]
           #   The fields of the primary version to include in the response.
+          # @param filter [String]
+          #   Optional. Only include resources that match the filter in the response.
+          # @param order_by [String]
+          #   Optional. Specify how the results should be sorted. If not specified, the
+          #   results will be sorted in the default order.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -588,12 +723,16 @@ module Google
               parent,
               page_size: nil,
               version_view: nil,
+              filter: nil,
+              order_by: nil,
               options: nil,
               &block
             req = {
               parent: parent,
               page_size: page_size,
-              version_view: version_view
+              version_view: version_view,
+              filter: filter,
+              order_by: order_by
             }.delete_if { |_, v| v.nil? }
             req = Google::Gax::to_proto(req, Google::Cloud::Kms::V1::ListCryptoKeysRequest)
             @list_crypto_keys.call(req, options, &block)
@@ -602,8 +741,7 @@ module Google
           # Lists {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions}.
           #
           # @param parent [String]
-          #   Required. The resource name of the
-          #   {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to list, in the format
+          #   Required. The resource name of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to list, in the format
           #   `projects/*/locations/*/keyRings/*/cryptoKeys/*`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
@@ -613,6 +751,11 @@ module Google
           #   resources in a page.
           # @param view [Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionView]
           #   The fields to include in the response.
+          # @param filter [String]
+          #   Optional. Only include resources that match the filter in the response.
+          # @param order_by [String]
+          #   Optional. Specify how the results should be sorted. If not specified, the
+          #   results will be sorted in the default order.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -648,12 +791,16 @@ module Google
               parent,
               page_size: nil,
               view: nil,
+              filter: nil,
+              order_by: nil,
               options: nil,
               &block
             req = {
               parent: parent,
               page_size: page_size,
-              view: view
+              view: view,
+              filter: filter,
+              order_by: order_by
             }.delete_if { |_, v| v.nil? }
             req = Google::Gax::to_proto(req, Google::Cloud::Kms::V1::ListCryptoKeyVersionsRequest)
             @list_crypto_key_versions.call(req, options, &block)
@@ -662,8 +809,7 @@ module Google
           # Returns metadata for a given {Google::Cloud::Kms::V1::KeyRing KeyRing}.
           #
           # @param name [String]
-          #   The {Google::Cloud::Kms::V1::KeyRing#name name} of the
-          #   {Google::Cloud::Kms::V1::KeyRing KeyRing} to get.
+          #   The {Google::Cloud::Kms::V1::KeyRing#name name} of the {Google::Cloud::Kms::V1::KeyRing KeyRing} to get.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -690,13 +836,41 @@ module Google
             @get_key_ring.call(req, options, &block)
           end
 
-          # Returns metadata for a given {Google::Cloud::Kms::V1::CryptoKey CryptoKey}, as
-          # well as its {Google::Cloud::Kms::V1::CryptoKey#primary primary}
-          # {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}.
+          # Returns metadata for a given {Google::Cloud::Kms::V1::ImportJob ImportJob}.
+          #
+          # @param name [String]
+          #   The {Google::Cloud::Kms::V1::ImportJob#name name} of the {Google::Cloud::Kms::V1::ImportJob ImportJob} to get.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @yield [result, operation] Access the result along with the RPC operation
+          # @yieldparam result [Google::Cloud::Kms::V1::ImportJob]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
+          # @return [Google::Cloud::Kms::V1::ImportJob]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/kms"
+          #
+          #   key_management_client = Google::Cloud::Kms.new(version: :v1)
+          #   formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.import_job_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[IMPORT_JOB]")
+          #   response = key_management_client.get_import_job(formatted_name)
+
+          def get_import_job \
+              name,
+              options: nil,
+              &block
+            req = {
+              name: name
+            }.delete_if { |_, v| v.nil? }
+            req = Google::Gax::to_proto(req, Google::Cloud::Kms::V1::GetImportJobRequest)
+            @get_import_job.call(req, options, &block)
+          end
+
+          # Returns metadata for a given {Google::Cloud::Kms::V1::CryptoKey CryptoKey}, as well as its
+          # {Google::Cloud::Kms::V1::CryptoKey#primary primary} {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}.
           #
           # @param name [String]
-          #   The {Google::Cloud::Kms::V1::CryptoKey#name name} of the
-          #   {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to get.
+          #   The {Google::Cloud::Kms::V1::CryptoKey#name name} of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to get.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -723,12 +897,10 @@ module Google
             @get_crypto_key.call(req, options, &block)
           end
 
-          # Returns metadata for a given
-          # {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}.
+          # Returns metadata for a given {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}.
           #
           # @param name [String]
-          #   The {Google::Cloud::Kms::V1::CryptoKeyVersion#name name} of the
-          #   {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to get.
+          #   The {Google::Cloud::Kms::V1::CryptoKeyVersion#name name} of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to get.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -755,13 +927,11 @@ module Google
             @get_crypto_key_version.call(req, options, &block)
           end
 
-          # Create a new {Google::Cloud::Kms::V1::KeyRing KeyRing} in a given Project and
-          # Location.
+          # Create a new {Google::Cloud::Kms::V1::KeyRing KeyRing} in a given Project and Location.
           #
           # @param parent [String]
           #   Required. The resource name of the location associated with the
-          #   {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format
-          #   `projects/*/locations/*`.
+          #   {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format `projects/*/locations/*`.
           # @param key_ring_id [String]
           #   Required. It must be unique within a location and match the regular
           #   expression `[a-zA-Z0-9_-]{1,63}`
@@ -805,16 +975,63 @@ module Google
             @create_key_ring.call(req, options, &block)
           end
 
-          # Create a new {Google::Cloud::Kms::V1::CryptoKey CryptoKey} within a
-          # {Google::Cloud::Kms::V1::KeyRing KeyRing}.
+          # Create a new {Google::Cloud::Kms::V1::ImportJob ImportJob} within a {Google::Cloud::Kms::V1::KeyRing KeyRing}.
+          #
+          # {Google::Cloud::Kms::V1::ImportJob#import_method ImportJob#import_method} is required.
+          #
+          # @param parent [String]
+          #   Required. The {Google::Cloud::Kms::V1::KeyRing#name name} of the {Google::Cloud::Kms::V1::KeyRing KeyRing} associated with the
+          #   {Google::Cloud::Kms::V1::ImportJob ImportJobs}.
+          # @param import_job_id [String]
+          #   Required. It must be unique within a KeyRing and match the regular
+          #   expression `[a-zA-Z0-9_-]{1,63}`
+          # @param import_job [Google::Cloud::Kms::V1::ImportJob | Hash]
+          #   Required. An {Google::Cloud::Kms::V1::ImportJob ImportJob} with initial field values.
+          #   A hash of the same form as `Google::Cloud::Kms::V1::ImportJob`
+          #   can also be provided.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @yield [result, operation] Access the result along with the RPC operation
+          # @yieldparam result [Google::Cloud::Kms::V1::ImportJob]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
+          # @return [Google::Cloud::Kms::V1::ImportJob]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/kms"
+          #
+          #   key_management_client = Google::Cloud::Kms.new(version: :v1)
+          #   formatted_parent = Google::Cloud::Kms::V1::KeyManagementServiceClient.key_ring_path("[PROJECT]", "[LOCATION]", "[KEY_RING]")
+          #   import_job_id = "my-import-job"
+          #   import_method = :RSA_OAEP_3072_SHA1_AES_256
+          #   protection_level = :HSM
+          #   import_job = { import_method: import_method, protection_level: protection_level }
+          #   response = key_management_client.create_import_job(formatted_parent, import_job_id, import_job)
+
+          def create_import_job \
+              parent,
+              import_job_id,
+              import_job,
+              options: nil,
+              &block
+            req = {
+              parent: parent,
+              import_job_id: import_job_id,
+              import_job: import_job
+            }.delete_if { |_, v| v.nil? }
+            req = Google::Gax::to_proto(req, Google::Cloud::Kms::V1::CreateImportJobRequest)
+            @create_import_job.call(req, options, &block)
+          end
+
+          # Create a new {Google::Cloud::Kms::V1::CryptoKey CryptoKey} within a {Google::Cloud::Kms::V1::KeyRing KeyRing}.
           #
           # {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose} and
           # {Google::Cloud::Kms::V1::CryptoKeyVersionTemplate#algorithm CryptoKey#version_template#algorithm}
           # are required.
           #
           # @param parent [String]
-          #   Required. The {Google::Cloud::Kms::V1::KeyRing#name name} of the KeyRing
-          #   associated with the {Google::Cloud::Kms::V1::CryptoKey CryptoKeys}.
+          #   Required. The {Google::Cloud::Kms::V1::KeyRing#name name} of the KeyRing associated with the
+          #   {Google::Cloud::Kms::V1::CryptoKey CryptoKeys}.
           # @param crypto_key_id [String]
           #   Required. It must be unique within a KeyRing and match the regular
           #   expression `[a-zA-Z0-9_-]{1,63}`
@@ -822,6 +1039,12 @@ module Google
           #   A {Google::Cloud::Kms::V1::CryptoKey CryptoKey} with initial field values.
           #   A hash of the same form as `Google::Cloud::Kms::V1::CryptoKey`
           #   can also be provided.
+          # @param skip_initial_version_creation [true, false]
+          #   If set to true, the request will create a {Google::Cloud::Kms::V1::CryptoKey CryptoKey} without any
+          #   {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions}. You must manually call
+          #   {Google::Cloud::Kms::V1::KeyManagementService::CreateCryptoKeyVersion CreateCryptoKeyVersion} or
+          #   {Google::Cloud::Kms::V1::KeyManagementService::ImportCryptoKeyVersion ImportCryptoKeyVersion}
+          #   before you can use this {Google::Cloud::Kms::V1::CryptoKey CryptoKey}.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -852,31 +1075,30 @@ module Google
               parent,
               crypto_key_id,
               crypto_key,
+              skip_initial_version_creation: nil,
               options: nil,
               &block
             req = {
               parent: parent,
               crypto_key_id: crypto_key_id,
-              crypto_key: crypto_key
+              crypto_key: crypto_key,
+              skip_initial_version_creation: skip_initial_version_creation
             }.delete_if { |_, v| v.nil? }
             req = Google::Gax::to_proto(req, Google::Cloud::Kms::V1::CreateCryptoKeyRequest)
             @create_crypto_key.call(req, options, &block)
           end
 
-          # Create a new {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} in a
-          # {Google::Cloud::Kms::V1::CryptoKey CryptoKey}.
+          # Create a new {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} in a {Google::Cloud::Kms::V1::CryptoKey CryptoKey}.
           #
           # The server will assign the next sequential id. If unset,
           # {Google::Cloud::Kms::V1::CryptoKeyVersion#state state} will be set to
           # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::ENABLED ENABLED}.
           #
           # @param parent [String]
-          #   Required. The {Google::Cloud::Kms::V1::CryptoKey#name name} of the
-          #   {Google::Cloud::Kms::V1::CryptoKey CryptoKey} associated with the
-          #   {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions}.
+          #   Required. The {Google::Cloud::Kms::V1::CryptoKey#name name} of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} associated with
+          #   the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions}.
           # @param crypto_key_version [Google::Cloud::Kms::V1::CryptoKeyVersion | Hash]
-          #   A {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} with initial
-          #   field values.
+          #   A {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} with initial field values.
           #   A hash of the same form as `Google::Cloud::Kms::V1::CryptoKeyVersion`
           #   can also be provided.
           # @param options [Google::Gax::CallOptions]
@@ -910,6 +1132,80 @@ module Google
             @create_crypto_key_version.call(req, options, &block)
           end
 
+          # Imports a new {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} into an existing {Google::Cloud::Kms::V1::CryptoKey CryptoKey} using the
+          # wrapped key material provided in the request.
+          #
+          # The version ID will be assigned the next sequential id within the
+          # {Google::Cloud::Kms::V1::CryptoKey CryptoKey}.
+          #
+          # @param parent [String]
+          #   Required. The {Google::Cloud::Kms::V1::CryptoKey#name name} of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to
+          #   be imported into.
+          # @param algorithm [Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionAlgorithm]
+          #   Required. The {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionAlgorithm algorithm} of
+          #   the key being imported. This does not need to match the
+          #   {Google::Cloud::Kms::V1::CryptoKey#version_template version_template} of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} this
+          #   version imports into.
+          # @param import_job [String]
+          #   Required. The {Google::Cloud::Kms::V1::ImportJob#name name} of the {Google::Cloud::Kms::V1::ImportJob ImportJob} that was used to
+          #   wrap this key material.
+          # @param rsa_aes_wrapped_key [String]
+          #   Wrapped key material produced with
+          #   {Google::Cloud::Kms::V1::ImportJob::ImportMethod::RSA_OAEP_3072_SHA1_AES_256 RSA_OAEP_3072_SHA1_AES_256}
+          #   or
+          #   {Google::Cloud::Kms::V1::ImportJob::ImportMethod::RSA_OAEP_4096_SHA1_AES_256 RSA_OAEP_4096_SHA1_AES_256}.
+          #
+          #   This field contains the concatenation of two wrapped keys:
+          #   <ol>
+          #     <li>An ephemeral AES-256 wrapping key wrapped with the
+          #         {Google::Cloud::Kms::V1::ImportJob#public_key public_key} using RSAES-OAEP with SHA-1,
+          #         MGF1 with SHA-1, and an empty label.
+          #     </li>
+          #     <li>The key to be imported, wrapped with the ephemeral AES-256 key
+          #         using AES-KWP (RFC 5649).
+          #     </li>
+          #   </ol>
+          #
+          #   This format is the same as the format produced by PKCS#11 mechanism
+          #   CKM_RSA_AES_KEY_WRAP.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @yield [result, operation] Access the result along with the RPC operation
+          # @yieldparam result [Google::Cloud::Kms::V1::CryptoKeyVersion]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
+          # @return [Google::Cloud::Kms::V1::CryptoKeyVersion]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/kms"
+          #
+          #   key_management_client = Google::Cloud::Kms.new(version: :v1)
+          #   formatted_parent = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
+          #
+          #   # TODO: Initialize `algorithm`:
+          #   algorithm = :CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED
+          #
+          #   # TODO: Initialize `import_job`:
+          #   import_job = ''
+          #   response = key_management_client.import_crypto_key_version(formatted_parent, algorithm, import_job)
+
+          def import_crypto_key_version \
+              parent,
+              algorithm,
+              import_job,
+              rsa_aes_wrapped_key: nil,
+              options: nil,
+              &block
+            req = {
+              parent: parent,
+              algorithm: algorithm,
+              import_job: import_job,
+              rsa_aes_wrapped_key: rsa_aes_wrapped_key
+            }.delete_if { |_, v| v.nil? }
+            req = Google::Gax::to_proto(req, Google::Cloud::Kms::V1::ImportCryptoKeyVersionRequest)
+            @import_crypto_key_version.call(req, options, &block)
+          end
+
           # Update a {Google::Cloud::Kms::V1::CryptoKey CryptoKey}.
           #
           # @param crypto_key [Google::Cloud::Kms::V1::CryptoKey | Hash]
@@ -953,22 +1249,16 @@ module Google
             @update_crypto_key.call(req, options, &block)
           end
 
-          # Update a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}'s
-          # metadata.
+          # Update a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}'s metadata.
           #
           # {Google::Cloud::Kms::V1::CryptoKeyVersion#state state} may be changed between
-          # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::ENABLED ENABLED}
-          # and
-          # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::DISABLED DISABLED}
-          # using this method. See
-          # {Google::Cloud::Kms::V1::KeyManagementService::DestroyCryptoKeyVersion DestroyCryptoKeyVersion}
-          # and
-          # {Google::Cloud::Kms::V1::KeyManagementService::RestoreCryptoKeyVersion RestoreCryptoKeyVersion}
-          # to move between other states.
+          # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::ENABLED ENABLED} and
+          # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::DISABLED DISABLED} using this
+          # method. See {Google::Cloud::Kms::V1::KeyManagementService::DestroyCryptoKeyVersion DestroyCryptoKeyVersion} and {Google::Cloud::Kms::V1::KeyManagementService::RestoreCryptoKeyVersion RestoreCryptoKeyVersion} to
+          # move between other states.
           #
           # @param crypto_key_version [Google::Cloud::Kms::V1::CryptoKeyVersion | Hash]
-          #   {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} with updated
-          #   values.
+          #   {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} with updated values.
           #   A hash of the same form as `Google::Cloud::Kms::V1::CryptoKeyVersion`
           #   can also be provided.
           # @param update_mask [Google::Protobuf::FieldMask | Hash]
@@ -1008,41 +1298,35 @@ module Google
             @update_crypto_key_version.call(req, options, &block)
           end
 
-          # Encrypts data, so that it can only be recovered by a call to
-          # {Google::Cloud::Kms::V1::KeyManagementService::Decrypt Decrypt}. The
-          # {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose} must be
+          # Encrypts data, so that it can only be recovered by a call to {Google::Cloud::Kms::V1::KeyManagementService::Decrypt Decrypt}.
+          # The {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose} must be
           # {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ENCRYPT_DECRYPT ENCRYPT_DECRYPT}.
           #
           # @param name [String]
-          #   Required. The resource name of the
-          #   {Google::Cloud::Kms::V1::CryptoKey CryptoKey} or
-          #   {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use for
-          #   encryption.
+          #   Required. The resource name of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} or {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}
+          #   to use for encryption.
           #
-          #   If a {Google::Cloud::Kms::V1::CryptoKey CryptoKey} is specified, the server
-          #   will use its {Google::Cloud::Kms::V1::CryptoKey#primary primary version}.
+          #   If a {Google::Cloud::Kms::V1::CryptoKey CryptoKey} is specified, the server will use its
+          #   {Google::Cloud::Kms::V1::CryptoKey#primary primary version}.
           # @param plaintext [String]
           #   Required. The data to encrypt. Must be no larger than 64KiB.
           #
           #   The maximum size depends on the key version's
-          #   {Google::Cloud::Kms::V1::CryptoKeyVersionTemplate#protection_level protection_level}.
-          #   For {Google::Cloud::Kms::V1::ProtectionLevel::SOFTWARE SOFTWARE} keys, the
-          #   plaintext must be no larger than 64KiB. For
-          #   {Google::Cloud::Kms::V1::ProtectionLevel::HSM HSM} keys, the combined length of
-          #   the plaintext and additional_authenticated_data fields must be no larger
-          #   than 8KiB.
+          #   {Google::Cloud::Kms::V1::CryptoKeyVersionTemplate#protection_level protection_level}. For
+          #   {Google::Cloud::Kms::V1::ProtectionLevel::SOFTWARE SOFTWARE} keys, the plaintext must be no larger
+          #   than 64KiB. For {Google::Cloud::Kms::V1::ProtectionLevel::HSM HSM} keys, the combined length of the
+          #   plaintext and additional_authenticated_data fields must be no larger than
+          #   8KiB.
           # @param additional_authenticated_data [String]
           #   Optional data that, if specified, must also be provided during decryption
-          #   through
-          #   {Google::Cloud::Kms::V1::DecryptRequest#additional_authenticated_data DecryptRequest#additional_authenticated_data}.
+          #   through {Google::Cloud::Kms::V1::DecryptRequest#additional_authenticated_data DecryptRequest#additional_authenticated_data}.
           #
           #   The maximum size depends on the key version's
-          #   {Google::Cloud::Kms::V1::CryptoKeyVersionTemplate#protection_level protection_level}.
-          #   For {Google::Cloud::Kms::V1::ProtectionLevel::SOFTWARE SOFTWARE} keys, the AAD
-          #   must be no larger than 64KiB. For
-          #   {Google::Cloud::Kms::V1::ProtectionLevel::HSM HSM} keys, the combined length of
-          #   the plaintext and additional_authenticated_data fields must be no larger
-          #   than 8KiB.
+          #   {Google::Cloud::Kms::V1::CryptoKeyVersionTemplate#protection_level protection_level}. For
+          #   {Google::Cloud::Kms::V1::ProtectionLevel::SOFTWARE SOFTWARE} keys, the AAD must be no larger than
+          #   64KiB. For {Google::Cloud::Kms::V1::ProtectionLevel::HSM HSM} keys, the combined length of the
+          #   plaintext and additional_authenticated_data fields must be no larger than
+          #   8KiB.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1076,15 +1360,12 @@ module Google
             @encrypt.call(req, options, &block)
           end
 
-          # Decrypts data that was protected by
-          # {Google::Cloud::Kms::V1::KeyManagementService::Encrypt Encrypt}. The
-          # {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose} must be
-          # {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ENCRYPT_DECRYPT ENCRYPT_DECRYPT}.
+          # Decrypts data that was protected by {Google::Cloud::Kms::V1::KeyManagementService::Encrypt Encrypt}. The {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose}
+          # must be {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ENCRYPT_DECRYPT ENCRYPT_DECRYPT}.
           #
           # @param name [String]
-          #   Required. The resource name of the
-          #   {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to use for decryption. The
-          #   server will choose the appropriate version.
+          #   Required. The resource name of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to use for decryption.
+          #   The server will choose the appropriate version.
           # @param ciphertext [String]
           #   Required. The encrypted data originally returned in
           #   {Google::Cloud::Kms::V1::EncryptResponse#ciphertext EncryptResponse#ciphertext}.
@@ -1124,18 +1405,14 @@ module Google
             @decrypt.call(req, options, &block)
           end
 
-          # Update the version of a {Google::Cloud::Kms::V1::CryptoKey CryptoKey} that
-          # will be used in
-          # {Google::Cloud::Kms::V1::KeyManagementService::Encrypt Encrypt}.
+          # Update the version of a {Google::Cloud::Kms::V1::CryptoKey CryptoKey} that will be used in {Google::Cloud::Kms::V1::KeyManagementService::Encrypt Encrypt}.
           #
           # Returns an error if called on an asymmetric key.
           #
           # @param name [String]
-          #   The resource name of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to
-          #   update.
+          #   The resource name of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to update.
           # @param crypto_key_version_id [String]
-          #   The id of the child
-          #   {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use as primary.
+          #   The id of the child {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use as primary.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1167,28 +1444,21 @@ module Google
             @update_crypto_key_primary_version.call(req, options, &block)
           end
 
-          # Schedule a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} for
-          # destruction.
+          # Schedule a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} for destruction.
           #
-          # Upon calling this method,
-          # {Google::Cloud::Kms::V1::CryptoKeyVersion#state CryptoKeyVersion#state} will
-          # be set to
+          # Upon calling this method, {Google::Cloud::Kms::V1::CryptoKeyVersion#state CryptoKeyVersion#state} will be set to
           # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::DESTROY_SCHEDULED DESTROY_SCHEDULED}
-          # and {Google::Cloud::Kms::V1::CryptoKeyVersion#destroy_time destroy_time} will
-          # be set to a time 24 hours in the future, at which point the
-          # {Google::Cloud::Kms::V1::CryptoKeyVersion#state state} will be changed to
-          # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::DESTROYED DESTROYED},
-          # and the key material will be irrevocably destroyed.
-          #
-          # Before the
-          # {Google::Cloud::Kms::V1::CryptoKeyVersion#destroy_time destroy_time} is
-          # reached,
-          # {Google::Cloud::Kms::V1::KeyManagementService::RestoreCryptoKeyVersion RestoreCryptoKeyVersion}
-          # may be called to reverse the process.
+          # and {Google::Cloud::Kms::V1::CryptoKeyVersion#destroy_time destroy_time} will be set to a time 24
+          # hours in the future, at which point the {Google::Cloud::Kms::V1::CryptoKeyVersion#state state}
+          # will be changed to
+          # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::DESTROYED DESTROYED}, and the key
+          # material will be irrevocably destroyed.
+          #
+          # Before the {Google::Cloud::Kms::V1::CryptoKeyVersion#destroy_time destroy_time} is reached,
+          # {Google::Cloud::Kms::V1::KeyManagementService::RestoreCryptoKeyVersion RestoreCryptoKeyVersion} may be called to reverse the process.
           #
           # @param name [String]
-          #   The resource name of the
-          #   {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to destroy.
+          #   The resource name of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to destroy.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1219,15 +1489,12 @@ module Google
           # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::DESTROY_SCHEDULED DESTROY_SCHEDULED}
           # state.
           #
-          # Upon restoration of the CryptoKeyVersion,
-          # {Google::Cloud::Kms::V1::CryptoKeyVersion#state state} will be set to
-          # {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::DISABLED DISABLED},
-          # and {Google::Cloud::Kms::V1::CryptoKeyVersion#destroy_time destroy_time} will
-          # be cleared.
+          # Upon restoration of the CryptoKeyVersion, {Google::Cloud::Kms::V1::CryptoKeyVersion#state state}
+          # will be set to {Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState::DISABLED DISABLED},
+          # and {Google::Cloud::Kms::V1::CryptoKeyVersion#destroy_time destroy_time} will be cleared.
           #
           # @param name [String]
-          #   The resource name of the
-          #   {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to restore.
+          #   The resource name of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to restore.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1254,16 +1521,14 @@ module Google
             @restore_crypto_key_version.call(req, options, &block)
           end
 
-          # Returns the public key for the given
-          # {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}. The
+          # Returns the public key for the given {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}. The
           # {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose} must be
-          # {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ASYMMETRIC_SIGN ASYMMETRIC_SIGN}
-          # or
+          # {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ASYMMETRIC_SIGN ASYMMETRIC_SIGN} or
           # {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ASYMMETRIC_DECRYPT ASYMMETRIC_DECRYPT}.
           #
           # @param name [String]
-          #   The {Google::Cloud::Kms::V1::CryptoKeyVersion#name name} of the
-          #   {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} public key to get.
+          #   The {Google::Cloud::Kms::V1::CryptoKeyVersion#name name} of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} public key to
+          #   get.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1291,19 +1556,15 @@ module Google
           end
 
           # Decrypts data that was encrypted with a public key retrieved from
-          # {Google::Cloud::Kms::V1::KeyManagementService::GetPublicKey GetPublicKey}
-          # corresponding to a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}
-          # with {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose}
-          # ASYMMETRIC_DECRYPT.
+          # {Google::Cloud::Kms::V1::KeyManagementService::GetPublicKey GetPublicKey} corresponding to a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} with
+          # {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose} ASYMMETRIC_DECRYPT.
           #
           # @param name [String]
-          #   Required. The resource name of the
-          #   {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use for
+          #   Required. The resource name of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use for
           #   decryption.
           # @param ciphertext [String]
-          #   Required. The data encrypted with the named
-          #   {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}'s public key using
-          #   OAEP.
+          #   Required. The data encrypted with the named {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}'s public
+          #   key using OAEP.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1335,16 +1596,12 @@ module Google
             @asymmetric_decrypt.call(req, options, &block)
           end
 
-          # Signs data using a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}
-          # with {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose}
+          # Signs data using a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} with {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose}
           # ASYMMETRIC_SIGN, producing a signature that can be verified with the public
-          # key retrieved from
-          # {Google::Cloud::Kms::V1::KeyManagementService::GetPublicKey GetPublicKey}.
+          # key retrieved from {Google::Cloud::Kms::V1::KeyManagementService::GetPublicKey GetPublicKey}.
           #
           # @param name [String]
-          #   Required. The resource name of the
-          #   {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use for
-          #   signing.
+          #   Required. The resource name of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use for signing.
           # @param digest [Google::Cloud::Kms::V1::Digest | Hash]
           #   Required. The digest of the data to sign. The digest must be produced with
           #   the same digest algorithm as specified by the key version's
@@ -1382,8 +1639,8 @@ module Google
             @asymmetric_sign.call(req, options, &block)
           end
 
-          # Sets the access control policy on the specified resource. Replaces any
-          # existing policy.
+          # Sets the access control policy on the specified resource. Replaces
+          # any existing policy.
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being specified.
@@ -1426,9 +1683,8 @@ module Google
             @set_iam_policy.call(req, options, &block)
           end
 
-          # Gets the access control policy for a resource.
-          # Returns an empty policy if the resource exists and does not have a policy
-          # set.
+          # Gets the access control policy for a resource. Returns an empty policy
+          # if the resource exists and does not have a policy set.
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
@@ -1459,13 +1715,13 @@ module Google
             @get_iam_policy.call(req, options, &block)
           end
 
-          # Returns permissions that a caller has on the specified resource.
-          # If the resource does not exist, this will return an empty set of
+          # Returns permissions that a caller has on the specified resource. If the
+          # resource does not exist, this will return an empty set of
           # permissions, not a NOT_FOUND error.
           #
-          # Note: This operation is designed to be used for building permission-aware
-          # UIs and command-line tools, not for authorization checking. This operation
-          # may "fail open" without warning.
+          # Note: This operation is designed to be used for building
+          # permission-aware UIs and command-line tools, not for authorization
+          # checking. This operation may "fail open" without warning.
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy detail is being requested.
diff --git a/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client_config.json b/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client_config.json
index 89b76c006..bb2e66798 100644
--- a/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client_config.json
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client_config.json
@@ -25,6 +25,11 @@
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
+        "ListImportJobs": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
         "ListCryptoKeys": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
@@ -40,6 +45,11 @@
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
+        "GetImportJob": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
         "GetCryptoKey": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
@@ -55,6 +65,11 @@
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
+        "CreateImportJob": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "CreateCryptoKey": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
@@ -65,6 +80,11 @@
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
+        "ImportCryptoKeyVersion": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "UpdateCryptoKey": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
diff --git a/google-cloud-kms/lib/google/cloud/kms/v1/resources_pb.rb b/google-cloud-kms/lib/google/cloud/kms/v1/resources_pb.rb
index c3c3b30d6..675558350 100644
--- a/google-cloud-kms/lib/google/cloud/kms/v1/resources_pb.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/resources_pb.rb
@@ -53,6 +53,9 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :generate_time, :message, 11, "google.protobuf.Timestamp"
     optional :destroy_time, :message, 5, "google.protobuf.Timestamp"
     optional :destroy_event_time, :message, 6, "google.protobuf.Timestamp"
+    optional :import_job, :string, 14
+    optional :import_time, :message, 15, "google.protobuf.Timestamp"
+    optional :import_failure_reason, :string, 16
   end
   add_enum "google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm" do
     value :CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED, 0
@@ -60,12 +63,15 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     value :RSA_SIGN_PSS_2048_SHA256, 2
     value :RSA_SIGN_PSS_3072_SHA256, 3
     value :RSA_SIGN_PSS_4096_SHA256, 4
+    value :RSA_SIGN_PSS_4096_SHA512, 15
     value :RSA_SIGN_PKCS1_2048_SHA256, 5
     value :RSA_SIGN_PKCS1_3072_SHA256, 6
     value :RSA_SIGN_PKCS1_4096_SHA256, 7
+    value :RSA_SIGN_PKCS1_4096_SHA512, 16
     value :RSA_DECRYPT_OAEP_2048_SHA256, 8
     value :RSA_DECRYPT_OAEP_3072_SHA256, 9
     value :RSA_DECRYPT_OAEP_4096_SHA256, 10
+    value :RSA_DECRYPT_OAEP_4096_SHA512, 17
     value :EC_SIGN_P256_SHA256, 12
     value :EC_SIGN_P384_SHA384, 13
   end
@@ -76,6 +82,8 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     value :DISABLED, 2
     value :DESTROYED, 3
     value :DESTROY_SCHEDULED, 4
+    value :PENDING_IMPORT, 6
+    value :IMPORT_FAILED, 7
   end
   add_enum "google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView" do
     value :CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED, 0
@@ -85,6 +93,32 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :pem, :string, 1
     optional :algorithm, :enum, 2, "google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm"
   end
+  add_message "google.cloud.kms.v1.ImportJob" do
+    optional :name, :string, 1
+    optional :import_method, :enum, 2, "google.cloud.kms.v1.ImportJob.ImportMethod"
+    optional :protection_level, :enum, 9, "google.cloud.kms.v1.ProtectionLevel"
+    optional :create_time, :message, 3, "google.protobuf.Timestamp"
+    optional :generate_time, :message, 4, "google.protobuf.Timestamp"
+    optional :expire_time, :message, 5, "google.protobuf.Timestamp"
+    optional :expire_event_time, :message, 10, "google.protobuf.Timestamp"
+    optional :state, :enum, 6, "google.cloud.kms.v1.ImportJob.ImportJobState"
+    optional :public_key, :message, 7, "google.cloud.kms.v1.ImportJob.WrappingPublicKey"
+    optional :attestation, :message, 8, "google.cloud.kms.v1.KeyOperationAttestation"
+  end
+  add_message "google.cloud.kms.v1.ImportJob.WrappingPublicKey" do
+    optional :pem, :string, 1
+  end
+  add_enum "google.cloud.kms.v1.ImportJob.ImportMethod" do
+    value :IMPORT_METHOD_UNSPECIFIED, 0
+    value :RSA_OAEP_3072_SHA1_AES_256, 1
+    value :RSA_OAEP_4096_SHA1_AES_256, 2
+  end
+  add_enum "google.cloud.kms.v1.ImportJob.ImportJobState" do
+    value :IMPORT_JOB_STATE_UNSPECIFIED, 0
+    value :PENDING_GENERATION, 1
+    value :ACTIVE, 2
+    value :EXPIRED, 3
+  end
   add_enum "google.cloud.kms.v1.ProtectionLevel" do
     value :PROTECTION_LEVEL_UNSPECIFIED, 0
     value :SOFTWARE, 1
@@ -107,6 +141,10 @@ module Google
         CryptoKeyVersion::CryptoKeyVersionState = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState").enummodule
         CryptoKeyVersion::CryptoKeyVersionView = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView").enummodule
         PublicKey = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.PublicKey").msgclass
+        ImportJob = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.ImportJob").msgclass
+        ImportJob::WrappingPublicKey = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.ImportJob.WrappingPublicKey").msgclass
+        ImportJob::ImportMethod = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.ImportJob.ImportMethod").enummodule
+        ImportJob::ImportJobState = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.ImportJob.ImportJobState").enummodule
         ProtectionLevel = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.ProtectionLevel").enummodule
       end
     end
diff --git a/google-cloud-kms/lib/google/cloud/kms/v1/service_pb.rb b/google-cloud-kms/lib/google/cloud/kms/v1/service_pb.rb
index a8ee7914f..e303e6709 100644
--- a/google-cloud-kms/lib/google/cloud/kms/v1/service_pb.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/service_pb.rb
@@ -7,25 +7,37 @@ require 'google/protobuf'
 require 'google/api/annotations_pb'
 require 'google/cloud/kms/v1/resources_pb'
 require 'google/protobuf/field_mask_pb'
-require 'google/protobuf/struct_pb'
-require 'google/protobuf/wrappers_pb'
+require 'google/api/client_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.kms.v1.ListKeyRingsRequest" do
     optional :parent, :string, 1
     optional :page_size, :int32, 2
     optional :page_token, :string, 3
+    optional :filter, :string, 4
+    optional :order_by, :string, 5
   end
   add_message "google.cloud.kms.v1.ListCryptoKeysRequest" do
     optional :parent, :string, 1
     optional :page_size, :int32, 2
     optional :page_token, :string, 3
     optional :version_view, :enum, 4, "google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView"
+    optional :filter, :string, 5
+    optional :order_by, :string, 6
   end
   add_message "google.cloud.kms.v1.ListCryptoKeyVersionsRequest" do
     optional :parent, :string, 1
     optional :page_size, :int32, 2
     optional :page_token, :string, 3
     optional :view, :enum, 4, "google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView"
+    optional :filter, :string, 5
+    optional :order_by, :string, 6
+  end
+  add_message "google.cloud.kms.v1.ListImportJobsRequest" do
+    optional :parent, :string, 1
+    optional :page_size, :int32, 2
+    optional :page_token, :string, 3
+    optional :filter, :string, 4
+    optional :order_by, :string, 5
   end
   add_message "google.cloud.kms.v1.ListKeyRingsResponse" do
     repeated :key_rings, :message, 1, "google.cloud.kms.v1.KeyRing"
@@ -42,6 +54,11 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :next_page_token, :string, 2
     optional :total_size, :int32, 3
   end
+  add_message "google.cloud.kms.v1.ListImportJobsResponse" do
+    repeated :import_jobs, :message, 1, "google.cloud.kms.v1.ImportJob"
+    optional :next_page_token, :string, 2
+    optional :total_size, :int32, 3
+  end
   add_message "google.cloud.kms.v1.GetKeyRingRequest" do
     optional :name, :string, 1
   end
@@ -54,6 +71,9 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.kms.v1.GetPublicKeyRequest" do
     optional :name, :string, 1
   end
+  add_message "google.cloud.kms.v1.GetImportJobRequest" do
+    optional :name, :string, 1
+  end
   add_message "google.cloud.kms.v1.CreateKeyRingRequest" do
     optional :parent, :string, 1
     optional :key_ring_id, :string, 2
@@ -63,11 +83,25 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :parent, :string, 1
     optional :crypto_key_id, :string, 2
     optional :crypto_key, :message, 3, "google.cloud.kms.v1.CryptoKey"
+    optional :skip_initial_version_creation, :bool, 5
   end
   add_message "google.cloud.kms.v1.CreateCryptoKeyVersionRequest" do
     optional :parent, :string, 1
     optional :crypto_key_version, :message, 2, "google.cloud.kms.v1.CryptoKeyVersion"
   end
+  add_message "google.cloud.kms.v1.ImportCryptoKeyVersionRequest" do
+    optional :parent, :string, 1
+    optional :algorithm, :enum, 2, "google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm"
+    optional :import_job, :string, 4
+    oneof :wrapped_key_material do
+      optional :rsa_aes_wrapped_key, :bytes, 5
+    end
+  end
+  add_message "google.cloud.kms.v1.CreateImportJobRequest" do
+    optional :parent, :string, 1
+    optional :import_job_id, :string, 2
+    optional :import_job, :message, 3, "google.cloud.kms.v1.ImportJob"
+  end
   add_message "google.cloud.kms.v1.UpdateCryptoKeyRequest" do
     optional :crypto_key, :message, 1, "google.cloud.kms.v1.CryptoKey"
     optional :update_mask, :message, 2, "google.protobuf.FieldMask"
@@ -136,16 +170,21 @@ module Google
         ListKeyRingsRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.ListKeyRingsRequest").msgclass
         ListCryptoKeysRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.ListCryptoKeysRequest").msgclass
         ListCryptoKeyVersionsRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.ListCryptoKeyVersionsRequest").msgclass
+        ListImportJobsRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.ListImportJobsRequest").msgclass
         ListKeyRingsResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.ListKeyRingsResponse").msgclass
         ListCryptoKeysResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.ListCryptoKeysResponse").msgclass
         ListCryptoKeyVersionsResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.ListCryptoKeyVersionsResponse").msgclass
+        ListImportJobsResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.ListImportJobsResponse").msgclass
         GetKeyRingRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.GetKeyRingRequest").msgclass
         GetCryptoKeyRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.GetCryptoKeyRequest").msgclass
         GetCryptoKeyVersionRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.GetCryptoKeyVersionRequest").msgclass
         GetPublicKeyRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.GetPublicKeyRequest").msgclass
+        GetImportJobRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.GetImportJobRequest").msgclass
         CreateKeyRingRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.CreateKeyRingRequest").msgclass
         CreateCryptoKeyRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.CreateCryptoKeyRequest").msgclass
         CreateCryptoKeyVersionRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.CreateCryptoKeyVersionRequest").msgclass
+        ImportCryptoKeyVersionRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.ImportCryptoKeyVersionRequest").msgclass
+        CreateImportJobRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.CreateImportJobRequest").msgclass
         UpdateCryptoKeyRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.UpdateCryptoKeyRequest").msgclass
         UpdateCryptoKeyVersionRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.UpdateCryptoKeyVersionRequest").msgclass
         EncryptRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.kms.v1.EncryptRequest").msgclass
diff --git a/google-cloud-kms/lib/google/cloud/kms/v1/service_services_pb.rb b/google-cloud-kms/lib/google/cloud/kms/v1/service_services_pb.rb
index 8f188173c..12fe1d50e 100644
--- a/google-cloud-kms/lib/google/cloud/kms/v1/service_services_pb.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/service_services_pb.rb
@@ -1,7 +1,7 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
 # Source: google/cloud/kms/v1/service.proto for package 'google.cloud.kms.v1'
 # Original file comments:
-# Copyright 2018 Google LLC.
+# Copyright 2019 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,110 +51,95 @@ module Google
             rpc :ListCryptoKeys, ListCryptoKeysRequest, ListCryptoKeysResponse
             # Lists [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion].
             rpc :ListCryptoKeyVersions, ListCryptoKeyVersionsRequest, ListCryptoKeyVersionsResponse
+            # Lists [ImportJobs][google.cloud.kms.v1.ImportJob].
+            rpc :ListImportJobs, ListImportJobsRequest, ListImportJobsResponse
             # Returns metadata for a given [KeyRing][google.cloud.kms.v1.KeyRing].
             rpc :GetKeyRing, GetKeyRingRequest, KeyRing
-            # Returns metadata for a given [CryptoKey][google.cloud.kms.v1.CryptoKey], as
-            # well as its [primary][google.cloud.kms.v1.CryptoKey.primary]
-            # [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion].
+            # Returns metadata for a given [CryptoKey][google.cloud.kms.v1.CryptoKey], as well as its
+            # [primary][google.cloud.kms.v1.CryptoKey.primary] [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion].
             rpc :GetCryptoKey, GetCryptoKeyRequest, CryptoKey
-            # Returns metadata for a given
-            # [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion].
+            # Returns metadata for a given [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion].
             rpc :GetCryptoKeyVersion, GetCryptoKeyVersionRequest, CryptoKeyVersion
-            # Returns the public key for the given
-            # [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]. The
+            # Returns the public key for the given [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]. The
             # [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] must be
-            # [ASYMMETRIC_SIGN][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_SIGN]
-            # or
+            # [ASYMMETRIC_SIGN][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_SIGN] or
             # [ASYMMETRIC_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_DECRYPT].
             rpc :GetPublicKey, GetPublicKeyRequest, PublicKey
-            # Create a new [KeyRing][google.cloud.kms.v1.KeyRing] in a given Project and
-            # Location.
+            # Returns metadata for a given [ImportJob][google.cloud.kms.v1.ImportJob].
+            rpc :GetImportJob, GetImportJobRequest, ImportJob
+            # Create a new [KeyRing][google.cloud.kms.v1.KeyRing] in a given Project and Location.
             rpc :CreateKeyRing, CreateKeyRingRequest, KeyRing
-            # Create a new [CryptoKey][google.cloud.kms.v1.CryptoKey] within a
-            # [KeyRing][google.cloud.kms.v1.KeyRing].
+            # Create a new [CryptoKey][google.cloud.kms.v1.CryptoKey] within a [KeyRing][google.cloud.kms.v1.KeyRing].
             #
             # [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] and
             # [CryptoKey.version_template.algorithm][google.cloud.kms.v1.CryptoKeyVersionTemplate.algorithm]
             # are required.
             rpc :CreateCryptoKey, CreateCryptoKeyRequest, CryptoKey
-            # Create a new [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] in a
-            # [CryptoKey][google.cloud.kms.v1.CryptoKey].
+            # Create a new [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] in a [CryptoKey][google.cloud.kms.v1.CryptoKey].
             #
             # The server will assign the next sequential id. If unset,
             # [state][google.cloud.kms.v1.CryptoKeyVersion.state] will be set to
             # [ENABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED].
             rpc :CreateCryptoKeyVersion, CreateCryptoKeyVersionRequest, CryptoKeyVersion
+            # Imports a new [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] into an existing [CryptoKey][google.cloud.kms.v1.CryptoKey] using the
+            # wrapped key material provided in the request.
+            #
+            # The version ID will be assigned the next sequential id within the
+            # [CryptoKey][google.cloud.kms.v1.CryptoKey].
+            rpc :ImportCryptoKeyVersion, ImportCryptoKeyVersionRequest, CryptoKeyVersion
+            # Create a new [ImportJob][google.cloud.kms.v1.ImportJob] within a [KeyRing][google.cloud.kms.v1.KeyRing].
+            #
+            # [ImportJob.import_method][google.cloud.kms.v1.ImportJob.import_method] is required.
+            rpc :CreateImportJob, CreateImportJobRequest, ImportJob
             # Update a [CryptoKey][google.cloud.kms.v1.CryptoKey].
             rpc :UpdateCryptoKey, UpdateCryptoKeyRequest, CryptoKey
-            # Update a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]'s
-            # metadata.
+            # Update a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]'s metadata.
             #
             # [state][google.cloud.kms.v1.CryptoKeyVersion.state] may be changed between
-            # [ENABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]
-            # and
-            # [DISABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]
-            # using this method. See
-            # [DestroyCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]
-            # and
-            # [RestoreCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]
-            # to move between other states.
+            # [ENABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED] and
+            # [DISABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED] using this
+            # method. See [DestroyCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion] and [RestoreCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion] to
+            # move between other states.
             rpc :UpdateCryptoKeyVersion, UpdateCryptoKeyVersionRequest, CryptoKeyVersion
-            # Encrypts data, so that it can only be recovered by a call to
-            # [Decrypt][google.cloud.kms.v1.KeyManagementService.Decrypt]. The
-            # [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] must be
+            # Encrypts data, so that it can only be recovered by a call to [Decrypt][google.cloud.kms.v1.KeyManagementService.Decrypt].
+            # The [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] must be
             # [ENCRYPT_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT].
             rpc :Encrypt, EncryptRequest, EncryptResponse
-            # Decrypts data that was protected by
-            # [Encrypt][google.cloud.kms.v1.KeyManagementService.Encrypt]. The
-            # [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] must be
-            # [ENCRYPT_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT].
+            # Decrypts data that was protected by [Encrypt][google.cloud.kms.v1.KeyManagementService.Encrypt]. The [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose]
+            # must be [ENCRYPT_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT].
             rpc :Decrypt, DecryptRequest, DecryptResponse
-            # Signs data using a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]
-            # with [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose]
+            # Signs data using a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] with [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose]
             # ASYMMETRIC_SIGN, producing a signature that can be verified with the public
-            # key retrieved from
-            # [GetPublicKey][google.cloud.kms.v1.KeyManagementService.GetPublicKey].
+            # key retrieved from [GetPublicKey][google.cloud.kms.v1.KeyManagementService.GetPublicKey].
             rpc :AsymmetricSign, AsymmetricSignRequest, AsymmetricSignResponse
             # Decrypts data that was encrypted with a public key retrieved from
-            # [GetPublicKey][google.cloud.kms.v1.KeyManagementService.GetPublicKey]
-            # corresponding to a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]
-            # with [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose]
-            # ASYMMETRIC_DECRYPT.
+            # [GetPublicKey][google.cloud.kms.v1.KeyManagementService.GetPublicKey] corresponding to a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] with
+            # [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] ASYMMETRIC_DECRYPT.
             rpc :AsymmetricDecrypt, AsymmetricDecryptRequest, AsymmetricDecryptResponse
-            # Update the version of a [CryptoKey][google.cloud.kms.v1.CryptoKey] that
-            # will be used in
-            # [Encrypt][google.cloud.kms.v1.KeyManagementService.Encrypt].
+            # Update the version of a [CryptoKey][google.cloud.kms.v1.CryptoKey] that will be used in [Encrypt][google.cloud.kms.v1.KeyManagementService.Encrypt].
             #
             # Returns an error if called on an asymmetric key.
             rpc :UpdateCryptoKeyPrimaryVersion, UpdateCryptoKeyPrimaryVersionRequest, CryptoKey
-            # Schedule a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] for
-            # destruction.
+            # Schedule a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] for destruction.
             #
-            # Upon calling this method,
-            # [CryptoKeyVersion.state][google.cloud.kms.v1.CryptoKeyVersion.state] will
-            # be set to
+            # Upon calling this method, [CryptoKeyVersion.state][google.cloud.kms.v1.CryptoKeyVersion.state] will be set to
             # [DESTROY_SCHEDULED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]
-            # and [destroy_time][google.cloud.kms.v1.CryptoKeyVersion.destroy_time] will
-            # be set to a time 24 hours in the future, at which point the
-            # [state][google.cloud.kms.v1.CryptoKeyVersion.state] will be changed to
-            # [DESTROYED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED],
-            # and the key material will be irrevocably destroyed.
+            # and [destroy_time][google.cloud.kms.v1.CryptoKeyVersion.destroy_time] will be set to a time 24
+            # hours in the future, at which point the [state][google.cloud.kms.v1.CryptoKeyVersion.state]
+            # will be changed to
+            # [DESTROYED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED], and the key
+            # material will be irrevocably destroyed.
             #
-            # Before the
-            # [destroy_time][google.cloud.kms.v1.CryptoKeyVersion.destroy_time] is
-            # reached,
-            # [RestoreCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]
-            # may be called to reverse the process.
+            # Before the [destroy_time][google.cloud.kms.v1.CryptoKeyVersion.destroy_time] is reached,
+            # [RestoreCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion] may be called to reverse the process.
             rpc :DestroyCryptoKeyVersion, DestroyCryptoKeyVersionRequest, CryptoKeyVersion
             # Restore a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] in the
             # [DESTROY_SCHEDULED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]
             # state.
             #
-            # Upon restoration of the CryptoKeyVersion,
-            # [state][google.cloud.kms.v1.CryptoKeyVersion.state] will be set to
-            # [DISABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED],
-            # and [destroy_time][google.cloud.kms.v1.CryptoKeyVersion.destroy_time] will
-            # be cleared.
+            # Upon restoration of the CryptoKeyVersion, [state][google.cloud.kms.v1.CryptoKeyVersion.state]
+            # will be set to [DISABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED],
+            # and [destroy_time][google.cloud.kms.v1.CryptoKeyVersion.destroy_time] will be cleared.
             rpc :RestoreCryptoKeyVersion, RestoreCryptoKeyVersionRequest, CryptoKeyVersion
           end
 
diff --git a/google-cloud-kms/synth.metadata b/google-cloud-kms/synth.metadata
index dcc4d41cc..d9e3d8273 100644
--- a/google-cloud-kms/synth.metadata
+++ b/google-cloud-kms/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-30T00:38:02.642224Z",
+  "updateTime": "2019-06-15T10:39:04.055Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.21.0",
-        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
+        "version": "0.26.0",
+        "dockerImage": "googleapis/artman@sha256:6db0735b0d3beec5b887153a2a7c7411fc7bb53f73f6f389a822096bd14a3a15"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
-        "internalRef": "250569499"
+        "sha": "7b58b37559f6a5337c4c564518e9573d742df225",
+        "internalRef": "253322136"
       }
     },
     {
diff --git a/google-cloud-kms/test/google/cloud/kms/v1/helpers_test.rb b/google-cloud-kms/test/google/cloud/kms/v1/helpers_test.rb
index b627c906e..ea7a572c4 100644
--- a/google-cloud-kms/test/google/cloud/kms/v1/helpers_test.rb
+++ b/google-cloud-kms/test/google/cloud/kms/v1/helpers_test.rb
@@ -76,6 +76,19 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
     end
   end
 
+  describe "the import_job_path instance method" do
+    it "correctly calls Google::Cloud::Kms::V1::KeyManagementServiceClient.import_job_path" do
+      Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+        parameters = Google::Cloud::Kms::V1::KeyManagementServiceClient.method("import_job_path").parameters.map { |arg| arg.last.to_s }
+        client = Google::Cloud::Kms.new version: :v1
+        assert_equal(
+          client.import_job_path(*parameters),
+          Google::Cloud::Kms::V1::KeyManagementServiceClient.import_job_path(*parameters)
+        )
+      end
+    end
+  end
+
   describe "the key_ring_path instance method" do
     it "correctly calls Google::Cloud::Kms::V1::KeyManagementServiceClient.key_ring_path" do
       Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
diff --git a/google-cloud-kms/test/google/cloud/kms/v1/key_management_service_client_test.rb b/google-cloud-kms/test/google/cloud/kms/v1/key_management_service_client_test.rb
index e225338a1..8d1012879 100644
--- a/google-cloud-kms/test/google/cloud/kms/v1/key_management_service_client_test.rb
+++ b/google-cloud-kms/test/google/cloud/kms/v1/key_management_service_client_test.rb
@@ -145,6 +145,83 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
     end
   end
 
+  describe 'list_import_jobs' do
+    custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Kms::V1::KeyManagementServiceClient#list_import_jobs."
+
+    it 'invokes list_import_jobs without error' do
+      # Create request parameters
+      formatted_parent = Google::Cloud::Kms::V1::KeyManagementServiceClient.key_ring_path("[PROJECT]", "[LOCATION]", "[KEY_RING]")
+
+      # Create expected grpc response
+      next_page_token = ""
+      total_size = 705419236
+      import_jobs_element = {}
+      import_jobs = [import_jobs_element]
+      expected_response = {
+        next_page_token: next_page_token,
+        total_size: total_size,
+        import_jobs: import_jobs
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Kms::V1::ListImportJobsResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Kms::V1::ListImportJobsRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:list_import_jobs, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockKeyManagementServiceCredentials_v1.new("list_import_jobs")
+
+      Google::Cloud::Kms::V1::KeyManagementService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Kms.new(version: :v1)
+
+          # Call method
+          response = client.list_import_jobs(formatted_parent)
+
+          # Verify the response
+          assert(response.instance_of?(Google::Gax::PagedEnumerable))
+          assert_equal(expected_response, response.page.response)
+          assert_nil(response.next_page)
+          assert_equal(expected_response.import_jobs.to_a, response.to_a)
+        end
+      end
+    end
+
+    it 'invokes list_import_jobs with error' do
+      # Create request parameters
+      formatted_parent = Google::Cloud::Kms::V1::KeyManagementServiceClient.key_ring_path("[PROJECT]", "[LOCATION]", "[KEY_RING]")
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Kms::V1::ListImportJobsRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:list_import_jobs, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockKeyManagementServiceCredentials_v1.new("list_import_jobs")
+
+      Google::Cloud::Kms::V1::KeyManagementService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Kms.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.list_import_jobs(formatted_parent)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
   describe 'list_crypto_keys' do
     custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Kms::V1::KeyManagementServiceClient#list_crypto_keys."
 
@@ -373,6 +450,80 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
     end
   end
 
+  describe 'get_import_job' do
+    custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Kms::V1::KeyManagementServiceClient#get_import_job."
+
+    it 'invokes get_import_job without error' do
+      # Create request parameters
+      formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.import_job_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[IMPORT_JOB]")
+
+      # Create expected grpc response
+      name_2 = "name2-1052831874"
+      expected_response = { name: name_2 }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Kms::V1::ImportJob)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Kms::V1::GetImportJobRequest, request)
+        assert_equal(formatted_name, request.name)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:get_import_job, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockKeyManagementServiceCredentials_v1.new("get_import_job")
+
+      Google::Cloud::Kms::V1::KeyManagementService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Kms.new(version: :v1)
+
+          # Call method
+          response = client.get_import_job(formatted_name)
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.get_import_job(formatted_name) do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes get_import_job with error' do
+      # Create request parameters
+      formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.import_job_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[IMPORT_JOB]")
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Kms::V1::GetImportJobRequest, request)
+        assert_equal(formatted_name, request.name)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:get_import_job, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockKeyManagementServiceCredentials_v1.new("get_import_job")
+
+      Google::Cloud::Kms::V1::KeyManagementService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Kms.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.get_import_job(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
   describe 'get_crypto_key' do
     custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Kms::V1::KeyManagementServiceClient#get_crypto_key."
 
@@ -456,7 +607,13 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
-      expected_response = { name: name_2 }
+      import_job = "importJob2125587491"
+      import_failure_reason = "importFailureReason-494073229"
+      expected_response = {
+        name: name_2,
+        import_job: import_job,
+        import_failure_reason: import_failure_reason
+      }
       expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Kms::V1::CryptoKeyVersion)
 
       # Mock Grpc layer
@@ -615,6 +772,104 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
     end
   end
 
+  describe 'create_import_job' do
+    custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Kms::V1::KeyManagementServiceClient#create_import_job."
+
+    it 'invokes create_import_job without error' do
+      # Create request parameters
+      formatted_parent = Google::Cloud::Kms::V1::KeyManagementServiceClient.key_ring_path("[PROJECT]", "[LOCATION]", "[KEY_RING]")
+      import_job_id = "my-import-job"
+      import_method = :RSA_OAEP_3072_SHA1_AES_256
+      protection_level = :HSM
+      import_job = { import_method: import_method, protection_level: protection_level }
+
+      # Create expected grpc response
+      name = "name3373707"
+      expected_response = { name: name }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Kms::V1::ImportJob)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Kms::V1::CreateImportJobRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        assert_equal(import_job_id, request.import_job_id)
+        assert_equal(Google::Gax::to_proto(import_job, Google::Cloud::Kms::V1::ImportJob), request.import_job)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:create_import_job, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockKeyManagementServiceCredentials_v1.new("create_import_job")
+
+      Google::Cloud::Kms::V1::KeyManagementService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Kms.new(version: :v1)
+
+          # Call method
+          response = client.create_import_job(
+            formatted_parent,
+            import_job_id,
+            import_job
+          )
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.create_import_job(
+            formatted_parent,
+            import_job_id,
+            import_job
+          ) do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes create_import_job with error' do
+      # Create request parameters
+      formatted_parent = Google::Cloud::Kms::V1::KeyManagementServiceClient.key_ring_path("[PROJECT]", "[LOCATION]", "[KEY_RING]")
+      import_job_id = "my-import-job"
+      import_method = :RSA_OAEP_3072_SHA1_AES_256
+      protection_level = :HSM
+      import_job = { import_method: import_method, protection_level: protection_level }
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Kms::V1::CreateImportJobRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        assert_equal(import_job_id, request.import_job_id)
+        assert_equal(Google::Gax::to_proto(import_job, Google::Cloud::Kms::V1::ImportJob), request.import_job)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:create_import_job, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockKeyManagementServiceCredentials_v1.new("create_import_job")
+
+      Google::Cloud::Kms::V1::KeyManagementService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Kms.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.create_import_job(
+              formatted_parent,
+              import_job_id,
+              import_job
+            )
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
   describe 'create_crypto_key' do
     custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Kms::V1::KeyManagementServiceClient#create_crypto_key."
 
@@ -737,7 +992,13 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
 
       # Create expected grpc response
       name = "name3373707"
-      expected_response = { name: name }
+      import_job = "importJob2125587491"
+      import_failure_reason = "importFailureReason-494073229"
+      expected_response = {
+        name: name,
+        import_job: import_job,
+        import_failure_reason: import_failure_reason
+      }
       expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Kms::V1::CryptoKeyVersion)
 
       # Mock Grpc layer
@@ -805,6 +1066,106 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
     end
   end
 
+  describe 'import_crypto_key_version' do
+    custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Kms::V1::KeyManagementServiceClient#import_crypto_key_version."
+
+    it 'invokes import_crypto_key_version without error' do
+      # Create request parameters
+      formatted_parent = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
+      algorithm = :CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED
+      import_job = ''
+
+      # Create expected grpc response
+      name = "name3373707"
+      import_job_2 = "importJob2-1714851050"
+      import_failure_reason = "importFailureReason-494073229"
+      expected_response = {
+        name: name,
+        import_job: import_job_2,
+        import_failure_reason: import_failure_reason
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Kms::V1::CryptoKeyVersion)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Kms::V1::ImportCryptoKeyVersionRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        assert_equal(algorithm, request.algorithm)
+        assert_equal(import_job, request.import_job)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:import_crypto_key_version, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockKeyManagementServiceCredentials_v1.new("import_crypto_key_version")
+
+      Google::Cloud::Kms::V1::KeyManagementService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Kms.new(version: :v1)
+
+          # Call method
+          response = client.import_crypto_key_version(
+            formatted_parent,
+            algorithm,
+            import_job
+          )
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.import_crypto_key_version(
+            formatted_parent,
+            algorithm,
+            import_job
+          ) do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes import_crypto_key_version with error' do
+      # Create request parameters
+      formatted_parent = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
+      algorithm = :CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED
+      import_job = ''
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Kms::V1::ImportCryptoKeyVersionRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        assert_equal(algorithm, request.algorithm)
+        assert_equal(import_job, request.import_job)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:import_crypto_key_version, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockKeyManagementServiceCredentials_v1.new("import_crypto_key_version")
+
+      Google::Cloud::Kms::V1::KeyManagementService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Kms.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.import_crypto_key_version(
+              formatted_parent,
+              algorithm,
+              import_job
+            )
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
   describe 'update_crypto_key' do
     custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Kms::V1::KeyManagementServiceClient#update_crypto_key."
 
@@ -893,7 +1254,13 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
 
       # Create expected grpc response
       name = "name3373707"
-      expected_response = { name: name }
+      import_job = "importJob2125587491"
+      import_failure_reason = "importFailureReason-494073229"
+      expected_response = {
+        name: name,
+        import_job: import_job,
+        import_failure_reason: import_failure_reason
+      }
       expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Kms::V1::CryptoKeyVersion)
 
       # Mock Grpc layer
@@ -1205,7 +1572,13 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
-      expected_response = { name: name_2 }
+      import_job = "importJob2125587491"
+      import_failure_reason = "importFailureReason-494073229"
+      expected_response = {
+        name: name_2,
+        import_job: import_job,
+        import_failure_reason: import_failure_reason
+      }
       expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Kms::V1::CryptoKeyVersion)
 
       # Mock Grpc layer
@@ -1279,7 +1652,13 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
-      expected_response = { name: name_2 }
+      import_job = "importJob2125587491"
+      import_failure_reason = "importFailureReason-494073229"
+      expected_response = {
+        name: name_2,
+        import_job: import_job,
+        import_failure_reason: import_failure_reason
+      }
       expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Kms::V1::CryptoKeyVersion)
 
       # Mock Grpc layer

```

</details>

This pull request was generated using releasetool.