### PR TITLE
test: add conformance-tests git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "conformance-tests"]
+	path = conformance-tests
+	url = https://github.com/googleapis/conformance-tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "conformance-tests"]
-	path = conformance-tests
+[submodule "conformance-tests-storage"]
+	path = google-cloud-storage/conformance
 	url = https://github.com/googleapis/conformance-tests


### PR DESCRIPTION
The googleapis/conformance-tests repo recommends that it should be imported using git submodules:

> Generally, conformance tests are accessed as git submodules in the repositories. 

The repo currently provides conformance test data for Storage, and will soon add Firestore and Bigtable.