### PR TITLE
Release google-cloud-vision 0.34.0

### DIFF
--- a/google-cloud-vision/CHANGELOG.md
+++ b/google-cloud-vision/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.34.0 / 2019-07-08
+
+* Support overriding service host and port.
+
 ### 0.33.1 / 2019-06-11
 
 * Update product category documentation.

--- a/google-cloud-vision/lib/google/cloud/vision/version.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Vision
-      VERSION = "0.33.1".freeze
+      VERSION = "0.34.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit 7382dd0d1434facf4c5ff8d93a298a390f72095e
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 13:19:49 2019 -0700

    feat(vision): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-vision/google-cloud-vision.gemspec b/google-cloud-vision/google-cloud-vision.gemspec
index 0ffb5cc0d..2949ff63e 100644
--- a/google-cloud-vision/google-cloud-vision.gemspec
+++ b/google-cloud-vision/google-cloud-vision.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
diff --git a/google-cloud-vision/lib/google/cloud/vision.rb b/google-cloud-vision/lib/google/cloud/vision.rb
index 4368caf3d..509a4ae12 100644
--- a/google-cloud-vision/lib/google/cloud/vision.rb
+++ b/google-cloud-vision/lib/google/cloud/vision.rb
@@ -148,6 +148,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
@@ -215,6 +219,10 @@ module Google
         #     The default timeout, in seconds, for calls made through this client.
         #   @param metadata [Hash]
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+        #   @param service_address [String]
+        #     Override for the service hostname, or `nil` to leave as the default.
+        #   @param service_port [Integer]
+        #     Override for the service port, or `nil` to leave as the default.
         #   @param exception_transformer [Proc]
         #     An optional proc that intercepts any exceptions raised during an API call to inject
         #     custom error handling.
diff --git a/google-cloud-vision/lib/google/cloud/vision/v1.rb b/google-cloud-vision/lib/google/cloud/vision/v1.rb
index f84a88567..c7a4f4f38 100644
--- a/google-cloud-vision/lib/google/cloud/vision/v1.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1.rb
@@ -133,6 +133,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -142,6 +146,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -153,6 +159,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Vision::V1::ImageAnnotatorClient.new(**kwargs)
@@ -204,6 +212,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -213,6 +225,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -224,6 +238,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Vision::V1::ProductSearchClient.new(**kwargs)
diff --git a/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_client.rb b/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_client.rb
index fdcd56a42..bc2d2e803 100644
--- a/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_client.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_client.rb
@@ -95,6 +95,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -104,6 +108,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -121,7 +127,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -166,8 +175,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @image_annotator_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-vision/lib/google/cloud/vision/v1/product_search_client.rb b/google-cloud-vision/lib/google/cloud/vision/v1/product_search_client.rb
index 763f9bb72..d94aa7014 100644
--- a/google-cloud-vision/lib/google/cloud/vision/v1/product_search_client.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/product_search_client.rb
@@ -205,6 +205,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -214,6 +218,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -231,7 +237,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -277,8 +286,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @product_search_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-vision/lib/google/cloud/vision/v1p3beta1.rb b/google-cloud-vision/lib/google/cloud/vision/v1p3beta1.rb
index 4acdb0b50..542afb78e 100644
--- a/google-cloud-vision/lib/google/cloud/vision/v1p3beta1.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1p3beta1.rb
@@ -148,6 +148,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -157,6 +161,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -168,6 +174,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Vision::V1p3beta1::ProductSearchClient.new(**kwargs)
@@ -206,6 +214,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -215,6 +227,8 @@ module Google
               client_config: nil,
               timeout: nil,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: nil
@@ -226,6 +240,8 @@ module Google
               metadata: metadata,
               exception_transformer: exception_transformer,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version
             }.select { |_, v| v != nil }
             Google::Cloud::Vision::V1p3beta1::ImageAnnotatorClient.new(**kwargs)
diff --git a/google-cloud-vision/lib/google/cloud/vision/v1p3beta1/image_annotator_client.rb b/google-cloud-vision/lib/google/cloud/vision/v1p3beta1/image_annotator_client.rb
index 26d07328d..9c8e5bc0a 100644
--- a/google-cloud-vision/lib/google/cloud/vision/v1p3beta1/image_annotator_client.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1p3beta1/image_annotator_client.rb
@@ -95,6 +95,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -104,6 +108,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -121,7 +127,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -166,8 +175,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @image_annotator_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-vision/lib/google/cloud/vision/v1p3beta1/product_search_client.rb b/google-cloud-vision/lib/google/cloud/vision/v1p3beta1/product_search_client.rb
index df881f71e..0e0006dd2 100644
--- a/google-cloud-vision/lib/google/cloud/vision/v1p3beta1/product_search_client.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1p3beta1/product_search_client.rb
@@ -207,6 +207,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -216,6 +220,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -233,7 +239,10 @@ module Google
               client_config: client_config,
               timeout: timeout,
               lib_name: lib_name,
+              service_address: service_address,
+              service_port: service_port,
               lib_version: lib_version,
+              metadata: metadata,
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
@@ -279,8 +288,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @product_search_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-vision/synth.metadata b/google-cloud-vision/synth.metadata
index 0a6837505..323f66467 100644
--- a/google-cloud-vision/synth.metadata
+++ b/google-cloud-vision/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-05-30T00:08:48.391017Z",
+  "updateTime": "2019-07-01T10:47:22.933938Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.21.0",
-        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
-        "internalRef": "250569499"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     },
     {
diff --git a/google-cloud-vision/synth.py b/google-cloud-vision/synth.py
index c72d907fd..aa0715f56 100644
--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -52,6 +52,51 @@ s.copy(v1p3beta1 / 'test/google/cloud/vision/v1p3beta1')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/vision.rb',
+        'lib/google/cloud/vision/v*.rb',
+        'lib/google/cloud/vision/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/vision/v*.rb',
+        'lib/google/cloud/vision/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/vision/v*.rb',
+        'lib/google/cloud/vision/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/vision/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/vision/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-vision.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # PERMANENT: Add migration guide to docs
 s.replace(
     'lib/google/cloud/vision.rb',
@@ -179,11 +224,3 @@ for version in ['v1', 'v1p3beta1']:
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)
-
-# Exception tests have to check for both custom errors and retry wrapper errors
-for version in ['v1', 'v1p3beta1']:
-    s.replace(
-        f'test/google/cloud/vision/{version}/*_client_test.rb',
-        'err = assert_raises Google::Gax::GaxError do',
-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'
-    )

```

</details>

This pull request was generated using releasetool.