### PR TITLE
Added `File.open` to quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -996,6 +996,8 @@ $ gem install google-cloud-text_to_speech
 #### Preview
 
 ```rb
+require "google/cloud/text_to_speech"
+
 text_to_speech_client = Google::Cloud::TextToSpeech.new
 text = "test"
 input = { text: text }

--- a/README.md
+++ b/README.md
@@ -996,17 +996,14 @@ $ gem install google-cloud-text_to_speech
 #### Preview
 
 ```rb
-require "google/cloud/text_to_speech/v1"
-
-text_to_speech_client = Google::Cloud::TextToSpeech::V1.new
-
-input = {text: "Hello, world!"}
-voice = {language_code: "en-US"}
-audio_config = {audio_encoding: Google::Cloud::Texttospeech::V1::AudioEncoding::MP3}
-response = text_to_speech_client.synthesize_speech input, voice, audio_config
-File.open "hello.mp3", "wb" do |file|
-  file.write response.audio_content
-end
+text_to_speech_client = Google::Cloud::TextToSpeech.new
+text = "test"
+input = { text: text }
+language_code = "en-US"
+voice = { language_code: language_code }
+audio_encoding = :MP3
+audio_config = { audio_encoding: audio_encoding }
+response = text_to_speech_client.synthesize_speech(input, voice, audio_config)
 ```
 
 ### Cloud Translation API (GA)

--- a/README.md
+++ b/README.md
@@ -1004,7 +1004,7 @@ input = {text: "Hello, world!"}
 voice = {language_code: "en-US"}
 audio_config = {audio_encoding: Google::Cloud::Texttospeech::V1::AudioEncoding::MP3}
 response = text_to_speech_client.synthesize_speech input, voice, audio_config
-File.open "hello.mp3", "w" do |file|
+File.open "hello.mp3", "wb" do |file|
   file.write response.audio_content
 end
 ```

--- a/google-cloud-text_to_speech/README.md
+++ b/google-cloud-text_to_speech/README.md
@@ -33,7 +33,6 @@ voice = { language_code: language_code }
 audio_encoding = :MP3
 audio_config = { audio_encoding: audio_encoding }
 response = text_to_speech_client.synthesize_speech(input, voice, audio_config)
-File.open('example.mp3', "wb"){|file| file.write response.audio_content}
 ```
 
 ### Next Steps

--- a/google-cloud-text_to_speech/README.md
+++ b/google-cloud-text_to_speech/README.md
@@ -33,6 +33,7 @@ voice = { language_code: language_code }
 audio_encoding = :MP3
 audio_config = { audio_encoding: audio_encoding }
 response = text_to_speech_client.synthesize_speech(input, voice, audio_config)
+File.open('example.mp3', "wb"){|file| file.write response.audio_content}
 ```
 
 ### Next Steps


### PR DESCRIPTION
Currently, the `response` object in the example is only stored in memory. It's not self-evident that the `response`'s `audio_content` method is the way to work with the audio.  Since the example is encoded as an MP3, I think it's natural to show the first-time user how to save that file to disk, and thus introduce them to that method.