### PR TITLE
use distribution name for devsite url

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -629,9 +629,11 @@ namespace :kokoro do
     require_relative "rakelib/devsite_builder.rb"
 
     Rake::Task["kokoro:load_env_vars"].invoke
-    # Temporary - change back to build_master
+
+    # Temporary
     DevsiteBuilder.new(__dir__).rebuild_all
     Rake::Task["docs:build_master"].invoke
+
     Rake::Task["test:codecov"].invoke
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -630,8 +630,8 @@ namespace :kokoro do
 
     Rake::Task["kokoro:load_env_vars"].invoke
 
-    # Temporary
-    DevsiteBuilder.new(__dir__).rebuild_all
+    # Temporary, change to build_master
+    DevsiteBuilder.new(__dir__).republish_all
     Rake::Task["docs:build_master"].invoke
 
     Rake::Task["test:codecov"].invoke

--- a/rakelib/devsite_builder.rb
+++ b/rakelib/devsite_builder.rb
@@ -16,7 +16,6 @@ class DevsiteBuilder < YardBuilder
       input_dir = "#{master_dir + gem}"
       output_dir = "#{gh_pages_dir + 'docs' + gem + 'master'}"
       build_gem_docs input_dir, output_dir
-      ensure_gem_latest_dir gem
       puts "Build #{gem} documentation for commit #{git_ref}"
     end
   end
@@ -25,8 +24,7 @@ class DevsiteBuilder < YardBuilder
     gem ||= File.basename input_dir
     gem_metadata = @metadata[gem]
     gem_metadata["version"] = version
-    docs = GemVersionDoc.new input_dir, output_dir, gem_metadata
-    docs.publish
+    GemVersionDoc.new input_dir, output_dir, gem_metadata
   end
 
   def publish_tag tag
@@ -34,31 +32,32 @@ class DevsiteBuilder < YardBuilder
 
     gem, version = split_tag tag
     add_release gem, version
-    build_docs_for_tag tag
+    publish_docs_for_tag tag
     ensure_gem_latest_dir gem
     puts "Add #{gem} documentation for #{version} release"
   end
 
-  def rebuild_all
+  def republish_all
     return if case_insensitive_check!
 
     current_git_commit master_dir
     load_releases.each do |gem, versions|
       versions.each do |version|
-        build_docs_for_tag "#{gem}/#{version}"
+        publish_docs_for_tag "#{gem}/#{version}"
       end
-      puts "Rebuild all #{gem} documentation (all tags)"
+      puts "Republished all #{gem} documentation (all tags)"
     end
   end
 
   private
 
-  def build_docs_for_tag tag
+  def publish_docs_for_tag tag
     gem, version = split_tag tag
     checkout_branch tag do |tag_repo|
       input_dir = "#{tag_repo + gem}"
       output_dir = "#{gh_pages_dir + 'docs' + gem + version}"
-      build_gem_docs input_dir, output_dir, gem, version
+      docs = build_gem_docs input_dir, output_dir, gem, version
+      docs.publish
     end
   end
 

--- a/rakelib/devsite_builder.rb
+++ b/rakelib/devsite_builder.rb
@@ -3,7 +3,6 @@ require_relative "gem_version_doc.rb"
 require_relative "repo_metadata.rb"
 
 class DevsiteBuilder < YardBuilder
-
   def initialize master_dir = "."
     @master_dir = Pathname.new master_dir
     collect_metadata
@@ -22,7 +21,7 @@ class DevsiteBuilder < YardBuilder
     end
   end
 
-  def build_gem_docs input_dir, output_dir, gem = nil, version = 'master'
+  def build_gem_docs input_dir, output_dir, gem = nil, version = "master"
     gem ||= File.basename input_dir
     gem_metadata = @metadata[gem]
     gem_metadata["version"] = version
@@ -48,8 +47,7 @@ class DevsiteBuilder < YardBuilder
       versions.each do |version|
         build_docs_for_tag "#{gem}/#{version}"
       end
-      build_gem_docs master_dir, gh_pages_dir, gem
-      puts "Rebuild all #{gem} documentation (all tags and master)"
+      puts "Rebuild all #{gem} documentation (all tags)"
     end
   end
 

--- a/rakelib/devsite_builder.rb
+++ b/rakelib/devsite_builder.rb
@@ -24,7 +24,9 @@ class DevsiteBuilder < YardBuilder
     gem ||= File.basename input_dir
     gem_metadata = @metadata[gem]
     gem_metadata["version"] = version
-    GemVersionDoc.new input_dir, output_dir, gem_metadata
+    docs = GemVersionDoc.new input_dir, output_dir, gem_metadata
+    docs.build
+    docs
   end
 
   def publish_tag tag
@@ -57,7 +59,7 @@ class DevsiteBuilder < YardBuilder
       input_dir = "#{tag_repo + gem}"
       output_dir = "#{gh_pages_dir + 'docs' + gem + version}"
       docs = build_gem_docs input_dir, output_dir, gem, version
-      docs.publish
+      docs.upload
     end
   end
 

--- a/rakelib/gem_version_doc.rb
+++ b/rakelib/gem_version_doc.rb
@@ -29,7 +29,7 @@ class GemVersionDoc < RepoDocCommon
 
     puts "cd #{@output_dir} [google-cloud-trace fixes]"
     Dir.chdir @output_dir do
-      Dir.glob(File.join("**","*.html")).each do |file_path|
+      Dir.glob(File.join("**", "*.html")).each do |file_path|
         file_contents = File.read file_path
         file_contents.gsub! "{% dynamic print site_values.console_name %}",
                             "Google Cloud Platform Console"

--- a/rakelib/repo_metadata.rb
+++ b/rakelib/repo_metadata.rb
@@ -4,10 +4,7 @@ require_relative "repo_doc_common.rb"
 class RepoMetadata < RepoDocCommon
   def initialize data
     @data = data
-
-    # Required until distribution_name is changed to distribution-name
-    @data.transform_keys! { |k| k.sub "_", "-" }
-    @data.delete_if { |k, _| !allowed_fields.include? k }
+    normalize_data!
   end
 
   def allowed_fields
@@ -22,6 +19,13 @@ class RepoMetadata < RepoDocCommon
     Dir.chdir output_directory do
       cmd "python3 -m docuploader create-metadata #{fields.join ' '}"
     end
+  end
+
+  def normalize_data!
+    # Required until distribution_name is changed to distribution-name
+    @data.transform_keys! { |k| k.sub "_", "-" }
+    @data["name"] = @data["distribution-name"]
+    @data.delete_if { |k, _| !allowed_fields.include? k }
   end
 
   def [] key


### PR DESCRIPTION
* DevsiteBuilder#republish_all no longer publishes master.
* Devsite URL is now "#{host}/#{ruby}/#{gem_name}" instead of "#{host}/#{ruby}/#{dns_api_name}"