### PR TITLE
Release google-cloud-os_login 0.3.0

### DIFF
--- a/google-cloud-os_login/CHANGELOG.md
+++ b/google-cloud-os_login/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.3.0 / 2019-07-08
+
+* Support overriding service host and port.
+
 ### 0.2.5 / 2019-06-11
 
 * Add VERSION constant

--- a/google-cloud-os_login/lib/google/cloud/os_login/version.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module OsLogin
-      VERSION = "0.2.5".freeze
+      VERSION = "0.3.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit c54b256712df03a9d8ae419594b04e0ff64e191c
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:55:25 2019 -0700

    feat(os_login): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-os_login/google-cloud-os_login.gemspec b/google-cloud-os_login/google-cloud-os_login.gemspec
index b5d908079..c0a32e518 100644
--- a/google-cloud-os_login/google-cloud-os_login.gemspec
+++ b/google-cloud-os_login/google-cloud-os_login.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
diff --git a/google-cloud-os_login/lib/google/cloud/os_login.rb b/google-cloud-os_login/lib/google/cloud/os_login.rb
index 77fc881a4..c856b4a50 100644
--- a/google-cloud-os_login/lib/google/cloud/os_login.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login.rb
@@ -122,6 +122,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-os_login/lib/google/cloud/os_login/v1.rb b/google-cloud-os_login/lib/google/cloud/os_login/v1.rb
index 2d265d692..48564fab2 100644
--- a/google-cloud-os_login/lib/google/cloud/os_login/v1.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1.rb
@@ -110,6 +110,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -119,6 +123,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -130,6 +136,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::OsLogin::V1::OsLoginServiceClient.new(**kwargs)
diff --git a/google-cloud-os_login/lib/google/cloud/os_login/v1/os_login_service_client.rb b/google-cloud-os_login/lib/google/cloud/os_login/v1/os_login_service_client.rb
index 50f43a101..2f0a78c83 100644
--- a/google-cloud-os_login/lib/google/cloud/os_login/v1/os_login_service_client.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1/os_login_service_client.rb
@@ -140,6 +140,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -149,6 +153,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -202,8 +208,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @os_login_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-os_login/lib/google/cloud/os_login/v1beta.rb b/google-cloud-os_login/lib/google/cloud/os_login/v1beta.rb
index cfe54485f..860c337df 100644
--- a/google-cloud-os_login/lib/google/cloud/os_login/v1beta.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1beta.rb
@@ -110,6 +110,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -119,6 +123,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -130,6 +136,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::OsLogin::V1beta::OsLoginServiceClient.new(**kwargs)
diff --git a/google-cloud-os_login/lib/google/cloud/os_login/v1beta/os_login_service_client.rb b/google-cloud-os_login/lib/google/cloud/os_login/v1beta/os_login_service_client.rb
index a76284be9..c48b21fd7 100644
--- a/google-cloud-os_login/lib/google/cloud/os_login/v1beta/os_login_service_client.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1beta/os_login_service_client.rb
@@ -140,6 +140,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -149,6 +153,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -202,8 +208,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @os_login_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-os_login/synth.metadata b/google-cloud-os_login/synth.metadata
index c3a406139..ed7140eb3 100644
--- a/google-cloud-os_login/synth.metadata
+++ b/google-cloud-os_login/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-04T19:29:28.899087Z",
+  "updateTime": "2019-07-01T10:42:36.867702Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.23.0",
-        "dockerImage": "googleapis/artman@sha256:846102ebf7ea2239162deea69f64940443b4147f7c2e68d64b332416f74211ba"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0026f4b890ed9e2388fb0573c0727defa6f5b82e",
-        "internalRef": "251265049"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     },
     {
diff --git a/google-cloud-os_login/synth.py b/google-cloud-os_login/synth.py
index 516a84b25..647cf9c4d 100644
--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -66,6 +66,51 @@ s.replace(
     ],
     '/os-login\\.googleapis\\.com', '/oslogin.googleapis.com')
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/os_login.rb',
+        'lib/google/cloud/os_login/v*.rb',
+        'lib/google/cloud/os_login/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/os_login/v*.rb',
+        'lib/google/cloud/os_login/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/os_login/v*.rb',
+        'lib/google/cloud/os_login/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/os_login/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/os_login/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-os_login.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [

```

</details>

This pull request was generated using releasetool.