### PR TITLE
Release google-cloud-kms 1.2.0

### DIFF
--- a/google-cloud-kms/CHANGELOG.md
+++ b/google-cloud-kms/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.2.0 / 2019-07-08
+
+* Add IAM GetPolicyOptions.
+* Support overriding service host and port.
+
 ### 1.1.0 / 2019-06-17
 
 * KeyManagementServiceClient  changes:

--- a/google-cloud-kms/lib/google/cloud/kms/version.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Kms
-      VERSION = "1.1.0".freeze
+      VERSION = "1.2.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add IAM GetPolicyOptions.
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit 8c8a7c186016471b8d2bf86355ec79f0e1756fe8
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Jul 3 13:42:02 2019 -0700

    feat(kms): Add IAM GetPolicyOptions

commit cf0cd38faa839436e483510b576ef52a333f2d1e
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:50:44 2019 -0700

    feat(kms): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-kms/google-cloud-kms.gemspec b/google-cloud-kms/google-cloud-kms.gemspec
index f7d5cb830..b529b0986 100644
--- a/google-cloud-kms/google-cloud-kms.gemspec
+++ b/google-cloud-kms/google-cloud-kms.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"
diff --git a/google-cloud-kms/lib/google/cloud/kms.rb b/google-cloud-kms/lib/google/cloud/kms.rb
index d3e56c08b..3fa788f7b 100644
--- a/google-cloud-kms/lib/google/cloud/kms.rb
+++ b/google-cloud-kms/lib/google/cloud/kms.rb
@@ -130,6 +130,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-kms/lib/google/cloud/kms/v1.rb b/google-cloud-kms/lib/google/cloud/kms/v1.rb
index 16fe19f1f..ef63e5a30 100644
--- a/google-cloud-kms/lib/google/cloud/kms/v1.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1.rb
@@ -120,6 +120,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -129,6 +133,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -140,6 +146,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Kms::V1::KeyManagementServiceClient.new(**kwargs)
diff --git a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/iam/v1/options.rb b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/iam/v1/options.rb
new file mode 100644
index 000000000..9a865a1d8
--- /dev/null
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/iam/v1/options.rb
@@ -0,0 +1,21 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Iam
+    module V1
+    end
+  end
+end
\ No newline at end of file
diff --git a/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client.rb b/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client.rb
index 3db4a5ac8..ec7410ffe 100644
--- a/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client.rb
@@ -242,6 +242,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -251,6 +255,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -306,8 +312,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @key_management_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -1689,6 +1695,11 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
           #   See the operation documentation for the appropriate value for this field.
+          # @param options_ [Google::Iam::V1::GetPolicyOptions | Hash]
+          #   OPTIONAL: A `GetPolicyOptions` object for specifying options to
+          #   `GetIamPolicy`. This field is only used by Cloud IAM.
+          #   A hash of the same form as `Google::Iam::V1::GetPolicyOptions`
+          #   can also be provided.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1706,10 +1717,12 @@ module Google
 
           def get_iam_policy \
               resource,
+              options_: nil,
               options: nil,
               &block
             req = {
-              resource: resource
+              resource: resource,
+              options: options_
             }.delete_if { |_, v| v.nil? }
             req = Google::Gax::to_proto(req, Google::Iam::V1::GetIamPolicyRequest)
             @get_iam_policy.call(req, options, &block)
diff --git a/google-cloud-kms/synth.metadata b/google-cloud-kms/synth.metadata
index d9e3d8273..6093f5955 100644
--- a/google-cloud-kms/synth.metadata
+++ b/google-cloud-kms/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-15T10:39:04.055Z",
+  "updateTime": "2019-07-02T10:39:51.160448Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.26.0",
-        "dockerImage": "googleapis/artman@sha256:6db0735b0d3beec5b887153a2a7c7411fc7bb53f73f6f389a822096bd14a3a15"
+        "version": "0.29.3",
+        "dockerImage": "googleapis/artman@sha256:8900f94a81adaab0238965aa8a7b3648791f4f3a95ee65adc6a56cfcc3753101"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7b58b37559f6a5337c4c564518e9573d742df225",
-        "internalRef": "253322136"
+        "sha": "5322233f8cbec4d3f8c17feca2507ef27d4a07c9",
+        "internalRef": "256042411"
       }
     },
     {
diff --git a/google-cloud-kms/synth.py b/google-cloud-kms/synth.py
index 5b117e0c3..15911768f 100644
--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -80,6 +80,51 @@ s.replace(
 
       ### Next Steps\n"""))
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/kms.rb',
+        'lib/google/cloud/kms/v*.rb',
+        'lib/google/cloud/kms/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/kms/v*.rb',
+        'lib/google/cloud/kms/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/kms/v*.rb',
+        'lib/google/cloud/kms/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/kms/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/kms/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-kms.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
@@ -175,11 +220,3 @@ s.replace(
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1']:
-    s.replace(
-        f'test/google/cloud/kms/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

```

</details>

This pull request was generated using releasetool.