### PR TITLE
Release google-cloud-dialogflow 0.5.0

### DIFF
--- a/google-cloud-dialogflow/CHANGELOG.md
+++ b/google-cloud-dialogflow/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 0.5.0 / 2019-07-08
+
+* Add AgentsClient#set_agent and AgentsClient#delete_agent 
+* Add Agent#api_version and Agent#tier
+* Update documentation and product links
+* Support overriding service host and port.
+
 ### 0.4.0 / 2019-06-12
 
 * Add SpeechModelVariant

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/version.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Dialogflow
-      VERSION = "0.4.0".freeze
+      VERSION = "0.5.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add AgentsClient#set_agent and AgentsClient#delete_agent 
* Add Agent#api_version and Agent#tier
* Update documentation and product links
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit e47df6431a2b5eec7365e3882b4e34fc4c9768a4
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Fri Jul 5 13:20:45 2019 -0700

    feat(dialogflow): Add SetAgentRequest and DeleteAgentRequest
    
    * Add AgentsClient methods:
      * AgentsClient#set_agent (SetAgentRequest)
      * AgentsClient#delete_agent (DeleteAgentRequest)
    * Add Agent#api_version (Agent::ApiVersion)
    * Add Agent#tier (Agent::Tier)
    * Add service_address and service_port to client constructor method
    * Update product links
    * Update documentation

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-dialogflow/google-cloud-dialogflow.gemspec b/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
index 9b1f1bea2..194b728de 100644
--- a/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
+++ b/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow.rb
index 785c0d117..b96d658b3 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow.rb
@@ -102,7 +102,7 @@ module Google
         # You can create an agent using both Dialogflow Standard Edition and
         # Dialogflow Enterprise Edition. For details, see
         # [Dialogflow
-        # Editions](https://cloud.google.com/dialogflow-enterprise/docs/editions).
+        # Editions](https://cloud.google.com/dialogflow/docs/editions).
         #
         # You can save your agent for backup or versioning by exporting the agent by
         # using the {Google::Cloud::Dialogflow::V2::Agents::ExportAgent ExportAgent} method. You can import a saved
@@ -110,13 +110,13 @@ module Google
         #
         # Dialogflow provides several
         # [prebuilt
-        # agents](https://cloud.google.com/dialogflow-enterprise/docs/agents-prebuilt)
+        # agents](https://cloud.google.com/dialogflow/docs/agents-prebuilt)
         # for common conversation scenarios such as determining a date and time,
         # converting currency, and so on.
         #
         # For more information about agents, see the
         # [Dialogflow
-        # documentation](https://cloud.google.com/dialogflow-enterprise/docs/agents-overview).
+        # documentation](https://cloud.google.com/dialogflow/docs/agents-overview).
         #
         # @param version [Symbol, String]
         #   The major version of the service to be used. By default :v2
@@ -148,6 +148,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
@@ -185,7 +189,7 @@ module Google
         #
         # For more information about contexts, see the
         # [Dialogflow
-        # documentation](https://cloud.google.com/dialogflow-enterprise/docs/contexts-overview).
+        # documentation](https://cloud.google.com/dialogflow/docs/contexts-overview).
         #
         # @param version [Symbol, String]
         #   The major version of the service to be used. By default :v2
@@ -217,6 +221,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
@@ -264,7 +272,7 @@ module Google
         #
         # For more information about entity types, see the
         # [Dialogflow
-        # documentation](https://cloud.google.com/dialogflow-enterprise/docs/entities-overview).
+        # documentation](https://cloud.google.com/dialogflow/docs/entities-overview).
         #
         # @param version [Symbol, String]
         #   The major version of the service to be used. By default :v2
@@ -296,6 +304,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
@@ -347,7 +359,7 @@ module Google
         #
         # For more information about intents, see the
         # [Dialogflow
-        # documentation](https://cloud.google.com/dialogflow-enterprise/docs/intents-overview).
+        # documentation](https://cloud.google.com/dialogflow/docs/intents-overview).
         #
         # @param version [Symbol, String]
         #   The major version of the service to be used. By default :v2
@@ -379,6 +391,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
@@ -411,7 +427,7 @@ module Google
         #
         # For more information about entity types, see the
         # [Dialogflow
-        # documentation](https://cloud.google.com/dialogflow-enterprise/docs/entities-overview).
+        # documentation](https://cloud.google.com/dialogflow/docs/entities-overview).
         #
         # @param version [Symbol, String]
         #   The major version of the service to be used. By default :v2
@@ -443,6 +459,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
@@ -498,6 +518,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2.rb
index 0f9afe19a..080166cda 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2.rb
@@ -103,7 +103,7 @@ module Google
           # You can create an agent using both Dialogflow Standard Edition and
           # Dialogflow Enterprise Edition. For details, see
           # [Dialogflow
-          # Editions](https://cloud.google.com/dialogflow-enterprise/docs/editions).
+          # Editions](https://cloud.google.com/dialogflow/docs/editions).
           #
           # You can save your agent for backup or versioning by exporting the agent by
           # using the {Google::Cloud::Dialogflow::V2::Agents::ExportAgent ExportAgent} method. You can import a saved
@@ -111,13 +111,13 @@ module Google
           #
           # Dialogflow provides several
           # [prebuilt
-          # agents](https://cloud.google.com/dialogflow-enterprise/docs/agents-prebuilt)
+          # agents](https://cloud.google.com/dialogflow/docs/agents-prebuilt)
           # for common conversation scenarios such as determining a date and time,
           # converting currency, and so on.
           #
           # For more information about agents, see the
           # [Dialogflow
-          # documentation](https://cloud.google.com/dialogflow-enterprise/docs/agents-overview).
+          # documentation](https://cloud.google.com/dialogflow/docs/agents-overview).
           #
           # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
           #   Provides the means for authenticating requests made by the client. This parameter can
@@ -145,6 +145,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -154,6 +158,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -165,6 +171,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Dialogflow::V2::AgentsClient.new(**kwargs)
@@ -190,7 +198,7 @@ module Google
           #
           # For more information about contexts, see the
           # [Dialogflow
-          # documentation](https://cloud.google.com/dialogflow-enterprise/docs/contexts-overview).
+          # documentation](https://cloud.google.com/dialogflow/docs/contexts-overview).
           #
           # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
           #   Provides the means for authenticating requests made by the client. This parameter can
@@ -218,6 +226,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -227,6 +239,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -238,6 +252,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Dialogflow::V2::ContextsClient.new(**kwargs)
@@ -273,7 +289,7 @@ module Google
           #
           # For more information about entity types, see the
           # [Dialogflow
-          # documentation](https://cloud.google.com/dialogflow-enterprise/docs/entities-overview).
+          # documentation](https://cloud.google.com/dialogflow/docs/entities-overview).
           #
           # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
           #   Provides the means for authenticating requests made by the client. This parameter can
@@ -301,6 +317,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -310,6 +330,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -321,6 +343,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Dialogflow::V2::EntityTypesClient.new(**kwargs)
@@ -360,7 +384,7 @@ module Google
           #
           # For more information about intents, see the
           # [Dialogflow
-          # documentation](https://cloud.google.com/dialogflow-enterprise/docs/intents-overview).
+          # documentation](https://cloud.google.com/dialogflow/docs/intents-overview).
           #
           # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
           #   Provides the means for authenticating requests made by the client. This parameter can
@@ -388,6 +412,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -397,6 +425,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -408,6 +438,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Dialogflow::V2::IntentsClient.new(**kwargs)
@@ -428,7 +460,7 @@ module Google
           #
           # For more information about entity types, see the
           # [Dialogflow
-          # documentation](https://cloud.google.com/dialogflow-enterprise/docs/entities-overview).
+          # documentation](https://cloud.google.com/dialogflow/docs/entities-overview).
           #
           # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
           #   Provides the means for authenticating requests made by the client. This parameter can
@@ -456,6 +488,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -465,6 +501,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -476,6 +514,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Dialogflow::V2::SessionEntityTypesClient.new(**kwargs)
@@ -515,6 +555,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -524,6 +568,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -535,6 +581,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Dialogflow::V2::SessionsClient.new(**kwargs)
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agent_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agent_pb.rb
index ee80fc853..93da6d5f3 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agent_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agent_pb.rb
@@ -8,7 +8,7 @@ require 'google/api/annotations_pb'
 require 'google/longrunning/operations_pb'
 require 'google/protobuf/empty_pb'
 require 'google/protobuf/field_mask_pb'
-require 'google/protobuf/struct_pb'
+require 'google/api/client_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.dialogflow.v2.Agent" do
     optional :parent, :string, 1
@@ -21,15 +21,36 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :enable_logging, :bool, 8
     optional :match_mode, :enum, 9, "google.cloud.dialogflow.v2.Agent.MatchMode"
     optional :classification_threshold, :float, 10
+    optional :api_version, :enum, 14, "google.cloud.dialogflow.v2.Agent.ApiVersion"
+    optional :tier, :enum, 15, "google.cloud.dialogflow.v2.Agent.Tier"
   end
   add_enum "google.cloud.dialogflow.v2.Agent.MatchMode" do
     value :MATCH_MODE_UNSPECIFIED, 0
     value :MATCH_MODE_HYBRID, 1
     value :MATCH_MODE_ML_ONLY, 2
   end
+  add_enum "google.cloud.dialogflow.v2.Agent.ApiVersion" do
+    value :API_VERSION_UNSPECIFIED, 0
+    value :API_VERSION_V1, 1
+    value :API_VERSION_V2, 2
+    value :API_VERSION_V2_BETA_1, 3
+  end
+  add_enum "google.cloud.dialogflow.v2.Agent.Tier" do
+    value :TIER_UNSPECIFIED, 0
+    value :TIER_STANDARD, 1
+    value :TIER_ENTERPRISE, 2
+    value :TIER_ENTERPRISE_PLUS, 3
+  end
   add_message "google.cloud.dialogflow.v2.GetAgentRequest" do
     optional :parent, :string, 1
   end
+  add_message "google.cloud.dialogflow.v2.SetAgentRequest" do
+    optional :agent, :message, 1, "google.cloud.dialogflow.v2.Agent"
+    optional :update_mask, :message, 2, "google.protobuf.FieldMask"
+  end
+  add_message "google.cloud.dialogflow.v2.DeleteAgentRequest" do
+    optional :parent, :string, 1
+  end
   add_message "google.cloud.dialogflow.v2.SearchAgentsRequest" do
     optional :parent, :string, 1
     optional :page_size, :int32, 2
@@ -74,7 +95,11 @@ module Google
       module V2
         Agent = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.Agent").msgclass
         Agent::MatchMode = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.Agent.MatchMode").enummodule
+        Agent::ApiVersion = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.Agent.ApiVersion").enummodule
+        Agent::Tier = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.Agent.Tier").enummodule
         GetAgentRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.GetAgentRequest").msgclass
+        SetAgentRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.SetAgentRequest").msgclass
+        DeleteAgentRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.DeleteAgentRequest").msgclass
         SearchAgentsRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.SearchAgentsRequest").msgclass
         SearchAgentsResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.SearchAgentsResponse").msgclass
         TrainAgentRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.dialogflow.v2.TrainAgentRequest").msgclass
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agent_services_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agent_services_pb.rb
index 97c23e860..35e0afc3e 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agent_services_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agent_services_pb.rb
@@ -39,7 +39,7 @@ module Google
           # You can create an agent using both Dialogflow Standard Edition and
           # Dialogflow Enterprise Edition. For details, see
           # [Dialogflow
-          # Editions](https://cloud.google.com/dialogflow-enterprise/docs/editions).
+          # Editions](https://cloud.google.com/dialogflow/docs/editions).
           #
           # You can save your agent for backup or versioning by exporting the agent by
           # using the [ExportAgent][google.cloud.dialogflow.v2.Agents.ExportAgent] method. You can import a saved
@@ -47,13 +47,13 @@ module Google
           #
           # Dialogflow provides several
           # [prebuilt
-          # agents](https://cloud.google.com/dialogflow-enterprise/docs/agents-prebuilt)
+          # agents](https://cloud.google.com/dialogflow/docs/agents-prebuilt)
           # for common conversation scenarios such as determining a date and time,
           # converting currency, and so on.
           #
           # For more information about agents, see the
           # [Dialogflow
-          # documentation](https://cloud.google.com/dialogflow-enterprise/docs/agents-overview).
+          # documentation](https://cloud.google.com/dialogflow/docs/agents-overview).
           class Service
 
             include GRPC::GenericService
@@ -64,6 +64,10 @@ module Google
 
             # Retrieves the specified agent.
             rpc :GetAgent, GetAgentRequest, Agent
+            # Creates/updates the specified agent.
+            rpc :SetAgent, SetAgentRequest, Agent
+            # Deletes the specified agent.
+            rpc :DeleteAgent, DeleteAgentRequest, Google::Protobuf::Empty
             # Returns the list of agents.
             #
             # Since there is at most one conversational agent per project, this method is
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agents_client.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agents_client.rb
index dcc87e984..dc5ba5ef6 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agents_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agents_client.rb
@@ -48,7 +48,7 @@ module Google
         # You can create an agent using both Dialogflow Standard Edition and
         # Dialogflow Enterprise Edition. For details, see
         # [Dialogflow
-        # Editions](https://cloud.google.com/dialogflow-enterprise/docs/editions).
+        # Editions](https://cloud.google.com/dialogflow/docs/editions).
         #
         # You can save your agent for backup or versioning by exporting the agent by
         # using the {Google::Cloud::Dialogflow::V2::Agents::ExportAgent ExportAgent} method. You can import a saved
@@ -56,13 +56,13 @@ module Google
         #
         # Dialogflow provides several
         # [prebuilt
-        # agents](https://cloud.google.com/dialogflow-enterprise/docs/agents-prebuilt)
+        # agents](https://cloud.google.com/dialogflow/docs/agents-prebuilt)
         # for common conversation scenarios such as determining a date and time,
         # converting currency, and so on.
         #
         # For more information about agents, see the
         # [Dialogflow
-        # documentation](https://cloud.google.com/dialogflow-enterprise/docs/agents-overview).
+        # documentation](https://cloud.google.com/dialogflow/docs/agents-overview).
         #
         # @!attribute [r] agents_stub
         #   @return [Google::Cloud::Dialogflow::V2::Agents::Stub]
@@ -144,6 +144,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -153,6 +157,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -170,7 +176,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -216,8 +225,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @agents_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -230,6 +239,22 @@ module Google
               &Google::Cloud::Dialogflow::V2::Agents::Stub.method(:new)
             )
 
+            @set_agent = Google::Gax.create_api_call(
+              @agents_stub.method(:set_agent),
+              defaults["set_agent"],
+              exception_transformer: exception_transformer,
+              params_extractor: proc do |request|
+                {'agent.parent' => request.agent.parent}
+              end
+            )
+            @delete_agent = Google::Gax.create_api_call(
+              @agents_stub.method(:delete_agent),
+              defaults["delete_agent"],
+              exception_transformer: exception_transformer,
+              params_extractor: proc do |request|
+                {'parent' => request.parent}
+              end
+            )
             @get_agent = Google::Gax.create_api_call(
               @agents_stub.method(:get_agent),
               defaults["get_agent"],
@@ -282,6 +307,77 @@ module Google
 
           # Service calls
 
+          # Creates/updates the specified agent.
+          #
+          # @param agent [Google::Cloud::Dialogflow::V2::Agent | Hash]
+          #   Required. The agent to update.
+          #   A hash of the same form as `Google::Cloud::Dialogflow::V2::Agent`
+          #   can also be provided.
+          # @param update_mask [Google::Protobuf::FieldMask | Hash]
+          #   Optional. The mask to control which fields get updated.
+          #   A hash of the same form as `Google::Protobuf::FieldMask`
+          #   can also be provided.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @yield [result, operation] Access the result along with the RPC operation
+          # @yieldparam result [Google::Cloud::Dialogflow::V2::Agent]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
+          # @return [Google::Cloud::Dialogflow::V2::Agent]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/dialogflow"
+          #
+          #   agents_client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
+          #
+          #   # TODO: Initialize `agent`:
+          #   agent = {}
+          #   response = agents_client.set_agent(agent)
+
+          def set_agent \
+              agent,
+              update_mask: nil,
+              options: nil,
+              &block
+            req = {
+              agent: agent,
+              update_mask: update_mask
+            }.delete_if { |_, v| v.nil? }
+            req = Google::Gax::to_proto(req, Google::Cloud::Dialogflow::V2::SetAgentRequest)
+            @set_agent.call(req, options, &block)
+          end
+
+          # Deletes the specified agent.
+          #
+          # @param parent [String]
+          #   Required. The project that the agent to delete is associated with.
+          #   Format: `projects/<Project ID>`.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @yield [result, operation] Access the result along with the RPC operation
+          # @yieldparam result []
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/dialogflow"
+          #
+          #   agents_client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
+          #   formatted_parent = Google::Cloud::Dialogflow::V2::AgentsClient.project_path("[PROJECT]")
+          #   agents_client.delete_agent(formatted_parent)
+
+          def delete_agent \
+              parent,
+              options: nil,
+              &block
+            req = {
+              parent: parent
+            }.delete_if { |_, v| v.nil? }
+            req = Google::Gax::to_proto(req, Google::Cloud::Dialogflow::V2::DeleteAgentRequest)
+            @delete_agent.call(req, options, &block)
+            nil
+          end
+
           # Retrieves the specified agent.
           #
           # @param parent [String]
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agents_client_config.json b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agents_client_config.json
index 929d5961b..ca9fd1a8b 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agents_client_config.json
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agents_client_config.json
@@ -20,6 +20,16 @@
         }
       },
       "methods": {
+        "SetAgent": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DeleteAgent": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
         "GetAgent": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/audio_config_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/audio_config_pb.rb
index 680e5bef6..5b3bc4829 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/audio_config_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/audio_config_pb.rb
@@ -4,6 +4,7 @@
 
 require 'google/protobuf'
 
+require 'google/protobuf/duration_pb'
 require 'google/api/annotations_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.dialogflow.v2.InputAudioConfig" do
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/context_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/context_pb.rb
index 6d29b8718..cd2febd54 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/context_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/context_pb.rb
@@ -8,6 +8,7 @@ require 'google/api/annotations_pb'
 require 'google/protobuf/empty_pb'
 require 'google/protobuf/field_mask_pb'
 require 'google/protobuf/struct_pb'
+require 'google/api/client_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.dialogflow.v2.Context" do
     optional :name, :string, 1
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/context_services_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/context_services_pb.rb
index 00d6e6007..998186c96 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/context_services_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/context_services_pb.rb
@@ -43,7 +43,7 @@ module Google
           #
           # For more information about contexts, see the
           # [Dialogflow
-          # documentation](https://cloud.google.com/dialogflow-enterprise/docs/contexts-overview).
+          # documentation](https://cloud.google.com/dialogflow/docs/contexts-overview).
           class Service
 
             include GRPC::GenericService
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/contexts_client.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/contexts_client.rb
index f56dc712b..0a9f1c223 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/contexts_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/contexts_client.rb
@@ -50,7 +50,7 @@ module Google
         #
         # For more information about contexts, see the
         # [Dialogflow
-        # documentation](https://cloud.google.com/dialogflow-enterprise/docs/contexts-overview).
+        # documentation](https://cloud.google.com/dialogflow/docs/contexts-overview).
         #
         # @!attribute [r] contexts_stub
         #   @return [Google::Cloud::Dialogflow::V2::Contexts::Stub]
@@ -148,6 +148,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -157,6 +161,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -211,8 +217,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @contexts_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/agent.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/agent.rb
index 8868e305f..4654219f4 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/agent.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/agent.rb
@@ -29,7 +29,7 @@ module Google
         #   @return [String]
         #     Required. The default language of the agent as a language tag. See
         #     [Language
-        #     Support](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     Support](https://cloud.google.com/dialogflow/docs/reference/language)
         #     for a list of the currently supported language codes. This field cannot be
         #     set by the `Update` method.
         # @!attribute [rw] supported_language_codes
@@ -50,7 +50,7 @@ module Google
         #     Optional. The URI of the agent's avatar.
         #     Avatars are used throughout the Dialogflow console and in the self-hosted
         #     [Web
-        #     Demo](https://cloud.google.com/dialogflow-enterprise/docs/integrations/web-demo)
+        #     Demo](https://cloud.google.com/dialogflow/docs/integrations/web-demo)
         #     integration.
         # @!attribute [rw] enable_logging
         #   @return [true, false]
@@ -67,7 +67,31 @@ module Google
         #     are no fallback intents defined, no intent will be triggered. The score
         #     values range from 0.0 (completely uncertain) to 1.0 (completely certain).
         #     If set to 0.0, the default of 0.3 is used.
+        # @!attribute [rw] api_version
+        #   @return [Google::Cloud::Dialogflow::V2::Agent::ApiVersion]
+        #     Optional. API version displayed in Dialogflow console. If not specified,
+        #     V2 API is assumed. Clients are free to query different service endpoints
+        #     for different API versions. However, bots connectors and webhook calls will
+        #     follow the specified API version.
+        # @!attribute [rw] tier
+        #   @return [Google::Cloud::Dialogflow::V2::Agent::Tier]
+        #     Optional. The agent tier. If not specified, TIER_STANDARD is assumed.
         class Agent
+          # API version for the agent.
+          module ApiVersion
+            # Not specified.
+            API_VERSION_UNSPECIFIED = 0
+
+            # Legacy V1 API.
+            API_VERSION_V1 = 1
+
+            # V2 API.
+            API_VERSION_V2 = 2
+
+            # V2beta1 API.
+            API_VERSION_V2_BETA_1 = 3
+          end
+
           # Match mode determines how intents are detected from user queries.
           module MatchMode
             # Not specified.
@@ -81,6 +105,21 @@ module Google
             # especially the ones using @sys.any or very large developer entities.
             MATCH_MODE_ML_ONLY = 2
           end
+
+          # Represents the agent tier.
+          module Tier
+            # Not specified. This value should never be used.
+            TIER_UNSPECIFIED = 0
+
+            # Standard tier.
+            TIER_STANDARD = 1
+
+            # Enterprise tier (Essentials).
+            TIER_ENTERPRISE = 2
+
+            # Enterprise tier (Plus).
+            TIER_ENTERPRISE_PLUS = 3
+          end
         end
 
         # The request message for {Google::Cloud::Dialogflow::V2::Agents::GetAgent Agents::GetAgent}.
@@ -90,6 +129,22 @@ module Google
         #     Format: `projects/<Project ID>`.
         class GetAgentRequest; end
 
+        # The request message for {Google::Cloud::Dialogflow::V2::Agents::SetAgent Agents::SetAgent}.
+        # @!attribute [rw] agent
+        #   @return [Google::Cloud::Dialogflow::V2::Agent]
+        #     Required. The agent to update.
+        # @!attribute [rw] update_mask
+        #   @return [Google::Protobuf::FieldMask]
+        #     Optional. The mask to control which fields get updated.
+        class SetAgentRequest; end
+
+        # The request message for {Google::Cloud::Dialogflow::V2::Agents::DeleteAgent Agents::DeleteAgent}.
+        # @!attribute [rw] parent
+        #   @return [String]
+        #     Required. The project that the agent to delete is associated with.
+        #     Format: `projects/<Project ID>`.
+        class DeleteAgentRequest; end
+
         # The request message for {Google::Cloud::Dialogflow::V2::Agents::SearchAgents Agents::SearchAgents}.
         # @!attribute [rw] parent
         #   @return [String]
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/audio_config.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/audio_config.rb
index ce8ee97c5..c0da5ab48 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/audio_config.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/audio_config.rb
@@ -32,15 +32,15 @@ module Google
         #   @return [String]
         #     Required. The language of the supplied audio. Dialogflow does not do
         #     translations. See [Language
-        #     Support](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     Support](https://cloud.google.com/dialogflow/docs/reference/language)
         #     for a list of the currently supported language codes. Note that queries in
         #     the same session do not necessarily need to specify the same language.
         # @!attribute [rw] phrase_hints
         #   @return [Array<String>]
-        #     Optional. The collection of phrase hints which are used to boost accuracy
-        #     of speech recognition.
-        #     Refer to
-        #     [Cloud Speech API
+        #     Optional. A list of strings containing words and phrases that the speech
+        #     recognizer should recognize with higher likelihood.
+        #
+        #     See [the Cloud Speech
         #     documentation](https://cloud.google.com/speech-to-text/docs/basics#phrase-hints)
         #     for more details.
         # @!attribute [rw] model_variant
@@ -194,7 +194,7 @@ module Google
           # model][InputAudioConfig.model] that the caller is eligible for.
           #
           # Please see the [Dialogflow
-          # docs](https://cloud.google.com/dialogflow-enterprise/docs/data-logging) for
+          # docs](https://cloud.google.com/dialogflow/docs/data-logging) for
           # how to make your project eligible for enhanced models.
           USE_BEST_AVAILABLE = 1
 
@@ -216,7 +216,7 @@ module Google
           #
           # * If the API caller isn't eligible for enhanced models, Dialogflow returns
           #   an error. Please see the [Dialogflow
-          #   docs](https://cloud.google.com/dialogflow-enterprise/docs/data-logging)
+          #   docs](https://cloud.google.com/dialogflow/docs/data-logging)
           #   for how to make your project eligible.
           USE_ENHANCED = 3
         end
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/context.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/context.rb
index eb3029179..b789bc003 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/context.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/context.rb
@@ -35,7 +35,7 @@ module Google
         #   @return [Google::Protobuf::Struct]
         #     Optional. The collection of parameters associated with this context.
         #     Refer to [this
-        #     doc](https://cloud.google.com/dialogflow-enterprise/docs/intents-actions-parameters)
+        #     doc](https://cloud.google.com/dialogflow/docs/intents-actions-parameters)
         #     for syntax.
         class Context; end
 
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/entity_type.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/entity_type.rb
index 2464ac78a..a9136661b 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/entity_type.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/entity_type.rb
@@ -104,7 +104,7 @@ module Google
         #     Optional. The language to list entity synonyms for. If not specified,
         #     the agent's default language is used.
         #     [Many
-        #     languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     languages](https://cloud.google.com/dialogflow/docs/reference/language)
         #     are supported. Note: languages must be enabled in the agent before they can
         #     be used.
         # @!attribute [rw] page_size
@@ -137,7 +137,7 @@ module Google
         #     Optional. The language to retrieve entity synonyms for. If not specified,
         #     the agent's default language is used.
         #     [Many
-        #     languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     languages](https://cloud.google.com/dialogflow/docs/reference/language)
         #     are supported. Note: languages must be enabled in the agent before they can
         #     be used.
         class GetEntityTypeRequest; end
@@ -155,7 +155,7 @@ module Google
         #     Optional. The language of entity synonyms defined in `entity_type`. If not
         #     specified, the agent's default language is used.
         #     [Many
-        #     languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     languages](https://cloud.google.com/dialogflow/docs/reference/language)
         #     are supported. Note: languages must be enabled in the agent before they can
         #     be used.
         class CreateEntityTypeRequest; end
@@ -169,7 +169,7 @@ module Google
         #     Optional. The language of entity synonyms defined in `entity_type`. If not
         #     specified, the agent's default language is used.
         #     [Many
-        #     languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     languages](https://cloud.google.com/dialogflow/docs/reference/language)
         #     are supported. Note: languages must be enabled in the agent before they can
         #     be used.
         # @!attribute [rw] update_mask
@@ -203,7 +203,7 @@ module Google
         #     Optional. The language of entity synonyms defined in `entity_types`. If not
         #     specified, the agent's default language is used.
         #     [Many
-        #     languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     languages](https://cloud.google.com/dialogflow/docs/reference/language)
         #     are supported. Note: languages must be enabled in the agent before they can
         #     be used.
         # @!attribute [rw] update_mask
@@ -241,7 +241,7 @@ module Google
         #     Optional. The language of entity synonyms defined in `entities`. If not
         #     specified, the agent's default language is used.
         #     [Many
-        #     languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     languages](https://cloud.google.com/dialogflow/docs/reference/language)
         #     are supported. Note: languages must be enabled in the agent before they can
         #     be used.
         class BatchCreateEntitiesRequest; end
@@ -259,7 +259,7 @@ module Google
         #     Optional. The language of entity synonyms defined in `entities`. If not
         #     specified, the agent's default language is used.
         #     [Many
-        #     languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     languages](https://cloud.google.com/dialogflow/docs/reference/language)
         #     are supported. Note: languages must be enabled in the agent before they can
         #     be used.
         # @!attribute [rw] update_mask
@@ -282,7 +282,7 @@ module Google
         #     Optional. The language of entity synonyms defined in `entities`. If not
         #     specified, the agent's default language is used.
         #     [Many
-        #     languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     languages](https://cloud.google.com/dialogflow/docs/reference/language)
         #     are supported. Note: languages must be enabled in the agent before they can
         #     be used.
         class BatchDeleteEntitiesRequest; end
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/intent.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/intent.rb
index d13e049e5..3163a81fa 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/intent.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/intent.rb
@@ -217,7 +217,7 @@ module Google
           # @!attribute [rw] prompts
           #   @return [Array<String>]
           #     Optional. The collection of prompts that the agent can present to the
-          #     user in order to collect value for the parameter.
+          #     user in order to collect a value for the parameter.
           # @!attribute [rw] is_list
           #   @return [true, false]
           #     Optional. Indicates whether the parameter represents a list of values.
@@ -580,7 +580,7 @@ module Google
         #     Optional. The language to list training phrases, parameters and rich
         #     messages for. If not specified, the agent's default language is used.
         #     [Many
-        #     languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     languages](https://cloud.google.com/dialogflow/docs/reference/language)
         #     are supported. Note: languages must be enabled in the agent before they can
         #     be used.
         # @!attribute [rw] intent_view
@@ -616,7 +616,7 @@ module Google
         #     Optional. The language to retrieve training phrases, parameters and rich
         #     messages for. If not specified, the agent's default language is used.
         #     [Many
-        #     languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     languages](https://cloud.google.com/dialogflow/docs/reference/language)
         #     are supported. Note: languages must be enabled in the agent before they can
         #     be used.
         # @!attribute [rw] intent_view
@@ -637,7 +637,7 @@ module Google
         #     Optional. The language of training phrases, parameters and rich messages
         #     defined in `intent`. If not specified, the agent's default language is
         #     used. [Many
-        #     languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     languages](https://cloud.google.com/dialogflow/docs/reference/language)
         #     are supported. Note: languages must be enabled in the agent before they can
         #     be used.
         # @!attribute [rw] intent_view
@@ -654,7 +654,7 @@ module Google
         #     Optional. The language of training phrases, parameters and rich messages
         #     defined in `intent`. If not specified, the agent's default language is
         #     used. [Many
-        #     languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     languages](https://cloud.google.com/dialogflow/docs/reference/language)
         #     are supported. Note: languages must be enabled in the agent before they can
         #     be used.
         # @!attribute [rw] update_mask
@@ -691,7 +691,7 @@ module Google
         #     Optional. The language of training phrases, parameters and rich messages
         #     defined in `intents`. If not specified, the agent's default language is
         #     used. [Many
-        #     languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     languages](https://cloud.google.com/dialogflow/docs/reference/language)
         #     are supported. Note: languages must be enabled in the agent before they can
         #     be used.
         # @!attribute [rw] update_mask
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/session.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/session.rb
index 059058c86..2d6a5cdce 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/session.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/session.rb
@@ -143,7 +143,7 @@ module Google
         #   @return [String]
         #     The language that was triggered during intent detection.
         #     See [Language
-        #     Support](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     Support](https://cloud.google.com/dialogflow/docs/reference/language)
         #     for a list of the currently supported language codes.
         # @!attribute [rw] speech_recognition_confidence
         #   @return [Float]
@@ -228,7 +228,7 @@ module Google
         #   @return [String]
         #     Required. The name of the session the query is sent to.
         #     Format of the session name:
-        #     `projects/<Project ID>/agent/sessions/<Session ID>`. It’s up to the API
+        #     `projects/<Project ID>/agent/sessions/<Session ID>`. It's up to the API
         #     caller to choose an appropriate `Session ID`. It can be a random number or
         #     some type of user identifier (preferably hashed). The length of the session
         #     ID must not exceed 36 characters.
@@ -295,11 +295,14 @@ module Google
         # @!attribute [rw] output_audio
         #   @return [String]
         #     The audio data bytes encoded as specified in the request.
+        #     Note: The output audio is generated based on the values of default platform
+        #     text responses found in the `query_result.fulfillment_messages` field. If
+        #     multiple default text responses exist, they will be concatenated when
+        #     generating audio. If no default platform text responses exist, the
+        #     generated audio content will be empty.
         # @!attribute [rw] output_audio_config
         #   @return [Google::Cloud::Dialogflow::V2::OutputAudioConfig]
-        #     Instructs the speech synthesizer how to generate the output audio. This
-        #     field is populated from the agent-level speech synthesizer configuration,
-        #     if enabled.
+        #     The config used by the speech synthesizer to generate the output audio.
         class StreamingDetectIntentResponse; end
 
         # Contains a speech recognition result corresponding to a portion of the audio
@@ -367,12 +370,12 @@ module Google
             TRANSCRIPT = 1
 
             # Event indicates that the server has detected the end of the user's speech
-            # utterance and expects no additional speech. Therefore, the server will
-            # not process additional audio (although it may subsequently return
-            # additional results). The client should stop sending additional audio
-            # data, half-close the gRPC connection, and wait for any additional results
-            # until the server closes the gRPC connection. This message is only sent if
-            # `single_utterance` was set to `true`, and is not used otherwise.
+            # utterance and expects no additional inputs.
+            # Therefore, the server will not process additional audio (although it may subsequently return additional results). The
+            # client should stop sending additional audio data, half-close the gRPC
+            # connection, and wait for any additional results until the server closes
+            # the gRPC connection. This message is only sent if `single_utterance` was
+            # set to `true`, and is not used otherwise.
             END_OF_SINGLE_UTTERANCE = 2
           end
         end
@@ -385,7 +388,7 @@ module Google
         # @!attribute [rw] language_code
         #   @return [String]
         #     Required. The language of this conversational query. See [Language
-        #     Support](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     Support](https://cloud.google.com/dialogflow/docs/reference/language)
         #     for a list of the currently supported language codes. Note that queries in
         #     the same session do not necessarily need to specify the same language.
         class TextInput; end
@@ -404,7 +407,7 @@ module Google
         # @!attribute [rw] language_code
         #   @return [String]
         #     Required. The language of this query. See [Language
-        #     Support](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+        #     Support](https://cloud.google.com/dialogflow/docs/reference/language)
         #     for a list of the currently supported language codes. Note that queries in
         #     the same session do not necessarily need to specify the same language.
         class EventInput; end
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_type_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_type_pb.rb
index cc7395ff4..f4f34fe87 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_type_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_type_pb.rb
@@ -8,7 +8,7 @@ require 'google/api/annotations_pb'
 require 'google/longrunning/operations_pb'
 require 'google/protobuf/empty_pb'
 require 'google/protobuf/field_mask_pb'
-require 'google/protobuf/struct_pb'
+require 'google/api/client_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.dialogflow.v2.EntityType" do
     optional :name, :string, 1
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_type_services_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_type_services_pb.rb
index b7695df6f..517fd5aea 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_type_services_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_type_services_pb.rb
@@ -53,7 +53,7 @@ module Google
           #
           # For more information about entity types, see the
           # [Dialogflow
-          # documentation](https://cloud.google.com/dialogflow-enterprise/docs/entities-overview).
+          # documentation](https://cloud.google.com/dialogflow/docs/entities-overview).
           class Service
 
             include GRPC::GenericService
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_types_client.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_types_client.rb
index a9a923d31..3fa2156a1 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_types_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_types_client.rb
@@ -62,7 +62,7 @@ module Google
         #
         # For more information about entity types, see the
         # [Dialogflow
-        # documentation](https://cloud.google.com/dialogflow-enterprise/docs/entities-overview).
+        # documentation](https://cloud.google.com/dialogflow/docs/entities-overview).
         #
         # @!attribute [r] entity_types_stub
         #   @return [Google::Cloud::Dialogflow::V2::EntityTypes::Stub]
@@ -161,6 +161,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -170,6 +174,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -187,7 +193,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -233,8 +242,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @entity_types_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -340,7 +349,7 @@ module Google
           #   Optional. The language to list entity synonyms for. If not specified,
           #   the agent's default language is used.
           #   [Many
-          #   languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+          #   languages](https://cloud.google.com/dialogflow/docs/reference/language)
           #   are supported. Note: languages must be enabled in the agent before they can
           #   be used.
           # @param page_size [Integer]
@@ -404,7 +413,7 @@ module Google
           #   Optional. The language to retrieve entity synonyms for. If not specified,
           #   the agent's default language is used.
           #   [Many
-          #   languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+          #   languages](https://cloud.google.com/dialogflow/docs/reference/language)
           #   are supported. Note: languages must be enabled in the agent before they can
           #   be used.
           # @param options [Google::Gax::CallOptions]
@@ -448,7 +457,7 @@ module Google
           #   Optional. The language of entity synonyms defined in `entity_type`. If not
           #   specified, the agent's default language is used.
           #   [Many
-          #   languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+          #   languages](https://cloud.google.com/dialogflow/docs/reference/language)
           #   are supported. Note: languages must be enabled in the agent before they can
           #   be used.
           # @param options [Google::Gax::CallOptions]
@@ -494,7 +503,7 @@ module Google
           #   Optional. The language of entity synonyms defined in `entity_type`. If not
           #   specified, the agent's default language is used.
           #   [Many
-          #   languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+          #   languages](https://cloud.google.com/dialogflow/docs/reference/language)
           #   are supported. Note: languages must be enabled in the agent before they can
           #   be used.
           # @param update_mask [Google::Protobuf::FieldMask | Hash]
@@ -584,7 +593,7 @@ module Google
           #   Optional. The language of entity synonyms defined in `entity_types`. If not
           #   specified, the agent's default language is used.
           #   [Many
-          #   languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+          #   languages](https://cloud.google.com/dialogflow/docs/reference/language)
           #   are supported. Note: languages must be enabled in the agent before they can
           #   be used.
           # @param update_mask [Google::Protobuf::FieldMask | Hash]
@@ -741,7 +750,7 @@ module Google
           #   Optional. The language of entity synonyms defined in `entities`. If not
           #   specified, the agent's default language is used.
           #   [Many
-          #   languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+          #   languages](https://cloud.google.com/dialogflow/docs/reference/language)
           #   are supported. Note: languages must be enabled in the agent before they can
           #   be used.
           # @param options [Google::Gax::CallOptions]
@@ -824,7 +833,7 @@ module Google
           #   Optional. The language of entity synonyms defined in `entities`. If not
           #   specified, the agent's default language is used.
           #   [Many
-          #   languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+          #   languages](https://cloud.google.com/dialogflow/docs/reference/language)
           #   are supported. Note: languages must be enabled in the agent before they can
           #   be used.
           # @param update_mask [Google::Protobuf::FieldMask | Hash]
@@ -911,7 +920,7 @@ module Google
           #   Optional. The language of entity synonyms defined in `entities`. If not
           #   specified, the agent's default language is used.
           #   [Many
-          #   languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+          #   languages](https://cloud.google.com/dialogflow/docs/reference/language)
           #   are supported. Note: languages must be enabled in the agent before they can
           #   be used.
           # @param options [Google::Gax::CallOptions]
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intent_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intent_pb.rb
index b9851557f..3c125e025 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intent_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intent_pb.rb
@@ -5,12 +5,14 @@
 require 'google/protobuf'
 
 require 'google/api/annotations_pb'
+require 'google/cloud/dialogflow/v2/audio_config_pb'
 require 'google/cloud/dialogflow/v2/context_pb'
 require 'google/longrunning/operations_pb'
 require 'google/protobuf/duration_pb'
 require 'google/protobuf/empty_pb'
 require 'google/protobuf/field_mask_pb'
 require 'google/protobuf/struct_pb'
+require 'google/api/client_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.dialogflow.v2.Intent" do
     optional :name, :string, 1
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intent_services_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intent_services_pb.rb
index 3cf378b56..ebab68ab2 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intent_services_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intent_services_pb.rb
@@ -57,7 +57,7 @@ module Google
           #
           # For more information about intents, see the
           # [Dialogflow
-          # documentation](https://cloud.google.com/dialogflow-enterprise/docs/intents-overview).
+          # documentation](https://cloud.google.com/dialogflow/docs/intents-overview).
           class Service
 
             include GRPC::GenericService
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intents_client.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intents_client.rb
index 51f862f7c..6d5bdf6af 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intents_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intents_client.rb
@@ -66,7 +66,7 @@ module Google
         #
         # For more information about intents, see the
         # [Dialogflow
-        # documentation](https://cloud.google.com/dialogflow-enterprise/docs/intents-overview).
+        # documentation](https://cloud.google.com/dialogflow/docs/intents-overview).
         #
         # @!attribute [r] intents_stub
         #   @return [Google::Cloud::Dialogflow::V2::Intents::Stub]
@@ -182,6 +182,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -191,6 +195,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -208,7 +214,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -254,8 +263,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @intents_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -337,7 +346,7 @@ module Google
           #   Optional. The language to list training phrases, parameters and rich
           #   messages for. If not specified, the agent's default language is used.
           #   [Many
-          #   languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+          #   languages](https://cloud.google.com/dialogflow/docs/reference/language)
           #   are supported. Note: languages must be enabled in the agent before they can
           #   be used.
           # @param intent_view [Google::Cloud::Dialogflow::V2::IntentView]
@@ -405,7 +414,7 @@ module Google
           #   Optional. The language to retrieve training phrases, parameters and rich
           #   messages for. If not specified, the agent's default language is used.
           #   [Many
-          #   languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+          #   languages](https://cloud.google.com/dialogflow/docs/reference/language)
           #   are supported. Note: languages must be enabled in the agent before they can
           #   be used.
           # @param intent_view [Google::Cloud::Dialogflow::V2::IntentView]
@@ -453,7 +462,7 @@ module Google
           #   Optional. The language of training phrases, parameters and rich messages
           #   defined in `intent`. If not specified, the agent's default language is
           #   used. [Many
-          #   languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+          #   languages](https://cloud.google.com/dialogflow/docs/reference/language)
           #   are supported. Note: languages must be enabled in the agent before they can
           #   be used.
           # @param intent_view [Google::Cloud::Dialogflow::V2::IntentView]
@@ -503,7 +512,7 @@ module Google
           #   Optional. The language of training phrases, parameters and rich messages
           #   defined in `intent`. If not specified, the agent's default language is
           #   used. [Many
-          #   languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+          #   languages](https://cloud.google.com/dialogflow/docs/reference/language)
           #   are supported. Note: languages must be enabled in the agent before they can
           #   be used.
           # @param update_mask [Google::Protobuf::FieldMask | Hash]
@@ -592,7 +601,7 @@ module Google
           #   Optional. The language of training phrases, parameters and rich messages
           #   defined in `intents`. If not specified, the agent's default language is
           #   used. [Many
-          #   languages](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+          #   languages](https://cloud.google.com/dialogflow/docs/reference/language)
           #   are supported. Note: languages must be enabled in the agent before they can
           #   be used.
           # @param intent_batch_uri [String]
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_type_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_type_pb.rb
index 83bf3ab94..1635fbe4c 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_type_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_type_pb.rb
@@ -8,6 +8,7 @@ require 'google/api/annotations_pb'
 require 'google/cloud/dialogflow/v2/entity_type_pb'
 require 'google/protobuf/empty_pb'
 require 'google/protobuf/field_mask_pb'
+require 'google/api/client_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.dialogflow.v2.SessionEntityType" do
     optional :name, :string, 1
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_type_services_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_type_services_pb.rb
index 53757505f..83abe9133 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_type_services_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_type_services_pb.rb
@@ -38,7 +38,7 @@ module Google
           #
           # For more information about entity types, see the
           # [Dialogflow
-          # documentation](https://cloud.google.com/dialogflow-enterprise/docs/entities-overview).
+          # documentation](https://cloud.google.com/dialogflow/docs/entities-overview).
           class Service
 
             include GRPC::GenericService
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_types_client.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_types_client.rb
index 5024072c2..e397cda1e 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_types_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_types_client.rb
@@ -45,7 +45,7 @@ module Google
         #
         # For more information about entity types, see the
         # [Dialogflow
-        # documentation](https://cloud.google.com/dialogflow-enterprise/docs/entities-overview).
+        # documentation](https://cloud.google.com/dialogflow/docs/entities-overview).
         #
         # @!attribute [r] session_entity_types_stub
         #   @return [Google::Cloud::Dialogflow::V2::SessionEntityTypes::Stub]
@@ -143,6 +143,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -152,6 +156,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -206,8 +212,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @session_entity_types_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_pb.rb
index 576d05baa..edb430aba 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_pb.rb
@@ -9,9 +9,11 @@ require 'google/cloud/dialogflow/v2/audio_config_pb'
 require 'google/cloud/dialogflow/v2/context_pb'
 require 'google/cloud/dialogflow/v2/intent_pb'
 require 'google/cloud/dialogflow/v2/session_entity_type_pb'
+require 'google/protobuf/duration_pb'
 require 'google/protobuf/struct_pb'
 require 'google/rpc/status_pb'
 require 'google/type/latlng_pb'
+require 'google/api/client_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.dialogflow.v2.DetectIntentRequest" do
     optional :session, :string, 1
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/sessions_client.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/sessions_client.rb
index a54bd32bc..170b70981 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/sessions_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/sessions_client.rb
@@ -106,6 +106,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -115,6 +119,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -168,8 +174,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @sessions_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/webhook_pb.rb b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/webhook_pb.rb
index 5747dbcd0..062d68655 100644
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/webhook_pb.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/webhook_pb.rb
@@ -7,6 +7,7 @@ require 'google/protobuf'
 require 'google/cloud/dialogflow/v2/context_pb'
 require 'google/cloud/dialogflow/v2/intent_pb'
 require 'google/cloud/dialogflow/v2/session_pb'
+require 'google/cloud/dialogflow/v2/session_entity_type_pb'
 require 'google/protobuf/struct_pb'
 require 'google/api/annotations_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
diff --git a/google-cloud-dialogflow/synth.metadata b/google-cloud-dialogflow/synth.metadata
index c6110b04a..c5323571a 100644
--- a/google-cloud-dialogflow/synth.metadata
+++ b/google-cloud-dialogflow/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-30T00:43:51.837253Z",
+  "updateTime": "2019-07-04T10:39:12.678062Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.21.0",
-        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
+        "version": "0.29.3",
+        "dockerImage": "googleapis/artman@sha256:8900f94a81adaab0238965aa8a7b3648791f4f3a95ee65adc6a56cfcc3753101"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
-        "internalRef": "250569499"
+        "sha": "b4c73face84fefb967ef6c72f0eae64faf67895f",
+        "internalRef": "256453142"
       }
     },
     {
diff --git a/google-cloud-dialogflow/synth.py b/google-cloud-dialogflow/synth.py
index f6c9a553a..d701f3606 100644
--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -41,6 +41,47 @@ s.copy(v2_library / 'google-cloud-dialogflow.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/dialogflow.rb',
+        'lib/google/cloud/dialogflow/v*.rb',
+        'lib/google/cloud/dialogflow/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/dialogflow/v*.rb',
+        'lib/google/cloud/dialogflow/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/dialogflow/v*.rb',
+        'lib/google/cloud/dialogflow/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/dialogflow/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/dialogflow/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2232
 s.replace(
     [
@@ -90,9 +131,9 @@ s.replace(
 
 s.replace(
     'google-cloud-dialogflow.gemspec',
-    'gem.add_dependency "google-gax", "~> 1.3"',
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.3"',
+        'gem.add_dependency "google-gax", "~> 1.7"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )
@@ -129,11 +170,3 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Dialogflow::VERSION'
 )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v2']:
-    s.replace(
-        f'test/google/cloud/dialogflow/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )
diff --git a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/agents_client_test.rb b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/agents_client_test.rb
index bf3d5d1b2..3314985d6 100644
--- a/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/agents_client_test.rb
+++ b/google-cloud-dialogflow/test/google/cloud/dialogflow/v2/agents_client_test.rb
@@ -68,6 +68,165 @@ end
 
 describe Google::Cloud::Dialogflow::V2::AgentsClient do
 
+  describe 'set_agent' do
+    custom_error = CustomTestError_v2.new "Custom test error for Google::Cloud::Dialogflow::V2::AgentsClient#set_agent."
+
+    it 'invokes set_agent without error' do
+      # Create request parameters
+      agent = {}
+
+      # Create expected grpc response
+      parent = "parent-995424086"
+      display_name = "displayName1615086568"
+      default_language_code = "defaultLanguageCode856575222"
+      time_zone = "timeZone36848094"
+      description = "description-1724546052"
+      avatar_uri = "avatarUri-402824826"
+      enable_logging = false
+      classification_threshold = 1.11581064E8
+      expected_response = {
+        parent: parent,
+        display_name: display_name,
+        default_language_code: default_language_code,
+        time_zone: time_zone,
+        description: description,
+        avatar_uri: avatar_uri,
+        enable_logging: enable_logging,
+        classification_threshold: classification_threshold
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Dialogflow::V2::Agent)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Dialogflow::V2::SetAgentRequest, request)
+        assert_equal(Google::Gax::to_proto(agent, Google::Cloud::Dialogflow::V2::Agent), request.agent)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v2.new(:set_agent, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockAgentsCredentials_v2.new("set_agent")
+
+      Google::Cloud::Dialogflow::V2::Agents::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Dialogflow::V2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
+
+          # Call method
+          response = client.set_agent(agent)
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.set_agent(agent) do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes set_agent with error' do
+      # Create request parameters
+      agent = {}
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Dialogflow::V2::SetAgentRequest, request)
+        assert_equal(Google::Gax::to_proto(agent, Google::Cloud::Dialogflow::V2::Agent), request.agent)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v2.new(:set_agent, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockAgentsCredentials_v2.new("set_agent")
+
+      Google::Cloud::Dialogflow::V2::Agents::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Dialogflow::V2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
+            client.set_agent(agent)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'delete_agent' do
+    custom_error = CustomTestError_v2.new "Custom test error for Google::Cloud::Dialogflow::V2::AgentsClient#delete_agent."
+
+    it 'invokes delete_agent without error' do
+      # Create request parameters
+      formatted_parent = Google::Cloud::Dialogflow::V2::AgentsClient.project_path("[PROJECT]")
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Dialogflow::V2::DeleteAgentRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        OpenStruct.new(execute: nil)
+      end
+      mock_stub = MockGrpcClientStub_v2.new(:delete_agent, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockAgentsCredentials_v2.new("delete_agent")
+
+      Google::Cloud::Dialogflow::V2::Agents::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Dialogflow::V2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
+
+          # Call method
+          response = client.delete_agent(formatted_parent)
+
+          # Verify the response
+          assert_nil(response)
+
+          # Call method with block
+          client.delete_agent(formatted_parent) do |response, operation|
+            # Verify the response
+            assert_nil(response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes delete_agent with error' do
+      # Create request parameters
+      formatted_parent = Google::Cloud::Dialogflow::V2::AgentsClient.project_path("[PROJECT]")
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Dialogflow::V2::DeleteAgentRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v2.new(:delete_agent, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockAgentsCredentials_v2.new("delete_agent")
+
+      Google::Cloud::Dialogflow::V2::Agents::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Dialogflow::V2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Dialogflow::Agents.new(version: :v2)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v2 do
+            client.delete_agent(formatted_parent)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
   describe 'get_agent' do
     custom_error = CustomTestError_v2.new "Custom test error for Google::Cloud::Dialogflow::V2::AgentsClient#get_agent."
 

```

</details>

This pull request was generated using releasetool.