### PR TITLE
feat(container_analysis): Obtain grafeas client from the container_analysis client

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,8 @@ $ gem install google-cloud-container_analysis
 ```ruby
 require "google/cloud/container_analysis"
 
-grafeas_client = Grafeas.new
+container_analysis_client = Google::Cloud::ContainerAnalysis.new
+grafeas_client = container_analysis_client.grafeas_client
 parent = Grafeas::V1::GrafeasClient.project_path "my-project"
 results = grafeas_client.list_occurrences(parent).each do |occurrence|
   # do something with occurrence

--- a/google-cloud-container_analysis/README.md
+++ b/google-cloud-container_analysis/README.md
@@ -24,7 +24,8 @@ $ gem install google-cloud-container_analysis
 ```ruby
 require "google/cloud/container_analysis"
 
-grafeas_client = Grafeas.new
+container_analysis_client = Google::Cloud::ContainerAnalysis.new
+grafeas_client = container_analysis_client.grafeas_client
 parent = Grafeas::V1::GrafeasClient.project_path "my-project"
 results = grafeas_client.list_occurrences(parent).each do |occurrence|
   # do something with occurrence

--- a/google-cloud-container_analysis/acceptance/google/cloud/container_analysis/v1/grafeas_service_smoke_test.rb
+++ b/google-cloud-container_analysis/acceptance/google/cloud/container_analysis/v1/grafeas_service_smoke_test.rb
@@ -19,7 +19,8 @@ require "google/cloud/container_analysis"
 
 describe "GrafeasService V1 smoke test" do
   it "runs one smoke test with list_occurrences" do
-    client = Grafeas.new(version: :v1)
+    ca_client = Google::Cloud::ContainerAnalysis.new
+    client = ca_client.grafeas_client
     parent = Grafeas::V1::GrafeasClient.project_path(ENV["CONTAINER_ANALYSIS_PROJECT"])
     results = client.list_occurrences(parent, page_size: 2)
     page = results.page

--- a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/container_analysis_client.rb
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/container_analysis_client.rb
@@ -53,6 +53,9 @@ module Google
           # @private
           attr_reader :container_analysis_stub
 
+          # @return [Grafeas::V1::GrafeasClient] a client for the Grafeas service
+          attr_reader :grafeas_client
+
           # The default address of the service.
           SERVICE_ADDRESS = "containeranalysis.googleapis.com".freeze
 
@@ -139,6 +142,11 @@ module Google
             require "google/devtools/containeranalysis/v1/containeranalysis_services_pb"
 
             credentials ||= Google::Cloud::ContainerAnalysis::V1::Credentials.default
+
+            @grafeas_client = ::Grafeas.new(
+              credentials: credentials, scopes: scopes, client_config: client_config,
+              timeout: timeout, lib_name: lib_name, lib_version: lib_version,
+              service_address: service_address, service_port: service_port, metadata: metadata)
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               updater_proc = Google::Cloud::ContainerAnalysis::V1::Credentials.new(credentials).updater_proc

--- a/google-cloud-container_analysis/synth.metadata
+++ b/google-cloud-container_analysis/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-07-02T10:38:21.226281Z",
+  "updateTime": "2019-07-02T19:38:33.389807Z",
   "sources": [
     {
       "generator": {
@@ -12,8 +12,8 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "5322233f8cbec4d3f8c17feca2507ef27d4a07c9",
-        "internalRef": "256042411"
+        "sha": "d7ad209003971f1902d12059878b87f33f3cbd5a",
+        "internalRef": "256211083"
       }
     },
     {

--- a/google-cloud-container_analysis/synth.py
+++ b/google-cloud-container_analysis/synth.py
@@ -109,6 +109,18 @@ s.replace(
     '\n\nrequire "grafeas"\nrequire "google/gax"\n'
 )
 
+# Expose the grafeas client as an attribute of the container_analysis client
+s.replace(
+    'lib/google/cloud/container_analysis/v*/*_client.rb',
+    '\n\n(\\s+)(credentials \\|\\|= \\S+)\n',
+    '\n\n\\1\\2\n\n\\1@grafeas_client = ::Grafeas.new(\n\\1  credentials: credentials, scopes: scopes, client_config: client_config,\n\\1  timeout: timeout, lib_name: lib_name, lib_version: lib_version,\n\\1  service_address: service_address, service_port: service_port, metadata: metadata)\n'
+)
+s.replace(
+    'lib/google/cloud/container_analysis/v*/*_client.rb',
+    '\n(\\s+)attr_reader :container_analysis_stub\n',
+    '\n\\1attr_reader :container_analysis_stub\n\n\\1# @return [Grafeas::V1::GrafeasClient] a client for the Grafeas service\n\\1attr_reader :grafeas_client\n'
+)
+
 # Credentials env vars
 s.replace(
     'lib/**/credentials.rb',


### PR DESCRIPTION
This is a synth hack that adds an attribute letting you get a grafeas client from a container_analysis client. This is a request from the container_analysis team to match the usage pattern used by other languages. (Note this also reran synth, so it includes an unrelated addition to `get_iam_policy`.)
