### PR TITLE
fix(dns): Ensure the DNS library uses a recent underlying client with the correct endpoint

### DIFF
--- a/google-cloud-dns/google-cloud-dns.gemspec
+++ b/google-cloud-dns/google-cloud-dns.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-api-client", "~> 0.23"
+  gem.add_dependency "google-api-client", ">= 0.30.4"
   gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
   gem.add_dependency "zonefile", "~> 1.04"
 

--- a/google-cloud-dns/google-cloud-dns.gemspec
+++ b/google-cloud-dns/google-cloud-dns.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-api-client", ">= 0.30.4"
+  gem.add_dependency "google-api-client", ">= 0.30.4", "< 1.0"
   gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
   gem.add_dependency "zonefile", "~> 1.04"
 


### PR DESCRIPTION
DNS is switching its endpoint URL. The underlying REST library has updated the endpoint as of version 0.30.4, so we need the veneer library to require a sufficiently recent dependency.

Note: switching from `~>` to `>=` because we literally need `0.30.4` or later, and the google-api-client library isn't really usefully semver anyway.