### PR TITLE
Release google-cloud-text_to_speech 0.4.0

### DIFF
--- a/google-cloud-text_to_speech/CHANGELOG.md
+++ b/google-cloud-text_to_speech/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.4.0 / 2019-07-08
+
+* Update code example in READMEs.
+* Support overriding service host and port.
+
 ### 0.3.1 / 2019-06-11
 
 * Add VERSION constant

--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/version.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module TextToSpeech
-      VERSION = "0.3.1".freeze
+      VERSION = "0.4.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Update code example in READMEs.
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit 393a9670224d5ffdff38c681683438d840118409
Author: Chris Smith <quartzmo@gmail.com>
Date:   Mon Jul 8 15:15:40 2019 -0600

    docs(text_to_speech): Update code example in READMEs and synth.py
    
    Thanks @256hz
    
    [refs #3507]

commit 75cf51c90787bdf785e199c23349fd89a72d68a1
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 13:18:11 2019 -0700

    feat(text_to_speech): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-text_to_speech/README.md b/google-cloud-text_to_speech/README.md
index 1a2228e43..debad6db3 100644
--- a/google-cloud-text_to_speech/README.md
+++ b/google-cloud-text_to_speech/README.md
@@ -33,6 +33,7 @@ voice = { language_code: language_code }
 audio_encoding = :MP3
 audio_config = { audio_encoding: audio_encoding }
 response = text_to_speech_client.synthesize_speech(input, voice, audio_config)
+File.write("example.mp3", response.audio_content, mode: "wb")
 ```
 
 ### Next Steps
diff --git a/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec b/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
index 1ae9275e4..2a6e1f733 100644
--- a/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
+++ b/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
diff --git a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech.rb b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech.rb
index 83ceb36aa..44bef9037 100644
--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech.rb
@@ -135,6 +135,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1.rb b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1.rb
index 3b1310f1a..780dfd8a6 100644
--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1.rb
@@ -123,6 +123,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -132,6 +136,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -143,6 +149,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::TextToSpeech::V1::TextToSpeechClient.new(**kwargs)
diff --git a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1/text_to_speech_client.rb b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1/text_to_speech_client.rb
index cddd31e0f..f438706ed 100644
--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1/text_to_speech_client.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1/text_to_speech_client.rb
@@ -85,6 +85,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -94,6 +98,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -147,8 +153,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @text_to_speech_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1.rb b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1.rb
index 935e54bab..dfa5e1f9b 100644
--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1.rb
@@ -123,6 +123,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -132,6 +136,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -143,6 +149,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::TextToSpeech::V1beta1::TextToSpeechClient.new(**kwargs)
diff --git a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1/text_to_speech_client.rb b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1/text_to_speech_client.rb
index cf9c4816a..2c759f816 100644
--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1/text_to_speech_client.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1/text_to_speech_client.rb
@@ -85,6 +85,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -94,6 +98,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -147,8 +153,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @text_to_speech_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-text_to_speech/synth.metadata b/google-cloud-text_to_speech/synth.metadata
index 561eb5060..4d586007c 100644
--- a/google-cloud-text_to_speech/synth.metadata
+++ b/google-cloud-text_to_speech/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-04T19:32:25.297729Z",
+  "updateTime": "2019-07-08T17:38:55.365672Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.23.0",
-        "dockerImage": "googleapis/artman@sha256:846102ebf7ea2239162deea69f64940443b4147f7c2e68d64b332416f74211ba"
+        "version": "0.29.3",
+        "dockerImage": "googleapis/artman@sha256:8900f94a81adaab0238965aa8a7b3648791f4f3a95ee65adc6a56cfcc3753101"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0026f4b890ed9e2388fb0573c0727defa6f5b82e",
-        "internalRef": "251265049"
+        "sha": "b4c73face84fefb967ef6c72f0eae64faf67895f",
+        "internalRef": "256453142"
       }
     },
     {
diff --git a/google-cloud-text_to_speech/synth.py b/google-cloud-text_to_speech/synth.py
index 2c5304e3b..6cf1764be 100644
--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -49,6 +49,51 @@ s.copy(v1beta1_library / 'test/google/cloud/text_to_speech/v1beta1')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/text_to_speech.rb',
+        'lib/google/cloud/text_to_speech/v*.rb',
+        'lib/google/cloud/text_to_speech/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/text_to_speech/v*.rb',
+        'lib/google/cloud/text_to_speech/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/text_to_speech/v*.rb',
+        'lib/google/cloud/text_to_speech/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/text_to_speech/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/text_to_speech/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-text_to_speech.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
     'lib/google/cloud/text_to_speech/*/*_client.rb',
@@ -119,3 +164,9 @@ for version in ['v1', 'v1beta1']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::TextToSpeech::VERSION'
     )
+
+s.replace(
+    'README.md',
+    'response = text_to_speech_client.synthesize_speech\(input, voice, audio_config\)\n',
+    'response = text_to_speech_client.synthesize_speech(input, voice, audio_config)\nFile.write("example.mp3", response.audio_content, mode: "wb")\n'
+)

```

</details>

This pull request was generated using releasetool.