### PR TITLE
Release google-cloud-logging 1.6.5

### DIFF
--- a/google-cloud-logging/CHANGELOG.md
+++ b/google-cloud-logging/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.6.5 / 2019-07-08
+
+* Support overriding service host and port in the low-level interface.
+
 ### 1.6.4 / 2019-06-11
 
 * Add documentation for MetricDescriptor#launch_stage and

--- a/google-cloud-logging/lib/google/cloud/logging/version.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Logging
-      VERSION = "1.6.4".freeze
+      VERSION = "1.6.5".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port in the low-level interface.

<details><summary>Commits since previous release</summary><pre><code>commit 61ea171d5f9db3b14fb6e54b8c172f1df23d4100
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:16:03 2019 -0700

    feat(logging): Add service_address and service_port in the low-level interface

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-logging/google-cloud-logging.gemspec b/google-cloud-logging/google-cloud-logging.gemspec
index 0db2f446b..2cb938a0c 100644
--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
diff --git a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
index 1a4326dc6..16c7ef5b9 100644
--- a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
@@ -152,6 +152,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -161,6 +165,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -215,8 +221,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @config_service_v2_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb b/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb
index 08bf8ab1d..ed86daa09 100644
--- a/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb
@@ -150,6 +150,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -159,6 +163,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -214,8 +220,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @logging_service_v2_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb b/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb
index 87267dca1..0425321b2 100644
--- a/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb
@@ -130,6 +130,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -139,6 +143,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -193,8 +199,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @metrics_service_v2_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-logging/synth.metadata b/google-cloud-logging/synth.metadata
index 92dc1555b..90d80e016 100644
--- a/google-cloud-logging/synth.metadata
+++ b/google-cloud-logging/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-11T10:39:37.629382Z",
+  "updateTime": "2019-07-01T10:42:02.835095Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "32b08107fa1710f46287c17d5bb2016e443ed3ba",
-        "internalRef": "247684466"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     }
   ],
diff --git a/google-cloud-logging/synth.py b/google-cloud-logging/synth.py
index 0a17f94b9..0fcda7a72 100644
--- a/google-cloud-logging/synth.py
+++ b/google-cloud-logging/synth.py
@@ -58,6 +58,32 @@ s.replace(
     'Google::Cloud::Logging::Metrics\\.new\\(version: :v2\\)',
     'Google::Cloud::Logging::V2::MetricsServiceV2Client.new')
 
+# Support for service_address
+s.replace(
+    'lib/google/cloud/logging/v*/*_client.rb',
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    'lib/google/cloud/logging/v*/*_client.rb',
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    'lib/google/cloud/logging/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/logging/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2124
 s.replace(
     'lib/google/cloud/logging/v2/credentials.rb',

```

</details>

This pull request was generated using releasetool.