### PR TITLE
Release google-cloud-language 0.33.0

### DIFF
--- a/google-cloud-language/CHANGELOG.md
+++ b/google-cloud-language/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.33.0 / 2019-07-08
+
+* Support overriding service host and port.
+
 ### 0.32.2 / 2019-06-11
 
 * Add VERSION constant

--- a/google-cloud-language/lib/google/cloud/language/version.rb
+++ b/google-cloud-language/lib/google/cloud/language/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Language
-      VERSION = "0.32.2".freeze
+      VERSION = "0.33.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit c21ece88109e9aee24d0d33c98d73798dc972c4a
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:51:10 2019 -0700

    feat(language): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-language/google-cloud-language.gemspec b/google-cloud-language/google-cloud-language.gemspec
index 731de1856..7c5ab4201 100644
--- a/google-cloud-language/google-cloud-language.gemspec
+++ b/google-cloud-language/google-cloud-language.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
diff --git a/google-cloud-language/lib/google/cloud/language.rb b/google-cloud-language/lib/google/cloud/language.rb
index 1444d771c..5dcbb2b67 100644
--- a/google-cloud-language/lib/google/cloud/language.rb
+++ b/google-cloud-language/lib/google/cloud/language.rb
@@ -122,6 +122,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-language/lib/google/cloud/language/v1.rb b/google-cloud-language/lib/google/cloud/language/v1.rb
index a07b8e6ec..068a2a2a1 100644
--- a/google-cloud-language/lib/google/cloud/language/v1.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1.rb
@@ -110,6 +110,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -119,6 +123,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -130,6 +136,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Language::V1::LanguageServiceClient.new(**kwargs)
diff --git a/google-cloud-language/lib/google/cloud/language/v1/language_service_client.rb b/google-cloud-language/lib/google/cloud/language/v1/language_service_client.rb
index f05ee5426..acb17d557 100644
--- a/google-cloud-language/lib/google/cloud/language/v1/language_service_client.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1/language_service_client.rb
@@ -87,6 +87,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -96,6 +100,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -149,8 +155,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @language_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-language/lib/google/cloud/language/v1beta2.rb b/google-cloud-language/lib/google/cloud/language/v1beta2.rb
index 23f04a491..979be6e94 100644
--- a/google-cloud-language/lib/google/cloud/language/v1beta2.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2.rb
@@ -122,6 +122,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -131,6 +135,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -142,6 +148,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Language::V1beta2::LanguageServiceClient.new(**kwargs)
diff --git a/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_client.rb b/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_client.rb
index 470a9db5e..9f7297840 100644
--- a/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_client.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_client.rb
@@ -86,6 +86,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -95,6 +99,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -148,8 +154,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @language_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-language/synth.metadata b/google-cloud-language/synth.metadata
index ce32a645e..42cf63484 100644
--- a/google-cloud-language/synth.metadata
+++ b/google-cloud-language/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-04T19:28:48.606547Z",
+  "updateTime": "2019-07-01T10:41:48.162320Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.23.0",
-        "dockerImage": "googleapis/artman@sha256:846102ebf7ea2239162deea69f64940443b4147f7c2e68d64b332416f74211ba"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0026f4b890ed9e2388fb0573c0727defa6f5b82e",
-        "internalRef": "251265049"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     },
     {
diff --git a/google-cloud-language/synth.py b/google-cloud-language/synth.py
index 12e1bc3f6..6c91bdb3e 100644
--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -54,6 +54,47 @@ s.copy(v1beta2_library / 'test/google/cloud/language/v1beta2')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/language.rb',
+        'lib/google/cloud/language/v*.rb',
+        'lib/google/cloud/language/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/language/v*.rb',
+        'lib/google/cloud/language/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/language/v*.rb',
+        'lib/google/cloud/language/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/language/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/language/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [
@@ -113,9 +154,9 @@ s.replace(
 
 s.replace(
     'google-cloud-language.gemspec',
-    'gem.add_dependency "google-gax", "~> 1.3"',
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.3"',
+        'gem.add_dependency "google-gax", "~> 1.7"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )

```

</details>

This pull request was generated using releasetool.