### PR TITLE
Release google-cloud-spanner 1.9.4

### DIFF
--- a/google-cloud-spanner/CHANGELOG.md
+++ b/google-cloud-spanner/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.9.4 / 2019-07-08
+
+* Add IAM GetPolicyOptions in the lower-level API.
+* Support overriding service host and port in the lower-level interface.
+
 ### 1.9.3 / 2019-06-27
 
 * Update network configuration for some initial_retry_delay_millis

--- a/google-cloud-spanner/lib/google/cloud/spanner/version.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Spanner
-      VERSION = "1.9.3".freeze
+      VERSION = "1.9.4".freeze
     end
   end
 end


### PR DESCRIPTION
* Add IAM GetPolicyOptions in the lower-level API.
* Support overriding service host and port in the lower-level interface.

<details><summary>Commits since previous release</summary><pre><code>commit 4a27768922ad5cddf5a40cab2ac70f8fe9c90a43
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Tue Jul 2 09:10:15 2019 -0700

    refactor(spanner): Add IAM GetPolicyOptions in the lower-level API

commit b3ef5db9a09abf2bfa0bbfe27869258784e10d77
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:18:11 2019 -0700

    feat(spanner): Add service_address and service_port in the low-level interface

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-spanner/google-cloud-spanner.gemspec b/google-cloud-spanner/google-cloud-spanner.gemspec
index d6c74dcdb..d001f02ca 100644
--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 1.0"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
 
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
index 23880f2a7..707bf580f 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
@@ -171,6 +171,7 @@ module Google
                   timeout: timeout,
                   lib_name: lib_name,
                   lib_version: lib_version,
+                  metadata: metadata,
                 )
 
                 if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -694,6 +695,11 @@ module Google
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being requested.
               #   See the operation documentation for the appropriate value for this field.
+              # @param options_ [Google::Iam::V1::GetPolicyOptions | Hash]
+              #   OPTIONAL: A `GetPolicyOptions` object for specifying options to
+              #   `GetIamPolicy`. This field is only used by Cloud IAM.
+              #   A hash of the same form as `Google::Iam::V1::GetPolicyOptions`
+              #   can also be provided.
               # @param options [Google::Gax::CallOptions]
               #   Overrides the default settings for this call, e.g, timeout,
               #   retries, etc.
@@ -711,10 +717,12 @@ module Google
 
               def get_iam_policy \
                   resource,
+                  options_: nil,
                   options: nil,
                   &block
                 req = {
-                  resource: resource
+                  resource: resource,
+                  options: options_
                 }.delete_if { |_, v| v.nil? }
                 req = Google::Gax::to_proto(req, Google::Iam::V1::GetIamPolicyRequest)
                 @get_iam_policy.call(req, options, &block)
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/iam_policy.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/iam_policy.rb
index d3abef3b1..fe84ba3bc 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/iam_policy.rb
@@ -34,6 +34,10 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
       #     See the operation documentation for the appropriate value for this field.
+      # @!attribute [rw] options
+      #   @return [Google::Iam::V1::GetPolicyOptions]
+      #     OPTIONAL: A `GetPolicyOptions` object for specifying options to
+      #     `GetIamPolicy`. This field is only used by Cloud IAM.
       class GetIamPolicyRequest; end
 
       # Request message for `TestIamPermissions` method.
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/options.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/options.rb
new file mode 100644
index 000000000..98271d48a
--- /dev/null
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/options.rb
@@ -0,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Iam
+    module V1
+      # Encapsulates settings provided to GetIamPolicy.
+      # @!attribute [rw] requested_policy_version
+      #   @return [Integer]
+      #     Optional. The policy format version to be returned.
+      #     Acceptable values are 0 and 1.
+      #     If the value is 0, or the field is omitted, policy format version 1 will be
+      #     returned.
+      class GetPolicyOptions; end
+    end
+  end
+end
\ No newline at end of file
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/iam_policy.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/iam_policy.rb
index d3abef3b1..fe84ba3bc 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/iam_policy.rb
@@ -34,6 +34,10 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
       #     See the operation documentation for the appropriate value for this field.
+      # @!attribute [rw] options
+      #   @return [Google::Iam::V1::GetPolicyOptions]
+      #     OPTIONAL: A `GetPolicyOptions` object for specifying options to
+      #     `GetIamPolicy`. This field is only used by Cloud IAM.
       class GetIamPolicyRequest; end
 
       # Request message for `TestIamPermissions` method.
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/options.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/options.rb
new file mode 100644
index 000000000..98271d48a
--- /dev/null
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/options.rb
@@ -0,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Iam
+    module V1
+      # Encapsulates settings provided to GetIamPolicy.
+      # @!attribute [rw] requested_policy_version
+      #   @return [Integer]
+      #     Optional. The policy format version to be returned.
+      #     Acceptable values are 0 and 1.
+      #     If the value is 0, or the field is omitted, policy format version 1 will be
+      #     returned.
+      class GetPolicyOptions; end
+    end
+  end
+end
\ No newline at end of file
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
index 99f01e2b0..acb437adf 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
@@ -204,6 +204,7 @@ module Google
                   timeout: timeout,
                   lib_name: lib_name,
                   lib_version: lib_version,
+                  metadata: metadata,
                 )
 
                 if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -872,6 +873,11 @@ module Google
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being requested.
               #   See the operation documentation for the appropriate value for this field.
+              # @param options_ [Google::Iam::V1::GetPolicyOptions | Hash]
+              #   OPTIONAL: A `GetPolicyOptions` object for specifying options to
+              #   `GetIamPolicy`. This field is only used by Cloud IAM.
+              #   A hash of the same form as `Google::Iam::V1::GetPolicyOptions`
+              #   can also be provided.
               # @param options [Google::Gax::CallOptions]
               #   Overrides the default settings for this call, e.g, timeout,
               #   retries, etc.
@@ -889,10 +895,12 @@ module Google
 
               def get_iam_policy \
                   resource,
+                  options_: nil,
                   options: nil,
                   &block
                 req = {
-                  resource: resource
+                  resource: resource,
+                  options: options_
                 }.delete_if { |_, v| v.nil? }
                 req = Google::Gax::to_proto(req, Google::Iam::V1::GetIamPolicyRequest)
                 @get_iam_policy.call(req, options, &block)
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
index 046138bfd..6fe7e5f99 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
@@ -138,6 +138,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -147,6 +151,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -201,8 +207,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @spanner_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-spanner/synth.metadata b/google-cloud-spanner/synth.metadata
index 0173db42e..9b9f84bc7 100644
--- a/google-cloud-spanner/synth.metadata
+++ b/google-cloud-spanner/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-20T10:42:03.440117Z",
+  "updateTime": "2019-07-02T10:42:20.884054Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.29.0",
-        "dockerImage": "googleapis/artman@sha256:b79c8c20ee51e5302686c9d1294672d59290df1489be93749ef17d0172cc508d"
+        "version": "0.29.3",
+        "dockerImage": "googleapis/artman@sha256:8900f94a81adaab0238965aa8a7b3648791f4f3a95ee65adc6a56cfcc3753101"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "45e125f9e30dc5d45b52752b3ab78dd4f6084f2d",
-        "internalRef": "254026509"
+        "sha": "5322233f8cbec4d3f8c17feca2507ef27d4a07c9",
+        "internalRef": "256042411"
       }
     }
   ],
diff --git a/google-cloud-spanner/synth.py b/google-cloud-spanner/synth.py
index 80f8b892f..4a9fee6f0 100644
--- a/google-cloud-spanner/synth.py
+++ b/google-cloud-spanner/synth.py
@@ -101,6 +101,32 @@ s.replace(
     ],
     '/spanner-admin-\\w+\\.googleapis\\.com', '/spanner.googleapis.com')
 
+# Support for service_address
+s.replace(
+    'lib/google/cloud/spanner/v*/*_client.rb',
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    'lib/google/cloud/spanner/v*/*_client.rb',
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    'lib/google/cloud/spanner/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/spanner/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [
@@ -195,21 +221,3 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Spanner::VERSION'
 )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1']:
-    s.replace(
-        f'test/google/cloud/spanner/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )
-    s.replace(
-        f'test/google/cloud/spanner/admin/database/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )
-    s.replace(
-        f'test/google/cloud/spanner/admin/instance/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

```

</details>

This pull request was generated using releasetool.