### PR TITLE
Release google-cloud-error_reporting 0.31.6

### DIFF
--- a/google-cloud-error_reporting/CHANGELOG.md
+++ b/google-cloud-error_reporting/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.31.6 / 2019-07-08
+
+* Support overriding service host and port in the low-level interface.
+
 ### 0.31.5 / 2019-06-11
 
 * Use VERSION constant in GAPIC client

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module ErrorReporting
-      VERSION = "0.31.5".freeze
+      VERSION = "0.31.6".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port in the low-level interface.

<details><summary>Commits since previous release</summary><pre><code>commit 9c900ec2c269ad7abbdd08af23bfe61ebee83bf5
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:14:45 2019 -0700

    feat(error_reporting): Add service_address and service_port in the low-level interface

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
index 515047bdf..12f771637 100644
--- a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
+++ b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
-  gem.add_dependency "google-gax", "~> 1.0"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
diff --git a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb
index e3fcbe3d6..a1b1536b4 100644
--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb
@@ -102,6 +102,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -111,6 +115,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -164,8 +170,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @error_group_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb
index 8244a20cf..cb5dae96b 100644
--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb
@@ -114,6 +114,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -123,6 +127,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -177,8 +183,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @error_stats_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb
index 8a090b398..85ecb4998 100644
--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb
@@ -100,6 +100,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -109,6 +113,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -162,8 +168,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @report_errors_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-error_reporting/synth.metadata b/google-cloud-error_reporting/synth.metadata
index dd0869a83..f0135f6d5 100644
--- a/google-cloud-error_reporting/synth.metadata
+++ b/google-cloud-error_reporting/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:39:52.813406Z",
+  "updateTime": "2019-07-01T10:40:36.260861Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     }
   ],
diff --git a/google-cloud-error_reporting/synth.py b/google-cloud-error_reporting/synth.py
index a1d0d284f..4d41bd7d9 100644
--- a/google-cloud-error_reporting/synth.py
+++ b/google-cloud-error_reporting/synth.py
@@ -34,6 +34,32 @@ s.copy(v1beta1_library / 'lib/google/devtools/clouderrorreporting/v1beta1')
 # Omitting lib/google/cloud/error_reporting/v1beta1.rb for now because we are
 # not exposing the low-level API.
 
+# Support for service_address
+s.replace(
+    'lib/google/cloud/error_reporting/v*/*_client.rb',
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    'lib/google/cloud/error_reporting/v*/*_client.rb',
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    'lib/google/cloud/error_reporting/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/error_reporting/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

```

</details>

This pull request was generated using releasetool.