### PR TITLE
Release google-cloud-redis 0.5.0

### DIFF
--- a/google-cloud-redis/CHANGELOG.md
+++ b/google-cloud-redis/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.5.0 / 2019-07-08
+
+* Support overriding service host and port.
+
 ### 0.4.0 / 2019-06-11
 
 * Add #import_instance and #export_instance

--- a/google-cloud-redis/lib/google/cloud/redis/version.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Redis
-      VERSION = "0.4.0".freeze
+      VERSION = "0.5.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit cbf853fba07aef5346328af49cc00b85affab426
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:57:48 2019 -0700

    feat(redis): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-redis/google-cloud-redis.gemspec b/google-cloud-redis/google-cloud-redis.gemspec
index 2dfe955b3..c391992b0 100644
--- a/google-cloud-redis/google-cloud-redis.gemspec
+++ b/google-cloud-redis/google-cloud-redis.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
diff --git a/google-cloud-redis/lib/google/cloud/redis.rb b/google-cloud-redis/lib/google/cloud/redis.rb
index 13653d393..3b00dd9d3 100644
--- a/google-cloud-redis/lib/google/cloud/redis.rb
+++ b/google-cloud-redis/lib/google/cloud/redis.rb
@@ -133,6 +133,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-redis/lib/google/cloud/redis/v1.rb b/google-cloud-redis/lib/google/cloud/redis/v1.rb
index cbc9b2906..ce2d66d86 100644
--- a/google-cloud-redis/lib/google/cloud/redis/v1.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1.rb
@@ -122,6 +122,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -131,6 +135,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -142,6 +148,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Redis::V1::CloudRedisClient.new(**kwargs)
diff --git a/google-cloud-redis/lib/google/cloud/redis/v1/cloud_redis_client.rb b/google-cloud-redis/lib/google/cloud/redis/v1/cloud_redis_client.rb
index 271ef1365..09f786aa8 100644
--- a/google-cloud-redis/lib/google/cloud/redis/v1/cloud_redis_client.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1/cloud_redis_client.rb
@@ -151,6 +151,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -160,6 +164,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -177,7 +183,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -223,8 +232,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @cloud_redis_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-redis/lib/google/cloud/redis/v1beta1.rb b/google-cloud-redis/lib/google/cloud/redis/v1beta1.rb
index 5d4a91d1c..1435453d1 100644
--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1.rb
@@ -122,6 +122,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -131,6 +135,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -142,6 +148,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Redis::V1beta1::CloudRedisClient.new(**kwargs)
diff --git a/google-cloud-redis/lib/google/cloud/redis/v1beta1/cloud_redis_client.rb b/google-cloud-redis/lib/google/cloud/redis/v1beta1/cloud_redis_client.rb
index 298ee5c2d..dd717af31 100644
--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1/cloud_redis_client.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1/cloud_redis_client.rb
@@ -151,6 +151,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -160,6 +164,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -177,7 +183,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -223,8 +232,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @cloud_redis_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-redis/synth.metadata b/google-cloud-redis/synth.metadata
index faf003297..d60a36498 100644
--- a/google-cloud-redis/synth.metadata
+++ b/google-cloud-redis/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-04T19:30:29.187626Z",
+  "updateTime": "2019-07-01T10:43:46.301192Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.23.0",
-        "dockerImage": "googleapis/artman@sha256:846102ebf7ea2239162deea69f64940443b4147f7c2e68d64b332416f74211ba"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0026f4b890ed9e2388fb0573c0727defa6f5b82e",
-        "internalRef": "251265049"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     },
     {
diff --git a/google-cloud-redis/synth.py b/google-cloud-redis/synth.py
index b31b917ad..04e472e09 100644
--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -51,6 +51,47 @@ s.copy(v1beta1_library / 'lib/google/cloud/redis/v1beta1')
 s.copy(v1beta1_library / 'lib/google/cloud/redis/v1beta1.rb')
 s.copy(v1beta1_library / 'test/google/cloud/redis/v1beta1')
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/redis.rb',
+        'lib/google/cloud/redis/v*.rb',
+        'lib/google/cloud/redis/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/redis/v*.rb',
+        'lib/google/cloud/redis/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/redis/v*.rb',
+        'lib/google/cloud/redis/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/redis/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/redis/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [
@@ -123,9 +164,9 @@ s.replace(
 
 s.replace(
     'google-cloud-redis.gemspec',
-    'gem.add_dependency "google-gax", "~> 1.3"',
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.3"',
+        'gem.add_dependency "google-gax", "~> 1.7"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )
@@ -163,11 +204,3 @@ for version in ['v1', 'v1beta1']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Redis::VERSION'
     )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1', 'v1beta1']:
-    s.replace(
-        f'test/google/cloud/redis/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

```

</details>

This pull request was generated using releasetool.