### PR TITLE
Release google-cloud-storage 1.19.0

### DIFF
--- a/google-cloud-storage/CHANGELOG.md
+++ b/google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.19.0 / 2019-07-11
+
+* Add Bucket#location_type
+  * Remove :multi_regional and :regional from storage_class docs
+
 ### 1.18.2 / 2019-05-21
 
 * Declare explicit dependency on mime-types

--- a/google-cloud-storage/lib/google/cloud/storage/version.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Storage
-      VERSION = "1.18.2".freeze
+      VERSION = "1.19.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add Bucket#location_type
  * Remove :multi_regional and :regional from storage_class docs

<details><summary>Commits since previous release</summary><pre><code>commit b8d08a77fd90a2e92aecccd8cb98cd826298fa76
Author: Chris Smith <quartzmo@gmail.com>
Date:   Wed Jul 10 17:13:06 2019 -0600

    feat(storage): Add Bucket#location_type
    
    * Remove :multi_regional and :regional from storage_class docs
    
    [pr #3303, closes #3302]

commit 77856f97ed3a5bc4006ff7bba6eb5ed2bc1c4342
Author: Mike Moore <mike@blowmage.com>
Date:   Tue Jun 18 11:41:20 2019 -0600

    test(storage): Fix lifecycle acceptance test
    
    Apiary now returns Date objects instead of String objects for date fields.
    
    [pr #3499]

commit c3f100da4536930396d0816303f696bdfaafddb8
Author: Graham Paye <paye@google.com>
Date:   Tue Jun 11 13:35:45 2019 -0700

    prepare repo-metadata.json for docuploader (#3444)

commit 49e1752d375c213af32f4bf202c2412ca489e271
Author: Chris Smith <quartzmo@gmail.com>
Date:   Fri May 24 20:02:17 2019 -0600

    test(storage): change String to Date in Lifecycle::Rule::Condition tests (#3417)
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-storage/.repo-metadata.json b/google-cloud-storage/.repo-metadata.json
new file mode 100644
index 000000000..1a2687f98
--- /dev/null
+++ b/google-cloud-storage/.repo-metadata.json
@@ -0,0 +1,5 @@
+{
+    "name": "storage",
+    "language": "ruby",
+    "distribution_name": "google-cloud-storage"
+}
diff --git a/google-cloud-storage/acceptance/storage/bucket_lock_retention_policy_test.rb b/google-cloud-storage/acceptance/storage/bucket_lock_retention_policy_test.rb
index e9d01004a..c03fdce9d 100644
--- a/google-cloud-storage/acceptance/storage/bucket_lock_retention_policy_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_lock_retention_policy_test.rb
@@ -204,6 +204,8 @@ describe Google::Cloud::Storage::Bucket, :lock_retention_policy, :storage do
     # Call to lock_retention_policy! should update bucket state
     bucket.retention_policy_locked?.must_equal true
 
+    bucket.location_type.must_equal "multi-region"
+
     err = expect do
       bucket.update do |b|
         b.retention_period = nil
diff --git a/google-cloud-storage/acceptance/storage/bucket_test.rb b/google-cloud-storage/acceptance/storage/bucket_test.rb
index 615ee521c..de3afc7e1 100644
--- a/google-cloud-storage/acceptance/storage/bucket_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_test.rb
@@ -40,6 +40,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
     one_off_bucket.website_404.must_be :nil?
     one_off_bucket.requester_pays.must_be :nil?
     one_off_bucket.labels.must_equal({})
+    one_off_bucket.location_type.must_equal "multi-region"
     one_off_bucket.user_project.must_equal true
     one_off_bucket.update do |b|
       b.storage_class = :nearline
@@ -55,6 +56,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
     one_off_bucket.requester_pays.must_equal true
     # labels with symbols are not strings
     one_off_bucket.labels.must_equal({ "foo" => "bar" })
+    one_off_bucket.location_type.must_equal "multi-region"
 
     one_off_bucket_copy = storage.bucket one_off_bucket_name, user_project: true
     one_off_bucket_copy.wont_be :nil?
@@ -76,6 +78,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
     bucket.created_at.must_be_kind_of DateTime
     bucket.api_url.must_equal "https://www.googleapis.com/storage/v1/b/#{bucket_name}"
     bucket.location.must_be_kind_of String
+    bucket.location_type.must_equal "multi-region"
     bucket.logging_bucket.must_be :nil?
     bucket.logging_prefix.must_be :nil?
     bucket.storage_class.must_equal "STANDARD"
@@ -152,7 +155,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
     bucket.lifecycle.last.action.must_equal "SetStorageClass"
     bucket.lifecycle.last.storage_class.must_equal "NEARLINE"
     bucket.lifecycle.last.age.must_equal 10
-    bucket.lifecycle.last.created_before.must_equal "2013-01-15"
+    bucket.lifecycle.last.created_before.must_equal Date.parse("2013-01-15")
     bucket.lifecycle.last.is_live.must_equal true
     bucket.lifecycle.last.matches_storage_class.must_equal ["MULTI_REGIONAL"]
     bucket.lifecycle.last.num_newer_versions.must_equal 3
@@ -175,7 +178,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
     bucket.lifecycle.last.action.must_equal "SetStorageClass"
     bucket.lifecycle.last.storage_class.must_equal "COLDLINE"
     bucket.lifecycle.last.age.must_equal 20
-    bucket.lifecycle.last.created_before.must_equal "2013-01-20"
+    bucket.lifecycle.last.created_before.must_equal Date.parse("2013-01-20")
     bucket.lifecycle.last.is_live.must_equal false
     bucket.lifecycle.last.matches_storage_class.must_equal ["NEARLINE"]
     bucket.lifecycle.last.num_newer_versions.must_equal 4
diff --git a/google-cloud-storage/acceptance/storage/buckets_test.rb b/google-cloud-storage/acceptance/storage/buckets_test.rb
index de67ad684..94deaf56f 100644
--- a/google-cloud-storage/acceptance/storage/buckets_test.rb
+++ b/google-cloud-storage/acceptance/storage/buckets_test.rb
@@ -30,9 +30,15 @@ describe "Storage", :buckets, :storage do
   it "gets pages of buckets" do
     first_buckets = storage.buckets max: 2
     first_buckets.next?.must_equal true
-    first_buckets.each { |b| b.must_be_kind_of Google::Cloud::Storage::Bucket }
+    first_buckets.each do |b|
+      b.must_be_kind_of Google::Cloud::Storage::Bucket
+      b.location_type.must_equal "multi-region"
+    end
     second_buckets = first_buckets.next
-    second_buckets.each { |b| b.must_be_kind_of Google::Cloud::Storage::Bucket }
+    second_buckets.each do |b|
+      b.must_be_kind_of Google::Cloud::Storage::Bucket
+      b.location_type.must_equal "multi-region"
+    end
   end
 
   it "gets pages of buckets with user_project set to true" do
diff --git a/google-cloud-storage/lib/google/cloud/storage/bucket.rb b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
index 06430c1c5..728cc7cf3 100644
--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -285,6 +285,22 @@ module Google
           @gapi.location
         end
 
+        ##
+        # The bucket's location type. Location type defines the geographic
+        # placement of the bucket's data and affects cost, performance, and
+        # availability. There are three possible values:
+        #
+        #  * `region` - Lowest latency within a single region
+        #  * `multi-region` - Highest availability across largest area
+        #  * `dual-region` - High availability and low latency across 2 regions
+        #
+        # @return [String] The location type code: "region", "multi-region", or
+        #   "dual-region"
+        #
+        def location_type
+          @gapi.location_type
+        end
+
         ##
         # The destination bucket name for the bucket's logs.
         #
@@ -353,9 +369,9 @@ module Google
         ##
         # Updates the bucket's storage class. This defines how objects in the
         # bucket are stored and determines the SLA and the cost of storage.
-        # Accepted values include `:multi_regional`, `:regional`, `:nearline`,
-        # and `:coldline`, as well as the equivalent strings returned by
-        # {Bucket#storage_class}. For more information, see [Storage
+        # Accepted values include `:standard`, `:nearline`, and `:coldline`, as
+        # well as the equivalent strings returned by {Bucket#storage_class}. For
+        # more information, see [Storage
         # Classes](https://cloud.google.com/storage/docs/storage-classes).
         #
         # @param [Symbol, String] new_storage_class Storage class of the bucket.
@@ -1119,10 +1135,10 @@ module Google
         #   file as "x-goog-meta-" response headers.
         # @param [Symbol, String] storage_class Storage class of the file.
         #   Determines how the file is stored and determines the SLA and the
-        #   cost of storage. Accepted values include `:multi_regional`,
-        #   `:regional`, `:nearline`, and `:coldline`, as well as the equivalent
-        #   strings returned by {#storage_class}. For more information, see
-        #   [Storage Classes](https://cloud.google.com/storage/docs/storage-classes)
+        #   cost of storage. Accepted values include `:standard`, `:nearline`,
+        #   and `:coldline`, as well as the equivalent strings returned by
+        #   {#storage_class}. For more information, see [Storage
+        #   Classes](https://cloud.google.com/storage/docs/storage-classes)
         #   and [Per-Object Storage
         #   Class](https://cloud.google.com/storage/docs/per-object-storage-class).
         #   The default value is the default storage class for the bucket.
diff --git a/google-cloud-storage/lib/google/cloud/storage/file.rb b/google-cloud-storage/lib/google/cloud/storage/file.rb
index 3a55c68b0..513e0b841 100644
--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -428,8 +428,7 @@ module Google
         # Rewrites the file with a new storage class, which determines the SLA
         # and the cost of storage. Accepted values include:
         #
-        # * `:multi_regional`
-        # * `:regional`
+        # * `:standard`
         # * `:nearline`
         # * `:coldline`
         #
diff --git a/google-cloud-storage/lib/google/cloud/storage/project.rb b/google-cloud-storage/lib/google/cloud/storage/project.rb
index 5f8838125..77a5b7166 100644
--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -295,8 +295,8 @@ module Google
         #   Logs](https://cloud.google.com/storage/docs/access-logs).
         # @param [Symbol, String] storage_class Defines how objects in the
         #   bucket are stored and determines the SLA and the cost of storage.
-        #   Accepted values include `:multi_regional`, `:regional`, `:nearline`,
-        #   and `:coldline`, as well as the equivalent strings returned by
+        #   Accepted values include `:standard`, `:nearline`, and `:coldline`,
+        #   as well as the equivalent strings returned by
         #   {Bucket#storage_class}. For more information, see [Storage
         #   Classes](https://cloud.google.com/storage/docs/storage-classes). The
         #   default value is the Standard storage class, which is equivalent to
diff --git a/google-cloud-storage/test/google/cloud/storage/bucket_lock_retention_policy_test.rb b/google-cloud-storage/test/google/cloud/storage/bucket_lock_retention_policy_test.rb
index 67fdb9ea2..4e46d98e6 100644
--- a/google-cloud-storage/test/google/cloud/storage/bucket_lock_retention_policy_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_lock_retention_policy_test.rb
@@ -90,6 +90,8 @@ describe Google::Cloud::Storage::Bucket, :lock_retention_policy, :mock_storage d
     bucket.lock_retention_policy!
 
     mock.verify
+
+    bucket.location_type.must_equal "multi-region"
   end
 
   it "locks its retention policy with user_project set to true" do
diff --git a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
index 6f80d198a..6482db9da 100644
--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -30,6 +30,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
                          "responseHeader" => ["X-My-Custom-Header"] }] }
   let(:bucket_lifecycle) { {"rule" => [{"action" => {"storageClass" => "NEARLINE","type" => "SetStorageClass"},"condition" => {"age" => 32}}]} }
   let(:bucket_location) { "US" }
+  let(:bucket_location_type) { "multi-region" }
   let(:bucket_logging_bucket) { "bucket-name-logging" }
   let(:bucket_logging_prefix) { "AccessLog" }
   let(:bucket_storage_class) { "STANDARD" }
@@ -56,6 +57,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     bucket_complete.created_at.must_be_within_delta bucket_complete_hash["timeCreated"].to_datetime
     bucket_complete.api_url.must_equal bucket_url
     bucket_complete.location.must_equal bucket_location
+    bucket_complete.location_type.must_equal bucket_location_type
     bucket_complete.logging_bucket.must_equal bucket_logging_bucket
     bucket_complete.logging_prefix.must_equal bucket_logging_prefix
     bucket_complete.storage_class.must_equal bucket_storage_class
diff --git a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
index bcbfac04c..7e21aa825 100644
--- a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
@@ -31,11 +31,12 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     http_method: ["*"],
     response_header: ["X-My-Custom-Header"]) }
   let(:bucket_cors_hash) { JSON.parse bucket_cors_gapi.to_json }
+  let(:bucket_lifecycle_created_before) { Date.parse("2013-01-15") }
   let(:bucket_lifecycle_gapi) do
     lifecycle_gapi lifecycle_rule_gapi("SetStorageClass",
                                        storage_class: "NEARLINE",
                                        age: 32,
-                                       created_before: "2013-01-15",
+                                       created_before: bucket_lifecycle_created_before,
                                        is_live: true,
                                        matches_storage_class: ["MULTI_REGIONAL"],
                                        num_newer_versions: 3)
@@ -145,6 +146,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
 
     bucket.logging_bucket.must_equal bucket_logging_bucket
     bucket.logging_prefix.must_equal bucket_logging_prefix
+    bucket.location_type.must_equal "multi-region"
 
     mock.verify
   end
@@ -493,7 +495,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       lifecycle = bucket.lifecycle do |l|
         l.add_set_storage_class_rule "NEARLINE",
                                      age: 32,
-                                     created_before: "2013-01-15",
+                                     created_before: bucket_lifecycle_created_before,
                                      is_live: true,
                                      matches_storage_class: ["MULTI_REGIONAL"],
                                      num_newer_versions: 3
@@ -506,7 +508,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       rule.action.must_equal "SetStorageClass"
       rule.storage_class.must_equal "NEARLINE"
       rule.age.must_equal 32
-      rule.created_before.must_equal "2013-01-15"
+      rule.created_before.must_equal bucket_lifecycle_created_before
       rule.is_live.must_equal true
       rule.matches_storage_class.must_equal ["MULTI_REGIONAL"]
       rule.num_newer_versions.must_equal 3
@@ -526,13 +528,14 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
           lifecycle_rule_gapi("SetStorageClass",
                               storage_class: "COLDLINE",
                               age: 32,
-                              created_before: "2013-01-15",
+                              created_before: bucket_lifecycle_created_before,
                               is_live: true,
                               matches_storage_class: ["MULTI_REGIONAL"],
                               num_newer_versions: 3),
           lifecycle_rule_gapi("Delete", age: 40, is_live: false)
         )
       )
+
       returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
         random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, nil, nil, bucket_lifecycle_hash).to_json
       mock.expect :patch_bucket, returned_bucket_gapi,
@@ -583,7 +586,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
             lifecycle_rule_gapi("SetStorageClass",
                                 storage_class: "NEARLINE",
                                 age: 32,
-                                created_before: "2013-01-15",
+                                created_before: bucket_lifecycle_created_before,
                                 is_live: true,
                                 matches_storage_class: ["MULTI_REGIONAL"],
                                 num_newer_versions: 3),
@@ -616,7 +619,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
             lifecycle_rule_gapi("SetStorageClass",
                                 storage_class: "NEARLINE",
                                 age: 32,
-                                created_before: "2013-01-15",
+                                created_before: bucket_lifecycle_created_before,
                                 is_live: true,
                                 matches_storage_class: ["MULTI_REGIONAL"],
                                 num_newer_versions: 3),
diff --git a/google-cloud-storage/test/google/cloud/storage/project_test.rb b/google-cloud-storage/test/google/cloud/storage/project_test.rb
index e98a01a20..be415794c 100644
--- a/google-cloud-storage/test/google/cloud/storage/project_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_test.rb
@@ -22,6 +22,7 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   let(:bucket_url_root) { "https://www.googleapis.com/storage/v1" }
   let(:bucket_url) { "#{bucket_url_root}/b/#{bucket_name}" }
   let(:bucket_location) { "EU" }
+  let(:bucket_location_type) { "multi-region" }
   let(:bucket_storage_class) { "DURABLE_REDUCED_AVAILABILITY" }
   let(:bucket_logging_bucket) { "bucket-name-logging" }
   let(:bucket_logging_prefix) { "AccessLog" }
@@ -50,7 +51,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   it "creates a bucket" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     storage.service.mocked_service = mock
 
     bucket = storage.create_bucket bucket_name
@@ -59,12 +61,14 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     bucket.must_be_kind_of Google::Cloud::Storage::Bucket
     bucket.name.must_equal bucket_name
+    bucket.location_type.must_equal bucket_location_type
   end
 
   it "creates a bucket with location" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name, location: bucket_location
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     storage.service.mocked_service = mock
 
     bucket = storage.create_bucket bucket_name, location: bucket_location
@@ -74,12 +78,14 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     bucket.must_be_kind_of Google::Cloud::Storage::Bucket
     bucket.name.must_equal bucket_name
     bucket.location.must_equal bucket_location
+    bucket.location_type.must_equal bucket_location_type
   end
 
   it "creates a bucket with storage_class" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name, storage_class: bucket_storage_class
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     storage.service.mocked_service = mock
 
     bucket = storage.create_bucket bucket_name, storage_class: bucket_storage_class
@@ -94,7 +100,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   it "creates a bucket with versioning" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name, versioning: Google::Apis::StorageV1::Bucket::Versioning.new(enabled: true)
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     storage.service.mocked_service = mock
 
     bucket = storage.create_bucket bucket_name, versioning: true
@@ -109,7 +116,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   it "creates a bucket with logging bucket and prefix" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name, logging: Google::Apis::StorageV1::Bucket::Logging.new(log_bucket: bucket_logging_bucket, log_object_prefix: bucket_logging_prefix)
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     storage.service.mocked_service = mock
 
     bucket = storage.create_bucket bucket_name, logging_bucket: bucket_logging_bucket, logging_prefix: bucket_logging_prefix
@@ -125,7 +133,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   it "creates a bucket with website main and 404" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name, website: Google::Apis::StorageV1::Bucket::Website.new(main_page_suffix: bucket_website_main, not_found_page: bucket_website_404)
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     storage.service.mocked_service = mock
 
     bucket = storage.create_bucket bucket_name, website_main: bucket_website_main, website_404: bucket_website_404
@@ -141,7 +150,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   it "creates a bucket with requester pays" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name, billing: Google::Apis::StorageV1::Bucket::Billing.new(requester_pays: bucket_requester_pays)
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     storage.service.mocked_service = mock
 
     bucket = storage.create_bucket bucket_name do |b|
@@ -158,7 +168,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   it "creates a bucket with requester pays and user_project set to true" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name, billing: Google::Apis::StorageV1::Bucket::Billing.new(requester_pays: bucket_requester_pays)
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: "test"]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: "test"]
     storage.service.mocked_service = mock
 
     bucket = storage.create_bucket bucket_name, user_project: true do |b|
@@ -176,7 +187,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   it "creates a bucket with requester pays and user_project set to another project ID" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name, billing: Google::Apis::StorageV1::Bucket::Billing.new(requester_pays: bucket_requester_pays)
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: "my-other-project"]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: "my-other-project"]
     storage.service.mocked_service = mock
 
     bucket = storage.create_bucket bucket_name, user_project: "my-other-project" do |b|
@@ -194,7 +206,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   it "creates a bucket with block CORS" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name, cors: bucket_cors_gapi
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     storage.service.mocked_service = mock
 
@@ -215,7 +228,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   it "creates a bucket with block lifecycle (Object Lifecycle Management)" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name, lifecycle: lifecycle_gapi(lifecycle_rule_gapi("SetStorageClass", storage_class: "NEARLINE", age: 32))
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     storage.service.mocked_service = mock
 
@@ -234,7 +248,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name
     created_bucket.labels = { "env" => "production", "foo" => "bar" }
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     storage.service.mocked_service = mock
 
@@ -255,7 +270,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name
     created_bucket.encryption = encryption_gapi(kms_key)
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     storage.service.mocked_service = mock
 
@@ -274,7 +290,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   it "creates a bucket with predefined acl" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: "private", predefined_default_object_acl: nil, user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: "private", predefined_default_object_acl: nil, user_project: nil]
     storage.service.mocked_service = mock
 
     bucket = storage.create_bucket bucket_name, acl: "private"
@@ -288,7 +305,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   it "creates a bucket with predefined acl alias" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: "publicRead", predefined_default_object_acl: nil, user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: "publicRead", predefined_default_object_acl: nil, user_project: nil]
     storage.service.mocked_service = mock
 
     bucket = storage.create_bucket bucket_name, acl: :public
@@ -302,7 +320,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   it "creates a bucket with predefined default acl" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: "private", user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: "private", user_project: nil]
     storage.service.mocked_service = mock
 
     bucket = storage.create_bucket bucket_name, default_acl: :private
@@ -316,7 +335,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   it "creates a bucket with predefined default acl alias" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: "publicRead", user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: "publicRead", user_project: nil]
     storage.service.mocked_service = mock
 
     bucket = storage.create_bucket bucket_name, default_acl: "public"
@@ -334,9 +354,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     created_bucket.retention_policy = Google::Apis::StorageV1::Bucket::RetentionPolicy.new(
       retention_period: bucket_retention_period
     )
-
+    resp_bucket = bucket_with_location created_bucket
     bucket_retention_effective_at = Time.now
-    resp_bucket = create_bucket_gapi bucket_name
     resp_bucket.retention_policy = Google::Apis::StorageV1::Bucket::RetentionPolicy.new(
         retention_period: bucket_retention_period,
         effective_time: bucket_retention_effective_at
@@ -361,7 +380,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name
     created_bucket.default_event_based_hold = true
-    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+    resp_bucket = bucket_with_location created_bucket
+    mock.expect :insert_bucket, resp_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     storage.service.mocked_service = mock
 
@@ -404,6 +424,9 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     mock.verify
 
     buckets.size.must_equal num_buckets
+    bucket = buckets.first
+    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
+    bucket.location_type.must_equal "multi-region"
   end
 
   it "lists buckets with find_buckets alias" do
@@ -728,6 +751,12 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     bucket.must_be :lazy?
   end
 
+  def bucket_with_location created_bucket
+    resp_bucket = created_bucket.dup
+    resp_bucket.location_type = bucket_location_type
+    resp_bucket
+  end
+
   def create_bucket_gapi name = nil, location: nil, storage_class: nil,
                          versioning: nil, logging: nil, website: nil, cors: nil,
                          billing: nil, lifecycle: nil
@@ -744,7 +773,7 @@ describe Google::Cloud::Storage::Project, :mock_storage do
   end
 
   def list_buckets_gapi count = 2, token = nil
-    buckets = count.times.map { random_bucket_hash }
+    buckets = count.times.map { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
     Google::Apis::StorageV1::Buckets.new(
       kind: "storage#buckets", items: buckets, next_page_token: token
     )
diff --git a/google-cloud-storage/test/helper.rb b/google-cloud-storage/test/helper.rb
index 9dcc39798..a98b42b63 100644
--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -50,7 +50,7 @@ class MockStorage < Minitest::Spec
     url_root="https://www.googleapis.com/storage/v1", location="US",
     storage_class="STANDARD", versioning=nil, logging_bucket=nil,
     logging_prefix=nil, website_main=nil, website_404=nil, cors=[], requester_pays=nil,
-    lifecycle=nil)
+    lifecycle=nil, location_type="multi-region")
     versioning_config = { "enabled" => versioning } if versioning
     { "kind" => "storage#bucket",
       "id" => name,
@@ -61,6 +61,7 @@ class MockStorage < Minitest::Spec
       "metageneration" => "1",
       "owner" => { "entity" => "project-owners-1234567890" },
       "location" => location,
+      "locationType" => location_type,
       "cors" => cors,
       "lifecycle" => lifecycle,
       "logging" => logging_hash(logging_bucket, logging_prefix),

```

</details>

This pull request was generated using releasetool.