### PR TITLE
Fix JSON deserialization

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -748,8 +748,7 @@ module Google
         #
         def models token: nil, max: nil
           ensure_service!
-          options = { token: token, max: max }
-          gapi = service.list_models dataset_id, options
+          gapi = service.list_models dataset_id, token: token, max: max
           Model::List.from_gapi gapi, service, dataset_id, max
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/model/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/model/list.rb
@@ -72,8 +72,7 @@ module Google
           def next
             return nil unless next?
             ensure_service!
-            options = { token: token, max: @max }
-            gapi = @service.list_models @dataset_id, options
+            gapi = @service.list_models @dataset_id, token: token, max: @max
             self.class.from_gapi gapi, @service, @dataset_id, @max
           end
 
@@ -143,8 +142,7 @@ module Google
           end
 
           ##
-          # @private New Model::List from a
-          # Google::Apis::BigqueryV2::ListModelsResponse object.
+          # @private New Model::List from a response object.
           def self.from_gapi gapi_list, service, dataset_id = nil, max = nil
             models = List.new(Array(gapi_list[:models]).map do |gapi_json|
               Model.from_gapi_json gapi_json, service

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -241,12 +241,14 @@ module Google
         ##
         # Lists all models in the specified dataset.
         # Requires the READER dataset role.
-        def list_models dataset_id, options = {}
+        def list_models dataset_id, max: nil, token: nil
+          options = { skip_deserialization: true }
           # The list operation is considered idempotent
           execute backoff: true do
             json_txt = service.list_models @project, dataset_id,
-                                           max_results: options[:max],
-                                           page_token:  options[:token]
+                                           max_results: max,
+                                           page_token:  token,
+                                           options:     options
             JSON.parse json_txt, symbolize_names: true
           end
         end
@@ -258,7 +260,8 @@ module Google
         def get_model dataset_id, model_id
           # The get operation is considered idempotent
           execute backoff: true do
-            json_txt = service.get_model @project, dataset_id, model_id
+            json_txt = service.get_model @project, dataset_id, model_id,
+                                         options: { skip_deserialization: true }
             JSON.parse json_txt, symbolize_names: true
           end
         end
@@ -268,7 +271,7 @@ module Google
         # are provided in the submitted model resource.
         def patch_model dataset_id, model_id, patched_model_gapi, etag = nil
           patch_with_backoff = false
-          options = {}
+          options = { skip_deserialization: true }
           if etag
             options[:header] = { "If-Match" => etag }
             # The patch with etag operation is considered idempotent

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -250,7 +250,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigquery::Dataset#model" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, ["my-project", "my_dataset", "my_model"]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, ["my-project", "my_dataset", "my_model", Hash]
     end
   end
 
@@ -259,13 +259,13 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :list_models, list_models_gapi_json("my_dataset"), ["my-project", "my_dataset", Hash]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
     end
   end
 
@@ -503,11 +503,11 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigquery::Model" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, [String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
       mock.expect :list_models, list_models_gapi_json("my_dataset"), [String, String, Hash]
       mock.expect :patch_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Object, Hash]
       mock.expect :delete_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
@@ -517,11 +517,11 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigquery::Model::List" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, [String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
-      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
+      mock.expect :get_model, random_model_full_hash("my_dataset", "my_model").to_json, [String, String, String, Hash]
       mock.expect :list_models, list_models_gapi_json("my_dataset"), [String, String, Hash]
     end
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset/model_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset/model_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::Bigquery::Dataset, :model, :mock_bigquery do
     found_model_id = "found_model"
 
     mock = Minitest::Mock.new
-    mock.expect :get_model, random_model_full_hash(dataset.dataset_id, found_model_id).to_json, [project, dataset.dataset_id, found_model_id]
+    mock.expect :get_model, random_model_full_hash(dataset.dataset_id, found_model_id).to_json, [project, dataset.dataset_id, found_model_id, options: { skip_deserialization: true }]
     dataset.service.mocked_service = mock
 
     model = dataset.model found_model_id

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset/models_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset/models_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
   it "lists models" do
     mock = Minitest::Mock.new
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 3),
-      [project, dataset.dataset_id, max_results: nil, page_token: nil]
+      [project, dataset.dataset_id, max_results: nil, page_token: nil, options: { skip_deserialization: true }]
     dataset.service.mocked_service = mock
 
     models = dataset.models
@@ -36,7 +36,7 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
   it "lists models with max set" do
     mock = Minitest::Mock.new
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 3, "next_page_token"),
-      [project, dataset.dataset_id, max_results: 3, page_token: nil]
+      [project, dataset.dataset_id, max_results: 3, page_token: nil, options: { skip_deserialization: true }]
     dataset.service.mocked_service = mock
 
     models = dataset.models max: 3
@@ -52,9 +52,9 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
   it "paginates models" do
     mock = Minitest::Mock.new
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 3, "next_page_token"),
-      [project, dataset.dataset_id, max_results: nil, page_token: nil]
+      [project, dataset.dataset_id, max_results: nil, page_token: nil, options: { skip_deserialization: true }]
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 2, nil),
-      [project, dataset.dataset_id, max_results: nil, page_token: "next_page_token"]
+      [project, dataset.dataset_id, max_results: nil, page_token: "next_page_token", options: { skip_deserialization: true }]
     dataset.service.mocked_service = mock
 
     first_models = dataset.models
@@ -75,9 +75,9 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
   it "paginates models with next? and next" do
     mock = Minitest::Mock.new
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 3, "next_page_token"),
-      [project, dataset.dataset_id, max_results: nil, page_token: nil]
+      [project, dataset.dataset_id, max_results: nil, page_token: nil, options: { skip_deserialization: true }]
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 2, nil),
-      [project, dataset.dataset_id, max_results: nil, page_token: "next_page_token"]
+      [project, dataset.dataset_id, max_results: nil, page_token: "next_page_token", options: { skip_deserialization: true }]
     dataset.service.mocked_service = mock
 
     first_models = dataset.models
@@ -98,9 +98,9 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
   it "paginates models with next? and next and max" do
     mock = Minitest::Mock.new
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 3, "next_page_token"),
-      [project, dataset.dataset_id, max_results: 3, page_token: nil]
+      [project, dataset.dataset_id, max_results: 3, page_token: nil, options: { skip_deserialization: true }]
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 2, nil),
-      [project, dataset.dataset_id, max_results: 3, page_token: "next_page_token"]
+      [project, dataset.dataset_id, max_results: 3, page_token: "next_page_token", options: { skip_deserialization: true }]
     dataset.service.mocked_service = mock
 
     first_models = dataset.models max: 3
@@ -120,9 +120,9 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
   it "paginates models with all" do
     mock = Minitest::Mock.new
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 3, "next_page_token"),
-      [project, dataset.dataset_id, max_results: nil, page_token: nil]
+      [project, dataset.dataset_id, max_results: nil, page_token: nil, options: { skip_deserialization: true }]
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 2, nil),
-      [project, dataset.dataset_id, max_results: nil, page_token: "next_page_token"]
+      [project, dataset.dataset_id, max_results: nil, page_token: "next_page_token", options: { skip_deserialization: true }]
     dataset.service.mocked_service = mock
 
     models = dataset.models.all.to_a
@@ -136,9 +136,9 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
   it "paginates models with all and max" do
     mock = Minitest::Mock.new
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 3, "next_page_token"),
-      [project, dataset.dataset_id, max_results: 3, page_token: nil]
+      [project, dataset.dataset_id, max_results: 3, page_token: nil, options: { skip_deserialization: true }]
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 2, nil),
-      [project, dataset.dataset_id, max_results: 3, page_token: "next_page_token"]
+      [project, dataset.dataset_id, max_results: 3, page_token: "next_page_token", options: { skip_deserialization: true }]
     dataset.service.mocked_service = mock
 
     models = dataset.models(max: 3).all.to_a
@@ -152,9 +152,9 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
   it "iterates models with all using Enumerator" do
     mock = Minitest::Mock.new
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 3, "next_page_token"),
-      [project, dataset.dataset_id, max_results: nil, page_token: nil]
+      [project, dataset.dataset_id, max_results: nil, page_token: nil, options: { skip_deserialization: true }]
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 3, "second_page_token"),
-      [project, dataset.dataset_id, max_results: nil, page_token: "next_page_token"]
+      [project, dataset.dataset_id, max_results: nil, page_token: "next_page_token", options: { skip_deserialization: true }]
     dataset.service.mocked_service = mock
 
     models = dataset.models.all.take(5)
@@ -168,9 +168,9 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
   it "iterates models with all with request_limit set" do
     mock = Minitest::Mock.new
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 3, "next_page_token"),
-      [project, dataset.dataset_id, max_results: nil, page_token: nil]
+      [project, dataset.dataset_id, max_results: nil, page_token: nil, options: { skip_deserialization: true }]
     mock.expect :list_models, list_models_gapi_json(dataset.dataset_id, 3, "second_page_token"),
-      [project, dataset.dataset_id, max_results: nil, page_token: "next_page_token"]
+      [project, dataset.dataset_id, max_results: nil, page_token: "next_page_token", options: { skip_deserialization: true }]
     dataset.service.mocked_service = mock
 
     models = dataset.models.all(request_limit: 1).to_a

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/partial/attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/partial/attributes_test.rb
@@ -52,7 +52,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
   it "gets full data for name" do
     mock = Minitest::Mock.new
     mock.expect :get_model, model_full_hash.to_json,
-      [model.project_id, model.dataset_id, model.model_id]
+      [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.name.must_equal model_name
@@ -66,7 +66,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
   it "gets full data for description" do
     mock = Minitest::Mock.new
     mock.expect :get_model, model_full_hash.to_json,
-      [model.project_id, model.dataset_id, model.model_id]
+      [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.description.must_equal description
@@ -80,7 +80,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
   it "gets full data for etag" do
     mock = Minitest::Mock.new
     mock.expect :get_model, model_full_hash.to_json,
-      [model.project_id, model.dataset_id, model.model_id]
+      [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.etag.must_equal etag
@@ -94,7 +94,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
   it "gets full data for location" do
     mock = Minitest::Mock.new
     mock.expect :get_model, model_full_hash.to_json,
-      [model.project_id, model.dataset_id, model.model_id]
+      [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.location.must_equal location_code
@@ -108,7 +108,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
   it "gets full data for expires_at" do
     mock = Minitest::Mock.new
     mock.expect :get_model, model_full_hash.to_json,
-      [model.project_id, model.dataset_id, model.model_id]
+      [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.expires_at.must_be_close_to ::Time.now, 1
@@ -124,7 +124,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
     model_without_exp_time = model_full_hash.dup
     model_without_exp_time.delete :expirationTime
     mock.expect :get_model, model_without_exp_time.to_json,
-      [model.project_id, model.dataset_id, model.model_id]
+      [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.expires_at.must_be :nil?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/partial/exists_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/partial/exists_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
 
   it "can test its existence with force to load resource" do
     mock = Minitest::Mock.new
-    mock.expect :get_model, model_hash.to_json, [model.project_id, model.dataset_id, model.model_id]
+    mock.expect :get_model, model_hash.to_json, [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.exists?(force: true).must_equal true

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/partial/update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/partial/update_test.rb
@@ -33,10 +33,10 @@ describe Google::Cloud::Bigquery::Model, :partial, :update, :mock_bigquery do
     mock = Minitest::Mock.new
     model_hash = random_model_full_hash dataset, model_id, name: new_model_name, description: description
     patched_model_full_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, friendly_name: "My Updated Model"
-    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id]
+    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_full_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_full_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
 
     model.service.mocked_service = mock
 
@@ -53,10 +53,10 @@ describe Google::Cloud::Bigquery::Model, :partial, :update, :mock_bigquery do
     mock = Minitest::Mock.new
     model_hash = random_model_full_hash dataset, model_id, name: model_name, description: new_description
     patched_model_full_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, description: "This is my updated model"
-    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id]
+    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_full_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_full_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.description = new_description
@@ -74,10 +74,10 @@ describe Google::Cloud::Bigquery::Model, :partial, :update, :mock_bigquery do
     model_hash = random_model_full_hash dataset, model_id, name: model_name, description: description
     model_hash["labels"] = new_labels
     patched_model_full_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, labels: new_labels
-    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id]
+    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_full_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_full_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.labels = new_labels
@@ -95,10 +95,10 @@ describe Google::Cloud::Bigquery::Model, :partial, :update, :mock_bigquery do
     model_hash = random_model_full_hash dataset, model_id, name: model_name, description: description
     model_hash["expirationTime"] = Google::Cloud::Bigquery::Convert.time_to_millis(one_hour_from_now)
     patched_model_full_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, expiration_time: Google::Cloud::Bigquery::Convert.time_to_millis(one_hour_from_now)
-    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id]
+    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_full_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_full_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.expires_at = one_hour_from_now
@@ -114,10 +114,10 @@ describe Google::Cloud::Bigquery::Model, :partial, :update, :mock_bigquery do
     model_hash = random_model_full_hash dataset, model_id, name: model_name, description: description
     model_hash["expirationTime"] = nil
     patched_model_full_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, expiration_time: nil
-    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id]
+    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_full_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_full_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.expires_at = nil

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/reference/exists_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/reference/exists_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Bigquery::Model, :reference, :attributes, :mock_bigquery
 
   it "can test its existence" do
     mock = Minitest::Mock.new
-    mock.expect :get_model, model_hash.to_json, [model.project_id, model.dataset_id, model.model_id]
+    mock.expect :get_model, model_hash.to_json, [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.exists?.must_equal true
@@ -35,7 +35,7 @@ describe Google::Cloud::Bigquery::Model, :reference, :attributes, :mock_bigquery
 
   it "can test its existence with force to load resource" do
     mock = Minitest::Mock.new
-    mock.expect :get_model, model_hash.to_json, [model.project_id, model.dataset_id, model.model_id]
+    mock.expect :get_model, model_hash.to_json, [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.exists?(force: true).must_equal true

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/reference/update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/reference/update_test.rb
@@ -32,10 +32,10 @@ describe Google::Cloud::Bigquery::Model, :reference, :update, :mock_bigquery do
     mock = Minitest::Mock.new
     model_hash = random_model_full_hash dataset, model_id, name: new_model_name, description: description
     patched_model_full_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, friendly_name: "My Updated Model"
-    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id]
+    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_full_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_full_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
 
     model.service.mocked_service = mock
 
@@ -52,10 +52,10 @@ describe Google::Cloud::Bigquery::Model, :reference, :update, :mock_bigquery do
     mock = Minitest::Mock.new
     model_hash = random_model_full_hash dataset, model_id, name: model_name, description: new_description
     patched_model_full_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, description: "This is my updated model"
-    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id]
+    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_full_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_full_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.description = new_description
@@ -73,10 +73,10 @@ describe Google::Cloud::Bigquery::Model, :reference, :update, :mock_bigquery do
     model_hash = random_model_full_hash dataset, model_id, name: model_name, description: description
     model_hash["labels"] = new_labels
     patched_model_full_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, labels: new_labels
-    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id]
+    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_full_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_full_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.labels = new_labels
@@ -94,10 +94,10 @@ describe Google::Cloud::Bigquery::Model, :reference, :update, :mock_bigquery do
     model_hash = random_model_full_hash dataset, model_id, name: model_name, description: description
     model_hash["expirationTime"] = Google::Cloud::Bigquery::Convert.time_to_millis(one_hour_from_now)
     patched_model_full_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, expiration_time: Google::Cloud::Bigquery::Convert.time_to_millis(one_hour_from_now)
-    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id]
+    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_full_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_full_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.expires_at = one_hour_from_now
@@ -113,10 +113,10 @@ describe Google::Cloud::Bigquery::Model, :reference, :update, :mock_bigquery do
     model_hash = random_model_full_hash dataset, model_id, name: model_name, description: description
     model_hash["expirationTime"] = nil
     patched_model_full_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, expiration_time: nil
-    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id]
+    mock.expect :get_model, random_model_full_hash(dataset, model_id).to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_full_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_full_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.expires_at = nil

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/resource/exists_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/resource/exists_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Bigquery::Model, :resource, :attributes, :mock_bigquery 
 
   it "can test its existence with force to load resource" do
     mock = Minitest::Mock.new
-    mock.expect :get_model, model_hash.to_json, [model.project_id, model.dataset_id, model.model_id]
+    mock.expect :get_model, model_hash.to_json, [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.exists?(force: true).must_equal true

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/resource/update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/resource/update_test.rb
@@ -36,8 +36,8 @@ describe Google::Cloud::Bigquery::Model, :resource, :update, :mock_bigquery do
     model_hash = random_model_full_hash dataset, model_id, name: new_model_name, description: description
     patched_model_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, friendly_name: "My Updated Model"
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
 
     model.service.mocked_service = mock
 
@@ -57,8 +57,8 @@ describe Google::Cloud::Bigquery::Model, :resource, :update, :mock_bigquery do
     model_hash = random_model_full_hash dataset, model_id, name: model_name, description: new_description
     patched_model_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, description: "This is my updated model"
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.description = new_description
@@ -79,8 +79,8 @@ describe Google::Cloud::Bigquery::Model, :resource, :update, :mock_bigquery do
     model_hash["labels"] = new_labels
     patched_model_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, labels: new_labels
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.labels = new_labels
@@ -101,8 +101,8 @@ describe Google::Cloud::Bigquery::Model, :resource, :update, :mock_bigquery do
     model_hash["expirationTime"] = Google::Cloud::Bigquery::Convert.time_to_millis(one_hour_from_now)
     patched_model_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, expiration_time: Google::Cloud::Bigquery::Convert.time_to_millis(one_hour_from_now)
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.expires_at = one_hour_from_now
@@ -121,8 +121,8 @@ describe Google::Cloud::Bigquery::Model, :resource, :update, :mock_bigquery do
     model_hash["expirationTime"] = nil
     patched_model_gapi = Google::Apis::BigqueryV2::Model.new model_reference: model.model_ref, expiration_time: nil
     mock.expect :patch_model, model_hash.to_json,
-      [project, dataset, model_id, patched_model_gapi, {options: {header: {"If-Match" => etag}}}]
-    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id]
+      [project, dataset, model_id, patched_model_gapi, options: { skip_deserialization: true, header: { "If-Match" => etag } }]
+    mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
     model.expires_at = nil


### PR DESCRIPTION
This PR fixes the JSON deserialization implementation for the Models API. This was added late in the development of the Models API feature, and needs correction.

[fixes #3643]