### PR TITLE
Release google-cloud-bigquery-data_transfer 0.3.0

### DIFF
--- a/google-cloud-bigquery-data_transfer/CHANGELOG.md
+++ b/google-cloud-bigquery-data_transfer/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Release History
 
+### 0.3.0 / 2019-06-17
+
+* DataTransferServiceClient changes:
+  * Add DataTransferServiceClient#start_manual_transfer_runs
+  * Deprecate DataTransferServiceClient#schedule_transfer_runs
+  * Add version_info argument to DataTransferServiceClient#create_transfer_config
+  * Add version_info argument to DataTransferServiceClient#update_transfer_config
+* DataSourceParameter changes:
+  * Add DataSourceParameter#deprecated attribute
+  * Deprecate DataSourceParameter#repeated attribute
+  * Deprecate DataSourceParameter#fields attribute
+  * Deprecate DataSourceParameter::Type::RECORD value
+* TransferConfig changes:
+  * Deprecate TransferConfig#schedule_options
+  * Deprecate TransferConfig#user_id
+* TransferRun changes:
+  * Deprecate TransferRun#user_id
+
 ### 0.2.5 / 2019-06-11
 
 * Add VERSION constant

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/version.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/version.rb
@@ -17,7 +17,7 @@ module Google
   module Cloud
     module Bigquery
       module DataTransfer
-        VERSION = "0.2.5".freeze
+        VERSION = "0.3.0".freeze
       end
     end
   end


### PR DESCRIPTION
* DataTransferServiceClient changes:
  * Add DataTransferServiceClient#start_manual_transfer_runs
  * Deprecate DataTransferServiceClient#schedule_transfer_runs
  * Add version_info argument to DataTransferServiceClient#create_transfer_config
  * Add version_info argument to DataTransferServiceClient#update_transfer_config
* DataSourceParameter changes:
  * Add DataSourceParameter#deprecated attribute
  * Deprecate DataSourceParameter#repeated attribute
  * Deprecate DataSourceParameter#fields attribute
  * Deprecate DataSourceParameter::Type::RECORD value
* TransferConfig changes:
  * Deprecate TransferConfig#schedule_options
  * Deprecate TransferConfig#user_id
* TransferRun changes:
  * Deprecate TransferRun#user_id

<details><summary>Commits since previous release</summary><pre><code>commit b383994751c8c9e630a78dbfe7852f3f56b4be04
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Fri Jun 14 08:33:40 2019 -0700

    feat(bigquery-data_transfer): Add StartManualTransferRuns
    
    * DataTransferServiceClient changes:
      * Add DataTransferServiceClient#start_manual_transfer_runs
      * Deprecate DataTransferServiceClient#schedule_transfer_runs
      * Add version_info argument to DataTransferServiceClient#create_transfer_config
      * Add version_info argument to DataTransferServiceClient#update_transfer_config
    * DataSourceParameter changes:
      * Add DataSourceParameter#deprecated attribute
      * Deprecate DataSourceParameter#repeated attribute
      * Deprecate DataSourceParameter#fields attribute
      * Deprecate DataSourceParameter::Type::RECORD value
    * TransferConfig changes:
      * Deprecate TransferConfig#schedule_options
      * Deprecate TransferConfig#user_id
    * TransferRun changes:
      * Deprecate TransferRun#user_id
    
    [pr #3484]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-bigquery-data_transfer/README.md b/google-cloud-bigquery-data_transfer/README.md
index b0576dbf4..a14649ba3 100644
--- a/google-cloud-bigquery-data_transfer/README.md
+++ b/google-cloud-bigquery-data_transfer/README.md
@@ -26,7 +26,7 @@ $ gem install google-cloud-bigquery-data_transfer
 require "google/cloud/bigquery/data_transfer"
 
 data_transfer_client = Google::Cloud::Bigquery::DataTransfer.new
-formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.project_path(project_id)
+formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.location_path(project_id, "us-central1")
 
 # Iterate over all results.
 data_transfer_client.list_data_sources(formatted_parent).each do |element|
diff --git a/google-cloud-bigquery-data_transfer/acceptance/google/cloud/bigquery/data_transfer/v1/data_transfer_service_smoke_test.rb b/google-cloud-bigquery-data_transfer/acceptance/google/cloud/bigquery/data_transfer/v1/data_transfer_service_smoke_test.rb
index f90c7faa0..cd799181a 100644
--- a/google-cloud-bigquery-data_transfer/acceptance/google/cloud/bigquery/data_transfer/v1/data_transfer_service_smoke_test.rb
+++ b/google-cloud-bigquery-data_transfer/acceptance/google/cloud/bigquery/data_transfer/v1/data_transfer_service_smoke_test.rb
@@ -27,7 +27,7 @@ describe "DataTransferServiceSmokeTest v1" do
     project_id = ENV["DATA_TRANSFER_TEST_PROJECT"].freeze
 
     data_transfer_client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
-    formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.project_path(project_id)
+    formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.location_path(project_id, "us-central1")
 
     # Iterate over all results.
     data_transfer_client.list_data_sources(formatted_parent).each do |element|
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer.rb
index c1de63c00..5640d5152 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer.rb
@@ -49,7 +49,7 @@ module Google
       # require "google/cloud/bigquery/data_transfer"
       #
       # data_transfer_client = Google::Cloud::Bigquery::DataTransfer.new
-      # formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.project_path(project_id)
+      # formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.location_path(project_id, "us-central1")
       #
       # # Iterate over all results.
       # data_transfer_client.list_data_sources(formatted_parent).each do |element|
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1.rb
index d61b0bf0c..ceca75a44 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1.rb
@@ -49,7 +49,7 @@ module Google
         # require "google/cloud/bigquery/data_transfer"
         #
         # data_transfer_client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
-        # formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.project_path(project_id)
+        # formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.location_path(project_id, "us-central1")
         #
         # # Iterate over all results.
         # data_transfer_client.list_data_sources(formatted_parent).each do |element|
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb
index cda8c8717..d72d86561 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb
@@ -359,6 +359,14 @@ module Google
                   {'name' => request.name}
                 end
               )
+              @start_manual_transfer_runs = Google::Gax.create_api_call(
+                @data_transfer_service_stub.method(:start_manual_transfer_runs),
+                defaults["start_manual_transfer_runs"],
+                exception_transformer: exception_transformer,
+                params_extractor: proc do |request|
+                  {'parent' => request.parent}
+                end
+              )
             end
 
             # Service calls
@@ -455,7 +463,7 @@ module Google
             #
             # @param parent [String]
             #   The BigQuery project id where the transfer configuration should be created.
-            #   Must be in the format /projects/\\{project_id}/locations/\\{location_id}
+            #   Must be in the format projects/\\{project_id}/locations/\\{location_id}
             #   If specified location and location of the destination bigquery dataset
             #   do not match - the request will fail.
             # @param transfer_config [Google::Cloud::Bigquery::Datatransfer::V1::TransferConfig | Hash]
@@ -479,6 +487,13 @@ module Google
             #     urn:ietf:wg:oauth:2.0:oob means that authorization code should be
             #     returned in the title bar of the browser, with the page text prompting
             #     the user to copy the code and paste it in the application.
+            # @param version_info [String]
+            #   Optional version info. If users want to find a very recent access token,
+            #   that is, immediately after approving access, users have to set the
+            #   version_info claim in the token request. To obtain the version_info, users
+            #   must use the "none+gsession" response type. which be return a
+            #   version_info back in the authorization response which be be put in a JWT
+            #   claim in the token request.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -501,12 +516,14 @@ module Google
                 parent,
                 transfer_config,
                 authorization_code: nil,
+                version_info: nil,
                 options: nil,
                 &block
               req = {
                 parent: parent,
                 transfer_config: transfer_config,
-                authorization_code: authorization_code
+                authorization_code: authorization_code,
+                version_info: version_info
               }.delete_if { |_, v| v.nil? }
               req = Google::Gax::to_proto(req, Google::Cloud::Bigquery::Datatransfer::V1::CreateTransferConfigRequest)
               @create_transfer_config.call(req, options, &block)
@@ -540,6 +557,13 @@ module Google
             #     urn:ietf:wg:oauth:2.0:oob means that authorization code should be
             #     returned in the title bar of the browser, with the page text prompting
             #     the user to copy the code and paste it in the application.
+            # @param version_info [String]
+            #   Optional version info. If users want to find a very recent access token,
+            #   that is, immediately after approving access, users have to set the
+            #   version_info claim in the token request. To obtain the version_info, users
+            #   must use the "none+gsession" response type. which be return a
+            #   version_info back in the authorization response which be be put in a JWT
+            #   claim in the token request.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -564,12 +588,14 @@ module Google
                 transfer_config,
                 update_mask,
                 authorization_code: nil,
+                version_info: nil,
                 options: nil,
                 &block
               req = {
                 transfer_config: transfer_config,
                 update_mask: update_mask,
-                authorization_code: authorization_code
+                authorization_code: authorization_code,
+                version_info: version_info
               }.delete_if { |_, v| v.nil? }
               req = Google::Gax::to_proto(req, Google::Cloud::Bigquery::Datatransfer::V1::UpdateTransferConfigRequest)
               @update_transfer_config.call(req, options, &block)
@@ -701,6 +727,7 @@ module Google
             # For each date - or whatever granularity the data source supports - in the
             # range, one transfer run is created.
             # Note that runs are created per UTC time in the time range.
+            # DEPRECATED: use StartManualTransferRuns instead.
             #
             # @param parent [String]
             #   Transfer configuration name in the form:
@@ -972,6 +999,52 @@ module Google
               req = Google::Gax::to_proto(req, Google::Cloud::Bigquery::Datatransfer::V1::CheckValidCredsRequest)
               @check_valid_creds.call(req, options, &block)
             end
+
+            # Start manual transfer runs to be executed now with schedule_time equal to
+            # current time. The transfer runs can be created for a time range where the
+            # run_time is between start_time (inclusive) and end_time (exclusive), or for
+            # a specific run_time.
+            #
+            # @param parent [String]
+            #   Transfer configuration name in the form:
+            #   `projects/{project_id}/transferConfigs/{config_id}`.
+            # @param requested_time_range [Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsRequest::TimeRange | Hash]
+            #   Time range for the transfer runs that should be started.
+            #   A hash of the same form as `Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsRequest::TimeRange`
+            #   can also be provided.
+            # @param requested_run_time [Google::Protobuf::Timestamp | Hash]
+            #   Specific run_time for a transfer run to be started. The
+            #   requested_run_time must not be in the future.
+            #   A hash of the same form as `Google::Protobuf::Timestamp`
+            #   can also be provided.
+            # @param options [Google::Gax::CallOptions]
+            #   Overrides the default settings for this call, e.g, timeout,
+            #   retries, etc.
+            # @yield [result, operation] Access the result along with the RPC operation
+            # @yieldparam result [Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsResponse]
+            # @yieldparam operation [GRPC::ActiveCall::Operation]
+            # @return [Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsResponse]
+            # @raise [Google::Gax::GaxError] if the RPC is aborted.
+            # @example
+            #   require "google/cloud/bigquery/data_transfer"
+            #
+            #   data_transfer_client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
+            #   response = data_transfer_client.start_manual_transfer_runs
+
+            def start_manual_transfer_runs \
+                parent: nil,
+                requested_time_range: nil,
+                requested_run_time: nil,
+                options: nil,
+                &block
+              req = {
+                parent: parent,
+                requested_time_range: requested_time_range,
+                requested_run_time: requested_run_time
+              }.delete_if { |_, v| v.nil? }
+              req = Google::Gax::to_proto(req, Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsRequest)
+              @start_manual_transfer_runs.call(req, options, &block)
+            end
           end
         end
       end
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_config.json b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_config.json
index 5949db4c5..07463d03d 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_config.json
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_config.json
@@ -84,6 +84,11 @@
           "timeout_millis": 30000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
+        },
+        "StartManualTransferRuns": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datasource.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datasource.rb
new file mode 100644
index 000000000..628547397
--- /dev/null
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datasource.rb
@@ -0,0 +1,25 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Bigquery
+      module Datatransfer
+        module V1
+        end
+      end
+    end
+  end
+end
\ No newline at end of file
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb
index 4387b5d63..362c36cef 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb
@@ -41,7 +41,7 @@ module Google
           #     Is parameter required.
           # @!attribute [rw] repeated
           #   @return [true, false]
-          #     Can parameter have multiple values.
+          #     Deprecated. This field has no effect.
           # @!attribute [rw] validation_regex
           #   @return [String]
           #     Regular expression which can be used for parameter validation.
@@ -56,7 +56,7 @@ module Google
           #     For integer and double values specifies maxminum allowed value.
           # @!attribute [rw] fields
           #   @return [Array<Google::Cloud::Bigquery::Datatransfer::V1::DataSourceParameter>]
-          #     When parameter is a record, describes child fields.
+          #     Deprecated. This field has no effect.
           # @!attribute [rw] validation_description
           #   @return [String]
           #     Description of the requirements for this field, in case the user input does
@@ -69,8 +69,11 @@ module Google
           #     Cannot be changed after initial creation.
           # @!attribute [rw] recurse
           #   @return [true, false]
-          #     If set to true, schema should be taken from the parent with the same
-          #     parameter_id. Only applicable when parameter type is RECORD.
+          #     Deprecated. This field has no effect.
+          # @!attribute [rw] deprecated
+          #   @return [true, false]
+          #     If true, it should not be used in new transfers, and it should not be
+          #     visible to users.
           class DataSourceParameter
             # Parameter type.
             module Type
@@ -90,7 +93,7 @@ module Google
               # Boolean parameter.
               BOOLEAN = 4
 
-              # Record parameter.
+              # Deprecated. This field has no effect.
               RECORD = 5
 
               # Page ID for a Google+ Page.
@@ -115,24 +118,21 @@ module Google
           # @!attribute [rw] client_id
           #   @return [String]
           #     Data source client id which should be used to receive refresh token.
-          #     When not supplied, no offline credentials are populated for data transfer.
           # @!attribute [rw] scopes
           #   @return [Array<String>]
-          #     Api auth scopes for which refresh token needs to be obtained. Only valid
-          #     when `client_id` is specified. Ignored otherwise. These are scopes needed
-          #     by a data source to prepare data and ingest them into BigQuery,
-          #     e.g., https://www.googleapis.com/auth/bigquery
+          #     Api auth scopes for which refresh token needs to be obtained. These are
+          #     scopes needed by a data source to prepare data and ingest them into
+          #     BigQuery, e.g., https://www.googleapis.com/auth/bigquery
           # @!attribute [rw] transfer_type
           #   @return [Google::Cloud::Bigquery::Datatransfer::V1::TransferType]
           #     Deprecated. This field has no effect.
           # @!attribute [rw] supports_multiple_transfers
           #   @return [true, false]
-          #     Indicates whether the data source supports multiple transfers
-          #     to different BigQuery targets.
+          #     Deprecated. This field has no effect.
           # @!attribute [rw] update_deadline_seconds
           #   @return [Integer]
           #     The number of seconds to wait for an update from the data source
-          #     before BigQuery marks the transfer as failed.
+          #     before the Data Transfer Service marks the transfer as FAILED.
           # @!attribute [rw] default_schedule
           #   @return [String]
           #     Default data transfer schedule.
@@ -248,7 +248,7 @@ module Google
           # @!attribute [rw] parent
           #   @return [String]
           #     The BigQuery project id where the transfer configuration should be created.
-          #     Must be in the format /projects/\\{project_id}/locations/\\{location_id}
+          #     Must be in the format projects/\\{project_id}/locations/\\{location_id}
           #     If specified location and location of the destination bigquery dataset
           #     do not match - the request will fail.
           # @!attribute [rw] transfer_config
@@ -272,6 +272,14 @@ module Google
           #       urn:ietf:wg:oauth:2.0:oob means that authorization code should be
           #       returned in the title bar of the browser, with the page text prompting
           #       the user to copy the code and paste it in the application.
+          # @!attribute [rw] version_info
+          #   @return [String]
+          #     Optional version info. If users want to find a very recent access token,
+          #     that is, immediately after approving access, users have to set the
+          #     version_info claim in the token request. To obtain the version_info, users
+          #     must use the "none+gsession" response type. which be return a
+          #     version_info back in the authorization response which be be put in a JWT
+          #     claim in the token request.
           class CreateTransferConfigRequest; end
 
           # A request to update a transfer configuration. To update the user id of the
@@ -300,6 +308,14 @@ module Google
           # @!attribute [rw] update_mask
           #   @return [Google::Protobuf::FieldMask]
           #     Required list of fields to be updated in this request.
+          # @!attribute [rw] version_info
+          #   @return [String]
+          #     Optional version info. If users want to find a very recent access token,
+          #     that is, immediately after approving access, users have to set the
+          #     version_info claim in the token request. To obtain the version_info, users
+          #     must use the "none+gsession" response type. which be return a
+          #     version_info back in the authorization response which be be put in a JWT
+          #     claim in the token request.
           class UpdateTransferConfigRequest; end
 
           # A request to get data transfer information.
@@ -481,6 +497,42 @@ module Google
           #   @return [Array<Google::Cloud::Bigquery::Datatransfer::V1::TransferRun>]
           #     The transfer runs that were scheduled.
           class ScheduleTransferRunsResponse; end
+
+          # A request to start manual transfer runs.
+          # @!attribute [rw] parent
+          #   @return [String]
+          #     Transfer configuration name in the form:
+          #     `projects/{project_id}/transferConfigs/{config_id}`.
+          # @!attribute [rw] requested_time_range
+          #   @return [Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsRequest::TimeRange]
+          #     Time range for the transfer runs that should be started.
+          # @!attribute [rw] requested_run_time
+          #   @return [Google::Protobuf::Timestamp]
+          #     Specific run_time for a transfer run to be started. The
+          #     requested_run_time must not be in the future.
+          class StartManualTransferRunsRequest
+            # A specification for a time range, this will request transfer runs with
+            # run_time between start_time (inclusive) and end_time (exclusive).
+            # @!attribute [rw] start_time
+            #   @return [Google::Protobuf::Timestamp]
+            #     Start time of the range of transfer runs. For example,
+            #     `"2017-05-25T00:00:00+00:00"`. The start_time must be strictly less than
+            #     the end_time. Creates transfer runs where run_time is in the range betwen
+            #     start_time (inclusive) and end_time (exlusive).
+            # @!attribute [rw] end_time
+            #   @return [Google::Protobuf::Timestamp]
+            #     End time of the range of transfer runs. For example,
+            #     `"2017-05-30T00:00:00+00:00"`. The end_time must not be in the future.
+            #     Creates transfer runs where run_time is in the range betwen start_time
+            #     (inclusive) and end_time (exlusive).
+            class TimeRange; end
+          end
+
+          # A response to start manual transfer runs.
+          # @!attribute [rw] runs
+          #   @return [Array<Google::Cloud::Bigquery::Datatransfer::V1::TransferRun>]
+          #     The transfer runs that were created.
+          class StartManualTransferRunsResponse; end
         end
       end
     end
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb
index 5e1e4934d..8440232f9 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb
@@ -18,6 +18,28 @@ module Google
     module Bigquery
       module Datatransfer
         module V1
+          # Options customizing the data transfer schedule.
+          # @!attribute [rw] disable_auto_scheduling
+          #   @return [true, false]
+          #     If true, automatic scheduling of data transfer runs for this configuration
+          #     will be disabled. The runs can be started on ad-hoc basis using
+          #     StartManualTransferRuns API. When automatic scheduling is disabled, the
+          #     TransferConfig.schedule field will be ignored.
+          # @!attribute [rw] start_time
+          #   @return [Google::Protobuf::Timestamp]
+          #     Specifies time to start scheduling transfer runs. The first run will be
+          #     scheduled at or after the start time according to a recurrence pattern
+          #     defined in the schedule string. The start time can be changed at any
+          #     moment. The time when a data transfer can be trigerred manually is not
+          #     limited by this option.
+          # @!attribute [rw] end_time
+          #   @return [Google::Protobuf::Timestamp]
+          #     Defines time to stop scheduling transfer runs. A transfer run cannot be
+          #     scheduled at or after the end time. The end time can be changed at any
+          #     moment. The time when a data transfer can be trigerred manually is not
+          #     limited by this option.
+          class ScheduleOptions; end
+
           # Represents a data transfer configuration. A transfer configuration
           # contains all metadata needed to perform a data transfer. For example,
           # `destination_dataset_id` specifies where data should be stored.
@@ -27,11 +49,12 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     The resource name of the transfer config.
-          #     Transfer config names have the form
-          #     `projects/{project_id}/transferConfigs/{config_id}`.
-          #     Where `config_id` is usually a uuid, even though it is not
-          #     guaranteed or required. The name is ignored when creating a transfer
-          #     config.
+          #     Transfer config names have the form of
+          #     `projects/{project_id}/locations/{region}/transferConfigs/{config_id}`.
+          #     The name is automatically generated based on the config_id specified in
+          #     CreateTransferConfigRequest along with project_id and region. If config_id
+          #     is not provided, usually a uuid, even though it is not guaranteed or
+          #     required, will be generated for config_id.
           # @!attribute [rw] destination_dataset_id
           #   @return [String]
           #     The BigQuery target dataset id.
@@ -58,6 +81,9 @@ module Google
           #     See more explanation about the format here:
           #     https://cloud.google.com/appengine/docs/flexible/python/scheduling-jobs-with-cron-yaml#the_schedule_format
           #     NOTE: the granularity should be at least 8 hours, or less frequent.
+          # @!attribute [rw] schedule_options
+          #   @return [Google::Cloud::Bigquery::Datatransfer::V1::ScheduleOptions]
+          #     Options customizing the data transfer schedule.
           # @!attribute [rw] data_refresh_window_days
           #   @return [Integer]
           #     The number of days to look back to automatically refresh the data.
@@ -81,11 +107,7 @@ module Google
           #     Output only. State of the most recently updated transfer run.
           # @!attribute [rw] user_id
           #   @return [Integer]
-          #     Output only. Unique ID of the user on whose behalf transfer is done.
-          #     Applicable only to data sources that do not support service accounts.
-          #     When set to 0, the data source service account credentials are used.
-          #     May be negative. Note, that this identifier is not stable.
-          #     It may change over time even for the same user.
+          #     Deprecated. Unique ID of the user on whose behalf transfer is done.
           # @!attribute [rw] dataset_region
           #   @return [String]
           #     Output only. Region in which BigQuery dataset is located.
@@ -103,8 +125,8 @@ module Google
           #     Minimum time after which a transfer run can be started.
           # @!attribute [rw] run_time
           #   @return [Google::Protobuf::Timestamp]
-          #     For batch transfer runs, specifies the date and time that
-          #     data should be ingested.
+          #     For batch transfer runs, specifies the date and time of the data should be
+          #     ingested.
           # @!attribute [rw] error_status
           #   @return [Google::Rpc::Status]
           #     Status of the transfer run.
@@ -133,18 +155,14 @@ module Google
           #     Data transfer run state. Ignored for input requests.
           # @!attribute [rw] user_id
           #   @return [Integer]
-          #     Output only. Unique ID of the user on whose behalf transfer is done.
-          #     Applicable only to data sources that do not support service accounts.
-          #     When set to 0, the data source service account credentials are used.
-          #     May be negative. Note, that this identifier is not stable.
-          #     It may change over time even for the same user.
+          #     Deprecated. Unique ID of the user on whose behalf transfer is done.
           # @!attribute [rw] schedule
           #   @return [String]
           #     Output only. Describes the schedule of this transfer run if it was
           #     created as part of a regular schedule. For batch transfer runs that are
           #     scheduled manually, this is empty.
           #     NOTE: the system might choose to delay the schedule depending on the
-          #     current load, so `schedule_time` doesn't always matches this.
+          #     current load, so `schedule_time` doesn't always match this.
           class TransferRun; end
 
           # Represents a user facing message for a particular data transfer run.
@@ -186,7 +204,7 @@ module Google
             # Data transfer is in progress.
             RUNNING = 3
 
-            # Data transfer completed successsfully.
+            # Data transfer completed successfully.
             SUCCEEDED = 4
 
             # Data transfer failed.
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/wrappers.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/wrappers.rb
index 26ae03ea5..f4f885a97 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/wrappers.rb
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,76 +15,12 @@
 
 module Google
   module Protobuf
-    # Wrapper message for +double+.
+    # Wrapper message for `double`.
     #
-    # The JSON representation for +DoubleValue+ is JSON number.
+    # The JSON representation for `DoubleValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The double value.
     class DoubleValue; end
-
-    # Wrapper message for +float+.
-    #
-    # The JSON representation for +FloatValue+ is JSON number.
-    # @!attribute [rw] value
-    #   @return [Float]
-    #     The float value.
-    class FloatValue; end
-
-    # Wrapper message for +int64+.
-    #
-    # The JSON representation for +Int64Value+ is JSON string.
-    # @!attribute [rw] value
-    #   @return [Integer]
-    #     The int64 value.
-    class Int64Value; end
-
-    # Wrapper message for +uint64+.
-    #
-    # The JSON representation for +UInt64Value+ is JSON string.
-    # @!attribute [rw] value
-    #   @return [Integer]
-    #     The uint64 value.
-    class UInt64Value; end
-
-    # Wrapper message for +int32+.
-    #
-    # The JSON representation for +Int32Value+ is JSON number.
-    # @!attribute [rw] value
-    #   @return [Integer]
-    #     The int32 value.
-    class Int32Value; end
-
-    # Wrapper message for +uint32+.
-    #
-    # The JSON representation for +UInt32Value+ is JSON number.
-    # @!attribute [rw] value
-    #   @return [Integer]
-    #     The uint32 value.
-    class UInt32Value; end
-
-    # Wrapper message for +bool+.
-    #
-    # The JSON representation for +BoolValue+ is JSON +true+ and +false+.
-    # @!attribute [rw] value
-    #   @return [true, false]
-    #     The bool value.
-    class BoolValue; end
-
-    # Wrapper message for +string+.
-    #
-    # The JSON representation for +StringValue+ is JSON string.
-    # @!attribute [rw] value
-    #   @return [String]
-    #     The string value.
-    class StringValue; end
-
-    # Wrapper message for +bytes+.
-    #
-    # The JSON representation for +BytesValue+ is JSON string.
-    # @!attribute [rw] value
-    #   @return [String]
-    #     The bytes value.
-    class BytesValue; end
   end
 end
\ No newline at end of file
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datasource_pb.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datasource_pb.rb
new file mode 100644
index 000000000..5643ba32d
--- /dev/null
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datasource_pb.rb
@@ -0,0 +1,170 @@
+# Generated by the protocol buffer compiler.  DO NOT EDIT!
+# source: google/cloud/bigquery/datatransfer/v1/datasource.proto
+
+
+require 'google/protobuf'
+
+require 'google/api/annotations_pb'
+require 'google/cloud/bigquery/datatransfer/v1/datatransfer_pb'
+require 'google/cloud/bigquery/datatransfer/v1/transfer_pb'
+require 'google/protobuf/duration_pb'
+require 'google/protobuf/empty_pb'
+require 'google/protobuf/field_mask_pb'
+require 'google/protobuf/timestamp_pb'
+require 'google/protobuf/wrappers_pb'
+require 'google/api/client_pb'
+Google::Protobuf::DescriptorPool.generated_pool.build do
+  add_message "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo" do
+    optional :sql, :string, 1
+    optional :destination_table_id, :string, 2
+    optional :destination_table_description, :string, 10
+    repeated :table_defs, :message, 3, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.TableDefinition"
+    repeated :user_defined_functions, :string, 4
+    optional :write_disposition, :enum, 6, "google.cloud.bigquery.datatransfer.v1.WriteDisposition"
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.FieldSchema" do
+    optional :field_name, :string, 1
+    optional :type, :enum, 2, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.FieldSchema.Type"
+    optional :is_repeated, :bool, 3
+    optional :description, :string, 4
+    optional :schema, :message, 5, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.RecordSchema"
+  end
+  add_enum "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.FieldSchema.Type" do
+    value :TYPE_UNSPECIFIED, 0
+    value :STRING, 1
+    value :INTEGER, 2
+    value :FLOAT, 3
+    value :RECORD, 4
+    value :BYTES, 5
+    value :BOOLEAN, 6
+    value :TIMESTAMP, 7
+    value :DATE, 8
+    value :TIME, 9
+    value :DATETIME, 10
+    value :NUMERIC, 11
+    value :GEOGRAPHY, 12
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.RecordSchema" do
+    repeated :fields, :message, 1, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.FieldSchema"
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.TableDefinition" do
+    optional :table_id, :string, 1
+    repeated :source_uris, :string, 2
+    optional :format, :enum, 3, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.Format"
+    optional :max_bad_records, :int32, 4
+    optional :encoding, :enum, 5, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.Encoding"
+    optional :csv_options, :message, 6, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.TableDefinition.CsvOptions"
+    optional :schema, :message, 7, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.RecordSchema"
+    optional :ignore_unknown_values, :message, 10, "google.protobuf.BoolValue"
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.TableDefinition.CsvOptions" do
+    optional :field_delimiter, :message, 1, "google.protobuf.StringValue"
+    optional :allow_quoted_newlines, :message, 2, "google.protobuf.BoolValue"
+    optional :quote_char, :message, 3, "google.protobuf.StringValue"
+    optional :skip_leading_rows, :message, 4, "google.protobuf.Int64Value"
+    optional :allow_jagged_rows, :message, 5, "google.protobuf.BoolValue"
+  end
+  add_enum "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.Format" do
+    value :FORMAT_UNSPECIFIED, 0
+    value :CSV, 1
+    value :JSON, 2
+    value :AVRO, 3
+    value :RECORDIO, 4
+    value :COLUMNIO, 5
+    value :CAPACITOR, 6
+    value :PARQUET, 7
+    value :ORC, 8
+  end
+  add_enum "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.Encoding" do
+    value :ENCODING_UNSPECIFIED, 0
+    value :ISO_8859_1, 1
+    value :UTF8, 2
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.UpdateTransferRunRequest" do
+    optional :transfer_run, :message, 1, "google.cloud.bigquery.datatransfer.v1.TransferRun"
+    optional :update_mask, :message, 2, "google.protobuf.FieldMask"
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.LogTransferRunMessagesRequest" do
+    optional :name, :string, 1
+    repeated :transfer_messages, :message, 2, "google.cloud.bigquery.datatransfer.v1.TransferMessage"
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.StartBigQueryJobsRequest" do
+    optional :name, :string, 1
+    repeated :imported_data, :message, 2, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo"
+    optional :user_credentials, :bytes, 3
+    optional :max_parallelism, :int32, 8
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.FinishRunRequest" do
+    optional :name, :string, 1
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.CreateDataSourceDefinitionRequest" do
+    optional :parent, :string, 1
+    optional :data_source_definition, :message, 2, "google.cloud.bigquery.datatransfer.v1.DataSourceDefinition"
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.UpdateDataSourceDefinitionRequest" do
+    optional :data_source_definition, :message, 1, "google.cloud.bigquery.datatransfer.v1.DataSourceDefinition"
+    optional :update_mask, :message, 2, "google.protobuf.FieldMask"
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.DeleteDataSourceDefinitionRequest" do
+    optional :name, :string, 1
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.GetDataSourceDefinitionRequest" do
+    optional :name, :string, 1
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.ListDataSourceDefinitionsRequest" do
+    optional :parent, :string, 1
+    optional :page_token, :string, 2
+    optional :page_size, :int32, 3
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.ListDataSourceDefinitionsResponse" do
+    repeated :data_source_definitions, :message, 1, "google.cloud.bigquery.datatransfer.v1.DataSourceDefinition"
+    optional :next_page_token, :string, 2
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.DataSourceDefinition" do
+    optional :name, :string, 21
+    optional :data_source, :message, 1, "google.cloud.bigquery.datatransfer.v1.DataSource"
+    optional :transfer_run_pubsub_topic, :string, 13
+    optional :run_time_offset, :message, 16, "google.protobuf.Duration"
+    optional :support_email, :string, 22
+    optional :service_account, :string, 2
+    optional :disabled, :bool, 5
+    optional :transfer_config_pubsub_topic, :string, 12
+    repeated :supported_location_ids, :string, 23
+  end
+  add_enum "google.cloud.bigquery.datatransfer.v1.WriteDisposition" do
+    value :WRITE_DISPOSITION_UNSPECIFIED, 0
+    value :WRITE_TRUNCATE, 1
+    value :WRITE_APPEND, 2
+  end
+end
+
+module Google
+  module Cloud
+    module Bigquery
+      module Datatransfer
+        module V1
+          ImportedDataInfo = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo").msgclass
+          ImportedDataInfo::FieldSchema = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.FieldSchema").msgclass
+          ImportedDataInfo::FieldSchema::Type = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.FieldSchema.Type").enummodule
+          ImportedDataInfo::RecordSchema = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.RecordSchema").msgclass
+          ImportedDataInfo::TableDefinition = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.TableDefinition").msgclass
+          ImportedDataInfo::TableDefinition::CsvOptions = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.TableDefinition.CsvOptions").msgclass
+          ImportedDataInfo::Format = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.Format").enummodule
+          ImportedDataInfo::Encoding = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.Encoding").enummodule
+          UpdateTransferRunRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.UpdateTransferRunRequest").msgclass
+          LogTransferRunMessagesRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.LogTransferRunMessagesRequest").msgclass
+          StartBigQueryJobsRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.StartBigQueryJobsRequest").msgclass
+          FinishRunRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.FinishRunRequest").msgclass
+          CreateDataSourceDefinitionRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.CreateDataSourceDefinitionRequest").msgclass
+          UpdateDataSourceDefinitionRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.UpdateDataSourceDefinitionRequest").msgclass
+          DeleteDataSourceDefinitionRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.DeleteDataSourceDefinitionRequest").msgclass
+          GetDataSourceDefinitionRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.GetDataSourceDefinitionRequest").msgclass
+          ListDataSourceDefinitionsRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ListDataSourceDefinitionsRequest").msgclass
+          ListDataSourceDefinitionsResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ListDataSourceDefinitionsResponse").msgclass
+          DataSourceDefinition = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.DataSourceDefinition").msgclass
+          WriteDisposition = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.WriteDisposition").enummodule
+        end
+      end
+    end
+  end
+end
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datasource_services_pb.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datasource_services_pb.rb
new file mode 100644
index 000000000..6b7dd30b2
--- /dev/null
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datasource_services_pb.rb
@@ -0,0 +1,103 @@
+# Generated by the protocol buffer compiler.  DO NOT EDIT!
+# Source: google/cloud/bigquery/datatransfer/v1/datasource.proto for package 'google.cloud.bigquery.datatransfer.v1'
+# Original file comments:
+# Copyright 2019 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+
+require 'grpc'
+require 'google/cloud/bigquery/datatransfer/v1/datasource_pb'
+
+module Google
+  module Cloud
+    module Bigquery
+      module Datatransfer
+        module V1
+          module DataSourceService
+            # The Google BigQuery Data Transfer API allows BigQuery users to
+            # configure transfer of their data from other Google Products into BigQuery.
+            # This service exposes methods that should be used by data source backend.
+            class Service
+
+              include GRPC::GenericService
+
+              self.marshal_class_method = :encode
+              self.unmarshal_class_method = :decode
+              self.service_name = 'google.cloud.bigquery.datatransfer.v1.DataSourceService'
+
+              # Update a transfer run. If successful, resets
+              # data_source.update_deadline_seconds timer.
+              rpc :UpdateTransferRun, UpdateTransferRunRequest, TransferRun
+              # Log messages for a transfer run. If successful (at least 1 message), resets
+              # data_source.update_deadline_seconds timer.
+              rpc :LogTransferRunMessages, LogTransferRunMessagesRequest, Google::Protobuf::Empty
+              # Notify the Data Transfer Service that data is ready for loading.
+              # The Data Transfer Service will start and monitor multiple BigQuery Load
+              # jobs for a transfer run. Monitored jobs will be automatically retried
+              # and produce log messages when starting and finishing a job.
+              # Can be called multiple times for the same transfer run.
+              rpc :StartBigQueryJobs, StartBigQueryJobsRequest, Google::Protobuf::Empty
+              # Notify the Data Transfer Service that the data source is done processing
+              # the run. No more status updates or requests to start/monitor jobs will be
+              # accepted. The run will be finalized by the Data Transfer Service when all
+              # monitored jobs are completed.
+              # Does not need to be called if the run is set to FAILED.
+              rpc :FinishRun, FinishRunRequest, Google::Protobuf::Empty
+              # Creates a data source definition.  Calling this method will automatically
+              # use your credentials to create the following Google Cloud resources in
+              # YOUR Google Cloud project.
+              # 1. OAuth client
+              # 2. Pub/Sub Topics and Subscriptions in each supported_location_ids. e.g.,
+              # projects/\\{project_id}/{topics|subscriptions}/bigquerydatatransfer.\\{data_source_id}.\\{location_id}.run
+              # The field data_source.client_id should be left empty in the input request,
+              # as the API will create a new OAuth client on behalf of the caller. On the
+              # other hand data_source.scopes usually need to be set when there are OAuth
+              # scopes that need to be granted by end users.
+              # 3. We need a longer deadline due to the 60 seconds SLO from Pub/Sub admin
+              # Operations. This also applies to update and delete data source definition.
+              rpc :CreateDataSourceDefinition, CreateDataSourceDefinitionRequest, DataSourceDefinition
+              # Updates an existing data source definition. If changing
+              # supported_location_ids, triggers same effects as mentioned in "Create a
+              # data source definition."
+              rpc :UpdateDataSourceDefinition, UpdateDataSourceDefinitionRequest, DataSourceDefinition
+              # Deletes a data source definition, all of the transfer configs associated
+              # with this data source definition (if any) must be deleted first by the user
+              # in ALL regions, in order to delete the data source definition.
+              # This method is primarily meant for deleting data sources created during
+              # testing stage.
+              # If the data source is referenced by transfer configs in the region
+              # specified in the request URL, the method will fail immediately. If in the
+              # current region (e.g., US) it's not used by any transfer configs, but in
+              # another region (e.g., EU) it is, then although the method will succeed in
+              # region US, but it will fail when the deletion operation is replicated to
+              # region EU. And eventually, the system will replicate the data source
+              # definition back from EU to US, in order to bring all regions to
+              # consistency. The final effect is that the data source appears to be
+              # 'undeleted' in the US region.
+              rpc :DeleteDataSourceDefinition, DeleteDataSourceDefinitionRequest, Google::Protobuf::Empty
+              # Retrieves an existing data source definition.
+              rpc :GetDataSourceDefinition, GetDataSourceDefinitionRequest, DataSourceDefinition
+              # Lists supported data source definitions.
+              rpc :ListDataSourceDefinitions, ListDataSourceDefinitionsRequest, ListDataSourceDefinitionsResponse
+            end
+
+            Stub = Service.rpc_stub_class
+          end
+        end
+      end
+    end
+  end
+end
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_pb.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_pb.rb
index 0032a1312..8a7635c48 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_pb.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_pb.rb
@@ -11,6 +11,7 @@ require 'google/protobuf/empty_pb'
 require 'google/protobuf/field_mask_pb'
 require 'google/protobuf/timestamp_pb'
 require 'google/protobuf/wrappers_pb'
+require 'google/api/client_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.bigquery.datatransfer.v1.DataSourceParameter" do
     optional :param_id, :string, 1
@@ -28,6 +29,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :validation_help_url, :string, 13
     optional :immutable, :bool, 14
     optional :recurse, :bool, 15
+    optional :deprecated, :bool, 20
   end
   add_enum "google.cloud.bigquery.datatransfer.v1.DataSourceParameter.Type" do
     value :TYPE_UNSPECIFIED, 0
@@ -84,11 +86,13 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :parent, :string, 1
     optional :transfer_config, :message, 2, "google.cloud.bigquery.datatransfer.v1.TransferConfig"
     optional :authorization_code, :string, 3
+    optional :version_info, :string, 5
   end
   add_message "google.cloud.bigquery.datatransfer.v1.UpdateTransferConfigRequest" do
     optional :transfer_config, :message, 1, "google.cloud.bigquery.datatransfer.v1.TransferConfig"
     optional :authorization_code, :string, 3
     optional :update_mask, :message, 4, "google.protobuf.FieldMask"
+    optional :version_info, :string, 5
   end
   add_message "google.cloud.bigquery.datatransfer.v1.GetTransferConfigRequest" do
     optional :name, :string, 1
@@ -151,6 +155,20 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.bigquery.datatransfer.v1.ScheduleTransferRunsResponse" do
     repeated :runs, :message, 1, "google.cloud.bigquery.datatransfer.v1.TransferRun"
   end
+  add_message "google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsRequest" do
+    optional :parent, :string, 1
+    oneof :time do
+      optional :requested_time_range, :message, 3, "google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsRequest.TimeRange"
+      optional :requested_run_time, :message, 4, "google.protobuf.Timestamp"
+    end
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsRequest.TimeRange" do
+    optional :start_time, :message, 1, "google.protobuf.Timestamp"
+    optional :end_time, :message, 2, "google.protobuf.Timestamp"
+  end
+  add_message "google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsResponse" do
+    repeated :runs, :message, 1, "google.cloud.bigquery.datatransfer.v1.TransferRun"
+  end
 end
 
 module Google
@@ -183,6 +201,9 @@ module Google
           CheckValidCredsResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.CheckValidCredsResponse").msgclass
           ScheduleTransferRunsRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ScheduleTransferRunsRequest").msgclass
           ScheduleTransferRunsResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ScheduleTransferRunsResponse").msgclass
+          StartManualTransferRunsRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsRequest").msgclass
+          StartManualTransferRunsRequest::TimeRange = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsRequest.TimeRange").msgclass
+          StartManualTransferRunsResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsResponse").msgclass
         end
       end
     end
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_services_pb.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_services_pb.rb
index b32af9f7f..e69e55ee7 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_services_pb.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_services_pb.rb
@@ -1,7 +1,7 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
 # Source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto for package 'google.cloud.bigquery.datatransfer.v1'
 # Original file comments:
-# Copyright 2018 Google Inc.
+# Copyright 2019 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+#
 
 
 require 'grpc'
@@ -60,7 +61,13 @@ module Google
               # For each date - or whatever granularity the data source supports - in the
               # range, one transfer run is created.
               # Note that runs are created per UTC time in the time range.
+              # DEPRECATED: use StartManualTransferRuns instead.
               rpc :ScheduleTransferRuns, ScheduleTransferRunsRequest, ScheduleTransferRunsResponse
+              # Start manual transfer runs to be executed now with schedule_time equal to
+              # current time. The transfer runs can be created for a time range where the
+              # run_time is between start_time (inclusive) and end_time (exclusive), or for
+              # a specific run_time.
+              rpc :StartManualTransferRuns, StartManualTransferRunsRequest, StartManualTransferRunsResponse
               # Returns information about the particular transfer run.
               rpc :GetTransferRun, GetTransferRunRequest, TransferRun
               # Deletes the specified transfer run.
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/transfer_pb.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/transfer_pb.rb
index 73920f4bf..8f39d5161 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/transfer_pb.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/transfer_pb.rb
@@ -9,6 +9,11 @@ require 'google/protobuf/struct_pb'
 require 'google/protobuf/timestamp_pb'
 require 'google/rpc/status_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
+  add_message "google.cloud.bigquery.datatransfer.v1.ScheduleOptions" do
+    optional :disable_auto_scheduling, :bool, 3
+    optional :start_time, :message, 1, "google.protobuf.Timestamp"
+    optional :end_time, :message, 2, "google.protobuf.Timestamp"
+  end
   add_message "google.cloud.bigquery.datatransfer.v1.TransferConfig" do
     optional :name, :string, 1
     optional :destination_dataset_id, :string, 2
@@ -16,6 +21,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :data_source_id, :string, 5
     optional :params, :message, 9, "google.protobuf.Struct"
     optional :schedule, :string, 7
+    optional :schedule_options, :message, 24, "google.cloud.bigquery.datatransfer.v1.ScheduleOptions"
     optional :data_refresh_window_days, :int32, 12
     optional :disabled, :bool, 13
     optional :update_time, :message, 4, "google.protobuf.Timestamp"
@@ -70,6 +76,7 @@ module Google
     module Bigquery
       module Datatransfer
         module V1
+          ScheduleOptions = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ScheduleOptions").msgclass
           TransferConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.TransferConfig").msgclass
           TransferRun = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.TransferRun").msgclass
           TransferMessage = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.TransferMessage").msgclass
diff --git a/google-cloud-bigquery-data_transfer/synth.metadata b/google-cloud-bigquery-data_transfer/synth.metadata
index e5687c216..e706e29b4 100644
--- a/google-cloud-bigquery-data_transfer/synth.metadata
+++ b/google-cloud-bigquery-data_transfer/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-30T00:53:14.681155Z",
+  "updateTime": "2019-06-14T10:38:39.797787Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.21.0",
-        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
+        "version": "0.25.0",
+        "dockerImage": "googleapis/artman@sha256:ef1a98ab1e2b8f05f4d9a56f27d63347aefe14020e5f2d585172b14ca76f1d90"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
-        "internalRef": "250569499"
+        "sha": "c23b68eecb00c4d285a730a49b1d7d943cd56183",
+        "internalRef": "253113405"
       }
     },
     {
diff --git a/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb b/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb
index 913b6664f..cfbeb01ac 100644
--- a/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb
+++ b/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb
@@ -1125,4 +1125,67 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       end
     end
   end
+
+  describe 'start_manual_transfer_runs' do
+    custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient#start_manual_transfer_runs."
+
+    it 'invokes start_manual_transfer_runs without error' do
+      # Create expected grpc response
+      expected_response = {}
+      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:start_manual_transfer_runs, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockDataTransferServiceCredentials_v1.new("start_manual_transfer_runs")
+
+      Google::Cloud::Bigquery::Datatransfer::V1::DataTransferService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Bigquery::DataTransfer::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
+
+          # Call method
+          response = client.start_manual_transfer_runs
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.start_manual_transfer_runs do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes start_manual_transfer_runs with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:start_manual_transfer_runs, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockDataTransferServiceCredentials_v1.new("start_manual_transfer_runs")
+
+      Google::Cloud::Bigquery::Datatransfer::V1::DataTransferService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Bigquery::DataTransfer::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.start_manual_transfer_runs
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
 end
\ No newline at end of file

```

</details>

This pull request was generated using releasetool.