### PR TITLE
Release google-cloud-dlp 0.11.0

### DIFF
--- a/google-cloud-dlp/CHANGELOG.md
+++ b/google-cloud-dlp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.11.0 / 2019-07-08
+
+* Add Action#publish_findings_to_cloud_data_catalog
+* Support overriding service host and port
+* Add AVRO constant to FileType and BytesType
+
 ### 0.10.0 / 2019-06-11
 
 * Add StoredInfoTypeVersion#stats (StoredInfoTypeStats)

--- a/google-cloud-dlp/lib/google/cloud/dlp/version.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Dlp
-      VERSION = "0.10.0".freeze
+      VERSION = "0.11.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add Action#publish_findings_to_cloud_data_catalog
* Support overriding service host and port
* Add AVRO constant to FileType and BytesType

<details><summary>Commits since previous release</summary><pre><code>commit 6af4b5b8312a0a7c0ca5077524e0eeaa5901708e
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Fri Jul 5 08:58:16 2019 -0700

    feat(dlp): Add Action#publish_findings_to_cloud_data_catalog (PublishFindingsToCloudDataCatalog)
    
    
    docs: Deprecate DetectionRule, use InspectionRuleSet

commit 47245e905237aeb978b87c2ac47218d5ac23511a
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:49:34 2019 -0700

    feat(dlp): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients

commit d17733d0c169bd2d912bb3910d66adacc104022c
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Tue Jun 18 11:54:47 2019 -0700

    feat(dlp): add AVRO constant to FileType and BytesType
    
    
    [pr #3502]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-dlp/google-cloud-dlp.gemspec b/google-cloud-dlp/google-cloud-dlp.gemspec
index 11397cba9..fe3283d3a 100644
--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
diff --git a/google-cloud-dlp/lib/google/cloud/dlp.rb b/google-cloud-dlp/lib/google/cloud/dlp.rb
index b54fc39da..272b4d722 100644
--- a/google-cloud-dlp/lib/google/cloud/dlp.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp.rb
@@ -129,6 +129,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-dlp/lib/google/cloud/dlp/v2.rb b/google-cloud-dlp/lib/google/cloud/dlp/v2.rb
index b6d5a7c9d..544a2bc80 100644
--- a/google-cloud-dlp/lib/google/cloud/dlp/v2.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2.rb
@@ -117,6 +117,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -126,6 +130,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -137,6 +143,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Dlp::V2::DlpServiceClient.new(**kwargs)
diff --git a/google-cloud-dlp/lib/google/cloud/dlp/v2/dlp_service_client.rb b/google-cloud-dlp/lib/google/cloud/dlp/v2/dlp_service_client.rb
index 9834e6399..9c2be2eaf 100644
--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/dlp_service_client.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/dlp_service_client.rb
@@ -284,6 +284,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -293,6 +297,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -347,8 +353,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @dlp_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/dlp.rb b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/dlp.rb
index ce78b5867..7865d3463 100644
--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/dlp.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/dlp.rb
@@ -163,6 +163,8 @@ module Google
             IMAGE_SVG = 4
 
             TEXT_UTF8 = 5
+
+            AVRO = 11
           end
         end
 
@@ -1937,6 +1939,9 @@ module Google
         # @!attribute [rw] publish_summary_to_cscc
         #   @return [Google::Privacy::Dlp::V2::Action::PublishSummaryToCscc]
         #     Publish summary to Cloud Security Command Center (Alpha).
+        # @!attribute [rw] publish_findings_to_cloud_data_catalog
+        #   @return [Google::Privacy::Dlp::V2::Action::PublishFindingsToCloudDataCatalog]
+        #     Publish findings to Cloud Datahub.
         # @!attribute [rw] job_notification_emails
         #   @return [Google::Privacy::Dlp::V2::Action::JobNotificationEmails]
         #     Enable email notification to project owners and editors on job's
@@ -1975,6 +1980,18 @@ module Google
           # Compatible with: Inspect
           class PublishSummaryToCscc; end
 
+          # Publish findings of a DlpJob to Cloud Data Catalog. Labels summarizing the
+          # results of the DlpJob will be applied to the entry for the resource scanned
+          # in Cloud Data Catalog. Any labels previously written by another DlpJob will
+          # be deleted. InfoType naming patterns are strictly enforced when using this
+          # feature. Note that the findings will be persisted in Cloud Data Catalog
+          # storage and are governed by Data Catalog service-specific policy, see
+          # https://cloud.google.com/terms/service-terms
+          # Only a single instance of this action can be specified and only allowed if
+          # all resources being scanned are BigQuery tables.
+          # Compatible with: Inspect
+          class PublishFindingsToCloudDataCatalog; end
+
           # Enable email notification to project owners and editors on jobs's
           # completion/failure.
           class JobNotificationEmails; end
diff --git a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/storage.rb b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/storage.rb
index 9275b413d..0d7e02b46 100644
--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/storage.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/storage.rb
@@ -140,9 +140,10 @@ module Google
           # not support the use of `detection_rules`.
           class SurrogateType; end
 
-          # Rule for modifying a CustomInfoType to alter behavior under certain
-          # circumstances, depending on the specific details of the rule. Not supported
-          # for the `surrogate_type` custom info type.
+          # Deprecated; use `InspectionRuleSet` instead. Rule for modifying a
+          # `CustomInfoType` to alter behavior under certain circumstances, depending
+          # on the specific details of the rule. Not supported for the `surrogate_type`
+          # custom infoType.
           # @!attribute [rw] hotword_rule
           #   @return [Google::Privacy::Dlp::V2::CustomInfoType::DetectionRule::HotwordRule]
           #     Hotword-based detection rule.
@@ -588,6 +589,10 @@ module Google
           #   bmp, gif, jpg, jpeg, jpe, png.
           # bytes_limit_per_file has no effect on image files.
           IMAGE = 3
+
+          # Included file extensions:
+          #   avro
+          AVRO = 7
         end
 
         # Categorization of results based on how likely they are to represent a match,
diff --git a/google-cloud-dlp/lib/google/privacy/dlp/v2/dlp_pb.rb b/google-cloud-dlp/lib/google/privacy/dlp/v2/dlp_pb.rb
index caada6581..08ae4a175 100644
--- a/google-cloud-dlp/lib/google/privacy/dlp/v2/dlp_pb.rb
+++ b/google-cloud-dlp/lib/google/privacy/dlp/v2/dlp_pb.rb
@@ -5,7 +5,6 @@
 require 'google/protobuf'
 
 require 'google/api/annotations_pb'
-require 'google/api/client_pb'
 require 'google/privacy/dlp/v2/storage_pb'
 require 'google/protobuf/duration_pb'
 require 'google/protobuf/empty_pb'
@@ -15,6 +14,7 @@ require 'google/rpc/status_pb'
 require 'google/type/date_pb'
 require 'google/type/dayofweek_pb'
 require 'google/type/timeofday_pb'
+require 'google/api/client_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.privacy.dlp.v2.ExcludeInfoTypes" do
     repeated :info_types, :message, 1, "google.privacy.dlp.v2.InfoType"
@@ -68,6 +68,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     value :IMAGE_PNG, 3
     value :IMAGE_SVG, 4
     value :TEXT_UTF8, 5
+    value :AVRO, 11
   end
   add_message "google.privacy.dlp.v2.ContentItem" do
     oneof :data_item do
@@ -667,6 +668,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :save_findings, :message, 1, "google.privacy.dlp.v2.Action.SaveFindings"
       optional :pub_sub, :message, 2, "google.privacy.dlp.v2.Action.PublishToPubSub"
       optional :publish_summary_to_cscc, :message, 3, "google.privacy.dlp.v2.Action.PublishSummaryToCscc"
+      optional :publish_findings_to_cloud_data_catalog, :message, 5, "google.privacy.dlp.v2.Action.PublishFindingsToCloudDataCatalog"
       optional :job_notification_emails, :message, 8, "google.privacy.dlp.v2.Action.JobNotificationEmails"
     end
   end
@@ -678,6 +680,8 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   end
   add_message "google.privacy.dlp.v2.Action.PublishSummaryToCscc" do
   end
+  add_message "google.privacy.dlp.v2.Action.PublishFindingsToCloudDataCatalog" do
+  end
   add_message "google.privacy.dlp.v2.Action.JobNotificationEmails" do
   end
   add_message "google.privacy.dlp.v2.CreateInspectTemplateRequest" do
@@ -1046,6 +1050,7 @@ module Google
         Action::SaveFindings = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.privacy.dlp.v2.Action.SaveFindings").msgclass
         Action::PublishToPubSub = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.privacy.dlp.v2.Action.PublishToPubSub").msgclass
         Action::PublishSummaryToCscc = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.privacy.dlp.v2.Action.PublishSummaryToCscc").msgclass
+        Action::PublishFindingsToCloudDataCatalog = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.privacy.dlp.v2.Action.PublishFindingsToCloudDataCatalog").msgclass
         Action::JobNotificationEmails = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.privacy.dlp.v2.Action.JobNotificationEmails").msgclass
         CreateInspectTemplateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.privacy.dlp.v2.CreateInspectTemplateRequest").msgclass
         UpdateInspectTemplateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.privacy.dlp.v2.UpdateInspectTemplateRequest").msgclass
diff --git a/google-cloud-dlp/lib/google/privacy/dlp/v2/storage_pb.rb b/google-cloud-dlp/lib/google/privacy/dlp/v2/storage_pb.rb
index fedfb9330..30591f301 100644
--- a/google-cloud-dlp/lib/google/privacy/dlp/v2/storage_pb.rb
+++ b/google-cloud-dlp/lib/google/privacy/dlp/v2/storage_pb.rb
@@ -184,6 +184,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     value :BINARY_FILE, 1
     value :TEXT_FILE, 2
     value :IMAGE, 3
+    value :AVRO, 7
   end
 end
 
diff --git a/google-cloud-dlp/synth.metadata b/google-cloud-dlp/synth.metadata
index 2ba2012b5..3729002e6 100644
--- a/google-cloud-dlp/synth.metadata
+++ b/google-cloud-dlp/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-06T10:38:44.275768Z",
+  "updateTime": "2019-07-04T10:39:28.971597Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.23.1",
-        "dockerImage": "googleapis/artman@sha256:9d5cae1454da64ac3a87028f8ef486b04889e351c83bb95e83b8fab3959faed0"
+        "version": "0.29.3",
+        "dockerImage": "googleapis/artman@sha256:8900f94a81adaab0238965aa8a7b3648791f4f3a95ee65adc6a56cfcc3753101"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "f03bf2139ee85aac88411d6c20a21f4c901fe83c",
-        "internalRef": "251806891"
+        "sha": "b4c73face84fefb967ef6c72f0eae64faf67895f",
+        "internalRef": "256453142"
       }
     },
     {
diff --git a/google-cloud-dlp/synth.py b/google-cloud-dlp/synth.py
index 2b616471b..5fe533a36 100644
--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -40,6 +40,47 @@ s.copy(v2_library / 'google-cloud-dlp.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/dlp.rb',
+        'lib/google/cloud/dlp/v*.rb',
+        'lib/google/cloud/dlp/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/dlp/v*.rb',
+        'lib/google/cloud/dlp/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/dlp/v*.rb',
+        'lib/google/cloud/dlp/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/dlp/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/dlp/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
@@ -92,9 +133,9 @@ s.replace(
 
 s.replace(
     'google-cloud-dlp.gemspec',
-    'gem.add_dependency "google-gax", "~> 1.3"',
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.3"',
+        'gem.add_dependency "google-gax", "~> 1.7"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )
@@ -131,11 +172,3 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Dlp::VERSION'
 )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v2']:
-    s.replace(
-        f'test/google/cloud/dlp/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

```

</details>

This pull request was generated using releasetool.