### PR TITLE
Release google-cloud-scheduler 1.1.0

### DIFF
--- a/google-cloud-scheduler/CHANGELOG.md
+++ b/google-cloud-scheduler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.1.0 / 2019-07-08
+
+* Support overriding service host and port.
+
 ### 1.0.1 / 2019-06-11
 
 * Add VERSION constant

--- a/google-cloud-scheduler/lib/google/cloud/scheduler/version.rb
+++ b/google-cloud-scheduler/lib/google/cloud/scheduler/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Scheduler
-      VERSION = "1.0.1".freeze
+      VERSION = "1.1.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit 09596d014d09a5f360156df88c88c9d26b9236c0
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:58:59 2019 -0700

    feat(scheduler): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-scheduler/google-cloud-scheduler.gemspec b/google-cloud-scheduler/google-cloud-scheduler.gemspec
index e408b6c94..21e35519f 100644
--- a/google-cloud-scheduler/google-cloud-scheduler.gemspec
+++ b/google-cloud-scheduler/google-cloud-scheduler.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "rubocop", "~> 0.50.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end
diff --git a/google-cloud-scheduler/lib/google/cloud/scheduler.rb b/google-cloud-scheduler/lib/google/cloud/scheduler.rb
index ab02cac3c..a03bfcf66 100644
--- a/google-cloud-scheduler/lib/google/cloud/scheduler.rb
+++ b/google-cloud-scheduler/lib/google/cloud/scheduler.rb
@@ -120,6 +120,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-scheduler/lib/google/cloud/scheduler/v1.rb b/google-cloud-scheduler/lib/google/cloud/scheduler/v1.rb
index d6cefbd4f..d97b0b5f3 100644
--- a/google-cloud-scheduler/lib/google/cloud/scheduler/v1.rb
+++ b/google-cloud-scheduler/lib/google/cloud/scheduler/v1.rb
@@ -109,6 +109,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -118,6 +122,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -129,6 +135,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Scheduler::V1::CloudSchedulerClient.new(**kwargs)
diff --git a/google-cloud-scheduler/lib/google/cloud/scheduler/v1/cloud_scheduler_client.rb b/google-cloud-scheduler/lib/google/cloud/scheduler/v1/cloud_scheduler_client.rb
index 4d09644a1..200b59703 100644
--- a/google-cloud-scheduler/lib/google/cloud/scheduler/v1/cloud_scheduler_client.rb
+++ b/google-cloud-scheduler/lib/google/cloud/scheduler/v1/cloud_scheduler_client.rb
@@ -146,6 +146,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -155,6 +159,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -209,8 +215,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @cloud_scheduler_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-scheduler/lib/google/cloud/scheduler/v1beta1.rb b/google-cloud-scheduler/lib/google/cloud/scheduler/v1beta1.rb
index 27f1f1fa8..705c87f61 100644
--- a/google-cloud-scheduler/lib/google/cloud/scheduler/v1beta1.rb
+++ b/google-cloud-scheduler/lib/google/cloud/scheduler/v1beta1.rb
@@ -109,6 +109,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -118,6 +122,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -129,6 +135,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Scheduler::V1beta1::CloudSchedulerClient.new(**kwargs)
diff --git a/google-cloud-scheduler/lib/google/cloud/scheduler/v1beta1/cloud_scheduler_client.rb b/google-cloud-scheduler/lib/google/cloud/scheduler/v1beta1/cloud_scheduler_client.rb
index 2167d7380..7951c22c2 100644
--- a/google-cloud-scheduler/lib/google/cloud/scheduler/v1beta1/cloud_scheduler_client.rb
+++ b/google-cloud-scheduler/lib/google/cloud/scheduler/v1beta1/cloud_scheduler_client.rb
@@ -146,6 +146,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -155,6 +159,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -209,8 +215,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @cloud_scheduler_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-scheduler/synth.metadata b/google-cloud-scheduler/synth.metadata
index 728013795..cc9a61973 100644
--- a/google-cloud-scheduler/synth.metadata
+++ b/google-cloud-scheduler/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-30T00:30:38.998401Z",
+  "updateTime": "2019-07-01T10:44:08.087222Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.21.0",
-        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
-        "internalRef": "250569499"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     },
     {
diff --git a/google-cloud-scheduler/synth.py b/google-cloud-scheduler/synth.py
index 725dffe19..e7b73192d 100644
--- a/google-cloud-scheduler/synth.py
+++ b/google-cloud-scheduler/synth.py
@@ -42,7 +42,6 @@ s.copy(v1beta1_library / 'test/google/cloud/scheduler/v1beta1')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
-
 v1_library = gapic.ruby_library(
     'scheduler',
     'v1',
@@ -60,12 +59,48 @@ s.copy(v1_library / '.gitignore')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-scheduler.gemspec', merge=ruby.merge_gemspec)
 
+# Support for service_address
 s.replace(
-    'google-cloud-scheduler.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
+    [
+        'lib/google/cloud/scheduler.rb',
+        'lib/google/cloud/scheduler/v*.rb',
+        'lib/google/cloud/scheduler/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/scheduler/v*.rb',
+        'lib/google/cloud/scheduler/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/scheduler/v*.rb',
+        'lib/google/cloud/scheduler/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/scheduler/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/scheduler/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+
 # https://github.com/googleapis/gapic-generator/issues/2279
 s.replace(
     'lib/**/*.rb',
@@ -103,9 +138,9 @@ for version in ['v1beta1', 'v1']:
 
 s.replace(
     'google-cloud-scheduler.gemspec',
-    'gem.add_dependency "google-gax", "~> 1.3"',
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.3"',
+        'gem.add_dependency "google-gax", "~> 1.7"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )
@@ -146,11 +181,3 @@ for version in ['v1', 'v1beta1']:
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1', 'v1beta1']:
-    s.replace(
-        f'test/google/cloud/scheduler/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

```

</details>

This pull request was generated using releasetool.