### PR TITLE
Release google-cloud-trace 0.34.4

### DIFF
--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.34.4 / 2019-07-08
+
+* Support overriding service host and port in the low-level interface.
+
 ### 0.34.3 / 2019-06-11
 
 * Accept Numeric in Google::Cloud::Trace::Utils.time_to_grpc

--- a/google-cloud-trace/lib/google/cloud/trace/version.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Trace
-      VERSION = "0.34.3".freeze
+      VERSION = "0.34.4".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port in the low-level interface.

<details><summary>Commits since previous release</summary><pre><code>commit d058eabfc685ead1a5d1d77886b54da479d703c9
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 13:18:51 2019 -0700

    feat(trace): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-trace/google-cloud-trace.gemspec b/google-cloud-trace/google-cloud-trace.gemspec
index 410505efe..f70ab0096 100644
--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
diff --git a/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client.rb b/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client.rb
index b5c9d273c..7b3ec09fc 100644
--- a/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client.rb
@@ -100,6 +100,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -109,6 +113,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -163,8 +169,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @trace_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-trace/lib/google/cloud/trace/v2.rb b/google-cloud-trace/lib/google/cloud/trace/v2.rb
index edcafd12a..2ddc830e6 100644
--- a/google-cloud-trace/lib/google/cloud/trace/v2.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2.rb
@@ -105,6 +105,8 @@ module Google
             client_config: client_config,
             timeout: timeout,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Trace::V2::TraceServiceClient.new(**kwargs)
diff --git a/google-cloud-trace/lib/google/cloud/trace/v2/trace_service_client.rb b/google-cloud-trace/lib/google/cloud/trace/v2/trace_service_client.rb
index 37dfb98de..ccb9dda47 100644
--- a/google-cloud-trace/lib/google/cloud/trace/v2/trace_service_client.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/trace_service_client.rb
@@ -124,6 +124,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -133,6 +137,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -186,8 +192,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @trace_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-trace/synth.metadata b/google-cloud-trace/synth.metadata
index d954817ff..42f9119fc 100644
--- a/google-cloud-trace/synth.metadata
+++ b/google-cloud-trace/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-10T10:45:20.657398Z",
+  "updateTime": "2019-07-01T10:46:30.431888Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.19.0",
-        "dockerImage": "googleapis/artman@sha256:d3df563538225ac6caac45d8ad86499500211d1bcb2536955a6dbda15e1b368e"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     }
   ],
diff --git a/google-cloud-trace/synth.py b/google-cloud-trace/synth.py
index 3270ee876..2eb05a534 100644
--- a/google-cloud-trace/synth.py
+++ b/google-cloud-trace/synth.py
@@ -42,6 +42,46 @@ s.copy(v2_library / 'lib/google/devtools/cloudtrace/v2')
 # Omitting lib/google/cloud/trace/v{1,2}.rb for now because we are not exposing
 # the low-level API.
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/trace/v*.rb',
+        'lib/google/cloud/trace/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/trace/v*.rb',
+        'lib/google/cloud/trace/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/trace/v*.rb',
+        'lib/google/cloud/trace/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/trace/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/trace/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2124
 s.replace(
     [

```

</details>

This pull request was generated using releasetool.