### PR TITLE
Release google-cloud-tasks 1.1.0

### DIFF
--- a/google-cloud-tasks/CHANGELOG.md
+++ b/google-cloud-tasks/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.1.0 / 2019-07-08
+
+* Add IAM GetPolicyOptions.
+* Support overriding service host and port.
+
 ### 1.0.1 / 2019-06-11
 
 * Add VERSION constant

--- a/google-cloud-tasks/lib/google/cloud/tasks/version.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Tasks
-      VERSION = "1.0.1".freeze
+      VERSION = "1.1.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add IAM GetPolicyOptions.
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit e539c65d15e67b8c8ef0a1be359276e46af0744d
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Tue Jul 2 09:24:06 2019 -0700

    feat(tasks): Add IAM GetPolicyOptions

commit e7e4c05167b182c7acfa26fc3e8a643a874dd3e0
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 13:17:43 2019 -0700

    feat(tasks): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-tasks/google-cloud-tasks.gemspec b/google-cloud-tasks/google-cloud-tasks.gemspec
index cea40403f..3b742edf6 100644
--- a/google-cloud-tasks/google-cloud-tasks.gemspec
+++ b/google-cloud-tasks/google-cloud-tasks.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
diff --git a/google-cloud-tasks/lib/google/cloud/tasks.rb b/google-cloud-tasks/lib/google/cloud/tasks.rb
index 7e4ea05c2..7c39f834f 100644
--- a/google-cloud-tasks/lib/google/cloud/tasks.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks.rb
@@ -120,6 +120,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-tasks/lib/google/cloud/tasks/v2.rb b/google-cloud-tasks/lib/google/cloud/tasks/v2.rb
index 29428c1e2..d5a5f5341 100644
--- a/google-cloud-tasks/lib/google/cloud/tasks/v2.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2.rb
@@ -109,6 +109,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -118,6 +122,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -129,6 +135,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Tasks::V2::CloudTasksClient.new(**kwargs)
diff --git a/google-cloud-tasks/lib/google/cloud/tasks/v2/cloud_tasks_client.rb b/google-cloud-tasks/lib/google/cloud/tasks/v2/cloud_tasks_client.rb
index 02f8c5351..0d091be62 100644
--- a/google-cloud-tasks/lib/google/cloud/tasks/v2/cloud_tasks_client.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2/cloud_tasks_client.rb
@@ -171,6 +171,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -180,6 +184,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -234,8 +240,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @cloud_tasks_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -791,6 +797,11 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
           #   See the operation documentation for the appropriate value for this field.
+          # @param options_ [Google::Iam::V1::GetPolicyOptions | Hash]
+          #   OPTIONAL: A `GetPolicyOptions` object for specifying options to
+          #   `GetIamPolicy`. This field is only used by Cloud IAM.
+          #   A hash of the same form as `Google::Iam::V1::GetPolicyOptions`
+          #   can also be provided.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -808,10 +819,12 @@ module Google
 
           def get_iam_policy \
               resource,
+              options_: nil,
               options: nil,
               &block
             req = {
-              resource: resource
+              resource: resource,
+              options: options_
             }.delete_if { |_, v| v.nil? }
             req = Google::Gax::to_proto(req, Google::Iam::V1::GetIamPolicyRequest)
             @get_iam_policy.call(req, options, &block)
diff --git a/google-cloud-tasks/lib/google/cloud/tasks/v2/doc/google/iam/v1/iam_policy.rb b/google-cloud-tasks/lib/google/cloud/tasks/v2/doc/google/iam/v1/iam_policy.rb
index d3abef3b1..fe84ba3bc 100644
--- a/google-cloud-tasks/lib/google/cloud/tasks/v2/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2/doc/google/iam/v1/iam_policy.rb
@@ -34,6 +34,10 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
       #     See the operation documentation for the appropriate value for this field.
+      # @!attribute [rw] options
+      #   @return [Google::Iam::V1::GetPolicyOptions]
+      #     OPTIONAL: A `GetPolicyOptions` object for specifying options to
+      #     `GetIamPolicy`. This field is only used by Cloud IAM.
       class GetIamPolicyRequest; end
 
       # Request message for `TestIamPermissions` method.
diff --git a/google-cloud-tasks/lib/google/cloud/tasks/v2/doc/google/iam/v1/options.rb b/google-cloud-tasks/lib/google/cloud/tasks/v2/doc/google/iam/v1/options.rb
new file mode 100644
index 000000000..98271d48a
--- /dev/null
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2/doc/google/iam/v1/options.rb
@@ -0,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Iam
+    module V1
+      # Encapsulates settings provided to GetIamPolicy.
+      # @!attribute [rw] requested_policy_version
+      #   @return [Integer]
+      #     Optional. The policy format version to be returned.
+      #     Acceptable values are 0 and 1.
+      #     If the value is 0, or the field is omitted, policy format version 1 will be
+      #     returned.
+      class GetPolicyOptions; end
+    end
+  end
+end
\ No newline at end of file
diff --git a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2.rb b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2.rb
index 3d9f02f37..98b02fa81 100644
--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2.rb
@@ -109,6 +109,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -118,6 +122,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -129,6 +135,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Tasks::V2beta2::CloudTasksClient.new(**kwargs)
diff --git a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/cloud_tasks_client.rb b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/cloud_tasks_client.rb
index f1a0da7c9..0c73e9d07 100644
--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/cloud_tasks_client.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/cloud_tasks_client.rb
@@ -171,6 +171,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -180,6 +184,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -234,8 +240,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @cloud_tasks_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -828,6 +834,11 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
           #   See the operation documentation for the appropriate value for this field.
+          # @param options_ [Google::Iam::V1::GetPolicyOptions | Hash]
+          #   OPTIONAL: A `GetPolicyOptions` object for specifying options to
+          #   `GetIamPolicy`. This field is only used by Cloud IAM.
+          #   A hash of the same form as `Google::Iam::V1::GetPolicyOptions`
+          #   can also be provided.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -845,10 +856,12 @@ module Google
 
           def get_iam_policy \
               resource,
+              options_: nil,
               options: nil,
               &block
             req = {
-              resource: resource
+              resource: resource,
+              options: options_
             }.delete_if { |_, v| v.nil? }
             req = Google::Gax::to_proto(req, Google::Iam::V1::GetIamPolicyRequest)
             @get_iam_policy.call(req, options, &block)
diff --git a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/iam_policy.rb b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/iam_policy.rb
index d3abef3b1..fe84ba3bc 100644
--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/iam_policy.rb
@@ -34,6 +34,10 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
       #     See the operation documentation for the appropriate value for this field.
+      # @!attribute [rw] options
+      #   @return [Google::Iam::V1::GetPolicyOptions]
+      #     OPTIONAL: A `GetPolicyOptions` object for specifying options to
+      #     `GetIamPolicy`. This field is only used by Cloud IAM.
       class GetIamPolicyRequest; end
 
       # Request message for `TestIamPermissions` method.
diff --git a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/options.rb b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/options.rb
new file mode 100644
index 000000000..98271d48a
--- /dev/null
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/options.rb
@@ -0,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Iam
+    module V1
+      # Encapsulates settings provided to GetIamPolicy.
+      # @!attribute [rw] requested_policy_version
+      #   @return [Integer]
+      #     Optional. The policy format version to be returned.
+      #     Acceptable values are 0 and 1.
+      #     If the value is 0, or the field is omitted, policy format version 1 will be
+      #     returned.
+      class GetPolicyOptions; end
+    end
+  end
+end
\ No newline at end of file
diff --git a/google-cloud-tasks/lib/google/cloud/tasks/v2beta3.rb b/google-cloud-tasks/lib/google/cloud/tasks/v2beta3.rb
index b3e1604c5..ebd27bb54 100644
--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta3.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta3.rb
@@ -109,6 +109,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -118,6 +122,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -129,6 +135,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Tasks::V2beta3::CloudTasksClient.new(**kwargs)
diff --git a/google-cloud-tasks/lib/google/cloud/tasks/v2beta3/cloud_tasks_client.rb b/google-cloud-tasks/lib/google/cloud/tasks/v2beta3/cloud_tasks_client.rb
index 5713b5e5f..3ef2246cc 100644
--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta3/cloud_tasks_client.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta3/cloud_tasks_client.rb
@@ -171,6 +171,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -180,6 +184,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -234,8 +240,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @cloud_tasks_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -791,6 +797,11 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
           #   See the operation documentation for the appropriate value for this field.
+          # @param options_ [Google::Iam::V1::GetPolicyOptions | Hash]
+          #   OPTIONAL: A `GetPolicyOptions` object for specifying options to
+          #   `GetIamPolicy`. This field is only used by Cloud IAM.
+          #   A hash of the same form as `Google::Iam::V1::GetPolicyOptions`
+          #   can also be provided.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -808,10 +819,12 @@ module Google
 
           def get_iam_policy \
               resource,
+              options_: nil,
               options: nil,
               &block
             req = {
-              resource: resource
+              resource: resource,
+              options: options_
             }.delete_if { |_, v| v.nil? }
             req = Google::Gax::to_proto(req, Google::Iam::V1::GetIamPolicyRequest)
             @get_iam_policy.call(req, options, &block)
diff --git a/google-cloud-tasks/lib/google/cloud/tasks/v2beta3/doc/google/iam/v1/iam_policy.rb b/google-cloud-tasks/lib/google/cloud/tasks/v2beta3/doc/google/iam/v1/iam_policy.rb
index d3abef3b1..fe84ba3bc 100644
--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta3/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta3/doc/google/iam/v1/iam_policy.rb
@@ -34,6 +34,10 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
       #     See the operation documentation for the appropriate value for this field.
+      # @!attribute [rw] options
+      #   @return [Google::Iam::V1::GetPolicyOptions]
+      #     OPTIONAL: A `GetPolicyOptions` object for specifying options to
+      #     `GetIamPolicy`. This field is only used by Cloud IAM.
       class GetIamPolicyRequest; end
 
       # Request message for `TestIamPermissions` method.
diff --git a/google-cloud-tasks/lib/google/cloud/tasks/v2beta3/doc/google/iam/v1/options.rb b/google-cloud-tasks/lib/google/cloud/tasks/v2beta3/doc/google/iam/v1/options.rb
new file mode 100644
index 000000000..98271d48a
--- /dev/null
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta3/doc/google/iam/v1/options.rb
@@ -0,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Iam
+    module V1
+      # Encapsulates settings provided to GetIamPolicy.
+      # @!attribute [rw] requested_policy_version
+      #   @return [Integer]
+      #     Optional. The policy format version to be returned.
+      #     Acceptable values are 0 and 1.
+      #     If the value is 0, or the field is omitted, policy format version 1 will be
+      #     returned.
+      class GetPolicyOptions; end
+    end
+  end
+end
\ No newline at end of file
diff --git a/google-cloud-tasks/synth.metadata b/google-cloud-tasks/synth.metadata
index 6b269aca4..571cba22f 100644
--- a/google-cloud-tasks/synth.metadata
+++ b/google-cloud-tasks/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-30T00:16:12.917635Z",
+  "updateTime": "2019-07-02T10:43:16.831546Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.21.0",
-        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
+        "version": "0.29.3",
+        "dockerImage": "googleapis/artman@sha256:8900f94a81adaab0238965aa8a7b3648791f4f3a95ee65adc6a56cfcc3753101"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
-        "internalRef": "250569499"
+        "sha": "5322233f8cbec4d3f8c17feca2507ef27d4a07c9",
+        "internalRef": "256042411"
       }
     },
     {
diff --git a/google-cloud-tasks/synth.py b/google-cloud-tasks/synth.py
index b26ef94e7..99a92a5d9 100644
--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -60,11 +60,46 @@ s.copy(v2_library / 'google-cloud-tasks.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
-# https://github.com/googleapis/gapic-generator/issues/2180
+# Support for service_address
 s.replace(
-    'google-cloud-tasks.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> ([\\d\\.]+)"\n\n',
-    '\n  gem.add_dependency "google-gax", "~> \\1"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
+    [
+        'lib/google/cloud/tasks.rb',
+        'lib/google/cloud/tasks/v*.rb',
+        'lib/google/cloud/tasks/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/tasks/v*.rb',
+        'lib/google/cloud/tasks/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/tasks/v*.rb',
+        'lib/google/cloud/tasks/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/tasks/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/tasks/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
@@ -133,11 +168,12 @@ for version in ['v2beta2', 'v2beta3', 'v2']:
         ])
     )
 
+# https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-tasks.gemspec',
-    'gem.add_dependency "google-gax", "~> 1.3"',
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.3"',
+        'gem.add_dependency "google-gax", "~> 1.7"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )
@@ -178,11 +214,3 @@ for version in ['v2', 'v2beta2', 'v2beta3']:
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v2beta2', 'v2beta3', 'v2']:
-    s.replace(
-        f'test/google/cloud/tasks/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

```

</details>

This pull request was generated using releasetool.