### PR TITLE
Release google-cloud-monitoring 0.30.0

### DIFF
--- a/google-cloud-monitoring/CHANGELOG.md
+++ b/google-cloud-monitoring/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.30.0 / 2019-07-08
+
+* Support overriding service host and port.
+
 ### 0.29.5 / 2019-06-11
 
 * Add documentation for MetricDescriptor#launch_stage and

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/version.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Monitoring
-      VERSION = "0.29.5".freeze
+      VERSION = "0.30.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit b33d427ec6eae96f133efd396d52b1666360227d
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:54:58 2019 -0700

    feat(monitoring): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-monitoring/google-cloud-monitoring.gemspec b/google-cloud-monitoring/google-cloud-monitoring.gemspec
index 3dea10481..61ad7efe8 100644
--- a/google-cloud-monitoring/google-cloud-monitoring.gemspec
+++ b/google-cloud-monitoring/google-cloud-monitoring.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"
 
   gem.add_development_dependency "minitest", "~> 5.10"
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring.rb b/google-cloud-monitoring/lib/google/cloud/monitoring.rb
index 928be9ca8..c4f2e301e 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring.rb
@@ -152,6 +152,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
@@ -215,6 +219,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
@@ -268,6 +276,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
@@ -321,6 +333,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
@@ -380,6 +396,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/v3.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/v3.rb
index 28f8da7c1..b38028126 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3.rb
@@ -146,6 +146,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -155,6 +159,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -166,6 +172,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Monitoring::V3::AlertPolicyServiceClient.new(**kwargs)
@@ -213,6 +221,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -222,6 +234,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -233,6 +247,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Monitoring::V3::GroupServiceClient.new(**kwargs)
@@ -270,6 +286,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -279,6 +299,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -290,6 +312,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Monitoring::V3::MetricServiceClient.new(**kwargs)
@@ -327,6 +351,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -336,6 +364,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -347,6 +377,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Monitoring::V3::NotificationChannelServiceClient.new(**kwargs)
@@ -390,6 +422,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -399,6 +435,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -410,6 +448,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Monitoring::V3::UptimeCheckServiceClient.new(**kwargs)
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/alert_policy_service_client.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/alert_policy_service_client.rb
index 93605d56d..118ccd52a 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/alert_policy_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/alert_policy_service_client.rb
@@ -156,6 +156,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -165,6 +169,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -219,8 +225,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @alert_policy_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb
index 443b944cd..8c57d9e96 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb
@@ -144,6 +144,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -153,6 +157,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -207,8 +213,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @group_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb
index f889d87b0..2256d81fd 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb
@@ -155,6 +155,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -164,6 +168,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -218,8 +224,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @metric_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/notification_channel_service_client.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/notification_channel_service_client.rb
index 1629a8a86..df428e9d5 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/notification_channel_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/notification_channel_service_client.rb
@@ -151,6 +151,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -160,6 +164,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -214,8 +220,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @notification_channel_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/uptime_check_service_client.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/uptime_check_service_client.rb
index 353315a0b..98be5b7ce 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/uptime_check_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/uptime_check_service_client.rb
@@ -140,6 +140,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -149,6 +153,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -203,8 +209,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @uptime_check_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-monitoring/synth.metadata b/google-cloud-monitoring/synth.metadata
index edf95fc11..22e75a714 100644
--- a/google-cloud-monitoring/synth.metadata
+++ b/google-cloud-monitoring/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-30T00:36:25.067893Z",
+  "updateTime": "2019-07-01T10:42:19.003575Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.21.0",
-        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
-        "internalRef": "250569499"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     },
     {
diff --git a/google-cloud-monitoring/synth.py b/google-cloud-monitoring/synth.py
index 4c74b07d0..4faa2985c 100644
--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -43,11 +43,52 @@ s.copy(v3_library / 'google-cloud-monitoring.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/monitoring.rb',
+        'lib/google/cloud/monitoring/v*.rb',
+        'lib/google/cloud/monitoring/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/monitoring/v*.rb',
+        'lib/google/cloud/monitoring/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/monitoring/v*.rb',
+        'lib/google/cloud/monitoring/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/monitoring/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/monitoring/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # PERMANENT: Use a compatible version of googleapis-common-protos-types
 s.replace(
     'google-cloud-monitoring.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> ([\\d\\.]+)"',
-    '\n  gem.add_dependency "google-gax", "~> \\1"\n  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"')
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"')
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
@@ -131,11 +172,3 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Monitoring::VERSION'
 )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v3']:
-    s.replace(
-        f'test/google/cloud/monitoring/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

```

</details>

This pull request was generated using releasetool.