### PR TITLE
Release google-cloud-recaptcha_enterprise 0.2.0

### DIFF
--- a/google-cloud-recaptcha_enterprise/CHANGELOG.md
+++ b/google-cloud-recaptcha_enterprise/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.0 / 2019-07-08
+
+* Support overriding service host and port.
+
 ### 0.1.1 / 2019-06-11
 
 * Add VERSION constant

--- a/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise/version.rb
+++ b/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module RecaptchaEnterprise
-      VERSION = "0.1.1".freeze
+      VERSION = "0.2.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit fe7da11bd4e7854e7d57ad7801d08b82b5cb03f7
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:56:55 2019 -0700

    feat(recaptcha_enterprise): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-recaptcha_enterprise/google-cloud-recaptcha_enterprise.gemspec b/google-cloud-recaptcha_enterprise/google-cloud-recaptcha_enterprise.gemspec
index de1b44909..c6cfbcca2 100644
--- a/google-cloud-recaptcha_enterprise/google-cloud-recaptcha_enterprise.gemspec
+++ b/google-cloud-recaptcha_enterprise/google-cloud-recaptcha_enterprise.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"
diff --git a/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise.rb b/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise.rb
index a0ff2eefa..ba3589b3a 100644
--- a/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise.rb
+++ b/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise.rb
@@ -119,6 +119,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise/v1beta1.rb b/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise/v1beta1.rb
index e38ac1878..ae9051e2f 100644
--- a/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise/v1beta1.rb
+++ b/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise/v1beta1.rb
@@ -108,6 +108,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -117,6 +121,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -128,6 +134,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::RecaptchaEnterprise::V1beta1::RecaptchaEnterpriseClient.new(**kwargs)
diff --git a/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise/v1beta1/recaptcha_enterprise_client.rb b/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise/v1beta1/recaptcha_enterprise_client.rb
index ce6630b53..c11f9dd59 100644
--- a/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise/v1beta1/recaptcha_enterprise_client.rb
+++ b/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise/v1beta1/recaptcha_enterprise_client.rb
@@ -117,6 +117,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -126,6 +130,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -179,8 +185,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @recaptcha_enterprise_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-recaptcha_enterprise/synth.metadata b/google-cloud-recaptcha_enterprise/synth.metadata
index 70a7fd73e..5f726a715 100644
--- a/google-cloud-recaptcha_enterprise/synth.metadata
+++ b/google-cloud-recaptcha_enterprise/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-30T00:33:20.746309Z",
+  "updateTime": "2019-07-01T10:43:26.237142Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.21.0",
-        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
-        "internalRef": "250569499"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     },
     {
diff --git a/google-cloud-recaptcha_enterprise/synth.py b/google-cloud-recaptcha_enterprise/synth.py
index d4a507f14..baef91ed7 100644
--- a/google-cloud-recaptcha_enterprise/synth.py
+++ b/google-cloud-recaptcha_enterprise/synth.py
@@ -43,11 +43,52 @@ s.copy(v1beta1_library / 'google-cloud-recaptcha_enterprise.gemspec', merge=ruby
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/recaptcha_enterprise.rb',
+        'lib/google/cloud/recaptcha_enterprise/v*.rb',
+        'lib/google/cloud/recaptcha_enterprise/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/recaptcha_enterprise/v*.rb',
+        'lib/google/cloud/recaptcha_enterprise/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/recaptcha_enterprise/v*.rb',
+        'lib/google/cloud/recaptcha_enterprise/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/recaptcha_enterprise/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/recaptcha_enterprise/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-recaptcha_enterprise.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> ([\\d\\.]+)"\n\n',
-    '\n  gem.add_dependency "google-gax", "~> \\1"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
@@ -188,11 +229,3 @@ s.replace(
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1beta1']:
-    s.replace(
-        f'test/google/cloud/recaptcha_enterprise/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

```

</details>

This pull request was generated using releasetool.