### PR TITLE
Release google-cloud-datastore 1.5.4

### DIFF
--- a/google-cloud-datastore/CHANGELOG.md
+++ b/google-cloud-datastore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.5.4 / 2019-07-08
+
+* Support overriding service host and port for low-level API.
+
 ### 1.5.3 / 2019-06-12
 
 * Enable grpc.service_config_disable_resolution

--- a/google-cloud-datastore/lib/google/cloud/datastore/version.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Datastore
-      VERSION = "1.5.3".freeze
+      VERSION = "1.5.4".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port for low-level API.

<details><summary>Commits since previous release</summary><pre><code>commit ed4e0934bdc8cbbef3d833597c3481b04bc6a948
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:12:56 2019 -0700

    feat(datastore): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-datastore/google-cloud-datastore.gemspec b/google-cloud-datastore/google-cloud-datastore.gemspec
index 5e73911fb..646c8384e 100644
--- a/google-cloud-datastore/google-cloud-datastore.gemspec
+++ b/google-cloud-datastore/google-cloud-datastore.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 1.0"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "google-protobuf", "~> 3.3"
 
   gem.add_development_dependency "minitest", "~> 5.10"
diff --git a/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb b/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb
index e8b6cfe4a..f1e8976cc 100644
--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb
@@ -91,6 +91,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -100,6 +104,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -153,8 +159,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @datastore_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-datastore/synth.metadata b/google-cloud-datastore/synth.metadata
index 355565d27..306d95567 100644
--- a/google-cloud-datastore/synth.metadata
+++ b/google-cloud-datastore/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:38:52.873324Z",
+  "updateTime": "2019-07-01T10:39:49.688989Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     }
   ],
diff --git a/google-cloud-datastore/synth.py b/google-cloud-datastore/synth.py
index d7baedd4e..486311b12 100644
--- a/google-cloud-datastore/synth.py
+++ b/google-cloud-datastore/synth.py
@@ -33,6 +33,32 @@ s.copy(v1_library / 'lib/google/datastore/v1')
 # Omitting lib/google/cloud/datastore/v1.rb for now because we are not exposing
 # the low-level API.
 
+# Support for service_address
+s.replace(
+    'lib/google/cloud/datastore/v*/*_client.rb',
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    'lib/google/cloud/datastore/v*/*_client.rb',
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    'lib/google/cloud/datastore/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/datastore/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2124
 s.replace(
     'lib/google/cloud/datastore/v1/credentials.rb',

```

</details>

This pull request was generated using releasetool.