### PR TITLE
Release google-cloud-webrisk 0.2.0

### DIFF
--- a/google-cloud-webrisk/CHANGELOG.md
+++ b/google-cloud-webrisk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.0 / 2019-07-08
+
+* Support overriding service host and port.
+
 ### 0.1.2 / 2019-06-11
 
 * Add VERSION constant

--- a/google-cloud-webrisk/lib/google/cloud/webrisk/version.rb
+++ b/google-cloud-webrisk/lib/google/cloud/webrisk/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Webrisk
-      VERSION = "0.1.2".freeze
+      VERSION = "0.2.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Support overriding service host and port.

<details><summary>Commits since previous release</summary><pre><code>commit fbdc85ba8838e12aeed6b8bc015806431e47dcee
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 13:20:15 2019 -0700

    feat(webrisk): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients

commit 05bc375c1586649e34c3e44a54acc50571975c84
Author: Chris Smith <quartzmo@gmail.com>
Date:   Mon Jun 17 14:38:01 2019 -0600

    test(webrisk): add TargetRubyVersion: 2.2 to .rubocop.yml
    
    
    [pr #3495]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-webrisk/.rubocop.yml b/google-cloud-webrisk/.rubocop.yml
index 75a2e8526..b06f898b4 100644
--- a/google-cloud-webrisk/.rubocop.yml
+++ b/google-cloud-webrisk/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.2
   Exclude:
     - "google-cloud-webrisk.gemspec"
     - "lib/google/**/*"
diff --git a/google-cloud-webrisk/google-cloud-webrisk.gemspec b/google-cloud-webrisk/google-cloud-webrisk.gemspec
index 22119b8c2..a43a012d0 100644
--- a/google-cloud-webrisk/google-cloud-webrisk.gemspec
+++ b/google-cloud-webrisk/google-cloud-webrisk.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
diff --git a/google-cloud-webrisk/lib/google/cloud/webrisk.rb b/google-cloud-webrisk/lib/google/cloud/webrisk.rb
index 34ed7f28b..21474a428 100644
--- a/google-cloud-webrisk/lib/google/cloud/webrisk.rb
+++ b/google-cloud-webrisk/lib/google/cloud/webrisk.rb
@@ -120,6 +120,10 @@ module Google
       #     The default timeout, in seconds, for calls made through this client.
       #   @param metadata [Hash]
       #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param service_address [String]
+      #     Override for the service hostname, or `nil` to leave as the default.
+      #   @param service_port [Integer]
+      #     Override for the service port, or `nil` to leave as the default.
       #   @param exception_transformer [Proc]
       #     An optional proc that intercepts any exceptions raised during an API call to inject
       #     custom error handling.
diff --git a/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1.rb b/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1.rb
index b6abd796d..dee91962d 100644
--- a/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1.rb
+++ b/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1.rb
@@ -108,6 +108,10 @@ module Google
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param service_address [String]
+        #   Override for the service hostname, or `nil` to leave as the default.
+        # @param service_port [Integer]
+        #   Override for the service port, or `nil` to leave as the default.
         # @param exception_transformer [Proc]
         #   An optional proc that intercepts any exceptions raised during an API call to inject
         #   custom error handling.
@@ -117,6 +121,8 @@ module Google
             client_config: nil,
             timeout: nil,
             metadata: nil,
+            service_address: nil,
+            service_port: nil,
             exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
@@ -128,6 +134,8 @@ module Google
             metadata: metadata,
             exception_transformer: exception_transformer,
             lib_name: lib_name,
+            service_address: service_address,
+            service_port: service_port,
             lib_version: lib_version
           }.select { |_, v| v != nil }
           Google::Cloud::Webrisk::V1beta1::WebRiskServiceV1Beta1Client.new(**kwargs)
diff --git a/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1/web_risk_service_v1_beta1_client.rb b/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1/web_risk_service_v1_beta1_client.rb
index f268e03a7..b7883ce46 100644
--- a/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1/web_risk_service_v1_beta1_client.rb
+++ b/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1/web_risk_service_v1_beta1_client.rb
@@ -86,6 +86,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -95,6 +99,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -148,8 +154,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @web_risk_service_v1_beta1_stub = Google::Gax::Grpc.create_stub(
               service_path,
diff --git a/google-cloud-webrisk/synth.metadata b/google-cloud-webrisk/synth.metadata
index 5e2d6ad87..1408e685e 100644
--- a/google-cloud-webrisk/synth.metadata
+++ b/google-cloud-webrisk/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-04T19:33:40.470247Z",
+  "updateTime": "2019-07-01T10:47:37.714440Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.23.0",
-        "dockerImage": "googleapis/artman@sha256:846102ebf7ea2239162deea69f64940443b4147f7c2e68d64b332416f74211ba"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0026f4b890ed9e2388fb0573c0727defa6f5b82e",
-        "internalRef": "251265049"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     },
     {
diff --git a/google-cloud-webrisk/synth.py b/google-cloud-webrisk/synth.py
index bd84d1a8a..2f854cbf7 100644
--- a/google-cloud-webrisk/synth.py
+++ b/google-cloud-webrisk/synth.py
@@ -29,7 +29,6 @@ v1beta1 = gapic.ruby_library(
 )
 
 s.copy(v1beta1 / 'lib')
-s.copy(v1beta1 / 'acceptance')
 s.copy(v1beta1 / 'test')
 s.copy(v1beta1 / 'README.md')
 s.copy(v1beta1 / 'LICENSE')
@@ -41,6 +40,51 @@ s.copy(v1beta1 / 'google-cloud-webrisk.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Support for service_address
+s.replace(
+    [
+        'lib/google/cloud/webrisk.rb',
+        'lib/google/cloud/webrisk/v*.rb',
+        'lib/google/cloud/webrisk/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/google/cloud/webrisk/v*.rb',
+        'lib/google/cloud/webrisk/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/google/cloud/webrisk/v*.rb',
+        'lib/google/cloud/webrisk/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/google/cloud/webrisk/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/webrisk/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'google-cloud-webrisk.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
     f'lib/google/cloud/webrisk/v1beta1/*_client.rb',

```

</details>

This pull request was generated using releasetool.