### PR TITLE
Release google-cloud-pubsub 0.37.1

### DIFF
--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.37.1 / 2019-07-09
+
+* Add IAM GetPolicyOptions in the lower-level interface.
+* Support overriding service host and port in the low-level interface.
+* Fixed race in TimedUnaryBuffer.
+
 ### 0.37.0 / 2019-06-17
 
 * Add Topic#persistence_regions

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module PubSub
-      VERSION = "0.37.0".freeze
+      VERSION = "0.37.1".freeze
     end
 
     Pubsub = PubSub unless const_defined? :Pubsub


### PR DESCRIPTION
* Add IAM GetPolicyOptions in the lower-level interface.
* Support overriding service host and port in the low-level interface.
* Fixed race in TimedUnaryBuffer.

<details><summary>Commits since previous release</summary><pre><code>commit 4b377494f0bc81e4190bb8533f586f6eed025df1
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Tue Jul 2 09:09:16 2019 -0700

    refactor(pubsub): Add IAM GetPolicyOptions in the lower-level API

commit 4f8c88d34b8cb27f4f0ad87be93c0ce5c808da35
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 12:17:28 2019 -0700

    feat(pubsub): Add service_address and service_port in the low-level interface

commit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients

commit 49a3948a9044e8d8e5f5f2bd9958803a6f7f66d5
Author: Daniel Azuma <dazuma@google.com>
Date:   Fri Jun 21 17:51:23 2019 -0700

    fix(pubsub): Fixed race in TimedUnaryBuffer
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-pubsub/google-cloud-pubsub.gemspec b/google-cloud-pubsub/google-cloud-pubsub.gemspec
index 7883135aa..44cfd7cea 100644
--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 1.3"
+  gem.add_dependency "google-gax", "~> 1.7"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
diff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
index ed92beabc..1abcaf2fa 100644
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
@@ -14,6 +14,7 @@
 
 
 require "concurrent"
+require "monitor"
 
 module Google
   module Cloud
@@ -22,9 +23,13 @@ module Google
         ##
         # @private
         class TimedUnaryBuffer
+          include MonitorMixin
+
           attr_reader :max_bytes, :interval
 
           def initialize subscriber, max_bytes: 10000000, interval: 1.0
+            super() # to init MonitorMixin
+
             @subscriber = subscriber
             @max_bytes = max_bytes
             @interval = interval
@@ -42,9 +47,11 @@ module Google
           def acknowledge ack_ids
             return if ack_ids.empty?
 
-            ack_ids.each do |ack_id|
-              # ack has no deadline set, use :ack indicate it is an ack
-              @register[ack_id] = :ack
+            synchronize do
+              ack_ids.each do |ack_id|
+                # ack has no deadline set, use :ack indicate it is an ack
+                @register[ack_id] = :ack
+              end
             end
 
             true
@@ -53,8 +60,10 @@ module Google
           def modify_ack_deadline deadline, ack_ids
             return if ack_ids.empty?
 
-            ack_ids.each do |ack_id|
-              @register[ack_id] = deadline
+            synchronize do
+              ack_ids.each do |ack_id|
+                @register[ack_id] = deadline
+              end
             end
 
             true
@@ -63,9 +72,11 @@ module Google
           def renew_lease deadline, ack_ids
             return if ack_ids.empty?
 
-            ack_ids.each do |ack_id|
-              # Do not overwrite pending actions when renewing leased messages.
-              @register[ack_id] ||= deadline
+            synchronize do
+              ack_ids.each do |ack_id|
+                # Don't overwrite pending actions when renewing leased messages.
+                @register[ack_id] ||= deadline
+              end
             end
 
             true
@@ -120,10 +131,13 @@ module Google
           private
 
           def flush_requests!
-            return {} if @register.empty?
-
-            prev_reg = @register
-            @register = Concurrent::Map.new
+            prev_reg =
+              synchronize do
+                return {} if @register.empty?
+                reg = @register
+                @register = Concurrent::Map.new
+                reg
+              end
 
             groups = prev_reg.each_pair.group_by { |_ack_id, delay| delay }
             req_hash = Hash[groups.map { |k, v| [k, v.map(&:first)] }]
diff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/iam/v1/options.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/iam/v1/options.rb
new file mode 100644
index 000000000..9a865a1d8
--- /dev/null
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/iam/v1/options.rb
@@ -0,0 +1,21 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Iam
+    module V1
+    end
+  end
+end
\ No newline at end of file
diff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_client.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_client.rb
index 620fd16be..bae96a519 100644
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_client.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_client.rb
@@ -146,6 +146,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -155,6 +159,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -211,8 +217,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @iam_policy_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -698,6 +704,11 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
           #   See the operation documentation for the appropriate value for this field.
+          # @param options_ [Google::Iam::V1::GetPolicyOptions | Hash]
+          #   OPTIONAL: A `GetPolicyOptions` object for specifying options to
+          #   `GetIamPolicy`. This field is only used by Cloud IAM.
+          #   A hash of the same form as `Google::Iam::V1::GetPolicyOptions`
+          #   can also be provided.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -715,10 +726,12 @@ module Google
 
           def get_iam_policy \
               resource,
+              options_: nil,
               options: nil,
               &block
             req = {
-              resource: resource
+              resource: resource,
+              options: options_
             }.delete_if { |_, v| v.nil? }
             req = Google::Gax::to_proto(req, Google::Iam::V1::GetIamPolicyRequest)
             @get_iam_policy.call(req, options, &block)
diff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client.rb
index f10ca9887..f58230c77 100644
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client.rb
@@ -170,6 +170,10 @@ module Google
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param service_address [String]
+          #   Override for the service hostname, or `nil` to leave as the default.
+          # @param service_port [Integer]
+          #   Override for the service port, or `nil` to leave as the default.
           # @param exception_transformer [Proc]
           #   An optional proc that intercepts any exceptions raised during an API call to inject
           #   custom error handling.
@@ -179,6 +183,8 @@ module Google
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
+              service_address: nil,
+              service_port: nil,
               exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
@@ -234,8 +240,8 @@ module Google
             end
 
             # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
+            service_path = service_address || self.class::SERVICE_ADDRESS
+            port = service_port || self.class::DEFAULT_SERVICE_PORT
             interceptors = self.class::GRPC_INTERCEPTORS
             @iam_policy_stub = Google::Gax::Grpc.create_stub(
               service_path,
@@ -1274,6 +1280,11 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
           #   See the operation documentation for the appropriate value for this field.
+          # @param options_ [Google::Iam::V1::GetPolicyOptions | Hash]
+          #   OPTIONAL: A `GetPolicyOptions` object for specifying options to
+          #   `GetIamPolicy`. This field is only used by Cloud IAM.
+          #   A hash of the same form as `Google::Iam::V1::GetPolicyOptions`
+          #   can also be provided.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1291,10 +1302,12 @@ module Google
 
           def get_iam_policy \
               resource,
+              options_: nil,
               options: nil,
               &block
             req = {
-              resource: resource
+              resource: resource,
+              options: options_
             }.delete_if { |_, v| v.nil? }
             req = Google::Gax::to_proto(req, Google::Iam::V1::GetIamPolicyRequest)
             @get_iam_policy.call(req, options, &block)
diff --git a/google-cloud-pubsub/synth.metadata b/google-cloud-pubsub/synth.metadata
index 26e2945e2..c20ef33b8 100644
--- a/google-cloud-pubsub/synth.metadata
+++ b/google-cloud-pubsub/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-04T19:29:56.267838Z",
+  "updateTime": "2019-07-02T10:41:01.966282Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.23.0",
-        "dockerImage": "googleapis/artman@sha256:846102ebf7ea2239162deea69f64940443b4147f7c2e68d64b332416f74211ba"
+        "version": "0.29.3",
+        "dockerImage": "googleapis/artman@sha256:8900f94a81adaab0238965aa8a7b3648791f4f3a95ee65adc6a56cfcc3753101"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0026f4b890ed9e2388fb0573c0727defa6f5b82e",
-        "internalRef": "251265049"
+        "sha": "5322233f8cbec4d3f8c17feca2507ef27d4a07c9",
+        "internalRef": "256042411"
       }
     }
   ],
diff --git a/google-cloud-pubsub/synth.py b/google-cloud-pubsub/synth.py
index 6ed5dc167..73406bc49 100644
--- a/google-cloud-pubsub/synth.py
+++ b/google-cloud-pubsub/synth.py
@@ -54,6 +54,32 @@ s.replace(
     '\n    end\n\n    Pubsub = PubSub unless const_defined? :Pubsub\n  end\nend'
 )
 
+# Support for service_address
+s.replace(
+    'lib/google/cloud/pubsub/v*/*_client.rb',
+    '\n(\\s+)#(\\s+)@param exception_transformer',
+    '\n\\1#\\2@param service_address [String]\n' +
+        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param service_port [Integer]\n' +
+        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +
+        '\\1#\\2@param exception_transformer'
+)
+s.replace(
+    'lib/google/cloud/pubsub/v*/*_client.rb',
+    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
+    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
+)
+s.replace(
+    'lib/google/cloud/pubsub/v*/*_client.rb',
+    'service_path = self\\.class::SERVICE_ADDRESS',
+    'service_path = service_address || self.class::SERVICE_ADDRESS'
+)
+s.replace(
+    'lib/google/cloud/pubsub/v*/*_client.rb',
+    'port = self\\.class::DEFAULT_SERVICE_PORT',
+    'port = service_port || self.class::DEFAULT_SERVICE_PORT'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2124
 s.replace(
     'lib/google/cloud/pubsub/v1/credentials.rb',

```

</details>

This pull request was generated using releasetool.