### PR TITLE
chore: Make it easier to override the service host in generated libraries

### DIFF
--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -51,11 +51,52 @@ s.copy(v1beta1_library / 'test/google/cloud/asset/v1beta1')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/asset.rb',
+        'lib/google/cloud/asset/v*.rb',
+        'lib/google/cloud/asset/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/asset/v*.rb',
+        'lib/google/cloud/asset/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/asset/v*.rb',
+        'lib/google/cloud/asset/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/asset/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/asset/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-asset.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> ([\\d\\.]+)"\n\n',
-    '\n  gem.add_dependency "google-gax", "~> \\1"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2232
 s.replace(
@@ -170,11 +211,3 @@ for version in ['v1', 'v1beta1']:
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate', shell=True)
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1', 'v1beta1']:
-    s.replace(
-        f'test/google/cloud/asset/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

--- a/google-cloud-automl/synth.py
+++ b/google-cloud-automl/synth.py
@@ -93,6 +93,51 @@ s.replace(
     'google.cloud.automl.v1beta1.AutoMl'
 )
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/automl.rb',
+        'lib/google/cloud/automl/v*.rb',
+        'lib/google/cloud/automl/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/automl/v*.rb',
+        'lib/google/cloud/automl/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/automl/v*.rb',
+        'lib/google/cloud/automl/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/automl/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/automl/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-automl.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -42,6 +42,51 @@ s.copy(v1_library / 'google-cloud-bigquery-data_transfer.gemspec', merge=ruby.me
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/bigquery/data_transfer.rb',
+        'lib/google/cloud/bigquery/data_transfer/v*.rb',
+        'lib/google/cloud/bigquery/data_transfer/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/bigquery/data_transfer/v*.rb',
+        'lib/google/cloud/bigquery/data_transfer/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/bigquery/data_transfer/v*.rb',
+        'lib/google/cloud/bigquery/data_transfer/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/bigquery/data_transfer/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/bigquery/data_transfer/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-bigquery-data_transfer.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # PERMANENT: Use custom credentials env variable names
 s.replace(
     'lib/google/cloud/bigquery/data_transfer/v1/credentials.rb',
@@ -143,11 +188,3 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Bigquery::DataTransfer::VERSION'
 )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1']:
-    s.replace(
-        f'test/google/cloud/bigquery/data_transfer/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

--- a/google-cloud-bigtable/google-cloud-bigtable.gemspec
+++ b/google-cloud-bigtable/google-cloud-bigtable.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.0"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   gem.add_dependency "google-cloud-core", "~> 1.1"
 

--- a/google-cloud-bigtable/synth.py
+++ b/google-cloud-bigtable/synth.py
@@ -43,6 +43,58 @@ s.copy(v2_admin_library / 'lib/google/cloud/bigtable/admin.rb')
 s.copy(v2_admin_library / 'lib/google/bigtable/admin/v2')
 s.copy(v2_admin_library / 'test/google/cloud/bigtable/admin/v2')
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/bigtable/v*.rb',
+        'lib/google/cloud/bigtable/v*/*_client.rb',
+        'lib/google/cloud/bigtable/admin/v*.rb',
+        'lib/google/cloud/bigtable/admin/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/bigtable/v*.rb',
+        'lib/google/cloud/bigtable/v*/*_client.rb',
+        'lib/google/cloud/bigtable/admin/v*.rb',
+        'lib/google/cloud/bigtable/admin/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/bigtable/v*.rb',
+        'lib/google/cloud/bigtable/v*/*_client.rb',
+        'lib/google/cloud/bigtable/admin/v*.rb',
+        'lib/google/cloud/bigtable/admin/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    [
+        'lib/google/cloud/bigtable/v*/*_client.rb',
+        'lib/google/cloud/bigtable/admin/v*/*_client.rb'
+    ],
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    [
+        'lib/google/cloud/bigtable/v*/*_client.rb',
+        'lib/google/cloud/bigtable/admin/v*/*_client.rb'
+    ],
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # PERMANENT: We're combining bigtable and bigtable-admin into one gem.
 s.replace(
     [
@@ -155,16 +207,3 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Bigtable::VERSION'
 )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v2']:
-    s.replace(
-        f'test/google/cloud/bigtable/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )
-    s.replace(
-        f'test/google/cloud/bigtable/admin/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -52,6 +52,51 @@ s.copy(v1_library / '.gitignore')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-container.gemspec', merge=ruby.merge_gemspec)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/container.rb',
+        'lib/google/cloud/container/v*.rb',
+        'lib/google/cloud/container/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/container/v*.rb',
+        'lib/google/cloud/container/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/container/v*.rb',
+        'lib/google/cloud/container/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/container/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/container/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-container.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [
@@ -137,12 +182,4 @@ for version in ['v1', 'v1beta1']:
         f'lib/google/cloud/container/{version}/cluster_manager_client.rb',
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Container::VERSION'
-    )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1', 'v1beta1']:
-    s.replace(
-        f'test/google/cloud/container/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
     )

--- a/google-cloud-container_analysis/synth.py
+++ b/google-cloud-container_analysis/synth.py
@@ -56,11 +56,52 @@ s.replace(
     'Google::Cloud::ContainerAnalysis::V1::ContainerAnalysisService::'
 )
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/container_analysis.rb',
+        'lib/google/cloud/container_analysis/v*.rb',
+        'lib/google/cloud/container_analysis/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/container_analysis/v*.rb',
+        'lib/google/cloud/container_analysis/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/container_analysis/v*.rb',
+        'lib/google/cloud/container_analysis/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/container_analysis/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/container_analysis/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # Container analysis should depend on grafeas-client for now
 s.replace(
     'google-cloud-container_analysis.gemspec',
-    '\n\n  gem.add_dependency "google-gax", "~> 1.3"',
-    '\n\n  gem.add_dependency "grafeas-client", "~> 0.1"\n  gem.add_dependency "google-gax", "~> 1.3"',
+    '\n\n  gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    '\n\n  gem.add_dependency "grafeas-client", "~> 0.1"\n  gem.add_dependency "google-gax", "~> 1.7"',
 )
 s.replace(
     'lib/google/cloud/container_analysis.rb',

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -59,6 +59,51 @@ s.replace(
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/dataproc.rb',
+        'lib/google/cloud/dataproc/v*.rb',
+        'lib/google/cloud/dataproc/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/dataproc/v*.rb',
+        'lib/google/cloud/dataproc/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/dataproc/v*.rb',
+        'lib/google/cloud/dataproc/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/dataproc/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/dataproc/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-dataproc.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-datastore/google-cloud-datastore.gemspec
+++ b/google-cloud-datastore/google-cloud-datastore.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 1.0"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "google-protobuf", "~> 3.3"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-datastore/synth.py
+++ b/google-cloud-datastore/synth.py
@@ -33,6 +33,32 @@ s.copy(v1_library / 'lib/google/datastore/v1')
 # Omitting lib/google/cloud/datastore/v1.rb for now because we are not exposing
 # the low-level API.
 
+# Support for service_address
+s.replace(
+    'lib/google/cloud/datastore/v*/*_client.rb',
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    'lib/google/cloud/datastore/v*/*_client.rb',
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    'lib/google/cloud/datastore/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/datastore/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2124
 s.replace(
     'lib/google/cloud/datastore/v1/credentials.rb',

--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "binding_of_caller", "~> 0.7"
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "google-cloud-logging", "~> 1.0"
-  gem.add_dependency "google-gax", "~> 1.0"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 

--- a/google-cloud-debugger/synth.py
+++ b/google-cloud-debugger/synth.py
@@ -65,6 +65,46 @@ s.replace(
     'lib/google/cloud/debugger/v2.rb',
     '/debugger\\.googleapis\\.com', '/clouddebugger.googleapis.com')
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/debugger/v*.rb',
+        'lib/google/cloud/debugger/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/debugger/v*.rb',
+        'lib/google/cloud/debugger/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/debugger/v*.rb',
+        'lib/google/cloud/debugger/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/debugger/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/debugger/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
@@ -113,11 +153,3 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Debugger::VERSION'
 )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v2']:
-    s.replace(
-        f'test/google/cloud/debugger/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -41,6 +41,47 @@ s.copy(v2_library / 'google-cloud-dialogflow.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/dialogflow.rb',
+        'lib/google/cloud/dialogflow/v*.rb',
+        'lib/google/cloud/dialogflow/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/dialogflow/v*.rb',
+        'lib/google/cloud/dialogflow/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/dialogflow/v*.rb',
+        'lib/google/cloud/dialogflow/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/dialogflow/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/dialogflow/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2232
 s.replace(
     [
@@ -90,9 +131,9 @@ s.replace(
 
 s.replace(
     'google-cloud-dialogflow.gemspec',
-    'gem.add_dependency "google-gax", "~> 1.3"',
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.3"',
+        'gem.add_dependency "google-gax", "~> 1.7"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )
@@ -129,11 +170,3 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Dialogflow::VERSION'
 )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v2']:
-    s.replace(
-        f'test/google/cloud/dialogflow/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -40,6 +40,47 @@ s.copy(v2_library / 'google-cloud-dlp.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/dlp.rb',
+        'lib/google/cloud/dlp/v*.rb',
+        'lib/google/cloud/dlp/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/dlp/v*.rb',
+        'lib/google/cloud/dlp/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/dlp/v*.rb',
+        'lib/google/cloud/dlp/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/dlp/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/dlp/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
@@ -92,9 +133,9 @@ s.replace(
 
 s.replace(
     'google-cloud-dlp.gemspec',
-    'gem.add_dependency "google-gax", "~> 1.3"',
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.3"',
+        'gem.add_dependency "google-gax", "~> 1.7"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )
@@ -131,11 +172,3 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Dlp::VERSION'
 )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v2']:
-    s.replace(
-        f'test/google/cloud/dlp/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

--- a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
+++ b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
-  gem.add_dependency "google-gax", "~> 1.0"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-error_reporting/synth.py
+++ b/google-cloud-error_reporting/synth.py
@@ -34,6 +34,32 @@ s.copy(v1beta1_library / 'lib/google/devtools/clouderrorreporting/v1beta1')
 # Omitting lib/google/cloud/error_reporting/v1beta1.rb for now because we are
 # not exposing the low-level API.
 
+# Support for service_address
+s.replace(
+    'lib/google/cloud/error_reporting/v*/*_client.rb',
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    'lib/google/cloud/error_reporting/v*/*_client.rb',
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    'lib/google/cloud/error_reporting/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/error_reporting/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-firestore/google-cloud-firestore.gemspec
+++ b/google-cloud-firestore/google-cloud-firestore.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 1.0"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_dependency "rbtree", "~> 0.4.2"
 

--- a/google-cloud-firestore/synth.py
+++ b/google-cloud-firestore/synth.py
@@ -75,6 +75,46 @@ s.replace(
     'Google::Cloud::Firestore\\.new\\(version: :v1\\)',
     'Google::Cloud::Firestore::V1.new')
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/firestore/v*.rb',
+        'lib/google/cloud/firestore/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/firestore/v*.rb',
+        'lib/google/cloud/firestore/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/firestore/v*.rb',
+        'lib/google/cloud/firestore/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/firestore/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/firestore/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
@@ -123,12 +163,4 @@ for version in ['v1', 'v1beta1']:
         f'lib/google/cloud/firestore/{version}/*_client.rb',
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Firestore::VERSION'
-    )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1', 'v1beta1']:
-    s.replace(
-        f'test/google/cloud/firestore/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
     )

--- a/google-cloud-irm/synth.py
+++ b/google-cloud-irm/synth.py
@@ -29,7 +29,6 @@ v1alpha2 = gapic.ruby_library(
     artman_output_name='google-cloud-ruby/google-cloud-irm',
     config_path='artman_irm_v1alpha2.yaml'
 )
-s.copy(v1alpha2 / 'acceptance')
 s.copy(v1alpha2 / 'lib')
 s.copy(v1alpha2 / 'test')
 s.copy(v1alpha2 / 'README.md')
@@ -41,6 +40,51 @@ s.copy(v1alpha2 / 'google-cloud-irm.gemspec', merge=ruby.merge_gemspec)
 # Copy common templates
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
+
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/irm.rb',
+        'lib/google/cloud/irm/v*.rb',
+        'lib/google/cloud/irm/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/irm/v*.rb',
+        'lib/google/cloud/irm/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/irm/v*.rb',
+        'lib/google/cloud/irm/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/irm/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/irm/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-irm.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
@@ -124,11 +168,3 @@ s.replace(
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1alpha2']:
-    s.replace(
-        f'test/google/cloud/irm/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -80,6 +80,51 @@ s.replace(
 
       ### Next Steps\n"""))
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/kms.rb',
+        'lib/google/cloud/kms/v*.rb',
+        'lib/google/cloud/kms/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/kms/v*.rb',
+        'lib/google/cloud/kms/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/kms/v*.rb',
+        'lib/google/cloud/kms/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/kms/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/kms/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-kms.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
@@ -175,11 +220,3 @@ s.replace(
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1']:
-    s.replace(
-        f'test/google/cloud/kms/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -54,6 +54,47 @@ s.copy(v1beta2_library / 'test/google/cloud/language/v1beta2')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/language.rb',
+        'lib/google/cloud/language/v*.rb',
+        'lib/google/cloud/language/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/language/v*.rb',
+        'lib/google/cloud/language/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/language/v*.rb',
+        'lib/google/cloud/language/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/language/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/language/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [
@@ -113,9 +154,9 @@ s.replace(
 
 s.replace(
     'google-cloud-language.gemspec',
-    'gem.add_dependency "google-gax", "~> 1.3"',
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.3"',
+        'gem.add_dependency "google-gax", "~> 1.7"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )

--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 

--- a/google-cloud-logging/synth.py
+++ b/google-cloud-logging/synth.py
@@ -58,6 +58,32 @@ s.replace(
     'Google::Cloud::Logging::Metrics\\.new\\(version: :v2\\)',
     'Google::Cloud::Logging::V2::MetricsServiceV2Client.new')
 
+# Support for service_address
+s.replace(
+    'lib/google/cloud/logging/v*/*_client.rb',
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    'lib/google/cloud/logging/v*/*_client.rb',
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    'lib/google/cloud/logging/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/logging/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2124
 s.replace(
     'lib/google/cloud/logging/v2/credentials.rb',

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -43,11 +43,52 @@ s.copy(v3_library / 'google-cloud-monitoring.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/monitoring.rb',
+        'lib/google/cloud/monitoring/v*.rb',
+        'lib/google/cloud/monitoring/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/monitoring/v*.rb',
+        'lib/google/cloud/monitoring/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/monitoring/v*.rb',
+        'lib/google/cloud/monitoring/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/monitoring/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/monitoring/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # PERMANENT: Use a compatible version of googleapis-common-protos-types
 s.replace(
     'google-cloud-monitoring.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> ([\\d\\.]+)"',
-    '\n  gem.add_dependency "google-gax", "~> \\1"\n  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"')
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"')
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
@@ -131,11 +172,3 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Monitoring::VERSION'
 )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v3']:
-    s.replace(
-        f'test/google/cloud/monitoring/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -66,6 +66,51 @@ s.replace(
     ],
     '/os-login\\.googleapis\\.com', '/oslogin.googleapis.com')
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/os_login.rb',
+        'lib/google/cloud/os_login/v*.rb',
+        'lib/google/cloud/os_login/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/os_login/v*.rb',
+        'lib/google/cloud/os_login/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/os_login/v*.rb',
+        'lib/google/cloud/os_login/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/os_login/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/os_login/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-os_login.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [

--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   gem.add_dependency "concurrent-ruby", "~> 1.1"

--- a/google-cloud-pubsub/synth.py
+++ b/google-cloud-pubsub/synth.py
@@ -54,6 +54,32 @@ s.replace(
     '\n    end\n\n    Pubsub = PubSub unless const_defined? :Pubsub\n  end\nend'
 )
 
+# Support for service_address
+s.replace(
+    'lib/google/cloud/pubsub/v*/*_client.rb',
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    'lib/google/cloud/pubsub/v*/*_client.rb',
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    'lib/google/cloud/pubsub/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/pubsub/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2124
 s.replace(
     'lib/google/cloud/pubsub/v1/credentials.rb',

--- a/google-cloud-recaptcha_enterprise/synth.py
+++ b/google-cloud-recaptcha_enterprise/synth.py
@@ -43,11 +43,52 @@ s.copy(v1beta1_library / 'google-cloud-recaptcha_enterprise.gemspec', merge=ruby
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/recaptcha_enterprise.rb',
+        'lib/google/cloud/recaptcha_enterprise/v*.rb',
+        'lib/google/cloud/recaptcha_enterprise/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/recaptcha_enterprise/v*.rb',
+        'lib/google/cloud/recaptcha_enterprise/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/recaptcha_enterprise/v*.rb',
+        'lib/google/cloud/recaptcha_enterprise/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/recaptcha_enterprise/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/recaptcha_enterprise/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-recaptcha_enterprise.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> ([\\d\\.]+)"\n\n',
-    '\n  gem.add_dependency "google-gax", "~> \\1"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
@@ -188,11 +229,3 @@ s.replace(
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1beta1']:
-    s.replace(
-        f'test/google/cloud/recaptcha_enterprise/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -51,6 +51,47 @@ s.copy(v1beta1_library / 'lib/google/cloud/redis/v1beta1')
 s.copy(v1beta1_library / 'lib/google/cloud/redis/v1beta1.rb')
 s.copy(v1beta1_library / 'test/google/cloud/redis/v1beta1')
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/redis.rb',
+        'lib/google/cloud/redis/v*.rb',
+        'lib/google/cloud/redis/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/redis/v*.rb',
+        'lib/google/cloud/redis/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/redis/v*.rb',
+        'lib/google/cloud/redis/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/redis/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/redis/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [
@@ -123,9 +164,9 @@ s.replace(
 
 s.replace(
     'google-cloud-redis.gemspec',
-    'gem.add_dependency "google-gax", "~> 1.3"',
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.3"',
+        'gem.add_dependency "google-gax", "~> 1.7"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )
@@ -162,12 +203,4 @@ for version in ['v1', 'v1beta1']:
         f'lib/google/cloud/redis/{version}/*_client.rb',
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Redis::VERSION'
-    )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1', 'v1beta1']:
-    s.replace(
-        f'test/google/cloud/redis/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
     )

--- a/google-cloud-scheduler/synth.py
+++ b/google-cloud-scheduler/synth.py
@@ -42,7 +42,6 @@ s.copy(v1beta1_library / 'test/google/cloud/scheduler/v1beta1')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
-
 v1_library = gapic.ruby_library(
     'scheduler',
     'v1',
@@ -60,11 +59,47 @@ s.copy(v1_library / '.gitignore')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-scheduler.gemspec', merge=ruby.merge_gemspec)
 
+# Support for service_address
 s.replace(
-    'google-cloud-scheduler.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
+    [
+        'lib/google/cloud/scheduler.rb',
+        'lib/google/cloud/scheduler/v*.rb',
+        'lib/google/cloud/scheduler/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
 )
+s.replace(
+    [
+        'lib/google/cloud/scheduler/v*.rb',
+        'lib/google/cloud/scheduler/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/scheduler/v*.rb',
+        'lib/google/cloud/scheduler/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/scheduler/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/scheduler/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 
 # https://github.com/googleapis/gapic-generator/issues/2279
 s.replace(
@@ -103,9 +138,9 @@ for version in ['v1beta1', 'v1']:
 
 s.replace(
     'google-cloud-scheduler.gemspec',
-    'gem.add_dependency "google-gax", "~> 1.3"',
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.3"',
+        'gem.add_dependency "google-gax", "~> 1.7"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )
@@ -146,11 +181,3 @@ for version in ['v1', 'v1beta1']:
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1', 'v1beta1']:
-    s.replace(
-        f'test/google/cloud/scheduler/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

--- a/google-cloud-security_center/synth.py
+++ b/google-cloud-security_center/synth.py
@@ -68,6 +68,51 @@ s.replace(
     'Google::Cloud::SecurityCenter'
 )
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/security_center.rb',
+        'lib/google/cloud/security_center/v*.rb',
+        'lib/google/cloud/security_center/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/security_center/v*.rb',
+        'lib/google/cloud/security_center/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/security_center/v*.rb',
+        'lib/google/cloud/security_center/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/security_center/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/security_center/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-security_center.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [
@@ -166,14 +211,6 @@ s.replace(
 
 # Generate the helper methods
 subprocess.call('bundle update && bundle exec rake generate_partials', shell=True)
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1']:
-    s.replace(
-        f'test/google/cloud/security_center/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )
 
 # Deal with weirdness where RunAssetDiscoveryResponse is defined in a separate
 # file that doesn't get required properly.

--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 1.0"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
 

--- a/google-cloud-spanner/synth.py
+++ b/google-cloud-spanner/synth.py
@@ -101,6 +101,32 @@ s.replace(
     ],
     '/spanner-admin-\\w+\\.googleapis\\.com', '/spanner.googleapis.com')
 
+# Support for service_address
+s.replace(
+    'lib/google/cloud/spanner/v*/*_client.rb',
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    'lib/google/cloud/spanner/v*/*_client.rb',
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    'lib/google/cloud/spanner/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/spanner/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [
@@ -195,21 +221,3 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Spanner::VERSION'
 )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1']:
-    s.replace(
-        f'test/google/cloud/spanner/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )
-    s.replace(
-        f'test/google/cloud/spanner/admin/database/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )
-    s.replace(
-        f'test/google/cloud/spanner/admin/instance/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -60,11 +60,46 @@ s.copy(v2_library / 'google-cloud-tasks.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
-# https://github.com/googleapis/gapic-generator/issues/2180
+# Support for service_address
 s.replace(
-    'google-cloud-tasks.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> ([\\d\\.]+)"\n\n',
-    '\n  gem.add_dependency "google-gax", "~> \\1"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
+    [
+        'lib/google/cloud/tasks.rb',
+        'lib/google/cloud/tasks/v*.rb',
+        'lib/google/cloud/tasks/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/tasks/v*.rb',
+        'lib/google/cloud/tasks/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/tasks/v*.rb',
+        'lib/google/cloud/tasks/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/tasks/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/tasks/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
@@ -133,11 +168,12 @@ for version in ['v2beta2', 'v2beta3', 'v2']:
         ])
     )
 
+# https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-tasks.gemspec',
-    'gem.add_dependency "google-gax", "~> 1.3"',
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.3"',
+        'gem.add_dependency "google-gax", "~> 1.7"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )
@@ -178,11 +214,3 @@ for version in ['v2', 'v2beta2', 'v2beta3']:
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v2beta2', 'v2beta3', 'v2']:
-    s.replace(
-        f'test/google/cloud/tasks/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -49,6 +49,51 @@ s.copy(v1beta1_library / 'test/google/cloud/text_to_speech/v1beta1')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/text_to_speech.rb',
+        'lib/google/cloud/text_to_speech/v*.rb',
+        'lib/google/cloud/text_to_speech/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/text_to_speech/v*.rb',
+        'lib/google/cloud/text_to_speech/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/text_to_speech/v*.rb',
+        'lib/google/cloud/text_to_speech/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/text_to_speech/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/text_to_speech/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-text_to_speech.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
     'lib/google/cloud/text_to_speech/*/*_client.rb',

--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-trace/synth.py
+++ b/google-cloud-trace/synth.py
@@ -42,6 +42,46 @@ s.copy(v2_library / 'lib/google/devtools/cloudtrace/v2')
 # Omitting lib/google/cloud/trace/v{1,2}.rb for now because we are not exposing
 # the low-level API.
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/trace/v*.rb',
+        'lib/google/cloud/trace/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/trace/v*.rb',
+        'lib/google/cloud/trace/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/trace/v*.rb',
+        'lib/google/cloud/trace/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/trace/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/trace/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2124
 s.replace(
     [

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -83,6 +83,51 @@ s.copy(v1beta2_library / 'test/google/cloud/video_intelligence/v1beta2')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/video_intelligence.rb',
+        'lib/google/cloud/video_intelligence/v*.rb',
+        'lib/google/cloud/video_intelligence/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/video_intelligence/v*.rb',
+        'lib/google/cloud/video_intelligence/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/video_intelligence/v*.rb',
+        'lib/google/cloud/video_intelligence/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/video_intelligence/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/video_intelligence/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-video_intelligence.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # PERMANENT: API name for videointelligence
 s.replace(
     [

--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -52,6 +52,51 @@ s.copy(v1p3beta1 / 'test/google/cloud/vision/v1p3beta1')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/vision.rb',
+        'lib/google/cloud/vision/v*.rb',
+        'lib/google/cloud/vision/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/vision/v*.rb',
+        'lib/google/cloud/vision/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/vision/v*.rb',
+        'lib/google/cloud/vision/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/vision/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/vision/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-vision.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # PERMANENT: Add migration guide to docs
 s.replace(
     'lib/google/cloud/vision.rb',
@@ -179,11 +224,3 @@ for version in ['v1', 'v1p3beta1']:
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1', 'v1p3beta1']:
-    s.replace(
-        f'test/google/cloud/vision/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

--- a/google-cloud-webrisk/synth.py
+++ b/google-cloud-webrisk/synth.py
@@ -29,7 +29,6 @@ v1beta1 = gapic.ruby_library(
 )
 
 s.copy(v1beta1 / 'lib')
-s.copy(v1beta1 / 'acceptance')
 s.copy(v1beta1 / 'test')
 s.copy(v1beta1 / 'README.md')
 s.copy(v1beta1 / 'LICENSE')
@@ -40,6 +39,51 @@ s.copy(v1beta1 / 'google-cloud-webrisk.gemspec', merge=ruby.merge_gemspec)
 # Copy common templates
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
+
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/webrisk.rb',
+        'lib/google/cloud/webrisk/v*.rb',
+        'lib/google/cloud/webrisk/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/webrisk/v*.rb',
+        'lib/google/cloud/webrisk/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/webrisk/v*.rb',
+        'lib/google/cloud/webrisk/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/webrisk/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/webrisk/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-webrisk.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(

--- a/grafeas-client/synth.py
+++ b/grafeas-client/synth.py
@@ -96,6 +96,51 @@ s.replace(
     'V1::GrafeasService::'
 )
 
+# Support for service_address
+s.replace(
+    [
+        'lib/grafeas.rb',
+        'lib/grafeas/v*.rb',
+        'lib/grafeas/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/grafeas/v*.rb',
+        'lib/grafeas/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/grafeas/v*.rb',
+        'lib/grafeas/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/grafeas/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/grafeas/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'grafeas-client.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [


### PR DESCRIPTION
Synth hack that adds `service_address` and `service_port` parameters to generated client constructors. This makes it easier/possible to point at a different backend. (Previously, you had to subclass the client class and change the constant, and it wasn't even possible to customize the corresponding LRO endpoint.)

This WIP shows the result for vision as an example. If people are good with how it looks, I'll add the remaining libraries.