### PR TITLE
Release grafeas-client 0.2.0

### DIFF
--- a/grafeas-client/CHANGELOG.md
+++ b/grafeas-client/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Release History
+### 0.2.0 / 2019-07-08
+
+* Support overriding service host and port.
+* VulnerabilityNote::Detail changes:
+    * BREAKING CHANGE: Remove min_affected_version
+    * Add affected_version_start
+    * Add affected_version_end
+* VulnerabilityOccurrence::PackageIssue changes:
+    * Remove min_affected_version
+    * Add affected_version
+
 ### 0.1.0 / 2019-06-21
 
 * Initial release.

--- a/grafeas-client/lib/grafeas/version.rb
+++ b/grafeas-client/lib/grafeas/version.rb
@@ -14,5 +14,5 @@
 
 
 module Grafeas
-  VERSION = "0.1.0".freeze
+  VERSION = "0.2.0".freeze
 end


### PR DESCRIPTION
* Support overriding service host and port.
* VulnerabilityNote::Detail changes:
    * BREAKING CHANGE: Remove min_affected_version
    * Add affected_version_start
    * Add affected_version_end
* VulnerabilityOccurrence::PackageIssue changes:
    * Remove min_affected_version
    * Add affected_version

<details><summary>Commits since previous release</summary><pre><code>commit 1723909568c088d6482ebfba3b80f44cf03a41bf
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 13:20:43 2019 -0700

    feat(grafeas-client): Add service_address and service_port to client constructor

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients

commit 958504233d533675248647aa0e405ad0fa5d3691
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jun 24 14:17:15 2019 -0700

    feat(grafeas-client): remove min_affected_version
    
    BREAKING CHANGE: remove min_affected_version from VulnerabilityNote::Detail and
    VulnerabilityOccurrence::PackageIssue.
    
    * VulnerabilityNote::Detail changes:
      * Remove min_affected_version
      * Add affected_version_start
      * Add affected_version_end
    * VulnerabilityOccurrence::PackageIssue changes:
      * Remove min_affected_version
      * Add affected_version
    
    [pr #3524]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/grafeas-client/grafeas-client.gemspec b/grafeas-client/grafeas-client.gemspec
index e867ac6c2..58247e7c9 100644
--- a/grafeas-client/grafeas-client.gemspec
+++ b/grafeas-client/grafeas-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"
diff --git a/grafeas-client/lib/grafeas.rb b/grafeas-client/lib/grafeas.rb
index ebdb1acbd..024081314 100644
--- a/grafeas-client/lib/grafeas.rb
+++ b/grafeas-client/lib/grafeas.rb
@@ -131,6 +131,10 @@ module Grafeas
   #     The default timeout, in seconds, for calls made through this client.
   #   @param metadata [Hash]
   #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+  #   @param service_address [String]
+  #     Override for the service hostname, or `nil` to leave as the default.
+  #   @param service_port [Integer]
+  #     Override for the service port, or `nil` to leave as the default.
   #   @param exception_transformer [Proc]
   #     An optional proc that intercepts any exceptions raised during an API call to inject
   #     custom error handling.
diff --git a/grafeas-client/lib/grafeas/v1.rb b/grafeas-client/lib/grafeas/v1.rb
index c6e1fddc6..55571d660 100644
--- a/grafeas-client/lib/grafeas/v1.rb
+++ b/grafeas-client/lib/grafeas/v1.rb
@@ -119,6 +119,10 @@ module Grafeas
     #   The default timeout, in seconds, for calls made through this client.
     # @param metadata [Hash]
     #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+    # @param service_address [String]
+    #   Override for the service hostname, or `nil` to leave as the default.
+    # @param service_port [Integer]
+    #   Override for the service port, or `nil` to leave as the default.
     # @param exception_transformer [Proc]
     #   An optional proc that intercepts any exceptions raised during an API call to inject
     #   custom error handling.
@@ -128,6 +132,8 @@ module Grafeas
         client_config: nil,
         timeout: nil,
         metadata: nil,
+        service_address: nil,
+        service_port: nil,
         exception_transformer: nil,
         lib_name: nil,
         lib_version: nil
@@ -139,6 +145,8 @@ module Grafeas
         metadata: metadata,
         exception_transformer: exception_transformer,
         lib_name: lib_name,
+        service_address: service_address,
+        service_port: service_port,
         lib_version: lib_version
       }.select { |_, v| v != nil }
       Grafeas::V1::GrafeasClient.new(**kwargs)
diff --git a/grafeas-client/lib/grafeas/v1/doc/grafeas/v1/vulnerability.rb b/grafeas-client/lib/grafeas/v1/doc/grafeas/v1/vulnerability.rb
index d72a9a04e..c37e9775b 100644
--- a/grafeas-client/lib/grafeas/v1/doc/grafeas/v1/vulnerability.rb
+++ b/grafeas-client/lib/grafeas/v1/doc/grafeas/v1/vulnerability.rb
@@ -55,22 +55,39 @@ module Grafeas
       # @!attribute [rw] affected_package
       #   @return [String]
       #     Required. The package this vulnerability affects.
-      # @!attribute [rw] min_affected_version
+      # @!attribute [rw] affected_version_start
       #   @return [Grafeas::V1::Version]
-      #     Required. The minimum version of the package this vulnerability affects.
+      #     The version number at the start of an interval in which this
+      #     vulnerability exists. A vulnerability can affect a package between
+      #     version numbers that are disjoint sets of intervals (example:
+      #     [1.0.0-1.1.0], [2.4.6-2.4.8] and [4.5.6-4.6.8]) each of which will be
+      #     represented in its own Detail. If a specific affected version is provided
+      #     by a vulnerability database, affected_version_start and
+      #     affected_version_end will be the same in that Detail.
+      # @!attribute [rw] affected_version_end
+      #   @return [Grafeas::V1::Version]
+      #     The version number at the end of an interval in which this vulnerability
+      #     exists. A vulnerability can affect a package between version numbers
+      #     that are disjoint sets of intervals (example: [1.0.0-1.1.0],
+      #     [2.4.6-2.4.8] and [4.5.6-4.6.8]) each of which will be represented in its
+      #     own Detail. If a specific affected version is provided by a vulnerability
+      #     database, affected_version_start and affected_version_end will be the
+      #     same in that Detail.
       # @!attribute [rw] fixed_cpe_uri
       #   @return [String]
-      #     The [CPE URI](https://cpe.mitre.org/specification/) this vulnerability
-      #     was fixed in. It is possible for this to be different from the
-      #     affected_cpe_uri.
+      #     The distro recommended [CPE URI](https://cpe.mitre.org/specification/)
+      #     to update to that contains a fix for this vulnerability. It is possible
+      #     for this to be different from the affected_cpe_uri.
       # @!attribute [rw] fixed_package
       #   @return [String]
-      #     The package this vulnerability was fixed in. It is possible for this to
-      #     be different from the affected_package.
+      #     The distro recommended package to update to that contains a fix for this
+      #     vulnerability. It is possible for this to be different from the
+      #     affected_package.
       # @!attribute [rw] fixed_version
       #   @return [Grafeas::V1::Version]
-      #     Required. The version of the package this vulnerability was fixed in.
-      #     Setting this to VersionKind.MAXIMUM means no fix is yet available.
+      #     The distro recommended version to update to that contains a
+      #     fix for this vulnerability. Setting this to VersionKind.MAXIMUM means no
+      #     such version is yet available.
       # @!attribute [rw] is_obsolete
       #   @return [true, false]
       #     Whether this detail is obsolete. Occurrences are expected not to point to
@@ -150,10 +167,10 @@ module Grafeas
       # @!attribute [rw] affected_package
       #   @return [String]
       #     Required. The package this vulnerability was found in.
-      # @!attribute [rw] min_affected_version
+      # @!attribute [rw] affected_version
       #   @return [Grafeas::V1::Version]
-      #     Required. The minimum version of the package this vulnerability exists
-      #     in.
+      #     Required. The version of the package that is installed on the resource
+      #     affected by this vulnerability.
       # @!attribute [rw] fixed_cpe_uri
       #   @return [String]
       #     The [CPE URI](https://cpe.mitre.org/specification/) this vulnerability
diff --git a/grafeas-client/lib/grafeas/v1/grafeas_client.rb b/grafeas-client/lib/grafeas/v1/grafeas_client.rb
index f7d67c859..1b7e19704 100644
--- a/grafeas-client/lib/grafeas/v1/grafeas_client.rb
+++ b/grafeas-client/lib/grafeas/v1/grafeas_client.rb
@@ -162,6 +162,10 @@ module Grafeas
       #   The default timeout, in seconds, for calls made through this client.
       # @param metadata [Hash]
       #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+      # @param service_address [String]
+      #   Override for the service hostname, or `nil` to leave as the default.
+      # @param service_port [Integer]
+      #   Override for the service port, or `nil` to leave as the default.
       # @param exception_transformer [Proc]
       #   An optional proc that intercepts any exceptions raised during an API call to inject
       #   custom error handling.
@@ -171,6 +175,8 @@ module Grafeas
           client_config: {},
           timeout: DEFAULT_TIMEOUT,
           metadata: nil,
+          service_address: nil,
+          service_port: nil,
           exception_transformer: nil,
           lib_name: nil,
           lib_version: ""
@@ -225,8 +231,8 @@ module Grafeas
         end
 
         # Allow overriding the service path/port in subclasses.
-        service_path = self.class::SERVICE_ADDRESS
-        port = self.class::DEFAULT_SERVICE_PORT
+        service_path = service_address || self.class::SERVICE_ADDRESS
+        port = service_port || self.class::DEFAULT_SERVICE_PORT
         interceptors = self.class::GRPC_INTERCEPTORS
         @grafeas_stub = Google::Gax::Grpc.create_stub(
           service_path,
diff --git a/grafeas-client/lib/grafeas/v1/vulnerability_pb.rb b/grafeas-client/lib/grafeas/v1/vulnerability_pb.rb
index b2244f24b..e50a37e17 100644
--- a/grafeas-client/lib/grafeas/v1/vulnerability_pb.rb
+++ b/grafeas-client/lib/grafeas/v1/vulnerability_pb.rb
@@ -21,11 +21,12 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :package_type, :string, 3
     optional :affected_cpe_uri, :string, 4
     optional :affected_package, :string, 5
-    optional :min_affected_version, :message, 6, "grafeas.v1.Version"
-    optional :fixed_cpe_uri, :string, 7
-    optional :fixed_package, :string, 8
-    optional :fixed_version, :message, 9, "grafeas.v1.Version"
-    optional :is_obsolete, :bool, 10
+    optional :affected_version_start, :message, 6, "grafeas.v1.Version"
+    optional :affected_version_end, :message, 7, "grafeas.v1.Version"
+    optional :fixed_cpe_uri, :string, 8
+    optional :fixed_package, :string, 9
+    optional :fixed_version, :message, 10, "grafeas.v1.Version"
+    optional :is_obsolete, :bool, 11
   end
   add_message "grafeas.v1.VulnerabilityNote.WindowsDetail" do
     optional :cpe_uri, :string, 1
@@ -51,7 +52,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "grafeas.v1.VulnerabilityOccurrence.PackageIssue" do
     optional :affected_cpe_uri, :string, 1
     optional :affected_package, :string, 2
-    optional :min_affected_version, :message, 3, "grafeas.v1.Version"
+    optional :affected_version, :message, 3, "grafeas.v1.Version"
     optional :fixed_cpe_uri, :string, 4
     optional :fixed_package, :string, 5
     optional :fixed_version, :message, 6, "grafeas.v1.Version"
diff --git a/grafeas-client/synth.metadata b/grafeas-client/synth.metadata
index 341b32d1e..39a29e154 100644
--- a/grafeas-client/synth.metadata
+++ b/grafeas-client/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-17T18:46:33.369562Z",
+  "updateTime": "2019-07-01T10:47:53.468500Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.26.0",
-        "dockerImage": "googleapis/artman@sha256:6db0735b0d3beec5b887153a2a7c7411fc7bb53f73f6f389a822096bd14a3a15"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7b58b37559f6a5337c4c564518e9573d742df225",
-        "internalRef": "253322136"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     },
     {
diff --git a/grafeas-client/synth.py b/grafeas-client/synth.py
index ae96ced11..9ace8bafa 100644
--- a/grafeas-client/synth.py
+++ b/grafeas-client/synth.py
@@ -96,6 +96,51 @@ s.replace(
     'V1::GrafeasService::'
 )
 
+# Support for service_address
+s.replace(
+    [
+        'lib/grafeas.rb',
+        'lib/grafeas/v*.rb',
+        'lib/grafeas/v*/*_client.rb'
+    ],
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    [
+        'lib/grafeas/v*.rb',
+        'lib/grafeas/v*/*_client.rb'
+    ],
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    [
+        'lib/grafeas/v*.rb',
+        'lib/grafeas/v*/*_client.rb'
+    ],
+    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',
+    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'
+)
+s.replace(
+    'lib/grafeas/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/grafeas/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+s.replace(
+    'grafeas-client.gemspec',
+    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
+    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [

```

</details>

This pull request was generated using releasetool.