### PR TITLE
Release google-cloud-container_analysis 0.2.0

### DIFF
--- a/google-cloud-container_analysis/CHANGELOG.md
+++ b/google-cloud-container_analysis/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Release History
+### 0.2.0 / 2019-07-08
+
+* Support obtaining grafeas client from the container_analysis client
+* Support overriding service host and port
+
 ### 0.1.0 / 2019-06-21
 
 * Initial release

--- a/google-cloud-container_analysis/lib/google/cloud/container_analysis/version.rb
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module ContainerAnalysis
-      VERSION = "0.1.0".freeze
+      VERSION = "0.2.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Support obtaining grafeas client from the container_analysis client
* Support overriding service host and port

<details><summary>Commits since previous release</summary><pre><code>commit 4c1835e789e4d8445a176b6bf98b56010e4b73cf
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Jul 2 13:16:05 2019 -0700

    feat(container_analysis): Obtain grafeas client from the container_analysis client
    
    
    [pr #3583]

commit 89ef2ecccc8a88083b64c0ca86ff30e6ce79e33f
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Tue Jul 2 09:12:08 2019 -0700

    feat(container_analysis): Add IAM GetPolicyOptions

commit 183d4273766020221d2b6351a664acbe6667d68c
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:11:26 2019 -0700

    feat(container_analysis): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients

commit 31f301bd7ea6c37c07592043943e217b6325317b
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed Jun 26 07:19:11 2019 -0700

    Ensure two blank lines after copyright block in container_analysis (#3527)

commit 73902dcc6978d65402be56a44971c2141b2f9a16
Author: Daniel Azuma <dazuma@google.com>
Date:   Fri Jun 21 17:52:16 2019 -0700

    chore: Add container_analysis library to main readme (#3515)
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-container_analysis/README.md b/google-cloud-container_analysis/README.md
index 49c9af90e..cba80009d 100644
--- a/google-cloud-container_analysis/README.md
+++ b/google-cloud-container_analysis/README.md
@@ -20,6 +20,18 @@ steps:
 $ gem install google-cloud-container_analysis
 ```
 
+### Preview
+```ruby
+require "google/cloud/container_analysis"
+
+container_analysis_client = Google::Cloud::ContainerAnalysis.new
+grafeas_client = container_analysis_client.grafeas_client
+parent = Grafeas::V1::GrafeasClient.project_path "my-project"
+results = grafeas_client.list_occurrences(parent).each do |occurrence|
+  # do something with occurrence
+end
+```
+
 ### Next Steps
 - Read the [Client Library Documentation][] for Container Analysis API
   to see other available methods on the client.
diff --git a/google-cloud-container_analysis/acceptance/google/cloud/container_analysis/v1/grafeas_service_smoke_test.rb b/google-cloud-container_analysis/acceptance/google/cloud/container_analysis/v1/grafeas_service_smoke_test.rb
index 3fd0ed230..28b2382a0 100644
--- a/google-cloud-container_analysis/acceptance/google/cloud/container_analysis/v1/grafeas_service_smoke_test.rb
+++ b/google-cloud-container_analysis/acceptance/google/cloud/container_analysis/v1/grafeas_service_smoke_test.rb
@@ -19,7 +19,8 @@ require "google/cloud/container_analysis"
 
 describe "GrafeasService V1 smoke test" do
   it "runs one smoke test with list_occurrences" do
-    client = Grafeas.new(version: :v1)
+    ca_client = Google::Cloud::ContainerAnalysis.new
+    client = ca_client.grafeas_client
     parent = Grafeas::V1::GrafeasClient.project_path(ENV["CONTAINER_ANALYSIS_PROJECT"])
     results = client.list_occurrences(parent, page_size: 2)
     page = results.page
diff --git a/google-cloud-container_analysis/google-cloud-container_analysis.gemspec b/google-cloud-container_analysis/google-cloud-container_analysis.gemspec
index dffa500b9..86d36da62 100644
--- a/google-cloud-container_analysis/google-cloud-container_analysis.gemspec
+++ b/google-cloud-container_analysis/google-cloud-container_analysis.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "grafeas-client", "~> 0.1"
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"
diff --git a/google-cloud-container_analysis/lib/google/cloud/container_analysis.rb b/google-cloud-container_analysis/lib/google/cloud/container_analysis.rb
index cb8c9251d..3473b02af 100644
--- a/google-cloud-container_analysis/lib/google/cloud/container_analysis.rb
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 require "grafeas"
 require "google/gax"
 require "pathname"
@@ -132,6 +133,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1.rb b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1.rb
index f78464159..18de2f2ee 100644
--- a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1.rb
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 require "google/cloud/container_analysis/v1/container_analysis_client"
 
 module Google
@@ -119,6 +120,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -128,6 +133,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -139,6 +146,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::ContainerAnalysis::V1::ContainerAnalysisClient.new(**kwargs)
diff --git a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/container_analysis_client.rb b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/container_analysis_client.rb
index 26237ab33..60d9e7a72 100644
--- a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/container_analysis_client.rb
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/container_analysis_client.rb
@@ -19,6 +19,7 @@
 # For the short term, the refresh process will only be runnable by Google
 # engineers.
 
+
 require "json"
 require "pathname"
 
@@ -52,6 +53,9 @@ module Google
           # @private
           attr_reader :container_analysis_stub
 
+          # @return [Grafeas::V1::GrafeasClient] a client for the Grafeas service
+          attr_reader :grafeas_client
+
           # The default address of the service.
           SERVICE_ADDRESS = "containeranalysis.googleapis.com".freeze
 
@@ -113,6 +117,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -122,6 +130,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -133,6 +143,11 @@ module Google
 
             credentials ||= Google::Cloud::ContainerAnalysis::V1::Credentials.default
 
+            @grafeas_client = ::Grafeas.new(
+              credentials: credentials, scopes: scopes, client_config: client_config,
+              timeout: timeout, lib_name: lib_name, lib_version: lib_version,
+              service_address: service_address, service_port: service_port, metadata: metadata)
+
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               updater_proc = Google::Cloud::ContainerAnalysis::V1::Credentials.new(credentials).updater_proc
             end
@@ -175,8 +190,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @container_analysis_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -279,6 +294,11 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
           #   See the operation documentation for the appropriate value for this field.
+          # @param options_ [Google::Iam::V1::GetPolicyOptions | Hash]
+          #   OPTIONAL: A `GetPolicyOptions` object for specifying options to
+          #   `GetIamPolicy`. This field is only used by Cloud IAM.
+          #   A hash of the same form as `Google::Iam::V1::GetPolicyOptions`
+          #   can also be provided.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -296,10 +316,12 @@ module Google
 
           def get_iam_policy \
               resource,
+              options_: nil,
               options: nil,
               &block
             req = {
-              resource: resource
+              resource: resource,
+              options: options_
             }.delete_if { |_, v| v.nil? }
             req = Google::Gax::to_proto(req, Google::Iam::V1::GetIamPolicyRequest)
             @get_iam_policy.call(req, options, &block)
diff --git a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/credentials.rb b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/credentials.rb
index 837ca90ed..a73c9ab78 100644
--- a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/credentials.rb
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/credentials.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 require "googleauth"
 
 module Google
diff --git a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/iam/v1/iam_policy.rb b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/iam/v1/iam_policy.rb
index 2abe1387a..fe84ba3bc 100644
--- a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/iam/v1/iam_policy.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 module Google
   module Iam
     module V1
@@ -33,6 +34,10 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
       #     See the operation documentation for the appropriate value for this field.
+      # @!attribute [rw] options
+      #   @return [Google::Iam::V1::GetPolicyOptions]
+      #     OPTIONAL: A `GetPolicyOptions` object for specifying options to
+      #     `GetIamPolicy`. This field is only used by Cloud IAM.
       class GetIamPolicyRequest; end
 
       # Request message for `TestIamPermissions` method.
diff --git a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/iam/v1/options.rb b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/iam/v1/options.rb
new file mode 100644
index 000000000..98271d48a
--- /dev/null
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/iam/v1/options.rb
@@ -0,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Iam
+    module V1
+      # Encapsulates settings provided to GetIamPolicy.
+      # @!attribute [rw] requested_policy_version
+      #   @return [Integer]
+      #     Optional. The policy format version to be returned.
+      #     Acceptable values are 0 and 1.
+      #     If the value is 0, or the field is omitted, policy format version 1 will be
+      #     returned.
+      class GetPolicyOptions; end
+    end
+  end
+end
\ No newline at end of file
diff --git a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/iam/v1/policy.rb b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/iam/v1/policy.rb
index 3b6e2b893..8dfa03345 100644
--- a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/iam/v1/policy.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 module Google
   module Iam
     module V1
diff --git a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/type/expr.rb b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/type/expr.rb
index ea9d386ee..4f1a812bd 100644
--- a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/type/expr.rb
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/doc/google/type/expr.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 module Google
   module Type
     # Represents an expression text. Example:
diff --git a/google-cloud-container_analysis/synth.metadata b/google-cloud-container_analysis/synth.metadata
index 3ea7efd97..381de4c80 100644
--- a/google-cloud-container_analysis/synth.metadata
+++ b/google-cloud-container_analysis/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-20T20:17:52.138400Z",
+  "updateTime": "2019-07-02T19:38:33.389807Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.29.0",
-        "dockerImage": "googleapis/artman@sha256:b79c8c20ee51e5302686c9d1294672d59290df1489be93749ef17d0172cc508d"
+        "version": "0.29.3",
+        "dockerImage": "googleapis/artman@sha256:8900f94a81adaab0238965aa8a7b3648791f4f3a95ee65adc6a56cfcc3753101"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a85bea321aab52403b5574c4e8347a1ef89b35dc",
-        "internalRef": "254254905"
+        "sha": "d7ad209003971f1902d12059878b87f33f3cbd5a",
+        "internalRef": "256211083"
       }
     },
     {
diff --git a/google-cloud-container_analysis/synth.py b/google-cloud-container_analysis/synth.py
index d89215b6c..77c6295f9 100644
--- a/google-cloud-container_analysis/synth.py
+++ b/google-cloud-container_analysis/synth.py
@@ -32,7 +32,6 @@ v1_library = gapic.ruby_library(
 
 s.copy(v1_library / 'lib')
 s.copy(v1_library / 'test')
-s.copy(v1_library / 'README.md')
 s.copy(v1_library / 'LICENSE')
 s.copy(v1_library / '.gitignore')
 s.copy(v1_library / '.yardopts')
@@ -57,11 +56,52 @@ s.replace(
     'Google::Cloud::ContainerAnalysis::V1::ContainerAnalysisService::'
 )
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/container_analysis.rb',
+        'lib/google/cloud/container_analysis/v*.rb',
+        'lib/google/cloud/container_analysis/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/container_analysis/v*.rb',
+        'lib/google/cloud/container_analysis/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/container_analysis/v*.rb',
+        'lib/google/cloud/container_analysis/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/container_analysis/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/container_analysis/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # Container analysis should depend on grafeas-client for now
 s.replace(
     'google-cloud-container_analysis.gemspec',
-    '\n\n  gem.add_dependency "google-gax", "~> 1.3"',
-    '\n\n  gem.add_dependency "grafeas-client", "~> 0.1"\n  gem.add_dependency "google-gax", "~> 1.3"',
+    '\n\n  gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    '\n\n  gem.add_dependency "grafeas-client", "~> 0.1"\n  gem.add_dependency "google-gax", "~> 1.7"',
 )
 s.replace(
     'lib/google/cloud/container_analysis.rb',
@@ -69,6 +109,18 @@ s.replace(
     '\n\nrequire "grafeas"\nrequire "google/gax"\n'
 )
 
+# Expose the grafeas client as an attribute of the container_analysis client
+s.replace(
+    'lib/google/cloud/container_analysis/v*/*_client.rb',
+    '\n\n(\\s+)(credentials \\|\\|= \\S+)\n',
+    '\n\n\\1\\2\n\n\\1@grafeas_client = ::Grafeas.new(\n\\1  credentials: credentials, scopes: scopes, client_config: client_config,\n\\1  timeout: timeout, lib_name: lib_name, lib_version: lib_version,\n\\1  service_address: service_address, service_port: service_port, metadata: metadata)\n'
+)
+s.replace(
+    'lib/google/cloud/container_analysis/v*/*_client.rb',
+    '\n(\\s+)attr_reader :container_analysis_stub\n',
+    '\n\\1attr_reader :container_analysis_stub\n\n\\1# @return [Grafeas::V1::GrafeasClient] a client for the Grafeas service\n\\1attr_reader :grafeas_client\n'
+)
+
 # Credentials env vars
 s.replace(
     'lib/**/credentials.rb',
@@ -107,7 +159,7 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2279
 s.replace(
-    'lib/**/*_pb.rb',
+    'lib/google/**/*.rb',
     '\\A(((#[^\n]*)?\n)*# (Copyright \\d+|Generated by the protocol buffer compiler)[^\n]+\n(#[^\n]*\n)*\n)([^\n])',
     '\\1\n\\6')
 

```

</details>

This pull request was generated using releasetool.