### PR TITLE
Release google-cloud-dataproc 0.5.0

### DIFF
--- a/google-cloud-dataproc/CHANGELOG.md
+++ b/google-cloud-dataproc/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.5.0 / 2019-07-08
+
+* Custom metadata headers are honored by long running operations calls.
+* Support overriding service host and port.
+
 ### 0.4.0 / 2019-06-11
 
 * Add AutoscalingPolicyServiceClient

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/version.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Dataproc
-      VERSION = "0.4.0".freeze
+      VERSION = "0.5.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Custom metadata headers are honored by long running operations calls.
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit a9beebfb3c026126d7c343f7c1978142a8d5d11b
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:12:25 2019 -0700

    feat(dataproc): Add service_address and service_port to client constructor
    
    
    fix: Custom metadata headers are honored by long running operations calls.

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-dataproc/google-cloud-dataproc.gemspec b/google-cloud-dataproc/google-cloud-dataproc.gemspec
index a3816b364..eab3c96e2 100644
--- a/google-cloud-dataproc/google-cloud-dataproc.gemspec
+++ b/google-cloud-dataproc/google-cloud-dataproc.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc.rb b/google-cloud-dataproc/lib/google/cloud/dataproc.rb
index a1dfe25c4..9f4932eb7 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc.rb
@@ -144,6 +144,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
@@ -197,6 +201,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
@@ -249,6 +257,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
@@ -302,6 +314,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1.rb
index 2587f379d..14517210e 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1.rb
@@ -137,6 +137,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -146,6 +150,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -157,6 +163,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Dataproc::V1::ClusterControllerClient.new(**kwargs)
@@ -193,6 +201,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -202,6 +214,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -213,6 +227,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Dataproc::V1::JobControllerClient.new(**kwargs)
@@ -250,6 +266,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -259,6 +279,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -270,6 +292,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Dataproc::V1::WorkflowTemplateServiceClient.new(**kwargs)
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/cluster_controller_client.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/cluster_controller_client.rb
index d6c75b316..0b504ad67 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/cluster_controller_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/cluster_controller_client.rb
@@ -102,6 +102,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -111,6 +115,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -128,7 +134,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -174,8 +183,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @cluster_controller_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/job_controller_client.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/job_controller_client.rb
index 9c3374e1a..8f79ce2ab 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/job_controller_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/job_controller_client.rb
@@ -94,6 +94,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -103,6 +107,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -157,8 +163,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @job_controller_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/workflow_template_service_client.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/workflow_template_service_client.rb
index cf3664951..ceb12b72a 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/workflow_template_service_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/workflow_template_service_client.rb
@@ -137,6 +137,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -146,6 +150,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -163,7 +169,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -209,8 +218,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @workflow_template_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2.rb
index a4ef7ea11..c311a3986 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2.rb
@@ -138,6 +138,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -147,6 +151,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -158,6 +164,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyServiceClient.new(**kwargs)
@@ -195,6 +203,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -204,6 +216,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -215,6 +229,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Dataproc::V1beta2::ClusterControllerClient.new(**kwargs)
@@ -251,6 +267,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -260,6 +280,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -271,6 +293,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Dataproc::V1beta2::JobControllerClient.new(**kwargs)
@@ -308,6 +332,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -317,6 +345,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -328,6 +358,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Dataproc::V1beta2::WorkflowTemplateServiceClient.new(**kwargs)
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policy_service_client.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policy_service_client.rb
index f96a08aa4..5accd4257 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policy_service_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/autoscaling_policy_service_client.rb
@@ -131,6 +131,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -140,6 +144,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -194,8 +200,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @autoscaling_policy_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/cluster_controller_client.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/cluster_controller_client.rb
index 696894c5e..1df7ea1e3 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/cluster_controller_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/cluster_controller_client.rb
@@ -102,6 +102,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -111,6 +115,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -128,7 +134,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -174,8 +183,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @cluster_controller_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/job_controller_client.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/job_controller_client.rb
index a04eaed09..8229808eb 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/job_controller_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/job_controller_client.rb
@@ -94,6 +94,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -103,6 +107,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -157,8 +163,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @job_controller_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/workflow_template_service_client.rb b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/workflow_template_service_client.rb
index d962ac31d..bb77583b0 100644
--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/workflow_template_service_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2/workflow_template_service_client.rb
@@ -137,6 +137,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -146,6 +150,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -163,7 +169,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -209,8 +218,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @workflow_template_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-dataproc/synth.metadata b/google-cloud-dataproc/synth.metadata
index f01b34ec9..221613b1f 100644
--- a/google-cloud-dataproc/synth.metadata
+++ b/google-cloud-dataproc/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-04T19:26:57.216831Z",
+  "updateTime": "2019-07-01T10:39:34.203694Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.23.0",
-        "dockerImage": "googleapis/artman@sha256:846102ebf7ea2239162deea69f64940443b4147f7c2e68d64b332416f74211ba"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0026f4b890ed9e2388fb0573c0727defa6f5b82e",
-        "internalRef": "251265049"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     },
     {
diff --git a/google-cloud-dataproc/synth.py b/google-cloud-dataproc/synth.py
index 079d317cb..e317bb333 100644
--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -59,6 +59,51 @@ s.replace(
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/dataproc.rb',
+        'lib/google/cloud/dataproc/v*.rb',
+        'lib/google/cloud/dataproc/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/dataproc/v*.rb',
+        'lib/google/cloud/dataproc/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/dataproc/v*.rb',
+        'lib/google/cloud/dataproc/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/dataproc/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/dataproc/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-dataproc.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

```

</details>

This pull request was generated using releasetool.