### PR TITLE
Release google-cloud-container 0.5.0

### DIFF
--- a/google-cloud-container/CHANGELOG.md
+++ b/google-cloud-container/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.5.0 / 2019-07-08
+
+* Support overriding service host and port
+
 ### 0.4.2 / 2019-06-11
 
 * Add VERSION constant

--- a/google-cloud-container/lib/google/cloud/container/version.rb
+++ b/google-cloud-container/lib/google/cloud/container/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Container
-      VERSION = "0.4.2".freeze
+      VERSION = "0.5.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port

<details><summary>Commits since previous release</summary><pre><code>commit e8e11d0e6c66ff3f0fb892a6a7237184a7fcadf1
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:10:49 2019 -0700

    feat(container): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-container/google-cloud-container.gemspec b/google-cloud-container/google-cloud-container.gemspec
index d22f80d74..04ec14927 100644
--- a/google-cloud-container/google-cloud-container.gemspec
+++ b/google-cloud-container/google-cloud-container.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
diff --git a/google-cloud-container/lib/google/cloud/container.rb b/google-cloud-container/lib/google/cloud/container.rb
index d43a19917..906778ac5 100644
--- a/google-cloud-container/lib/google/cloud/container.rb
+++ b/google-cloud-container/lib/google/cloud/container.rb
@@ -131,6 +131,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-container/lib/google/cloud/container/v1.rb b/google-cloud-container/lib/google/cloud/container/v1.rb
index a8835c8ad..74bbb3e76 100644
--- a/google-cloud-container/lib/google/cloud/container/v1.rb
+++ b/google-cloud-container/lib/google/cloud/container/v1.rb
@@ -119,6 +119,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -128,6 +132,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -139,6 +145,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Container::V1::ClusterManagerClient.new(**kwargs)
diff --git a/google-cloud-container/lib/google/cloud/container/v1/cluster_manager_client.rb b/google-cloud-container/lib/google/cloud/container/v1/cluster_manager_client.rb
index 31a6c85d3..21f4c7792 100644
--- a/google-cloud-container/lib/google/cloud/container/v1/cluster_manager_client.rb
+++ b/google-cloud-container/lib/google/cloud/container/v1/cluster_manager_client.rb
@@ -85,6 +85,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -94,6 +98,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -147,8 +153,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @cluster_manager_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-container/lib/google/cloud/container/v1beta1.rb b/google-cloud-container/lib/google/cloud/container/v1beta1.rb
index ede4bf73b..4d546c076 100644
--- a/google-cloud-container/lib/google/cloud/container/v1beta1.rb
+++ b/google-cloud-container/lib/google/cloud/container/v1beta1.rb
@@ -119,6 +119,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -128,6 +132,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -139,6 +145,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Container::V1beta1::ClusterManagerClient.new(**kwargs)
diff --git a/google-cloud-container/lib/google/cloud/container/v1beta1/cluster_manager_client.rb b/google-cloud-container/lib/google/cloud/container/v1beta1/cluster_manager_client.rb
index 4bbf29570..7444118a7 100644
--- a/google-cloud-container/lib/google/cloud/container/v1beta1/cluster_manager_client.rb
+++ b/google-cloud-container/lib/google/cloud/container/v1beta1/cluster_manager_client.rb
@@ -94,6 +94,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -103,6 +107,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -157,8 +163,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @cluster_manager_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-container/synth.metadata b/google-cloud-container/synth.metadata
index 4825fdb0b..e2fb85814 100644
--- a/google-cloud-container/synth.metadata
+++ b/google-cloud-container/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:38:18.660373Z",
+  "updateTime": "2019-07-01T10:38:58.833681Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     },
     {
diff --git a/google-cloud-container/synth.py b/google-cloud-container/synth.py
index 7004afb10..e7a209806 100644
--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -52,6 +52,51 @@ s.copy(v1_library / '.gitignore')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-container.gemspec', merge=ruby.merge_gemspec)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/container.rb',
+        'lib/google/cloud/container/v*.rb',
+        'lib/google/cloud/container/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/container/v*.rb',
+        'lib/google/cloud/container/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/container/v*.rb',
+        'lib/google/cloud/container/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/container/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/container/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-container.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [
@@ -138,11 +183,3 @@ for version in ['v1', 'v1beta1']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Container::VERSION'
     )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1', 'v1beta1']:
-    s.replace(
-        f'test/google/cloud/container/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

```

</details>

This pull request was generated using releasetool.