### PR TITLE
Release google-cloud-video_intelligence 1.3.0

### DIFF
--- a/google-cloud-video_intelligence/CHANGELOG.md
+++ b/google-cloud-video_intelligence/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.3.0 / 2019-07-08
+
+* Use canonical module capitalization for VideoIntelligence type namespace.
+* Support overriding service host and port.
+
 ### 1.2.0 / 2019-06-14
 
 * Add VideoContext#object_tracking_config (ObjectTrackingConfig)

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/version.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module VideoIntelligence
-      VERSION = "1.2.0".freeze
+      VERSION = "1.3.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Use canonical module capitalization for VideoIntelligence type namespace.
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit 2276604a98d9768ca66db59cf93a1dc4d1da1691
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Jul 2 07:50:13 2019 -0700

    feat(video_intelligence): Use VideoIntelligence namespace
    
    * Use canonical module capitalization for VideoIntelligence type namespace
    
    [pr #3582]

commit 5412be9b3b44195acd897c78ba66a02d47baf5a3
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 13:19:23 2019 -0700

    feat(video_intelligence): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec b/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
index 4fd6257d2..fd0b915db 100644
--- a/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
+++ b/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence.rb
index 1e7b0eb82..43bdf7243 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence.rb
@@ -157,6 +157,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1.rb
index 48311fd02..c8ee684b2 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1.rb
@@ -147,6 +147,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -156,6 +160,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -167,6 +173,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::VideoIntelligence::V1::VideoIntelligenceServiceClient.new(**kwargs)
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/cloud/videointelligence/v1/video_intelligence.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/cloud/videointelligence/v1/video_intelligence.rb
index f442cc6fc..45f2bae4e 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/cloud/videointelligence/v1/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/cloud/videointelligence/v1/video_intelligence.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Cloud
-    module Videointelligence
+    module VideoIntelligence
       module V1
         # Video annotation request.
         # @!attribute [rw] input_uri
@@ -36,10 +36,10 @@ module Google
         #     If unset, the input video(s) should be specified via `input_uri`.
         #     If set, `input_uri` should be unset.
         # @!attribute [rw] features
-        #   @return [Array<Google::Cloud::Videointelligence::V1::Feature>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::Feature>]
         #     Requested video annotation features.
         # @!attribute [rw] video_context
-        #   @return [Google::Cloud::Videointelligence::V1::VideoContext]
+        #   @return [Google::Cloud::VideoIntelligence::V1::VideoContext]
         #     Additional video context and/or feature-specific parameters.
         # @!attribute [rw] output_uri
         #   @return [String]
@@ -58,36 +58,36 @@ module Google
 
         # Video context and/or feature-specific parameters.
         # @!attribute [rw] segments
-        #   @return [Array<Google::Cloud::Videointelligence::V1::VideoSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::VideoSegment>]
         #     Video segments to annotate. The segments may overlap and are not required
         #     to be contiguous or span the whole video. If unspecified, each video is
         #     treated as a single segment.
         # @!attribute [rw] label_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1::LabelDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1::LabelDetectionConfig]
         #     Config for LABEL_DETECTION.
         # @!attribute [rw] shot_change_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1::ShotChangeDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1::ShotChangeDetectionConfig]
         #     Config for SHOT_CHANGE_DETECTION.
         # @!attribute [rw] explicit_content_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1::ExplicitContentDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1::ExplicitContentDetectionConfig]
         #     Config for EXPLICIT_CONTENT_DETECTION.
         # @!attribute [rw] face_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1::FaceDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1::FaceDetectionConfig]
         #     Config for FACE_DETECTION.
         # @!attribute [rw] speech_transcription_config
-        #   @return [Google::Cloud::Videointelligence::V1::SpeechTranscriptionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1::SpeechTranscriptionConfig]
         #     Config for SPEECH_TRANSCRIPTION.
         # @!attribute [rw] text_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1::TextDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1::TextDetectionConfig]
         #     Config for TEXT_DETECTION.
         # @!attribute [rw] object_tracking_config
-        #   @return [Google::Cloud::Videointelligence::V1::ObjectTrackingConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1::ObjectTrackingConfig]
         #     Config for OBJECT_TRACKING.
         class VideoContext; end
 
         # Config for LABEL_DETECTION.
         # @!attribute [rw] label_detection_mode
-        #   @return [Google::Cloud::Videointelligence::V1::LabelDetectionMode]
+        #   @return [Google::Cloud::VideoIntelligence::V1::LabelDetectionMode]
         #     What labels should be detected with LABEL_DETECTION, in addition to
         #     video-level labels or segment-level labels.
         #     If unspecified, defaults to `SHOT_MODE`.
@@ -182,7 +182,7 @@ module Google
 
         # Video segment level annotation results for label detection.
         # @!attribute [rw] segment
-        #   @return [Google::Cloud::Videointelligence::V1::VideoSegment]
+        #   @return [Google::Cloud::VideoIntelligence::V1::VideoSegment]
         #     Video segment where a label was detected.
         # @!attribute [rw] confidence
         #   @return [Float]
@@ -215,19 +215,19 @@ module Google
 
         # Label annotation.
         # @!attribute [rw] entity
-        #   @return [Google::Cloud::Videointelligence::V1::Entity]
+        #   @return [Google::Cloud::VideoIntelligence::V1::Entity]
         #     Detected entity.
         # @!attribute [rw] category_entities
-        #   @return [Array<Google::Cloud::Videointelligence::V1::Entity>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::Entity>]
         #     Common categories for the detected entity.
         #     E.g. when the label is `Terrier` the category is likely `dog`. And in some
         #     cases there might be more than one categories e.g. `Terrier` could also be
         #     a `pet`.
         # @!attribute [rw] segments
-        #   @return [Array<Google::Cloud::Videointelligence::V1::LabelSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::LabelSegment>]
         #     All video segments where a label was detected.
         # @!attribute [rw] frames
-        #   @return [Array<Google::Cloud::Videointelligence::V1::LabelFrame>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::LabelFrame>]
         #     All video frames where a label was detected.
         class LabelAnnotation; end
 
@@ -237,7 +237,7 @@ module Google
         #     Time-offset, relative to the beginning of the video, corresponding to the
         #     video frame for this location.
         # @!attribute [rw] pornography_likelihood
-        #   @return [Google::Cloud::Videointelligence::V1::Likelihood]
+        #   @return [Google::Cloud::VideoIntelligence::V1::Likelihood]
         #     Likelihood of the pornography content..
         class ExplicitContentFrame; end
 
@@ -245,7 +245,7 @@ module Google
         # If no explicit content has been detected in a frame, no annotations are
         # present for that frame.
         # @!attribute [rw] frames
-        #   @return [Array<Google::Cloud::Videointelligence::V1::ExplicitContentFrame>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::ExplicitContentFrame>]
         #     All video frames where explicit content was detected.
         class ExplicitContentAnnotation; end
 
@@ -268,13 +268,13 @@ module Google
 
         # Video segment level annotation results for face detection.
         # @!attribute [rw] segment
-        #   @return [Google::Cloud::Videointelligence::V1::VideoSegment]
+        #   @return [Google::Cloud::VideoIntelligence::V1::VideoSegment]
         #     Video segment where a face was detected.
         class FaceSegment; end
 
         # Video frame level annotation results for face detection.
         # @!attribute [rw] normalized_bounding_boxes
-        #   @return [Array<Google::Cloud::Videointelligence::V1::NormalizedBoundingBox>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::NormalizedBoundingBox>]
         #     Normalized Bounding boxes in a frame.
         #     There can be more than one boxes if the same face is detected in multiple
         #     locations within the current frame.
@@ -289,10 +289,10 @@ module Google
         #   @return [String]
         #     Thumbnail of a representative face view (in JPEG format).
         # @!attribute [rw] segments
-        #   @return [Array<Google::Cloud::Videointelligence::V1::FaceSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::FaceSegment>]
         #     All video segments where a face was detected.
         # @!attribute [rw] frames
-        #   @return [Array<Google::Cloud::Videointelligence::V1::FaceFrame>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::FaceFrame>]
         #     All video frames where a face was detected.
         class FaceAnnotation; end
 
@@ -302,36 +302,36 @@ module Google
         #     Video file location in
         #     [Google Cloud Storage](https://cloud.google.com/storage/).
         # @!attribute [rw] segment_label_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1::LabelAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::LabelAnnotation>]
         #     Label annotations on video level or user specified segment level.
         #     There is exactly one element for each unique label.
         # @!attribute [rw] shot_label_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1::LabelAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::LabelAnnotation>]
         #     Label annotations on shot level.
         #     There is exactly one element for each unique label.
         # @!attribute [rw] frame_label_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1::LabelAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::LabelAnnotation>]
         #     Label annotations on frame level.
         #     There is exactly one element for each unique label.
         # @!attribute [rw] face_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1::FaceAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::FaceAnnotation>]
         #     Face annotations. There is exactly one element for each unique face.
         # @!attribute [rw] shot_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1::VideoSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::VideoSegment>]
         #     Shot annotations. Each shot is represented as a video segment.
         # @!attribute [rw] explicit_annotation
-        #   @return [Google::Cloud::Videointelligence::V1::ExplicitContentAnnotation]
+        #   @return [Google::Cloud::VideoIntelligence::V1::ExplicitContentAnnotation]
         #     Explicit content annotation.
         # @!attribute [rw] speech_transcriptions
-        #   @return [Array<Google::Cloud::Videointelligence::V1::SpeechTranscription>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::SpeechTranscription>]
         #     Speech transcription.
         # @!attribute [rw] text_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1::TextAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::TextAnnotation>]
         #     OCR text detection and tracking.
         #     Annotations for list of detected text snippets. Each will have list of
         #     frame information associated with it.
         # @!attribute [rw] object_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1::ObjectTrackingAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::ObjectTrackingAnnotation>]
         #     Annotations for list of objects detected and tracked in video.
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]
@@ -343,7 +343,7 @@ module Google
         # field of the `Operation` returned by the `GetOperation`
         # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_results
-        #   @return [Array<Google::Cloud::Videointelligence::V1::VideoAnnotationResults>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::VideoAnnotationResults>]
         #     Annotation results for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoResponse; end
 
@@ -368,7 +368,7 @@ module Google
         # field of the `Operation` returned by the `GetOperation`
         # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_progress
-        #   @return [Array<Google::Cloud::Videointelligence::V1::VideoAnnotationProgress>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::VideoAnnotationProgress>]
         #     Progress metadata for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoProgress; end
 
@@ -394,7 +394,7 @@ module Google
         #     with asterisks, e.g. "f***". If set to `false` or omitted, profanities
         #     won't be filtered out.
         # @!attribute [rw] speech_contexts
-        #   @return [Array<Google::Cloud::Videointelligence::V1::SpeechContext>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::SpeechContext>]
         #     *Optional* A means to provide context to assist the speech recognition.
         # @!attribute [rw] enable_automatic_punctuation
         #   @return [true, false]
@@ -444,7 +444,7 @@ module Google
 
         # A speech recognition result corresponding to a portion of the audio.
         # @!attribute [rw] alternatives
-        #   @return [Array<Google::Cloud::Videointelligence::V1::SpeechRecognitionAlternative>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::SpeechRecognitionAlternative>]
         #     May contain one or more recognition hypotheses (up to the maximum specified
         #     in `max_alternatives`).  These alternatives are ordered in terms of
         #     accuracy, with the top (first) alternative being the most probable, as
@@ -470,7 +470,7 @@ module Google
         #     `confidence` field as it is not guaranteed to be accurate or consistent.
         #     The default of 0.0 is a sentinel value indicating `confidence` was not set.
         # @!attribute [rw] words
-        #   @return [Array<Google::Cloud::Videointelligence::V1::WordInfo>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::WordInfo>]
         #     A list of word-specific information for each recognized word.
         class SpeechRecognitionAlternative; end
 
@@ -537,20 +537,20 @@ module Google
         # than 0, or greater than 1 due to trignometric calculations for location of
         # the box.
         # @!attribute [rw] vertices
-        #   @return [Array<Google::Cloud::Videointelligence::V1::NormalizedVertex>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::NormalizedVertex>]
         #     Normalized vertices of the bounding polygon.
         class NormalizedBoundingPoly; end
 
         # Video segment level annotation results for text detection.
         # @!attribute [rw] segment
-        #   @return [Google::Cloud::Videointelligence::V1::VideoSegment]
+        #   @return [Google::Cloud::VideoIntelligence::V1::VideoSegment]
         #     Video segment where a text snippet was detected.
         # @!attribute [rw] confidence
         #   @return [Float]
         #     Confidence for the track of detected text. It is calculated as the highest
         #     over all frames where OCR detected text appears.
         # @!attribute [rw] frames
-        #   @return [Array<Google::Cloud::Videointelligence::V1::TextFrame>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::TextFrame>]
         #     Information related to the frames where OCR detected text appears.
         class TextSegment; end
 
@@ -558,7 +558,7 @@ module Google
         # Contains information regarding timestamp and bounding box locations for the
         # frames containing detected OCR text snippets.
         # @!attribute [rw] rotated_bounding_box
-        #   @return [Google::Cloud::Videointelligence::V1::NormalizedBoundingPoly]
+        #   @return [Google::Cloud::VideoIntelligence::V1::NormalizedBoundingPoly]
         #     Bounding polygon of the detected text for this frame.
         # @!attribute [rw] time_offset
         #   @return [Google::Protobuf::Duration]
@@ -572,14 +572,14 @@ module Google
         #   @return [String]
         #     The detected text.
         # @!attribute [rw] segments
-        #   @return [Array<Google::Cloud::Videointelligence::V1::TextSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::TextSegment>]
         #     All video segments where OCR detected text appears.
         class TextAnnotation; end
 
         # Video frame level annotations for object detection and tracking. This field
         # stores per frame location, time offset, and confidence.
         # @!attribute [rw] normalized_bounding_box
-        #   @return [Google::Cloud::Videointelligence::V1::NormalizedBoundingBox]
+        #   @return [Google::Cloud::VideoIntelligence::V1::NormalizedBoundingBox]
         #     The normalized bounding box location of this object track for the frame.
         # @!attribute [rw] time_offset
         #   @return [Google::Protobuf::Duration]
@@ -588,7 +588,7 @@ module Google
 
         # Annotations corresponding to one tracked object.
         # @!attribute [rw] segment
-        #   @return [Google::Cloud::Videointelligence::V1::VideoSegment]
+        #   @return [Google::Cloud::VideoIntelligence::V1::VideoSegment]
         #     Non-streaming batch mode ONLY.
         #     Each object track corresponds to one video segment where it appears.
         # @!attribute [rw] track_id
@@ -600,13 +600,13 @@ module Google
         #     the customers can correlate the results of the ongoing
         #     ObjectTrackAnnotation of the same track_id over time.
         # @!attribute [rw] entity
-        #   @return [Google::Cloud::Videointelligence::V1::Entity]
+        #   @return [Google::Cloud::VideoIntelligence::V1::Entity]
         #     Entity to specify the object category that this track is labeled as.
         # @!attribute [rw] confidence
         #   @return [Float]
         #     Object category's labeling confidence of this track.
         # @!attribute [rw] frames
-        #   @return [Array<Google::Cloud::Videointelligence::V1::ObjectTrackingFrame>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1::ObjectTrackingFrame>]
         #     Information corresponding to all frames where this object track appears.
         #     Non-streaming batch mode: it may be one or multiple ObjectTrackingFrame
         #     messages in frames.
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/video_intelligence_service_client.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/video_intelligence_service_client.rb
index af8665c8c..fcdf0604b 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/video_intelligence_service_client.rb
@@ -38,7 +38,7 @@ module Google
         # Service that implements Google Cloud Video Intelligence API.
         #
         # @!attribute [r] video_intelligence_service_stub
-        #   @return [Google::Cloud::Videointelligence::V1::VideoIntelligenceService::Stub]
+        #   @return [Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Stub]
         class VideoIntelligenceServiceClient
           # @private
           attr_reader :video_intelligence_service_stub
@@ -92,6 +92,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -101,6 +105,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -118,7 +124,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -163,8 +172,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @video_intelligence_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -174,7 +183,7 @@ module Google
               updater_proc: updater_proc,
               scopes: scopes,
               interceptors: interceptors,
-              &Google::Cloud::Videointelligence::V1::VideoIntelligenceService::Stub.method(:new)
+              &Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Stub.method(:new)
             )
 
             @annotate_video = Google::Gax.create_api_call(
@@ -206,11 +215,11 @@ module Google
           #   The video data bytes.
           #   If unset, the input video(s) should be specified via `input_uri`.
           #   If set, `input_uri` should be unset.
-          # @param features [Array<Google::Cloud::Videointelligence::V1::Feature>]
+          # @param features [Array<Google::Cloud::VideoIntelligence::V1::Feature>]
           #   Requested video annotation features.
-          # @param video_context [Google::Cloud::Videointelligence::V1::VideoContext | Hash]
+          # @param video_context [Google::Cloud::VideoIntelligence::V1::VideoContext | Hash]
           #   Additional video context and/or feature-specific parameters.
-          #   A hash of the same form as `Google::Cloud::Videointelligence::V1::VideoContext`
+          #   A hash of the same form as `Google::Cloud::VideoIntelligence::V1::VideoContext`
           #   can also be provided.
           # @param output_uri [String]
           #   Optional location where the output (in JSON format) should be stored.
@@ -279,12 +288,12 @@ module Google
               output_uri: output_uri,
               location_id: location_id
             }.delete_if { |_, v| v.nil? }
-            req = Google::Gax::to_proto(req, Google::Cloud::Videointelligence::V1::AnnotateVideoRequest)
+            req = Google::Gax::to_proto(req, Google::Cloud::VideoIntelligence::V1::AnnotateVideoRequest)
             operation = Google::Gax::Operation.new(
               @annotate_video.call(req, options),
               @operations_client,
-              Google::Cloud::Videointelligence::V1::AnnotateVideoResponse,
-              Google::Cloud::Videointelligence::V1::AnnotateVideoProgress,
+              Google::Cloud::VideoIntelligence::V1::AnnotateVideoResponse,
+              Google::Cloud::VideoIntelligence::V1::AnnotateVideoProgress,
               call_options: options
             )
             operation.on_done { |operation| yield(operation) } if block_given?
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1.rb
index cfd5e6a9c..353d1d0e9 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1.rb
@@ -109,6 +109,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -118,6 +122,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -129,6 +135,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::VideoIntelligence::V1beta1::VideoIntelligenceServiceClient.new(**kwargs)
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/cloud/videointelligence/v1beta1/video_intelligence.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/cloud/videointelligence/v1beta1/video_intelligence.rb
index ebd55687f..3ef43042b 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/cloud/videointelligence/v1beta1/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/cloud/videointelligence/v1beta1/video_intelligence.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Cloud
-    module Videointelligence
+    module VideoIntelligence
       module V1beta1
         # Video annotation request.
         # @!attribute [rw] input_uri
@@ -35,10 +35,10 @@ module Google
         #     The video data bytes. Encoding: base64. If unset, the input video(s)
         #     should be specified via `input_uri`. If set, `input_uri` should be unset.
         # @!attribute [rw] features
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta1::Feature>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta1::Feature>]
         #     Requested video annotation features.
         # @!attribute [rw] video_context
-        #   @return [Google::Cloud::Videointelligence::V1beta1::VideoContext]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta1::VideoContext]
         #     Additional video context and/or feature-specific parameters.
         # @!attribute [rw] output_uri
         #   @return [String]
@@ -57,12 +57,12 @@ module Google
 
         # Video context and/or feature-specific parameters.
         # @!attribute [rw] segments
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta1::VideoSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta1::VideoSegment>]
         #     Video segments to annotate. The segments may overlap and are not required
         #     to be contiguous or span the whole video. If unspecified, each video
         #     is treated as a single segment.
         # @!attribute [rw] label_detection_mode
-        #   @return [Google::Cloud::Videointelligence::V1beta1::LabelDetectionMode]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta1::LabelDetectionMode]
         #     If label detection has been requested, what labels should be detected
         #     in addition to video-level labels or segment-level labels. If unspecified,
         #     defaults to `SHOT_MODE`.
@@ -99,7 +99,7 @@ module Google
 
         # Label location.
         # @!attribute [rw] segment
-        #   @return [Google::Cloud::Videointelligence::V1beta1::VideoSegment]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta1::VideoSegment]
         #     Video segment. Set to [-1, -1] for video-level labels.
         #     Set to [timestamp, timestamp] for frame-level labels.
         #     Otherwise, corresponds to one of `AnnotateSpec.segments`
@@ -108,7 +108,7 @@ module Google
         #   @return [Float]
         #     Confidence that the label is accurate. Range: [0, 1].
         # @!attribute [rw] level
-        #   @return [Google::Cloud::Videointelligence::V1beta1::LabelLevel]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta1::LabelLevel]
         #     Label level.
         class LabelLocation; end
 
@@ -120,7 +120,7 @@ module Google
         #   @return [String]
         #     Language code for `description` in BCP-47 format.
         # @!attribute [rw] locations
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta1::LabelLocation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta1::LabelLocation>]
         #     Where the label was detected and with what confidence.
         class LabelAnnotation; end
 
@@ -130,20 +130,20 @@ module Google
         # have been detected in a frame, the likelihood is set to `UNKNOWN`
         # for all other types of unsafe content.
         # @!attribute [rw] adult
-        #   @return [Google::Cloud::Videointelligence::V1beta1::Likelihood]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta1::Likelihood]
         #     Likelihood of adult content.
         # @!attribute [rw] spoof
-        #   @return [Google::Cloud::Videointelligence::V1beta1::Likelihood]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta1::Likelihood]
         #     Likelihood that an obvious modification was made to the original
         #     version to make it appear funny or offensive.
         # @!attribute [rw] medical
-        #   @return [Google::Cloud::Videointelligence::V1beta1::Likelihood]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta1::Likelihood]
         #     Likelihood of medical content.
         # @!attribute [rw] violent
-        #   @return [Google::Cloud::Videointelligence::V1beta1::Likelihood]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta1::Likelihood]
         #     Likelihood of violent content.
         # @!attribute [rw] racy
-        #   @return [Google::Cloud::Videointelligence::V1beta1::Likelihood]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta1::Likelihood]
         #     Likelihood of racy content.
         # @!attribute [rw] time_offset
         #   @return [Integer]
@@ -167,7 +167,7 @@ module Google
 
         # Face location.
         # @!attribute [rw] bounding_box
-        #   @return [Google::Cloud::Videointelligence::V1beta1::BoundingBox]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta1::BoundingBox]
         #     Bounding box in a frame.
         # @!attribute [rw] time_offset
         #   @return [Integer]
@@ -179,12 +179,12 @@ module Google
         #   @return [String]
         #     Thumbnail of a representative face view (in JPEG format). Encoding: base64.
         # @!attribute [rw] segments
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta1::VideoSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta1::VideoSegment>]
         #     All locations where a face was detected.
         #     Faces are detected and tracked on a per-video basis
         #     (as opposed to across multiple videos).
         # @!attribute [rw] locations
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta1::FaceLocation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta1::FaceLocation>]
         #     Face locations at one frame per second.
         class FaceAnnotation; end
 
@@ -194,16 +194,16 @@ module Google
         #     Video file location in
         #     [Google Cloud Storage](https://cloud.google.com/storage/).
         # @!attribute [rw] label_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta1::LabelAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta1::LabelAnnotation>]
         #     Label annotations. There is exactly one element for each unique label.
         # @!attribute [rw] face_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta1::FaceAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta1::FaceAnnotation>]
         #     Face annotations. There is exactly one element for each unique face.
         # @!attribute [rw] shot_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta1::VideoSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta1::VideoSegment>]
         #     Shot annotations. Each shot is represented as a video segment.
         # @!attribute [rw] safe_search_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta1::SafeSearchAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta1::SafeSearchAnnotation>]
         #     Safe search annotations.
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]
@@ -215,7 +215,7 @@ module Google
         # field of the `Operation` returned by the `GetOperation`
         # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_results
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta1::VideoAnnotationResults>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta1::VideoAnnotationResults>]
         #     Annotation results for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoResponse; end
 
@@ -240,7 +240,7 @@ module Google
         # field of the `Operation` returned by the `GetOperation`
         # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_progress
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta1::VideoAnnotationProgress>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta1::VideoAnnotationProgress>]
         #     Progress metadata for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoProgress; end
 
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client.rb
index d603ff77b..bfe5275f1 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client.rb
@@ -38,7 +38,7 @@ module Google
         # Service that implements Google Cloud Video Intelligence API.
         #
         # @!attribute [r] video_intelligence_service_stub
-        #   @return [Google::Cloud::Videointelligence::V1beta1::VideoIntelligenceService::Stub]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta1::VideoIntelligenceService::Stub]
         class VideoIntelligenceServiceClient
           # @private
           attr_reader :video_intelligence_service_stub
@@ -92,6 +92,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -101,6 +105,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -118,7 +124,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -163,8 +172,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @video_intelligence_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -174,7 +183,7 @@ module Google
               updater_proc: updater_proc,
               scopes: scopes,
               interceptors: interceptors,
-              &Google::Cloud::Videointelligence::V1beta1::VideoIntelligenceService::Stub.method(:new)
+              &Google::Cloud::VideoIntelligence::V1beta1::VideoIntelligenceService::Stub.method(:new)
             )
 
             @annotate_video = Google::Gax.create_api_call(
@@ -202,14 +211,14 @@ module Google
           #   videos. Supported wildcards: '*' to match 0 or more characters;
           #   '?' to match 1 character. If unset, the input video should be embedded
           #   in the request as `input_content`. If set, `input_content` should be unset.
-          # @param features [Array<Google::Cloud::Videointelligence::V1beta1::Feature>]
+          # @param features [Array<Google::Cloud::VideoIntelligence::V1beta1::Feature>]
           #   Requested video annotation features.
           # @param input_content [String]
           #   The video data bytes. Encoding: base64. If unset, the input video(s)
           #   should be specified via `input_uri`. If set, `input_uri` should be unset.
-          # @param video_context [Google::Cloud::Videointelligence::V1beta1::VideoContext | Hash]
+          # @param video_context [Google::Cloud::VideoIntelligence::V1beta1::VideoContext | Hash]
           #   Additional video context and/or feature-specific parameters.
-          #   A hash of the same form as `Google::Cloud::Videointelligence::V1beta1::VideoContext`
+          #   A hash of the same form as `Google::Cloud::VideoIntelligence::V1beta1::VideoContext`
           #   can also be provided.
           # @param output_uri [String]
           #   Optional location where the output (in JSON format) should be stored.
@@ -278,12 +287,12 @@ module Google
               output_uri: output_uri,
               location_id: location_id
             }.delete_if { |_, v| v.nil? }
-            req = Google::Gax::to_proto(req, Google::Cloud::Videointelligence::V1beta1::AnnotateVideoRequest)
+            req = Google::Gax::to_proto(req, Google::Cloud::VideoIntelligence::V1beta1::AnnotateVideoRequest)
             operation = Google::Gax::Operation.new(
               @annotate_video.call(req, options),
               @operations_client,
-              Google::Cloud::Videointelligence::V1beta1::AnnotateVideoResponse,
-              Google::Cloud::Videointelligence::V1beta1::AnnotateVideoProgress,
+              Google::Cloud::VideoIntelligence::V1beta1::AnnotateVideoResponse,
+              Google::Cloud::VideoIntelligence::V1beta1::AnnotateVideoProgress,
               call_options: options
             )
             operation.on_done { |operation| yield(operation) } if block_given?
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
index efab94f0d..b50014e5a 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
@@ -109,6 +109,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -118,6 +122,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -129,6 +135,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::VideoIntelligence::V1beta2::VideoIntelligenceServiceClient.new(**kwargs)
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/cloud/videointelligence/v1beta2/video_intelligence.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/cloud/videointelligence/v1beta2/video_intelligence.rb
index a797ad8b4..8e1073416 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/cloud/videointelligence/v1beta2/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/cloud/videointelligence/v1beta2/video_intelligence.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Cloud
-    module Videointelligence
+    module VideoIntelligence
       module V1beta2
         # Video annotation request.
         # @!attribute [rw] input_uri
@@ -36,10 +36,10 @@ module Google
         #     If unset, the input video(s) should be specified via `input_uri`.
         #     If set, `input_uri` should be unset.
         # @!attribute [rw] features
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::Feature>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::Feature>]
         #     Requested video annotation features.
         # @!attribute [rw] video_context
-        #   @return [Google::Cloud::Videointelligence::V1beta2::VideoContext]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta2::VideoContext]
         #     Additional video context and/or feature-specific parameters.
         # @!attribute [rw] output_uri
         #   @return [String]
@@ -58,27 +58,27 @@ module Google
 
         # Video context and/or feature-specific parameters.
         # @!attribute [rw] segments
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::VideoSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::VideoSegment>]
         #     Video segments to annotate. The segments may overlap and are not required
         #     to be contiguous or span the whole video. If unspecified, each video
         #     is treated as a single segment.
         # @!attribute [rw] label_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1beta2::LabelDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta2::LabelDetectionConfig]
         #     Config for LABEL_DETECTION.
         # @!attribute [rw] shot_change_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1beta2::ShotChangeDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta2::ShotChangeDetectionConfig]
         #     Config for SHOT_CHANGE_DETECTION.
         # @!attribute [rw] explicit_content_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1beta2::ExplicitContentDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta2::ExplicitContentDetectionConfig]
         #     Config for EXPLICIT_CONTENT_DETECTION.
         # @!attribute [rw] face_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1beta2::FaceDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta2::FaceDetectionConfig]
         #     Config for FACE_DETECTION.
         class VideoContext; end
 
         # Config for LABEL_DETECTION.
         # @!attribute [rw] label_detection_mode
-        #   @return [Google::Cloud::Videointelligence::V1beta2::LabelDetectionMode]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta2::LabelDetectionMode]
         #     What labels should be detected with LABEL_DETECTION, in addition to
         #     video-level labels or segment-level labels.
         #     If unspecified, defaults to `SHOT_MODE`.
@@ -134,7 +134,7 @@ module Google
 
         # Video segment level annotation results for label detection.
         # @!attribute [rw] segment
-        #   @return [Google::Cloud::Videointelligence::V1beta2::VideoSegment]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta2::VideoSegment]
         #     Video segment where a label was detected.
         # @!attribute [rw] confidence
         #   @return [Float]
@@ -167,19 +167,19 @@ module Google
 
         # Label annotation.
         # @!attribute [rw] entity
-        #   @return [Google::Cloud::Videointelligence::V1beta2::Entity]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta2::Entity]
         #     Detected entity.
         # @!attribute [rw] category_entities
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::Entity>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::Entity>]
         #     Common categories for the detected entity.
         #     E.g. when the label is `Terrier` the category is likely `dog`. And in some
         #     cases there might be more than one categories e.g. `Terrier` could also be
         #     a `pet`.
         # @!attribute [rw] segments
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::LabelSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::LabelSegment>]
         #     All video segments where a label was detected.
         # @!attribute [rw] frames
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::LabelFrame>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::LabelFrame>]
         #     All video frames where a label was detected.
         class LabelAnnotation; end
 
@@ -189,7 +189,7 @@ module Google
         #     Time-offset, relative to the beginning of the video, corresponding to the
         #     video frame for this location.
         # @!attribute [rw] pornography_likelihood
-        #   @return [Google::Cloud::Videointelligence::V1beta2::Likelihood]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta2::Likelihood]
         #     Likelihood of the pornography content..
         class ExplicitContentFrame; end
 
@@ -197,7 +197,7 @@ module Google
         # If no explicit content has been detected in a frame, no annotations are
         # present for that frame.
         # @!attribute [rw] frames
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::ExplicitContentFrame>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::ExplicitContentFrame>]
         #     All video frames where explicit content was detected.
         class ExplicitContentAnnotation; end
 
@@ -220,13 +220,13 @@ module Google
 
         # Video segment level annotation results for face detection.
         # @!attribute [rw] segment
-        #   @return [Google::Cloud::Videointelligence::V1beta2::VideoSegment]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta2::VideoSegment]
         #     Video segment where a face was detected.
         class FaceSegment; end
 
         # Video frame level annotation results for face detection.
         # @!attribute [rw] normalized_bounding_boxes
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::NormalizedBoundingBox>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::NormalizedBoundingBox>]
         #     Normalized Bounding boxes in a frame.
         #     There can be more than one boxes if the same face is detected in multiple
         #     locations within the current frame.
@@ -241,10 +241,10 @@ module Google
         #   @return [String]
         #     Thumbnail of a representative face view (in JPEG format).
         # @!attribute [rw] segments
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::FaceSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::FaceSegment>]
         #     All video segments where a face was detected.
         # @!attribute [rw] frames
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::FaceFrame>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::FaceFrame>]
         #     All video frames where a face was detected.
         class FaceAnnotation; end
 
@@ -254,25 +254,25 @@ module Google
         #     Video file location in
         #     [Google Cloud Storage](https://cloud.google.com/storage/).
         # @!attribute [rw] segment_label_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::LabelAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::LabelAnnotation>]
         #     Label annotations on video level or user specified segment level.
         #     There is exactly one element for each unique label.
         # @!attribute [rw] shot_label_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::LabelAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::LabelAnnotation>]
         #     Label annotations on shot level.
         #     There is exactly one element for each unique label.
         # @!attribute [rw] frame_label_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::LabelAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::LabelAnnotation>]
         #     Label annotations on frame level.
         #     There is exactly one element for each unique label.
         # @!attribute [rw] face_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::FaceAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::FaceAnnotation>]
         #     Face annotations. There is exactly one element for each unique face.
         # @!attribute [rw] shot_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::VideoSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::VideoSegment>]
         #     Shot annotations. Each shot is represented as a video segment.
         # @!attribute [rw] explicit_annotation
-        #   @return [Google::Cloud::Videointelligence::V1beta2::ExplicitContentAnnotation]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta2::ExplicitContentAnnotation]
         #     Explicit content annotation.
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]
@@ -284,7 +284,7 @@ module Google
         # field of the `Operation` returned by the `GetOperation`
         # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_results
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::VideoAnnotationResults>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::VideoAnnotationResults>]
         #     Annotation results for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoResponse; end
 
@@ -309,7 +309,7 @@ module Google
         # field of the `Operation` returned by the `GetOperation`
         # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_progress
-        #   @return [Array<Google::Cloud::Videointelligence::V1beta2::VideoAnnotationProgress>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1beta2::VideoAnnotationProgress>]
         #     Progress metadata for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoProgress; end
 
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client.rb
index b2549d70e..dc8779c77 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client.rb
@@ -38,7 +38,7 @@ module Google
         # Service that implements Google Cloud Video Intelligence API.
         #
         # @!attribute [r] video_intelligence_service_stub
-        #   @return [Google::Cloud::Videointelligence::V1beta2::VideoIntelligenceService::Stub]
+        #   @return [Google::Cloud::VideoIntelligence::V1beta2::VideoIntelligenceService::Stub]
         class VideoIntelligenceServiceClient
           # @private
           attr_reader :video_intelligence_service_stub
@@ -92,6 +92,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -101,6 +105,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -118,7 +124,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -163,8 +172,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @video_intelligence_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -174,7 +183,7 @@ module Google
               updater_proc: updater_proc,
               scopes: scopes,
               interceptors: interceptors,
-              &Google::Cloud::Videointelligence::V1beta2::VideoIntelligenceService::Stub.method(:new)
+              &Google::Cloud::VideoIntelligence::V1beta2::VideoIntelligenceService::Stub.method(:new)
             )
 
             @annotate_video = Google::Gax.create_api_call(
@@ -206,11 +215,11 @@ module Google
           #   The video data bytes.
           #   If unset, the input video(s) should be specified via `input_uri`.
           #   If set, `input_uri` should be unset.
-          # @param features [Array<Google::Cloud::Videointelligence::V1beta2::Feature>]
+          # @param features [Array<Google::Cloud::VideoIntelligence::V1beta2::Feature>]
           #   Requested video annotation features.
-          # @param video_context [Google::Cloud::Videointelligence::V1beta2::VideoContext | Hash]
+          # @param video_context [Google::Cloud::VideoIntelligence::V1beta2::VideoContext | Hash]
           #   Additional video context and/or feature-specific parameters.
-          #   A hash of the same form as `Google::Cloud::Videointelligence::V1beta2::VideoContext`
+          #   A hash of the same form as `Google::Cloud::VideoIntelligence::V1beta2::VideoContext`
           #   can also be provided.
           # @param output_uri [String]
           #   Optional location where the output (in JSON format) should be stored.
@@ -279,12 +288,12 @@ module Google
               output_uri: output_uri,
               location_id: location_id
             }.delete_if { |_, v| v.nil? }
-            req = Google::Gax::to_proto(req, Google::Cloud::Videointelligence::V1beta2::AnnotateVideoRequest)
+            req = Google::Gax::to_proto(req, Google::Cloud::VideoIntelligence::V1beta2::AnnotateVideoRequest)
             operation = Google::Gax::Operation.new(
               @annotate_video.call(req, options),
               @operations_client,
-              Google::Cloud::Videointelligence::V1beta2::AnnotateVideoResponse,
-              Google::Cloud::Videointelligence::V1beta2::AnnotateVideoProgress,
+              Google::Cloud::VideoIntelligence::V1beta2::AnnotateVideoResponse,
+              Google::Cloud::VideoIntelligence::V1beta2::AnnotateVideoProgress,
               call_options: options
             )
             operation.on_done { |operation| yield(operation) } if block_given?
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1.rb
index aa2009a78..3aaf48aaa 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1.rb
@@ -147,6 +147,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -156,6 +160,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -167,6 +173,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::VideoIntelligence::V1p1beta1::VideoIntelligenceServiceClient.new(**kwargs)
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1/doc/google/cloud/videointelligence/v1p1beta1/video_intelligence.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1/doc/google/cloud/videointelligence/v1p1beta1/video_intelligence.rb
index 727bb284e..c296440bf 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1/doc/google/cloud/videointelligence/v1p1beta1/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1/doc/google/cloud/videointelligence/v1p1beta1/video_intelligence.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Cloud
-    module Videointelligence
+    module VideoIntelligence
       module V1p1beta1
         # Video annotation request.
         # @!attribute [rw] input_uri
@@ -36,10 +36,10 @@ module Google
         #     If unset, the input video(s) should be specified via `input_uri`.
         #     If set, `input_uri` should be unset.
         # @!attribute [rw] features
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::Feature>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::Feature>]
         #     Requested video annotation features.
         # @!attribute [rw] video_context
-        #   @return [Google::Cloud::Videointelligence::V1p1beta1::VideoContext]
+        #   @return [Google::Cloud::VideoIntelligence::V1p1beta1::VideoContext]
         #     Additional video context and/or feature-specific parameters.
         # @!attribute [rw] output_uri
         #   @return [String]
@@ -58,27 +58,27 @@ module Google
 
         # Video context and/or feature-specific parameters.
         # @!attribute [rw] segments
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::VideoSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::VideoSegment>]
         #     Video segments to annotate. The segments may overlap and are not required
         #     to be contiguous or span the whole video. If unspecified, each video is
         #     treated as a single segment.
         # @!attribute [rw] label_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1p1beta1::LabelDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1p1beta1::LabelDetectionConfig]
         #     Config for LABEL_DETECTION.
         # @!attribute [rw] shot_change_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1p1beta1::ShotChangeDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1p1beta1::ShotChangeDetectionConfig]
         #     Config for SHOT_CHANGE_DETECTION.
         # @!attribute [rw] explicit_content_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1p1beta1::ExplicitContentDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1p1beta1::ExplicitContentDetectionConfig]
         #     Config for EXPLICIT_CONTENT_DETECTION.
         # @!attribute [rw] speech_transcription_config
-        #   @return [Google::Cloud::Videointelligence::V1p1beta1::SpeechTranscriptionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1p1beta1::SpeechTranscriptionConfig]
         #     Config for SPEECH_TRANSCRIPTION.
         class VideoContext; end
 
         # Config for LABEL_DETECTION.
         # @!attribute [rw] label_detection_mode
-        #   @return [Google::Cloud::Videointelligence::V1p1beta1::LabelDetectionMode]
+        #   @return [Google::Cloud::VideoIntelligence::V1p1beta1::LabelDetectionMode]
         #     What labels should be detected with LABEL_DETECTION, in addition to
         #     video-level labels or segment-level labels.
         #     If unspecified, defaults to `SHOT_MODE`.
@@ -123,7 +123,7 @@ module Google
 
         # Video segment level annotation results for label detection.
         # @!attribute [rw] segment
-        #   @return [Google::Cloud::Videointelligence::V1p1beta1::VideoSegment]
+        #   @return [Google::Cloud::VideoIntelligence::V1p1beta1::VideoSegment]
         #     Video segment where a label was detected.
         # @!attribute [rw] confidence
         #   @return [Float]
@@ -156,19 +156,19 @@ module Google
 
         # Label annotation.
         # @!attribute [rw] entity
-        #   @return [Google::Cloud::Videointelligence::V1p1beta1::Entity]
+        #   @return [Google::Cloud::VideoIntelligence::V1p1beta1::Entity]
         #     Detected entity.
         # @!attribute [rw] category_entities
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::Entity>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::Entity>]
         #     Common categories for the detected entity.
         #     E.g. when the label is `Terrier` the category is likely `dog`. And in some
         #     cases there might be more than one categories e.g. `Terrier` could also be
         #     a `pet`.
         # @!attribute [rw] segments
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::LabelSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::LabelSegment>]
         #     All video segments where a label was detected.
         # @!attribute [rw] frames
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::LabelFrame>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::LabelFrame>]
         #     All video frames where a label was detected.
         class LabelAnnotation; end
 
@@ -178,7 +178,7 @@ module Google
         #     Time-offset, relative to the beginning of the video, corresponding to the
         #     video frame for this location.
         # @!attribute [rw] pornography_likelihood
-        #   @return [Google::Cloud::Videointelligence::V1p1beta1::Likelihood]
+        #   @return [Google::Cloud::VideoIntelligence::V1p1beta1::Likelihood]
         #     Likelihood of the pornography content..
         class ExplicitContentFrame; end
 
@@ -186,7 +186,7 @@ module Google
         # If no explicit content has been detected in a frame, no annotations are
         # present for that frame.
         # @!attribute [rw] frames
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::ExplicitContentFrame>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::ExplicitContentFrame>]
         #     All video frames where explicit content was detected.
         class ExplicitContentAnnotation; end
 
@@ -196,25 +196,25 @@ module Google
         #     Output only. Video file location in
         #     [Google Cloud Storage](https://cloud.google.com/storage/).
         # @!attribute [rw] segment_label_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::LabelAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::LabelAnnotation>]
         #     Label annotations on video level or user specified segment level.
         #     There is exactly one element for each unique label.
         # @!attribute [rw] shot_label_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::LabelAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::LabelAnnotation>]
         #     Label annotations on shot level.
         #     There is exactly one element for each unique label.
         # @!attribute [rw] frame_label_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::LabelAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::LabelAnnotation>]
         #     Label annotations on frame level.
         #     There is exactly one element for each unique label.
         # @!attribute [rw] shot_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::VideoSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::VideoSegment>]
         #     Shot annotations. Each shot is represented as a video segment.
         # @!attribute [rw] explicit_annotation
-        #   @return [Google::Cloud::Videointelligence::V1p1beta1::ExplicitContentAnnotation]
+        #   @return [Google::Cloud::VideoIntelligence::V1p1beta1::ExplicitContentAnnotation]
         #     Explicit content annotation.
         # @!attribute [rw] speech_transcriptions
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::SpeechTranscription>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::SpeechTranscription>]
         #     Speech transcription.
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]
@@ -226,7 +226,7 @@ module Google
         # field of the `Operation` returned by the `GetOperation`
         # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_results
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::VideoAnnotationResults>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::VideoAnnotationResults>]
         #     Annotation results for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoResponse; end
 
@@ -251,7 +251,7 @@ module Google
         # field of the `Operation` returned by the `GetOperation`
         # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_progress
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::VideoAnnotationProgress>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::VideoAnnotationProgress>]
         #     Progress metadata for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoProgress; end
 
@@ -277,7 +277,7 @@ module Google
         #     with asterisks, e.g. "f***". If set to `false` or omitted, profanities
         #     won't be filtered out.
         # @!attribute [rw] speech_contexts
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::SpeechContext>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::SpeechContext>]
         #     *Optional* A means to provide context to assist the speech recognition.
         # @!attribute [rw] enable_automatic_punctuation
         #   @return [true, false]
@@ -307,7 +307,7 @@ module Google
 
         # A speech recognition result corresponding to a portion of the audio.
         # @!attribute [rw] alternatives
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::SpeechRecognitionAlternative>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::SpeechRecognitionAlternative>]
         #     Output only. May contain one or more recognition hypotheses (up to the
         #     maximum specified in `max_alternatives`).
         #     These alternatives are ordered in terms of accuracy, with the top (first)
@@ -327,7 +327,7 @@ module Google
         #     `confidence` field as it is not guaranteed to be accurate or consistent.
         #     The default of 0.0 is a sentinel value indicating `confidence` was not set.
         # @!attribute [rw] words
-        #   @return [Array<Google::Cloud::Videointelligence::V1p1beta1::WordInfo>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p1beta1::WordInfo>]
         #     Output only. A list of word-specific information for each recognized word.
         class SpeechRecognitionAlternative; end
 
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1/video_intelligence_service_client.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1/video_intelligence_service_client.rb
index d24899f73..3bbe73620 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1/video_intelligence_service_client.rb
@@ -38,7 +38,7 @@ module Google
         # Service that implements Google Cloud Video Intelligence API.
         #
         # @!attribute [r] video_intelligence_service_stub
-        #   @return [Google::Cloud::Videointelligence::V1p1beta1::VideoIntelligenceService::Stub]
+        #   @return [Google::Cloud::VideoIntelligence::V1p1beta1::VideoIntelligenceService::Stub]
         class VideoIntelligenceServiceClient
           # @private
           attr_reader :video_intelligence_service_stub
@@ -92,6 +92,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -101,6 +105,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -118,7 +124,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -163,8 +172,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @video_intelligence_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -174,7 +183,7 @@ module Google
               updater_proc: updater_proc,
               scopes: scopes,
               interceptors: interceptors,
-              &Google::Cloud::Videointelligence::V1p1beta1::VideoIntelligenceService::Stub.method(:new)
+              &Google::Cloud::VideoIntelligence::V1p1beta1::VideoIntelligenceService::Stub.method(:new)
             )
 
             @annotate_video = Google::Gax.create_api_call(
@@ -206,11 +215,11 @@ module Google
           #   The video data bytes.
           #   If unset, the input video(s) should be specified via `input_uri`.
           #   If set, `input_uri` should be unset.
-          # @param features [Array<Google::Cloud::Videointelligence::V1p1beta1::Feature>]
+          # @param features [Array<Google::Cloud::VideoIntelligence::V1p1beta1::Feature>]
           #   Requested video annotation features.
-          # @param video_context [Google::Cloud::Videointelligence::V1p1beta1::VideoContext | Hash]
+          # @param video_context [Google::Cloud::VideoIntelligence::V1p1beta1::VideoContext | Hash]
           #   Additional video context and/or feature-specific parameters.
-          #   A hash of the same form as `Google::Cloud::Videointelligence::V1p1beta1::VideoContext`
+          #   A hash of the same form as `Google::Cloud::VideoIntelligence::V1p1beta1::VideoContext`
           #   can also be provided.
           # @param output_uri [String]
           #   Optional location where the output (in JSON format) should be stored.
@@ -279,12 +288,12 @@ module Google
               output_uri: output_uri,
               location_id: location_id
             }.delete_if { |_, v| v.nil? }
-            req = Google::Gax::to_proto(req, Google::Cloud::Videointelligence::V1p1beta1::AnnotateVideoRequest)
+            req = Google::Gax::to_proto(req, Google::Cloud::VideoIntelligence::V1p1beta1::AnnotateVideoRequest)
             operation = Google::Gax::Operation.new(
               @annotate_video.call(req, options),
               @operations_client,
-              Google::Cloud::Videointelligence::V1p1beta1::AnnotateVideoResponse,
-              Google::Cloud::Videointelligence::V1p1beta1::AnnotateVideoProgress,
+              Google::Cloud::VideoIntelligence::V1p1beta1::AnnotateVideoResponse,
+              Google::Cloud::VideoIntelligence::V1p1beta1::AnnotateVideoProgress,
               call_options: options
             )
             operation.on_done { |operation| yield(operation) } if block_given?
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1.rb
index e82793cc0..4fb9500bb 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1.rb
@@ -147,6 +147,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -156,6 +160,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -167,6 +173,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::VideoIntelligence::V1p2beta1::VideoIntelligenceServiceClient.new(**kwargs)
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1/doc/google/cloud/videointelligence/v1p2beta1/video_intelligence.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1/doc/google/cloud/videointelligence/v1p2beta1/video_intelligence.rb
index ac3d01a10..9db289b8d 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1/doc/google/cloud/videointelligence/v1p2beta1/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1/doc/google/cloud/videointelligence/v1p2beta1/video_intelligence.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Cloud
-    module Videointelligence
+    module VideoIntelligence
       module V1p2beta1
         # Video annotation request.
         # @!attribute [rw] input_uri
@@ -36,10 +36,10 @@ module Google
         #     If unset, the input video(s) should be specified via `input_uri`.
         #     If set, `input_uri` should be unset.
         # @!attribute [rw] features
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::Feature>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::Feature>]
         #     Requested video annotation features.
         # @!attribute [rw] video_context
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::VideoContext]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::VideoContext]
         #     Additional video context and/or feature-specific parameters.
         # @!attribute [rw] output_uri
         #   @return [String]
@@ -58,27 +58,27 @@ module Google
 
         # Video context and/or feature-specific parameters.
         # @!attribute [rw] segments
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::VideoSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::VideoSegment>]
         #     Video segments to annotate. The segments may overlap and are not required
         #     to be contiguous or span the whole video. If unspecified, each video is
         #     treated as a single segment.
         # @!attribute [rw] label_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::LabelDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::LabelDetectionConfig]
         #     Config for LABEL_DETECTION.
         # @!attribute [rw] shot_change_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::ShotChangeDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::ShotChangeDetectionConfig]
         #     Config for SHOT_CHANGE_DETECTION.
         # @!attribute [rw] explicit_content_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::ExplicitContentDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::ExplicitContentDetectionConfig]
         #     Config for EXPLICIT_CONTENT_DETECTION.
         # @!attribute [rw] text_detection_config
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::TextDetectionConfig]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::TextDetectionConfig]
         #     Config for TEXT_DETECTION.
         class VideoContext; end
 
         # Config for LABEL_DETECTION.
         # @!attribute [rw] label_detection_mode
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::LabelDetectionMode]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::LabelDetectionMode]
         #     What labels should be detected with LABEL_DETECTION, in addition to
         #     video-level labels or segment-level labels.
         #     If unspecified, defaults to `SHOT_MODE`.
@@ -133,7 +133,7 @@ module Google
 
         # Video segment level annotation results for label detection.
         # @!attribute [rw] segment
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::VideoSegment]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::VideoSegment]
         #     Video segment where a label was detected.
         # @!attribute [rw] confidence
         #   @return [Float]
@@ -166,19 +166,19 @@ module Google
 
         # Label annotation.
         # @!attribute [rw] entity
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::Entity]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::Entity]
         #     Detected entity.
         # @!attribute [rw] category_entities
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::Entity>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::Entity>]
         #     Common categories for the detected entity.
         #     E.g. when the label is `Terrier` the category is likely `dog`. And in some
         #     cases there might be more than one categories e.g. `Terrier` could also be
         #     a `pet`.
         # @!attribute [rw] segments
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::LabelSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::LabelSegment>]
         #     All video segments where a label was detected.
         # @!attribute [rw] frames
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::LabelFrame>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::LabelFrame>]
         #     All video frames where a label was detected.
         class LabelAnnotation; end
 
@@ -188,7 +188,7 @@ module Google
         #     Time-offset, relative to the beginning of the video, corresponding to the
         #     video frame for this location.
         # @!attribute [rw] pornography_likelihood
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::Likelihood]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::Likelihood]
         #     Likelihood of the pornography content..
         class ExplicitContentFrame; end
 
@@ -196,7 +196,7 @@ module Google
         # If no explicit content has been detected in a frame, no annotations are
         # present for that frame.
         # @!attribute [rw] frames
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::ExplicitContentFrame>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::ExplicitContentFrame>]
         #     All video frames where explicit content was detected.
         class ExplicitContentAnnotation; end
 
@@ -223,30 +223,30 @@ module Google
         #     Video file location in
         #     [Google Cloud Storage](https://cloud.google.com/storage/).
         # @!attribute [rw] segment_label_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::LabelAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::LabelAnnotation>]
         #     Label annotations on video level or user specified segment level.
         #     There is exactly one element for each unique label.
         # @!attribute [rw] shot_label_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::LabelAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::LabelAnnotation>]
         #     Label annotations on shot level.
         #     There is exactly one element for each unique label.
         # @!attribute [rw] frame_label_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::LabelAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::LabelAnnotation>]
         #     Label annotations on frame level.
         #     There is exactly one element for each unique label.
         # @!attribute [rw] shot_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::VideoSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::VideoSegment>]
         #     Shot annotations. Each shot is represented as a video segment.
         # @!attribute [rw] explicit_annotation
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::ExplicitContentAnnotation]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::ExplicitContentAnnotation]
         #     Explicit content annotation.
         # @!attribute [rw] text_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::TextAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::TextAnnotation>]
         #     OCR text detection and tracking.
         #     Annotations for list of detected text snippets. Each will have list of
         #     frame information associated with it.
         # @!attribute [rw] object_annotations
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::ObjectTrackingAnnotation>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::ObjectTrackingAnnotation>]
         #     Annotations for list of objects detected and tracked in video.
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]
@@ -258,7 +258,7 @@ module Google
         # field of the `Operation` returned by the `GetOperation`
         # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_results
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::VideoAnnotationResults>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::VideoAnnotationResults>]
         #     Annotation results for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoResponse; end
 
@@ -283,7 +283,7 @@ module Google
         # field of the `Operation` returned by the `GetOperation`
         # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_progress
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::VideoAnnotationProgress>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::VideoAnnotationProgress>]
         #     Progress metadata for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoProgress; end
 
@@ -316,20 +316,20 @@ module Google
         # than 0, or greater than 1 due to trignometric calculations for location of
         # the box.
         # @!attribute [rw] vertices
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::NormalizedVertex>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::NormalizedVertex>]
         #     Normalized vertices of the bounding polygon.
         class NormalizedBoundingPoly; end
 
         # Video segment level annotation results for text detection.
         # @!attribute [rw] segment
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::VideoSegment]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::VideoSegment]
         #     Video segment where a text snippet was detected.
         # @!attribute [rw] confidence
         #   @return [Float]
         #     Confidence for the track of detected text. It is calculated as the highest
         #     over all frames where OCR detected text appears.
         # @!attribute [rw] frames
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::TextFrame>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::TextFrame>]
         #     Information related to the frames where OCR detected text appears.
         class TextSegment; end
 
@@ -337,7 +337,7 @@ module Google
         # Contains information regarding timestamp and bounding box locations for the
         # frames containing detected OCR text snippets.
         # @!attribute [rw] rotated_bounding_box
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::NormalizedBoundingPoly]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::NormalizedBoundingPoly]
         #     Bounding polygon of the detected text for this frame.
         # @!attribute [rw] time_offset
         #   @return [Google::Protobuf::Duration]
@@ -351,14 +351,14 @@ module Google
         #   @return [String]
         #     The detected text.
         # @!attribute [rw] segments
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::TextSegment>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::TextSegment>]
         #     All video segments where OCR detected text appears.
         class TextAnnotation; end
 
         # Video frame level annotations for object detection and tracking. This field
         # stores per frame location, time offset, and confidence.
         # @!attribute [rw] normalized_bounding_box
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::NormalizedBoundingBox]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::NormalizedBoundingBox]
         #     The normalized bounding box location of this object track for the frame.
         # @!attribute [rw] time_offset
         #   @return [Google::Protobuf::Duration]
@@ -367,16 +367,16 @@ module Google
 
         # Annotations corresponding to one tracked object.
         # @!attribute [rw] entity
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::Entity]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::Entity]
         #     Entity to specify the object category that this track is labeled as.
         # @!attribute [rw] confidence
         #   @return [Float]
         #     Object category's labeling confidence of this track.
         # @!attribute [rw] frames
-        #   @return [Array<Google::Cloud::Videointelligence::V1p2beta1::ObjectTrackingFrame>]
+        #   @return [Array<Google::Cloud::VideoIntelligence::V1p2beta1::ObjectTrackingFrame>]
         #     Information corresponding to all frames where this object track appears.
         # @!attribute [rw] segment
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::VideoSegment]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::VideoSegment]
         #     Each object track corresponds to one video segment where it appears.
         class ObjectTrackingAnnotation; end
 
diff --git a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1/video_intelligence_service_client.rb b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1/video_intelligence_service_client.rb
index 5c96c81cd..26f65128e 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1/video_intelligence_service_client.rb
@@ -38,7 +38,7 @@ module Google
         # Service that implements Google Cloud Video Intelligence API.
         #
         # @!attribute [r] video_intelligence_service_stub
-        #   @return [Google::Cloud::Videointelligence::V1p2beta1::VideoIntelligenceService::Stub]
+        #   @return [Google::Cloud::VideoIntelligence::V1p2beta1::VideoIntelligenceService::Stub]
         class VideoIntelligenceServiceClient
           # @private
           attr_reader :video_intelligence_service_stub
@@ -92,6 +92,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -101,6 +105,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -118,7 +124,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -163,8 +172,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @video_intelligence_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -174,7 +183,7 @@ module Google
               updater_proc: updater_proc,
               scopes: scopes,
               interceptors: interceptors,
-              &Google::Cloud::Videointelligence::V1p2beta1::VideoIntelligenceService::Stub.method(:new)
+              &Google::Cloud::VideoIntelligence::V1p2beta1::VideoIntelligenceService::Stub.method(:new)
             )
 
             @annotate_video = Google::Gax.create_api_call(
@@ -206,11 +215,11 @@ module Google
           #   The video data bytes.
           #   If unset, the input video(s) should be specified via `input_uri`.
           #   If set, `input_uri` should be unset.
-          # @param features [Array<Google::Cloud::Videointelligence::V1p2beta1::Feature>]
+          # @param features [Array<Google::Cloud::VideoIntelligence::V1p2beta1::Feature>]
           #   Requested video annotation features.
-          # @param video_context [Google::Cloud::Videointelligence::V1p2beta1::VideoContext | Hash]
+          # @param video_context [Google::Cloud::VideoIntelligence::V1p2beta1::VideoContext | Hash]
           #   Additional video context and/or feature-specific parameters.
-          #   A hash of the same form as `Google::Cloud::Videointelligence::V1p2beta1::VideoContext`
+          #   A hash of the same form as `Google::Cloud::VideoIntelligence::V1p2beta1::VideoContext`
           #   can also be provided.
           # @param output_uri [String]
           #   Optional location where the output (in JSON format) should be stored.
@@ -279,12 +288,12 @@ module Google
               output_uri: output_uri,
               location_id: location_id
             }.delete_if { |_, v| v.nil? }
-            req = Google::Gax::to_proto(req, Google::Cloud::Videointelligence::V1p2beta1::AnnotateVideoRequest)
+            req = Google::Gax::to_proto(req, Google::Cloud::VideoIntelligence::V1p2beta1::AnnotateVideoRequest)
             operation = Google::Gax::Operation.new(
               @annotate_video.call(req, options),
               @operations_client,
-              Google::Cloud::Videointelligence::V1p2beta1::AnnotateVideoResponse,
-              Google::Cloud::Videointelligence::V1p2beta1::AnnotateVideoProgress,
+              Google::Cloud::VideoIntelligence::V1p2beta1::AnnotateVideoResponse,
+              Google::Cloud::VideoIntelligence::V1p2beta1::AnnotateVideoProgress,
               call_options: options
             )
             operation.on_done { |operation| yield(operation) } if block_given?
diff --git a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1/video_intelligence_pb.rb b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1/video_intelligence_pb.rb
index e03986cfa..651637881 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1/video_intelligence_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1/video_intelligence_pb.rb
@@ -216,47 +216,48 @@ end
 
 module Google
   module Cloud
-    module Videointelligence
-      module V1
-        AnnotateVideoRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.AnnotateVideoRequest").msgclass
-        VideoContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.VideoContext").msgclass
-        LabelDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.LabelDetectionConfig").msgclass
-        ShotChangeDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.ShotChangeDetectionConfig").msgclass
-        ExplicitContentDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.ExplicitContentDetectionConfig").msgclass
-        FaceDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.FaceDetectionConfig").msgclass
-        ObjectTrackingConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.ObjectTrackingConfig").msgclass
-        TextDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.TextDetectionConfig").msgclass
-        VideoSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.VideoSegment").msgclass
-        LabelSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.LabelSegment").msgclass
-        LabelFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.LabelFrame").msgclass
-        Entity = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.Entity").msgclass
-        LabelAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.LabelAnnotation").msgclass
-        ExplicitContentFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.ExplicitContentFrame").msgclass
-        ExplicitContentAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.ExplicitContentAnnotation").msgclass
-        NormalizedBoundingBox = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.NormalizedBoundingBox").msgclass
-        FaceSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.FaceSegment").msgclass
-        FaceFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.FaceFrame").msgclass
-        FaceAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.FaceAnnotation").msgclass
-        VideoAnnotationResults = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.VideoAnnotationResults").msgclass
-        AnnotateVideoResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.AnnotateVideoResponse").msgclass
-        VideoAnnotationProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.VideoAnnotationProgress").msgclass
-        AnnotateVideoProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.AnnotateVideoProgress").msgclass
-        SpeechTranscriptionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.SpeechTranscriptionConfig").msgclass
-        SpeechContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.SpeechContext").msgclass
-        SpeechTranscription = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.SpeechTranscription").msgclass
-        SpeechRecognitionAlternative = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.SpeechRecognitionAlternative").msgclass
-        WordInfo = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.WordInfo").msgclass
-        NormalizedVertex = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.NormalizedVertex").msgclass
-        NormalizedBoundingPoly = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.NormalizedBoundingPoly").msgclass
-        TextSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.TextSegment").msgclass
-        TextFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.TextFrame").msgclass
-        TextAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.TextAnnotation").msgclass
-        ObjectTrackingFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.ObjectTrackingFrame").msgclass
-        ObjectTrackingAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.ObjectTrackingAnnotation").msgclass
-        Feature = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.Feature").enummodule
-        LabelDetectionMode = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.LabelDetectionMode").enummodule
-        Likelihood = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.Likelihood").enummodule
-      end
+    module VideoIntelligence
     end
+    Videointelligence = VideoIntelligence unless const_defined? :Videointelligence
   end
 end
+module Google::Cloud::VideoIntelligence::V1
+  AnnotateVideoRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.AnnotateVideoRequest").msgclass
+  VideoContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.VideoContext").msgclass
+  LabelDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.LabelDetectionConfig").msgclass
+  ShotChangeDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.ShotChangeDetectionConfig").msgclass
+  ExplicitContentDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.ExplicitContentDetectionConfig").msgclass
+  FaceDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.FaceDetectionConfig").msgclass
+  ObjectTrackingConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.ObjectTrackingConfig").msgclass
+  TextDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.TextDetectionConfig").msgclass
+  VideoSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.VideoSegment").msgclass
+  LabelSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.LabelSegment").msgclass
+  LabelFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.LabelFrame").msgclass
+  Entity = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.Entity").msgclass
+  LabelAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.LabelAnnotation").msgclass
+  ExplicitContentFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.ExplicitContentFrame").msgclass
+  ExplicitContentAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.ExplicitContentAnnotation").msgclass
+  NormalizedBoundingBox = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.NormalizedBoundingBox").msgclass
+  FaceSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.FaceSegment").msgclass
+  FaceFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.FaceFrame").msgclass
+  FaceAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.FaceAnnotation").msgclass
+  VideoAnnotationResults = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.VideoAnnotationResults").msgclass
+  AnnotateVideoResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.AnnotateVideoResponse").msgclass
+  VideoAnnotationProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.VideoAnnotationProgress").msgclass
+  AnnotateVideoProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.AnnotateVideoProgress").msgclass
+  SpeechTranscriptionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.SpeechTranscriptionConfig").msgclass
+  SpeechContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.SpeechContext").msgclass
+  SpeechTranscription = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.SpeechTranscription").msgclass
+  SpeechRecognitionAlternative = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.SpeechRecognitionAlternative").msgclass
+  WordInfo = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.WordInfo").msgclass
+  NormalizedVertex = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.NormalizedVertex").msgclass
+  NormalizedBoundingPoly = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.NormalizedBoundingPoly").msgclass
+  TextSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.TextSegment").msgclass
+  TextFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.TextFrame").msgclass
+  TextAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.TextAnnotation").msgclass
+  ObjectTrackingFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.ObjectTrackingFrame").msgclass
+  ObjectTrackingAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.ObjectTrackingAnnotation").msgclass
+  Feature = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.Feature").enummodule
+  LabelDetectionMode = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.LabelDetectionMode").enummodule
+  Likelihood = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1.Likelihood").enummodule
+end
diff --git a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1/video_intelligence_services_pb.rb b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1/video_intelligence_services_pb.rb
index 315d13ed8..ee1b51010 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1/video_intelligence_services_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1/video_intelligence_services_pb.rb
@@ -1,5 +1,5 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
-# Source: google/cloud/videointelligence/v1/video_intelligence.proto for package 'google.cloud.videointelligence.v1'
+# Source: google/cloud/videointelligence/v1/video_intelligence.proto for package 'Google::Cloud::VideoIntelligence::V1'
 # Original file comments:
 # Copyright 2018 Google LLC.
 #
@@ -23,28 +23,29 @@ require 'google/cloud/videointelligence/v1/video_intelligence_pb'
 
 module Google
   module Cloud
-    module Videointelligence
-      module V1
-        module VideoIntelligenceService
-          # Service that implements Google Cloud Video Intelligence API.
-          class Service
-
-            include GRPC::GenericService
+    module VideoIntelligence
+    end
+    Videointelligence = VideoIntelligence unless const_defined? :Videointelligence
+  end
+end
+module Google::Cloud::VideoIntelligence::V1
+  module VideoIntelligenceService
+    # Service that implements Google Cloud Video Intelligence API.
+    class Service
 
-            self.marshal_class_method = :encode
-            self.unmarshal_class_method = :decode
-            self.service_name = 'google.cloud.videointelligence.v1.VideoIntelligenceService'
+      include GRPC::GenericService
 
-            # Performs asynchronous video annotation. Progress and results can be
-            # retrieved through the `google.longrunning.Operations` interface.
-            # `Operation.metadata` contains `AnnotateVideoProgress` (progress).
-            # `Operation.response` contains `AnnotateVideoResponse` (results).
-            rpc :AnnotateVideo, AnnotateVideoRequest, Google::Longrunning::Operation
-          end
+      self.marshal_class_method = :encode
+      self.unmarshal_class_method = :decode
+      self.service_name = 'google.cloud.videointelligence.v1.VideoIntelligenceService'
 
-          Stub = Service.rpc_stub_class
-        end
-      end
+      # Performs asynchronous video annotation. Progress and results can be
+      # retrieved through the `google.longrunning.Operations` interface.
+      # `Operation.metadata` contains `AnnotateVideoProgress` (progress).
+      # `Operation.response` contains `AnnotateVideoResponse` (results).
+      rpc :AnnotateVideo, AnnotateVideoRequest, Google::Longrunning::Operation
     end
+
+    Stub = Service.rpc_stub_class
   end
 end
diff --git a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta1/video_intelligence_pb.rb b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta1/video_intelligence_pb.rb
index bb964f0d2..15ecded75 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta1/video_intelligence_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta1/video_intelligence_pb.rb
@@ -115,26 +115,27 @@ end
 
 module Google
   module Cloud
-    module Videointelligence
-      module V1beta1
-        AnnotateVideoRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.AnnotateVideoRequest").msgclass
-        VideoContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.VideoContext").msgclass
-        VideoSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.VideoSegment").msgclass
-        LabelLocation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.LabelLocation").msgclass
-        LabelAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.LabelAnnotation").msgclass
-        SafeSearchAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.SafeSearchAnnotation").msgclass
-        BoundingBox = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.BoundingBox").msgclass
-        FaceLocation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.FaceLocation").msgclass
-        FaceAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.FaceAnnotation").msgclass
-        VideoAnnotationResults = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.VideoAnnotationResults").msgclass
-        AnnotateVideoResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.AnnotateVideoResponse").msgclass
-        VideoAnnotationProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.VideoAnnotationProgress").msgclass
-        AnnotateVideoProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.AnnotateVideoProgress").msgclass
-        Feature = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.Feature").enummodule
-        LabelLevel = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.LabelLevel").enummodule
-        LabelDetectionMode = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.LabelDetectionMode").enummodule
-        Likelihood = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.Likelihood").enummodule
-      end
+    module VideoIntelligence
     end
+    Videointelligence = VideoIntelligence unless const_defined? :Videointelligence
   end
 end
+module Google::Cloud::VideoIntelligence::V1beta1
+  AnnotateVideoRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.AnnotateVideoRequest").msgclass
+  VideoContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.VideoContext").msgclass
+  VideoSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.VideoSegment").msgclass
+  LabelLocation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.LabelLocation").msgclass
+  LabelAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.LabelAnnotation").msgclass
+  SafeSearchAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.SafeSearchAnnotation").msgclass
+  BoundingBox = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.BoundingBox").msgclass
+  FaceLocation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.FaceLocation").msgclass
+  FaceAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.FaceAnnotation").msgclass
+  VideoAnnotationResults = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.VideoAnnotationResults").msgclass
+  AnnotateVideoResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.AnnotateVideoResponse").msgclass
+  VideoAnnotationProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.VideoAnnotationProgress").msgclass
+  AnnotateVideoProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.AnnotateVideoProgress").msgclass
+  Feature = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.Feature").enummodule
+  LabelLevel = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.LabelLevel").enummodule
+  LabelDetectionMode = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.LabelDetectionMode").enummodule
+  Likelihood = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta1.Likelihood").enummodule
+end
diff --git a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta1/video_intelligence_services_pb.rb b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta1/video_intelligence_services_pb.rb
index 7fea1dfad..3cbccc3f6 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta1/video_intelligence_services_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta1/video_intelligence_services_pb.rb
@@ -1,5 +1,5 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
-# Source: google/cloud/videointelligence/v1beta1/video_intelligence.proto for package 'google.cloud.videointelligence.v1beta1'
+# Source: google/cloud/videointelligence/v1beta1/video_intelligence.proto for package 'Google::Cloud::VideoIntelligence::V1beta1'
 # Original file comments:
 # Copyright 2017 Google Inc.
 #
@@ -22,28 +22,29 @@ require 'google/cloud/videointelligence/v1beta1/video_intelligence_pb'
 
 module Google
   module Cloud
-    module Videointelligence
-      module V1beta1
-        module VideoIntelligenceService
-          # Service that implements Google Cloud Video Intelligence API.
-          class Service
-
-            include GRPC::GenericService
+    module VideoIntelligence
+    end
+    Videointelligence = VideoIntelligence unless const_defined? :Videointelligence
+  end
+end
+module Google::Cloud::VideoIntelligence::V1beta1
+  module VideoIntelligenceService
+    # Service that implements Google Cloud Video Intelligence API.
+    class Service
 
-            self.marshal_class_method = :encode
-            self.unmarshal_class_method = :decode
-            self.service_name = 'google.cloud.videointelligence.v1beta1.VideoIntelligenceService'
+      include GRPC::GenericService
 
-            # Performs asynchronous video annotation. Progress and results can be
-            # retrieved through the `google.longrunning.Operations` interface.
-            # `Operation.metadata` contains `AnnotateVideoProgress` (progress).
-            # `Operation.response` contains `AnnotateVideoResponse` (results).
-            rpc :AnnotateVideo, AnnotateVideoRequest, Google::Longrunning::Operation
-          end
+      self.marshal_class_method = :encode
+      self.unmarshal_class_method = :decode
+      self.service_name = 'google.cloud.videointelligence.v1beta1.VideoIntelligenceService'
 
-          Stub = Service.rpc_stub_class
-        end
-      end
+      # Performs asynchronous video annotation. Progress and results can be
+      # retrieved through the `google.longrunning.Operations` interface.
+      # `Operation.metadata` contains `AnnotateVideoProgress` (progress).
+      # `Operation.response` contains `AnnotateVideoResponse` (results).
+      rpc :AnnotateVideo, AnnotateVideoRequest, Google::Longrunning::Operation
     end
+
+    Stub = Service.rpc_stub_class
   end
 end
diff --git a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta2/video_intelligence_pb.rb b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta2/video_intelligence_pb.rb
index e14499d45..41526c8df 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta2/video_intelligence_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta2/video_intelligence_pb.rb
@@ -135,33 +135,34 @@ end
 
 module Google
   module Cloud
-    module Videointelligence
-      module V1beta2
-        AnnotateVideoRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.AnnotateVideoRequest").msgclass
-        VideoContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.VideoContext").msgclass
-        LabelDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.LabelDetectionConfig").msgclass
-        ShotChangeDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.ShotChangeDetectionConfig").msgclass
-        ExplicitContentDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.ExplicitContentDetectionConfig").msgclass
-        FaceDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.FaceDetectionConfig").msgclass
-        VideoSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.VideoSegment").msgclass
-        LabelSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.LabelSegment").msgclass
-        LabelFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.LabelFrame").msgclass
-        Entity = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.Entity").msgclass
-        LabelAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.LabelAnnotation").msgclass
-        ExplicitContentFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.ExplicitContentFrame").msgclass
-        ExplicitContentAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.ExplicitContentAnnotation").msgclass
-        NormalizedBoundingBox = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.NormalizedBoundingBox").msgclass
-        FaceSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.FaceSegment").msgclass
-        FaceFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.FaceFrame").msgclass
-        FaceAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.FaceAnnotation").msgclass
-        VideoAnnotationResults = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.VideoAnnotationResults").msgclass
-        AnnotateVideoResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.AnnotateVideoResponse").msgclass
-        VideoAnnotationProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.VideoAnnotationProgress").msgclass
-        AnnotateVideoProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.AnnotateVideoProgress").msgclass
-        Feature = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.Feature").enummodule
-        LabelDetectionMode = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.LabelDetectionMode").enummodule
-        Likelihood = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.Likelihood").enummodule
-      end
+    module VideoIntelligence
     end
+    Videointelligence = VideoIntelligence unless const_defined? :Videointelligence
   end
 end
+module Google::Cloud::VideoIntelligence::V1beta2
+  AnnotateVideoRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.AnnotateVideoRequest").msgclass
+  VideoContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.VideoContext").msgclass
+  LabelDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.LabelDetectionConfig").msgclass
+  ShotChangeDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.ShotChangeDetectionConfig").msgclass
+  ExplicitContentDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.ExplicitContentDetectionConfig").msgclass
+  FaceDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.FaceDetectionConfig").msgclass
+  VideoSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.VideoSegment").msgclass
+  LabelSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.LabelSegment").msgclass
+  LabelFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.LabelFrame").msgclass
+  Entity = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.Entity").msgclass
+  LabelAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.LabelAnnotation").msgclass
+  ExplicitContentFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.ExplicitContentFrame").msgclass
+  ExplicitContentAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.ExplicitContentAnnotation").msgclass
+  NormalizedBoundingBox = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.NormalizedBoundingBox").msgclass
+  FaceSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.FaceSegment").msgclass
+  FaceFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.FaceFrame").msgclass
+  FaceAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.FaceAnnotation").msgclass
+  VideoAnnotationResults = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.VideoAnnotationResults").msgclass
+  AnnotateVideoResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.AnnotateVideoResponse").msgclass
+  VideoAnnotationProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.VideoAnnotationProgress").msgclass
+  AnnotateVideoProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.AnnotateVideoProgress").msgclass
+  Feature = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.Feature").enummodule
+  LabelDetectionMode = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.LabelDetectionMode").enummodule
+  Likelihood = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1beta2.Likelihood").enummodule
+end
diff --git a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta2/video_intelligence_services_pb.rb b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta2/video_intelligence_services_pb.rb
index 0576d12ad..36884f431 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta2/video_intelligence_services_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta2/video_intelligence_services_pb.rb
@@ -1,5 +1,5 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
-# Source: google/cloud/videointelligence/v1beta2/video_intelligence.proto for package 'google.cloud.videointelligence.v1beta2'
+# Source: google/cloud/videointelligence/v1beta2/video_intelligence.proto for package 'Google::Cloud::VideoIntelligence::V1beta2'
 # Original file comments:
 # Copyright 2017 Google Inc.
 #
@@ -22,28 +22,29 @@ require 'google/cloud/videointelligence/v1beta2/video_intelligence_pb'
 
 module Google
   module Cloud
-    module Videointelligence
-      module V1beta2
-        module VideoIntelligenceService
-          # Service that implements Google Cloud Video Intelligence API.
-          class Service
-
-            include GRPC::GenericService
+    module VideoIntelligence
+    end
+    Videointelligence = VideoIntelligence unless const_defined? :Videointelligence
+  end
+end
+module Google::Cloud::VideoIntelligence::V1beta2
+  module VideoIntelligenceService
+    # Service that implements Google Cloud Video Intelligence API.
+    class Service
 
-            self.marshal_class_method = :encode
-            self.unmarshal_class_method = :decode
-            self.service_name = 'google.cloud.videointelligence.v1beta2.VideoIntelligenceService'
+      include GRPC::GenericService
 
-            # Performs asynchronous video annotation. Progress and results can be
-            # retrieved through the `google.longrunning.Operations` interface.
-            # `Operation.metadata` contains `AnnotateVideoProgress` (progress).
-            # `Operation.response` contains `AnnotateVideoResponse` (results).
-            rpc :AnnotateVideo, AnnotateVideoRequest, Google::Longrunning::Operation
-          end
+      self.marshal_class_method = :encode
+      self.unmarshal_class_method = :decode
+      self.service_name = 'google.cloud.videointelligence.v1beta2.VideoIntelligenceService'
 
-          Stub = Service.rpc_stub_class
-        end
-      end
+      # Performs asynchronous video annotation. Progress and results can be
+      # retrieved through the `google.longrunning.Operations` interface.
+      # `Operation.metadata` contains `AnnotateVideoProgress` (progress).
+      # `Operation.response` contains `AnnotateVideoResponse` (results).
+      rpc :AnnotateVideo, AnnotateVideoRequest, Google::Longrunning::Operation
     end
+
+    Stub = Service.rpc_stub_class
   end
 end
diff --git a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p1beta1/video_intelligence_pb.rb b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p1beta1/video_intelligence_pb.rb
index e8da5387f..dbfae5841 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p1beta1/video_intelligence_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p1beta1/video_intelligence_pb.rb
@@ -137,33 +137,34 @@ end
 
 module Google
   module Cloud
-    module Videointelligence
-      module V1p1beta1
-        AnnotateVideoRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.AnnotateVideoRequest").msgclass
-        VideoContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.VideoContext").msgclass
-        LabelDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.LabelDetectionConfig").msgclass
-        ShotChangeDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.ShotChangeDetectionConfig").msgclass
-        ExplicitContentDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.ExplicitContentDetectionConfig").msgclass
-        VideoSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.VideoSegment").msgclass
-        LabelSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.LabelSegment").msgclass
-        LabelFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.LabelFrame").msgclass
-        Entity = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.Entity").msgclass
-        LabelAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.LabelAnnotation").msgclass
-        ExplicitContentFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.ExplicitContentFrame").msgclass
-        ExplicitContentAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.ExplicitContentAnnotation").msgclass
-        VideoAnnotationResults = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.VideoAnnotationResults").msgclass
-        AnnotateVideoResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.AnnotateVideoResponse").msgclass
-        VideoAnnotationProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.VideoAnnotationProgress").msgclass
-        AnnotateVideoProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.AnnotateVideoProgress").msgclass
-        SpeechTranscriptionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.SpeechTranscriptionConfig").msgclass
-        SpeechContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.SpeechContext").msgclass
-        SpeechTranscription = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.SpeechTranscription").msgclass
-        SpeechRecognitionAlternative = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.SpeechRecognitionAlternative").msgclass
-        WordInfo = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.WordInfo").msgclass
-        Feature = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.Feature").enummodule
-        LabelDetectionMode = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.LabelDetectionMode").enummodule
-        Likelihood = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.Likelihood").enummodule
-      end
+    module VideoIntelligence
     end
+    Videointelligence = VideoIntelligence unless const_defined? :Videointelligence
   end
 end
+module Google::Cloud::VideoIntelligence::V1p1beta1
+  AnnotateVideoRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.AnnotateVideoRequest").msgclass
+  VideoContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.VideoContext").msgclass
+  LabelDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.LabelDetectionConfig").msgclass
+  ShotChangeDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.ShotChangeDetectionConfig").msgclass
+  ExplicitContentDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.ExplicitContentDetectionConfig").msgclass
+  VideoSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.VideoSegment").msgclass
+  LabelSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.LabelSegment").msgclass
+  LabelFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.LabelFrame").msgclass
+  Entity = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.Entity").msgclass
+  LabelAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.LabelAnnotation").msgclass
+  ExplicitContentFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.ExplicitContentFrame").msgclass
+  ExplicitContentAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.ExplicitContentAnnotation").msgclass
+  VideoAnnotationResults = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.VideoAnnotationResults").msgclass
+  AnnotateVideoResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.AnnotateVideoResponse").msgclass
+  VideoAnnotationProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.VideoAnnotationProgress").msgclass
+  AnnotateVideoProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.AnnotateVideoProgress").msgclass
+  SpeechTranscriptionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.SpeechTranscriptionConfig").msgclass
+  SpeechContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.SpeechContext").msgclass
+  SpeechTranscription = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.SpeechTranscription").msgclass
+  SpeechRecognitionAlternative = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.SpeechRecognitionAlternative").msgclass
+  WordInfo = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.WordInfo").msgclass
+  Feature = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.Feature").enummodule
+  LabelDetectionMode = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.LabelDetectionMode").enummodule
+  Likelihood = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p1beta1.Likelihood").enummodule
+end
diff --git a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p1beta1/video_intelligence_services_pb.rb b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p1beta1/video_intelligence_services_pb.rb
index 0143ec29b..4d92c31ef 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p1beta1/video_intelligence_services_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p1beta1/video_intelligence_services_pb.rb
@@ -1,5 +1,5 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
-# Source: google/cloud/videointelligence/v1p1beta1/video_intelligence.proto for package 'google.cloud.videointelligence.v1p1beta1'
+# Source: google/cloud/videointelligence/v1p1beta1/video_intelligence.proto for package 'Google::Cloud::VideoIntelligence::V1p1beta1'
 # Original file comments:
 # Copyright 2018 Google Inc.
 #
@@ -22,28 +22,29 @@ require 'google/cloud/videointelligence/v1p1beta1/video_intelligence_pb'
 
 module Google
   module Cloud
-    module Videointelligence
-      module V1p1beta1
-        module VideoIntelligenceService
-          # Service that implements Google Cloud Video Intelligence API.
-          class Service
-
-            include GRPC::GenericService
+    module VideoIntelligence
+    end
+    Videointelligence = VideoIntelligence unless const_defined? :Videointelligence
+  end
+end
+module Google::Cloud::VideoIntelligence::V1p1beta1
+  module VideoIntelligenceService
+    # Service that implements Google Cloud Video Intelligence API.
+    class Service
 
-            self.marshal_class_method = :encode
-            self.unmarshal_class_method = :decode
-            self.service_name = 'google.cloud.videointelligence.v1p1beta1.VideoIntelligenceService'
+      include GRPC::GenericService
 
-            # Performs asynchronous video annotation. Progress and results can be
-            # retrieved through the `google.longrunning.Operations` interface.
-            # `Operation.metadata` contains `AnnotateVideoProgress` (progress).
-            # `Operation.response` contains `AnnotateVideoResponse` (results).
-            rpc :AnnotateVideo, AnnotateVideoRequest, Google::Longrunning::Operation
-          end
+      self.marshal_class_method = :encode
+      self.unmarshal_class_method = :decode
+      self.service_name = 'google.cloud.videointelligence.v1p1beta1.VideoIntelligenceService'
 
-          Stub = Service.rpc_stub_class
-        end
-      end
+      # Performs asynchronous video annotation. Progress and results can be
+      # retrieved through the `google.longrunning.Operations` interface.
+      # `Operation.metadata` contains `AnnotateVideoProgress` (progress).
+      # `Operation.response` contains `AnnotateVideoResponse` (results).
+      rpc :AnnotateVideo, AnnotateVideoRequest, Google::Longrunning::Operation
     end
+
+    Stub = Service.rpc_stub_class
   end
 end
diff --git a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p2beta1/video_intelligence_pb.rb b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p2beta1/video_intelligence_pb.rb
index d05a4a729..ebe1a5852 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p2beta1/video_intelligence_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p2beta1/video_intelligence_pb.rb
@@ -154,37 +154,38 @@ end
 
 module Google
   module Cloud
-    module Videointelligence
-      module V1p2beta1
-        AnnotateVideoRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.AnnotateVideoRequest").msgclass
-        VideoContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.VideoContext").msgclass
-        LabelDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.LabelDetectionConfig").msgclass
-        ShotChangeDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.ShotChangeDetectionConfig").msgclass
-        ExplicitContentDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.ExplicitContentDetectionConfig").msgclass
-        TextDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.TextDetectionConfig").msgclass
-        VideoSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.VideoSegment").msgclass
-        LabelSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.LabelSegment").msgclass
-        LabelFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.LabelFrame").msgclass
-        Entity = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.Entity").msgclass
-        LabelAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.LabelAnnotation").msgclass
-        ExplicitContentFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.ExplicitContentFrame").msgclass
-        ExplicitContentAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.ExplicitContentAnnotation").msgclass
-        NormalizedBoundingBox = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.NormalizedBoundingBox").msgclass
-        VideoAnnotationResults = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.VideoAnnotationResults").msgclass
-        AnnotateVideoResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.AnnotateVideoResponse").msgclass
-        VideoAnnotationProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.VideoAnnotationProgress").msgclass
-        AnnotateVideoProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.AnnotateVideoProgress").msgclass
-        NormalizedVertex = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.NormalizedVertex").msgclass
-        NormalizedBoundingPoly = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.NormalizedBoundingPoly").msgclass
-        TextSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.TextSegment").msgclass
-        TextFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.TextFrame").msgclass
-        TextAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.TextAnnotation").msgclass
-        ObjectTrackingFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.ObjectTrackingFrame").msgclass
-        ObjectTrackingAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.ObjectTrackingAnnotation").msgclass
-        Feature = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.Feature").enummodule
-        LabelDetectionMode = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.LabelDetectionMode").enummodule
-        Likelihood = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.Likelihood").enummodule
-      end
+    module VideoIntelligence
     end
+    Videointelligence = VideoIntelligence unless const_defined? :Videointelligence
   end
 end
+module Google::Cloud::VideoIntelligence::V1p2beta1
+  AnnotateVideoRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.AnnotateVideoRequest").msgclass
+  VideoContext = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.VideoContext").msgclass
+  LabelDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.LabelDetectionConfig").msgclass
+  ShotChangeDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.ShotChangeDetectionConfig").msgclass
+  ExplicitContentDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.ExplicitContentDetectionConfig").msgclass
+  TextDetectionConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.TextDetectionConfig").msgclass
+  VideoSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.VideoSegment").msgclass
+  LabelSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.LabelSegment").msgclass
+  LabelFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.LabelFrame").msgclass
+  Entity = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.Entity").msgclass
+  LabelAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.LabelAnnotation").msgclass
+  ExplicitContentFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.ExplicitContentFrame").msgclass
+  ExplicitContentAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.ExplicitContentAnnotation").msgclass
+  NormalizedBoundingBox = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.NormalizedBoundingBox").msgclass
+  VideoAnnotationResults = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.VideoAnnotationResults").msgclass
+  AnnotateVideoResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.AnnotateVideoResponse").msgclass
+  VideoAnnotationProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.VideoAnnotationProgress").msgclass
+  AnnotateVideoProgress = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.AnnotateVideoProgress").msgclass
+  NormalizedVertex = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.NormalizedVertex").msgclass
+  NormalizedBoundingPoly = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.NormalizedBoundingPoly").msgclass
+  TextSegment = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.TextSegment").msgclass
+  TextFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.TextFrame").msgclass
+  TextAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.TextAnnotation").msgclass
+  ObjectTrackingFrame = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.ObjectTrackingFrame").msgclass
+  ObjectTrackingAnnotation = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.ObjectTrackingAnnotation").msgclass
+  Feature = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.Feature").enummodule
+  LabelDetectionMode = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.LabelDetectionMode").enummodule
+  Likelihood = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.videointelligence.v1p2beta1.Likelihood").enummodule
+end
diff --git a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p2beta1/video_intelligence_services_pb.rb b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p2beta1/video_intelligence_services_pb.rb
index 4f518ed07..5b8de29ea 100644
--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p2beta1/video_intelligence_services_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1p2beta1/video_intelligence_services_pb.rb
@@ -1,5 +1,5 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
-# Source: google/cloud/videointelligence/v1p2beta1/video_intelligence.proto for package 'google.cloud.videointelligence.v1p2beta1'
+# Source: google/cloud/videointelligence/v1p2beta1/video_intelligence.proto for package 'Google::Cloud::VideoIntelligence::V1p2beta1'
 # Original file comments:
 # Copyright 2018 Google LLC.
 #
@@ -23,28 +23,29 @@ require 'google/cloud/videointelligence/v1p2beta1/video_intelligence_pb'
 
 module Google
   module Cloud
-    module Videointelligence
-      module V1p2beta1
-        module VideoIntelligenceService
-          # Service that implements Google Cloud Video Intelligence API.
-          class Service
-
-            include GRPC::GenericService
+    module VideoIntelligence
+    end
+    Videointelligence = VideoIntelligence unless const_defined? :Videointelligence
+  end
+end
+module Google::Cloud::VideoIntelligence::V1p2beta1
+  module VideoIntelligenceService
+    # Service that implements Google Cloud Video Intelligence API.
+    class Service
 
-            self.marshal_class_method = :encode
-            self.unmarshal_class_method = :decode
-            self.service_name = 'google.cloud.videointelligence.v1p2beta1.VideoIntelligenceService'
+      include GRPC::GenericService
 
-            # Performs asynchronous video annotation. Progress and results can be
-            # retrieved through the `google.longrunning.Operations` interface.
-            # `Operation.metadata` contains `AnnotateVideoProgress` (progress).
-            # `Operation.response` contains `AnnotateVideoResponse` (results).
-            rpc :AnnotateVideo, AnnotateVideoRequest, Google::Longrunning::Operation
-          end
+      self.marshal_class_method = :encode
+      self.unmarshal_class_method = :decode
+      self.service_name = 'google.cloud.videointelligence.v1p2beta1.VideoIntelligenceService'
 
-          Stub = Service.rpc_stub_class
-        end
-      end
+      # Performs asynchronous video annotation. Progress and results can be
+      # retrieved through the `google.longrunning.Operations` interface.
+      # `Operation.metadata` contains `AnnotateVideoProgress` (progress).
+      # `Operation.response` contains `AnnotateVideoResponse` (results).
+      rpc :AnnotateVideo, AnnotateVideoRequest, Google::Longrunning::Operation
     end
+
+    Stub = Service.rpc_stub_class
   end
 end
diff --git a/google-cloud-video_intelligence/synth.metadata b/google-cloud-video_intelligence/synth.metadata
index f5f69de4f..f8e7df0c9 100644
--- a/google-cloud-video_intelligence/synth.metadata
+++ b/google-cloud-video_intelligence/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-14T10:44:48.002538Z",
+  "updateTime": "2019-07-01T22:23:25.387249Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.25.0",
-        "dockerImage": "googleapis/artman@sha256:ef1a98ab1e2b8f05f4d9a56f27d63347aefe14020e5f2d585172b14ca76f1d90"
+        "version": "0.29.3",
+        "dockerImage": "googleapis/artman@sha256:8900f94a81adaab0238965aa8a7b3648791f4f3a95ee65adc6a56cfcc3753101"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "c23b68eecb00c4d285a730a49b1d7d943cd56183",
-        "internalRef": "253113405"
+        "sha": "5322233f8cbec4d3f8c17feca2507ef27d4a07c9",
+        "internalRef": "256042411"
       }
     },
     {
diff --git a/google-cloud-video_intelligence/synth.py b/google-cloud-video_intelligence/synth.py
index 6615f2bf5..2bec03abc 100644
--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -83,6 +83,51 @@ s.copy(v1beta2_library / 'test/google/cloud/video_intelligence/v1beta2')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/video_intelligence.rb',
+        'lib/google/cloud/video_intelligence/v*.rb',
+        'lib/google/cloud/video_intelligence/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/video_intelligence/v*.rb',
+        'lib/google/cloud/video_intelligence/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/video_intelligence/v*.rb',
+        'lib/google/cloud/video_intelligence/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/video_intelligence/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/video_intelligence/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-video_intelligence.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # PERMANENT: API name for videointelligence
 s.replace(
     [
@@ -178,3 +223,21 @@ for version in ['v1', 'v1beta1', 'v1beta2', 'v1p1beta1', 'v1p2beta1']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::VideoIntelligence::VERSION'
     )
+
+# https://github.com/googleapis/gapic-generator/issues/2525
+s.replace(
+    'lib/google/cloud/video_intelligence/v*/**/*.rb',
+    'Google::Cloud::Videointelligence',
+    'Google::Cloud::VideoIntelligence')
+s.replace(
+    'lib/google/cloud/video_intelligence/v*/doc/google/cloud/videointelligence/**/*.rb',
+    '\n    module Videointelligence\n',
+    '\n    module VideoIntelligence\n'
+)
+
+# https://github.com/protocolbuffers/protobuf/issues/5584
+s.replace(
+    'lib/google/cloud/videointelligence/v*/*_pb.rb',
+    '\nmodule Google::Cloud::VideoIntelligence::V(\\w+)\n',
+    '\nmodule Google\n  module Cloud\n    module VideoIntelligence\n    end\n    Videointelligence = VideoIntelligence unless const_defined? :Videointelligence\n  end\nend\nmodule Google::Cloud::VideoIntelligence::V\\1\n',
+)

```

</details>

This pull request was generated using releasetool.