### PR TITLE
Release google-cloud-security_center 0.3.0

### DIFF
--- a/google-cloud-security_center/CHANGELOG.md
+++ b/google-cloud-security_center/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.3.0 / 2019-07-08
+
+* Add IAM GetPolicyOptions.
+* Support overriding service host and port.
+* Explicitly require all protobuf classes.
+
 ### 0.2.1 / 2019-06-11
 
 * Update IAM:

--- a/google-cloud-security_center/lib/google/cloud/security_center/version.rb
+++ b/google-cloud-security_center/lib/google/cloud/security_center/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module SecurityCenter
-      VERSION = "0.2.1".freeze
+      VERSION = "0.3.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add IAM GetPolicyOptions.
* Support overriding service host and port.
* Explicitly require all protobuf classes.

<details><summary>Commits since previous release</summary><pre><code>commit b64a7c9003ca7dde3b7e7561b965f96183e342a3
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Tue Jul 2 09:25:12 2019 -0700

    feat(security_center): Add IAM GetPolicyOptions

commit 0f39910f2ec7d69c725bba7fd070bed0e1ae7e17
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 13:02:03 2019 -0700

    feat(security_center): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients

commit b368ad3f494f94c0ff7d25d3bc0c9466972b3d78
Author: Mike Moore <mike@blowmage.com>
Date:   Mon Jun 17 16:01:40 2019 -0600

    test(securitycenter): Fix acceptance rake task
    
    [pr #3496]

commit 189bd958e94a0a698d9997771b7cc3828ea5cb5b
Author: Daniel Azuma <dazuma@google.com>
Date:   Mon Jun 17 11:39:55 2019 -0700

    Explicitly require run_asset_discovery_response_pb in security_center (#3493)
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-security_center/Rakefile b/google-cloud-security_center/Rakefile
index 6d4d42756..bd03cf7a4 100644
--- a/google-cloud-security_center/Rakefile
+++ b/google-cloud-security_center/Rakefile
@@ -83,8 +83,8 @@ task :acceptance, :project, :keyfile do |t, args|
   end
   # clear any env var already set
   require "google/cloud/security_center/v1/credentials"
-  (Google::Cloud::VideoIntelligence::V1::Credentials::PATH_ENV_VARS +
-   Google::Cloud::VideoIntelligence::V1::Credentials::JSON_ENV_VARS).each do |path|
+  (Google::Cloud::SecurityCenter::V1::Credentials::PATH_ENV_VARS +
+   Google::Cloud::SecurityCenter::V1::Credentials::JSON_ENV_VARS).each do |path|
     ENV[path] = nil
   end
   # always overwrite when running tests
diff --git a/google-cloud-security_center/google-cloud-security_center.gemspec b/google-cloud-security_center/google-cloud-security_center.gemspec
index 765f6f916..50850e4c3 100644
--- a/google-cloud-security_center/google-cloud-security_center.gemspec
+++ b/google-cloud-security_center/google-cloud-security_center.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"
diff --git a/google-cloud-security_center/lib/google/cloud/security_center.rb b/google-cloud-security_center/lib/google/cloud/security_center.rb
index 54a7d90e9..5641d7d67 100644
--- a/google-cloud-security_center/lib/google/cloud/security_center.rb
+++ b/google-cloud-security_center/lib/google/cloud/security_center.rb
@@ -120,6 +120,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-security_center/lib/google/cloud/security_center/v1.rb b/google-cloud-security_center/lib/google/cloud/security_center/v1.rb
index 91544c929..42f95f58a 100644
--- a/google-cloud-security_center/lib/google/cloud/security_center/v1.rb
+++ b/google-cloud-security_center/lib/google/cloud/security_center/v1.rb
@@ -110,6 +110,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -119,6 +123,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -130,6 +136,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::SecurityCenter::V1::SecurityCenterClient.new(**kwargs)
diff --git a/google-cloud-security_center/lib/google/cloud/security_center/v1/doc/google/iam/v1/iam_policy.rb b/google-cloud-security_center/lib/google/cloud/security_center/v1/doc/google/iam/v1/iam_policy.rb
index d3abef3b1..fe84ba3bc 100644
--- a/google-cloud-security_center/lib/google/cloud/security_center/v1/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-security_center/lib/google/cloud/security_center/v1/doc/google/iam/v1/iam_policy.rb
@@ -34,6 +34,10 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
       #     See the operation documentation for the appropriate value for this field.
+      # @!attribute [rw] options
+      #   @return [Google::Iam::V1::GetPolicyOptions]
+      #     OPTIONAL: A `GetPolicyOptions` object for specifying options to
+      #     `GetIamPolicy`. This field is only used by Cloud IAM.
       class GetIamPolicyRequest; end
 
       # Request message for `TestIamPermissions` method.
diff --git a/google-cloud-security_center/lib/google/cloud/security_center/v1/doc/google/iam/v1/options.rb b/google-cloud-security_center/lib/google/cloud/security_center/v1/doc/google/iam/v1/options.rb
new file mode 100644
index 000000000..98271d48a
--- /dev/null
+++ b/google-cloud-security_center/lib/google/cloud/security_center/v1/doc/google/iam/v1/options.rb
@@ -0,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Iam
+    module V1
+      # Encapsulates settings provided to GetIamPolicy.
+      # @!attribute [rw] requested_policy_version
+      #   @return [Integer]
+      #     Optional. The policy format version to be returned.
+      #     Acceptable values are 0 and 1.
+      #     If the value is 0, or the field is omitted, policy format version 1 will be
+      #     returned.
+      class GetPolicyOptions; end
+    end
+  end
+end
\ No newline at end of file
diff --git a/google-cloud-security_center/lib/google/cloud/security_center/v1/security_center_client.rb b/google-cloud-security_center/lib/google/cloud/security_center/v1/security_center_client.rb
index 80bd26a33..ed826e78e 100644
--- a/google-cloud-security_center/lib/google/cloud/security_center/v1/security_center_client.rb
+++ b/google-cloud-security_center/lib/google/cloud/security_center/v1/security_center_client.rb
@@ -28,6 +28,7 @@ require "google/gax/operation"
 require "google/longrunning/operations_client"
 
 require "google/cloud/security_center/v1/securitycenter_service_pb"
+require "google/cloud/security_center/v1/run_asset_discovery_response_pb"
 require "google/cloud/security_center/v1/credentials"
 require "google/cloud/security_center/version"
 
@@ -250,6 +251,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -259,6 +264,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -276,7 +283,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -322,8 +332,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @security_center_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -581,6 +591,11 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
           #   See the operation documentation for the appropriate value for this field.
+          # @param options_ [Google::Iam::V1::GetPolicyOptions | Hash]
+          #   OPTIONAL: A `GetPolicyOptions` object for specifying options to
+          #   `GetIamPolicy`. This field is only used by Cloud IAM.
+          #   A hash of the same form as `Google::Iam::V1::GetPolicyOptions`
+          #   can also be provided.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -598,10 +613,12 @@ module Google
 
           def get_iam_policy \
               resource,
+              options_: nil,
               options: nil,
               &block
             req = {
-              resource: resource
+              resource: resource,
+              options: options_
             }.delete_if { |_, v| v.nil? }
             req = Google::Gax::to_proto(req, Google::Iam::V1::GetIamPolicyRequest)
             @get_iam_policy.call(req, options, &block)
diff --git a/google-cloud-security_center/lib/google/cloud/security_center/v1/securitycenter_service_pb.rb b/google-cloud-security_center/lib/google/cloud/security_center/v1/securitycenter_service_pb.rb
index 851d1b777..f77da0c7b 100644
--- a/google-cloud-security_center/lib/google/cloud/security_center/v1/securitycenter_service_pb.rb
+++ b/google-cloud-security_center/lib/google/cloud/security_center/v1/securitycenter_service_pb.rb
@@ -8,6 +8,7 @@ require 'google/api/annotations_pb'
 require 'google/cloud/security_center/v1/asset_pb'
 require 'google/cloud/security_center/v1/finding_pb'
 require 'google/cloud/security_center/v1/organization_settings_pb'
+require 'google/cloud/security_center/v1/run_asset_discovery_response_pb'
 require 'google/cloud/security_center/v1/security_marks_pb'
 require 'google/cloud/security_center/v1/source_pb'
 require 'google/iam/v1/iam_policy_pb'
diff --git a/google-cloud-security_center/synth.metadata b/google-cloud-security_center/synth.metadata
index 5659ba200..913ffde05 100644
--- a/google-cloud-security_center/synth.metadata
+++ b/google-cloud-security_center/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-30T00:28:53.080931Z",
+  "updateTime": "2019-07-02T10:41:58.465215Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.21.0",
-        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
+        "version": "0.29.3",
+        "dockerImage": "googleapis/artman@sha256:8900f94a81adaab0238965aa8a7b3648791f4f3a95ee65adc6a56cfcc3753101"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
-        "internalRef": "250569499"
+        "sha": "5322233f8cbec4d3f8c17feca2507ef27d4a07c9",
+        "internalRef": "256042411"
       }
     },
     {
diff --git a/google-cloud-security_center/synth.py b/google-cloud-security_center/synth.py
index 8259c593c..6f8564ceb 100644
--- a/google-cloud-security_center/synth.py
+++ b/google-cloud-security_center/synth.py
@@ -68,6 +68,51 @@ s.replace(
     'Google::Cloud::SecurityCenter'
 )
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/security_center.rb',
+        'lib/google/cloud/security_center/v*.rb',
+        'lib/google/cloud/security_center/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/security_center/v*.rb',
+        'lib/google/cloud/security_center/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/security_center/v*.rb',
+        'lib/google/cloud/security_center/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/security_center/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/security_center/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-security_center.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [
@@ -167,10 +212,10 @@ s.replace(
 # Generate the helper methods
 subprocess.call('bundle update && bundle exec rake generate_partials', shell=True)
 
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1']:
-    s.replace(
-        f'test/google/cloud/security_center/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )
+# Deal with weirdness where RunAssetDiscoveryResponse is defined in a separate
+# file that doesn't get required properly.
+s.replace(
+    'lib/google/cloud/security_center/v1/security_center_client.rb',
+    '\nrequire "google/cloud/security_center/v1/securitycenter_service_pb"\n',
+    '\nrequire "google/cloud/security_center/v1/securitycenter_service_pb"\nrequire "google/cloud/security_center/v1/run_asset_discovery_response_pb"\n'
+)

```

</details>

This pull request was generated using releasetool.