### PR TITLE
Release google-cloud-bigquery 1.12.0

### DIFF
--- a/google-cloud-bigquery/CHANGELOG.md
+++ b/google-cloud-bigquery/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History
 
+### 1.12.0 / 2019-07-09
+
+* Add BigQuery Model API
+  * Add Model
+  * Add StandardSql Field, DataType, StructType
+  * Add Dataset#model and Dataset#models
+* Correct Float value conversion
+  * Ensure that NaN, Infinity, and -Infinity are converted correctly.
+
 ### 1.11.2 / 2019-06-11
 
 * Update "Loading data" link

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigquery
-      VERSION = "1.11.2".freeze
+      VERSION = "1.12.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add BigQuery Model API
  * Add Model
  * Add StandardSql Field, DataType, StructType
  * Add Dataset#model and Dataset#models
* Correct Float value conversion
  * Ensure that NaN, Infinity, and -Infinity are converted correctly.

This pull request was generated using releasetool.