### PR TITLE
Release google-cloud-speech 0.36.0

### DIFF
--- a/google-cloud-speech/CHANGELOG.md
+++ b/google-cloud-speech/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.36.0 / 2019-07-08
+
+* Update documentation.
+* Support overriding service host and port.
+
 ### 0.35.0 / 2019-06-11
 
 * Update documentation for SpeechContext phrases

--- a/google-cloud-speech/lib/google/cloud/speech/version.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Speech
-      VERSION = "0.35.0".freeze
+      VERSION = "0.36.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Update documentation.
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit 8573de4061f5b05fd75ee6cccae1dc770cd5d79f
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 13:09:12 2019 -0700

    feat(speech): Add service_address and service_port to client constructor
    
    
    * Update documentation

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-speech/google-cloud-speech.gemspec b/google-cloud-speech/google-cloud-speech.gemspec
index 7b74ea134..a5f32f40c 100644
--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
diff --git a/google-cloud-speech/lib/google/cloud/speech.rb b/google-cloud-speech/lib/google/cloud/speech.rb
index a2e1ee87b..227dc1c1c 100644
--- a/google-cloud-speech/lib/google/cloud/speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech.rb
@@ -145,6 +145,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-speech/lib/google/cloud/speech/v1.rb b/google-cloud-speech/lib/google/cloud/speech/v1.rb
index a6c161223..51a715f1d 100644
--- a/google-cloud-speech/lib/google/cloud/speech/v1.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1.rb
@@ -128,6 +128,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -137,6 +141,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -148,6 +154,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Speech::V1::SpeechClient.new(**kwargs)
diff --git a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb
index 35c2ab5f7..3a4872698 100644
--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb
@@ -206,19 +206,12 @@ module Google
         #   @return [true, false]
         #     *Optional* Set to true to use an enhanced model for speech recognition.
         #     If `use_enhanced` is set to true and the `model` field is not set, then
-        #     an appropriate enhanced model is chosen if:
-        #     1. project is eligible for requesting enhanced models
-        #     2. an enhanced model exists for the audio
+        #     an appropriate enhanced model is chosen if an enhanced model exists for
+        #     the audio.
         #
         #     If `use_enhanced` is true and an enhanced version of the specified model
         #     does not exist, then the speech is recognized using the standard version
         #     of the specified model.
-        #
-        #     Enhanced speech models require that you opt-in to data logging using
-        #     instructions in the
-        #     [documentation](https://cloud.google.com/speech-to-text/docs/enable-data-logging). If you set
-        #     `use_enhanced` to true and you have not enabled audio logging, then you
-        #     will receive an error.
         class RecognitionConfig
           # The encoding of the audio data sent in the request.
           #
diff --git a/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb b/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb
index 75b4f0759..bce4afc85 100644
--- a/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb
@@ -92,6 +92,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -101,6 +105,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -118,7 +124,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -163,8 +172,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @speech_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1.rb b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1.rb
index fdd2d59f3..f3ec5886d 100644
--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1.rb
@@ -127,6 +127,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -136,6 +140,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -147,6 +153,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Speech::V1p1beta1::SpeechClient.new(**kwargs)
diff --git a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/cloud/speech/v1p1beta1/cloud_speech.rb b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/cloud/speech/v1p1beta1/cloud_speech.rb
index 9b546cd52..eb6364003 100644
--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/cloud/speech/v1p1beta1/cloud_speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/cloud/speech/v1p1beta1/cloud_speech.rb
@@ -243,19 +243,12 @@ module Google
         #   @return [true, false]
         #     *Optional* Set to true to use an enhanced model for speech recognition.
         #     If `use_enhanced` is set to true and the `model` field is not set, then
-        #     an appropriate enhanced model is chosen if:
-        #     1. project is eligible for requesting enhanced models
-        #     2. an enhanced model exists for the audio
+        #     an appropriate enhanced model is chosen if an enhanced model exists for
+        #     the audio.
         #
         #     If `use_enhanced` is true and an enhanced version of the specified model
         #     does not exist, then the speech is recognized using the standard version
         #     of the specified model.
-        #
-        #     Enhanced speech models require that you opt-in to data logging using
-        #     instructions in the
-        #     [documentation](https://cloud.google.com/speech-to-text/docs/enable-data-logging). If you set
-        #     `use_enhanced` to true and you have not enabled audio logging, then you
-        #     will receive an error.
         class RecognitionConfig
           # The encoding of the audio data sent in the request.
           #
diff --git a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/speech_client.rb b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/speech_client.rb
index 9030eb0c2..931412a66 100644
--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/speech_client.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/speech_client.rb
@@ -92,6 +92,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -101,6 +105,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -118,7 +124,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -163,8 +172,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @speech_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-speech/synth.metadata b/google-cloud-speech/synth.metadata
index 43e997c63..e0b598617 100644
--- a/google-cloud-speech/synth.metadata
+++ b/google-cloud-speech/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-05T10:41:16.900630Z",
+  "updateTime": "2019-07-01T10:45:07.393608Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.23.1",
-        "dockerImage": "googleapis/artman@sha256:9d5cae1454da64ac3a87028f8ef486b04889e351c83bb95e83b8fab3959faed0"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4f3516a6f96dac182973a3573ff5117e8e4f76c7",
-        "internalRef": "251559960"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     },
     {
diff --git a/google-cloud-speech/synth.py b/google-cloud-speech/synth.py
index 16f27ef64..65e92efe9 100644
--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -121,6 +121,51 @@ s.replace(
 
         gem.platform\\1= Gem::Platform::RUBY"""))
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/speech.rb',
+        'lib/google/cloud/speech/v*.rb',
+        'lib/google/cloud/speech/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/speech/v*.rb',
+        'lib/google/cloud/speech/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/speech/v*.rb',
+        'lib/google/cloud/speech/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/speech/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/speech/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-speech.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2122
 s.replace(
     [
@@ -210,11 +255,3 @@ for version in ['v1', 'v1p1beta1']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Speech::VERSION'
     )
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1', 'v1p1beta1']:
-    s.replace(
-        f'test/google/cloud/speech/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

```

</details>

This pull request was generated using releasetool.