### PR TITLE
Release google-cloud-debugger 0.33.6

### DIFF
--- a/google-cloud-debugger/CHANGELOG.md
+++ b/google-cloud-debugger/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.33.6 / 2019-07-08
+
+* Support overriding service host and port in the low-level client.
+
 ### 0.33.5 / 2019-06-11
 
 * Google::Cloud::Env provides additional configuration options including retries and cache control

--- a/google-cloud-debugger/lib/google/cloud/debugger/version.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Debugger
-      VERSION = "0.33.5".freeze
+      VERSION = "0.33.6".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port in the low-level client.

<details><summary>Commits since previous release</summary><pre><code>commit 3d3af070d936a7a233a824f6b6920eb6c9643926
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:14:10 2019 -0700

    feat(debugger): Add service_address and service_port in the low-level interface

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-debugger/google-cloud-debugger.gemspec b/google-cloud-debugger/google-cloud-debugger.gemspec
index 0088abee5..4d9f60b29 100644
--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "binding_of_caller", "~> 0.7"
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "google-cloud-logging", "~> 1.0"
-  gem.add_dependency "google-gax", "~> 1.0"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
diff --git a/google-cloud-debugger/lib/google/cloud/debugger/v2.rb b/google-cloud-debugger/lib/google/cloud/debugger/v2.rb
index 24dc18f39..dd0811da2 100644
--- a/google-cloud-debugger/lib/google/cloud/debugger/v2.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2.rb
@@ -129,6 +129,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -138,6 +142,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -149,6 +155,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Debugger::V2::Controller2Client.new(**kwargs)
@@ -196,6 +204,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -205,6 +217,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -216,6 +230,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Debugger::V2::Debugger2Client.new(**kwargs)
diff --git a/google-cloud-debugger/lib/google/cloud/debugger/v2/controller2_client.rb b/google-cloud-debugger/lib/google/cloud/debugger/v2/controller2_client.rb
index 5814528cf..b9c2fa174 100644
--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/controller2_client.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/controller2_client.rb
@@ -105,6 +105,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -114,6 +118,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -167,8 +173,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @controller2_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-debugger/lib/google/cloud/debugger/v2/debugger2_client.rb b/google-cloud-debugger/lib/google/cloud/debugger/v2/debugger2_client.rb
index 67b926055..213c1cf58 100644
--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/debugger2_client.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/debugger2_client.rb
@@ -97,6 +97,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -106,6 +110,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -159,8 +165,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @debugger2_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-debugger/synth.metadata b/google-cloud-debugger/synth.metadata
index 6e5b4428a..b9df3d32e 100644
--- a/google-cloud-debugger/synth.metadata
+++ b/google-cloud-debugger/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-30T00:45:14.150410Z",
+  "updateTime": "2019-07-01T10:40:04.019390Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.21.0",
-        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
-        "internalRef": "250569499"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     }
   ],
diff --git a/google-cloud-debugger/synth.py b/google-cloud-debugger/synth.py
index ae10bee7a..d65499316 100644
--- a/google-cloud-debugger/synth.py
+++ b/google-cloud-debugger/synth.py
@@ -65,6 +65,46 @@ s.replace(
     'lib/google/cloud/debugger/v2.rb',
     '/debugger\\.googleapis\\.com', '/clouddebugger.googleapis.com')
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/debugger/v*.rb',
+        'lib/google/cloud/debugger/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/debugger/v*.rb',
+        'lib/google/cloud/debugger/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/debugger/v*.rb',
+        'lib/google/cloud/debugger/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/debugger/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/debugger/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
@@ -113,11 +153,3 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Debugger::VERSION'
 )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v2']:
-    s.replace(
-        f'test/google/cloud/debugger/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

```

</details>

This pull request was generated using releasetool.