### PR TITLE
Release google-cloud-firestore 0.26.1

### DIFF
--- a/google-cloud-firestore/CHANGELOG.md
+++ b/google-cloud-firestore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.26.1 / 2019-07-08
+
+* Support overriding service host and port in the low-level interface.
+
 ### 0.26.0 / 2019-06-13
 
 BREAKING CHANGE: The default return value of Client#transaction has been

--- a/google-cloud-firestore/lib/google/cloud/firestore/version.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Firestore
-      VERSION = "0.26.0".freeze
+      VERSION = "0.26.1".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port in the low-level interface.