### PR TITLE
Release google-cloud-phishing_protection 0.2.0

### DIFF
--- a/google-cloud-phishing_protection/CHANGELOG.md
+++ b/google-cloud-phishing_protection/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.0 / 2019-07-08
+
+* Support overriding service host and port.
+
 ### 0.1.1 / 2019-06-11
 
 * Add VERSION constant

--- a/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/version.rb
+++ b/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module PhishingProtection
-      VERSION = "0.1.1".freeze
+      VERSION = "0.2.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit 3909e6ee399b20b561648a0206efc1b0321ce857
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:56:19 2019 -0700

    feat(phishing_protection): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-phishing_protection/google-cloud-phishing_protection.gemspec b/google-cloud-phishing_protection/google-cloud-phishing_protection.gemspec
index eb3c9262a..4135c6c6d 100644
--- a/google-cloud-phishing_protection/google-cloud-phishing_protection.gemspec
+++ b/google-cloud-phishing_protection/google-cloud-phishing_protection.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
diff --git a/google-cloud-phishing_protection/lib/google/cloud/phishing_protection.rb b/google-cloud-phishing_protection/lib/google/cloud/phishing_protection.rb
index 5e4f65f53..d17392ff4 100644
--- a/google-cloud-phishing_protection/lib/google/cloud/phishing_protection.rb
+++ b/google-cloud-phishing_protection/lib/google/cloud/phishing_protection.rb
@@ -119,6 +119,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/v1beta1.rb b/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/v1beta1.rb
index 50f8f1973..f3dc4d5aa 100644
--- a/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/v1beta1.rb
+++ b/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/v1beta1.rb
@@ -108,6 +108,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -117,6 +121,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -128,6 +134,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::PhishingProtection::V1beta1::PhishingProtectionClient.new(**kwargs)
diff --git a/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/v1beta1/phishing_protection_client.rb b/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/v1beta1/phishing_protection_client.rb
index 4e0fe45b3..4d36e9cbc 100644
--- a/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/v1beta1/phishing_protection_client.rb
+++ b/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/v1beta1/phishing_protection_client.rb
@@ -100,6 +100,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -109,6 +113,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -162,8 +168,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @phishing_protection_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-phishing_protection/synth.metadata b/google-cloud-phishing_protection/synth.metadata
index 15411af53..5a7f1b23e 100644
--- a/google-cloud-phishing_protection/synth.metadata
+++ b/google-cloud-phishing_protection/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-30T00:34:42.809673Z",
+  "updateTime": "2019-07-01T10:42:53.450235Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.21.0",
-        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
-        "internalRef": "250569499"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     },
     {
diff --git a/google-cloud-phishing_protection/synth.py b/google-cloud-phishing_protection/synth.py
index 95bc2180e..ede8d5689 100644
--- a/google-cloud-phishing_protection/synth.py
+++ b/google-cloud-phishing_protection/synth.py
@@ -34,7 +34,6 @@ v1beta1_library = gapic.ruby_library(
 
 s.copy(v1beta1_library / 'lib')
 s.copy(v1beta1_library / 'test')
-s.copy(v1beta1_library / 'acceptance')
 s.copy(v1beta1_library / 'README.md')
 s.copy(v1beta1_library / 'LICENSE')
 s.copy(v1beta1_library / '.gitignore')
@@ -45,11 +44,46 @@ s.copy(v1beta1_library / 'google-cloud-phishing_protection.gemspec', merge=ruby.
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
-# https://github.com/googleapis/gapic-generator/issues/2180
+# Support for service_address
 s.replace(
-    'google-cloud-phishing_protection.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> ([\\d\\.]+)"\n\n',
-    '\n  gem.add_dependency "google-gax", "~> \\1"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
+    [
+        'lib/google/cloud/phishing_protection.rb',
+        'lib/google/cloud/phishing_protection/v*.rb',
+        'lib/google/cloud/phishing_protection/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/phishing_protection/v*.rb',
+        'lib/google/cloud/phishing_protection/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/phishing_protection/v*.rb',
+        'lib/google/cloud/phishing_protection/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/phishing_protection/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/phishing_protection/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
@@ -101,12 +135,14 @@ s.replace(
     'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
+# https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-phishing_protection.gemspec',
-    'gem.add_dependency "google-gax", "~> 1.3"',
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.3"',
-        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
+        'gem.add_dependency "google-gax", "~> 1.7"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"'
     ])
 )
 
@@ -199,11 +235,3 @@ s.replace(
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1beta1']:
-    s.replace(
-        f'test/google/cloud/phishing_protection/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

```

</details>

This pull request was generated using releasetool.