### PR TITLE
Fix for protobuf 3.9.0

### DIFF
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/chunk_processor.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/chunk_processor.rb
@@ -245,7 +245,7 @@ module Google
         # @raise [Google::Cloud::Bigtable::InvalidRowStateError]
         #
         def raise_if condition, message
-          raise InvalidRowStateError.new(message, chunk.to_hash) if condition
+          raise InvalidRowStateError.new(message, chunk.to_h) if condition
         end
       end
     end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(instance_id, request.instance_id)
         assert_equal(Google::Gax::to_proto(instance, Google::Bigtable::Admin::V2::Instance), request.instance)
-        assert_equal(clusters, request.clusters)
+        assert_equal(clusters, request.clusters.to_h)
         OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub_v2.new(:create_instance, mock_method)
@@ -146,7 +146,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(instance_id, request.instance_id)
         assert_equal(Google::Gax::to_proto(instance, Google::Bigtable::Admin::V2::Instance), request.instance)
-        assert_equal(clusters, request.clusters)
+        assert_equal(clusters, request.clusters.to_h)
         OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub_v2.new(:create_instance, mock_method)
@@ -186,7 +186,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(instance_id, request.instance_id)
         assert_equal(Google::Gax::to_proto(instance, Google::Bigtable::Admin::V2::Instance), request.instance)
-        assert_equal(clusters, request.clusters)
+        assert_equal(clusters, request.clusters.to_h)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v2.new(:create_instance, mock_method)
@@ -386,7 +386,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_name, request.name)
         assert_equal(display_name, request.display_name)
         assert_equal(type, request.type)
-        assert_equal(labels, request.labels)
+        assert_equal(labels, request.labels.to_h)
         OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub_v2.new(:update_instance, mock_method)
@@ -437,7 +437,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_name, request.name)
         assert_equal(display_name, request.display_name)
         assert_equal(type, request.type)
-        assert_equal(labels, request.labels)
+        assert_equal(labels, request.labels.to_h)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v2.new(:update_instance, mock_method)
@@ -455,7 +455,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
               formatted_name,
               display_name,
               type,
-              labels
+              labels.to_h
             )
           end
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance_test.rb
@@ -53,13 +53,13 @@ describe Google::Cloud::Bigtable::Instance, :mock_bigtable do
 
     it "set labels using hash" do
       instance.labels = { "env" => "test1" }
-      instance.labels.must_equal({"env" => "test1"})
+      instance.labels.to_h.must_equal({"env" => "test1"})
 
       instance.labels = { :env => "test2" }
-      instance.labels.must_equal({"env" => "test2"})
+      instance.labels.to_h.must_equal({"env" => "test2"})
 
       instance.labels = { data: "users", appprofile: 12345 }
-      instance.labels.must_equal({ "data" => "users", "appprofile" => "12345" })
+      instance.labels.to_h.must_equal({ "data" => "users", "appprofile" => "12345" })
     end
 
     it "clear lables if labels value is nil" do

--- a/google-cloud-container/test/google/cloud/container/v1/cluster_manager_client_test.rb
+++ b/google-cloud-container/test/google/cloud/container/v1/cluster_manager_client_test.rb
@@ -2691,7 +2691,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
-        assert_equal(resource_labels, request.resource_labels)
+        assert_equal(resource_labels, request.resource_labels.to_h)
         assert_equal(label_fingerprint, request.label_fingerprint)
         OpenStruct.new(execute: expected_response)
       end
@@ -2746,7 +2746,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
-        assert_equal(resource_labels, request.resource_labels)
+        assert_equal(resource_labels, request.resource_labels.to_h)
         assert_equal(label_fingerprint, request.label_fingerprint)
         raise custom_error
       end

--- a/google-cloud-container/test/google/cloud/container/v1beta1/cluster_manager_client_test.rb
+++ b/google-cloud-container/test/google/cloud/container/v1beta1/cluster_manager_client_test.rb
@@ -2699,7 +2699,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
-        assert_equal(resource_labels, request.resource_labels)
+        assert_equal(resource_labels, request.resource_labels.to_h)
         assert_equal(label_fingerprint, request.label_fingerprint)
         OpenStruct.new(execute: expected_response)
       end
@@ -2754,7 +2754,7 @@ describe Google::Cloud::Container::V1beta1::ClusterManagerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
-        assert_equal(resource_labels, request.resource_labels)
+        assert_equal(resource_labels, request.resource_labels.to_h)
         assert_equal(label_fingerprint, request.label_fingerprint)
         raise custom_error
       end

--- a/google-cloud-datastore/lib/google/cloud/datastore/convert.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/convert.rb
@@ -100,7 +100,7 @@ module Google
             return Time.at grpc_value.timestamp_value.seconds,
                            grpc_value.timestamp_value.nanos/1000.0
           elsif grpc_value.value_type == :geo_point_value
-            return grpc_value.geo_point_value.to_hash
+            return grpc_value.geo_point_value.to_h
           elsif grpc_value.value_type == :blob_value
             return StringIO.new(
               grpc_value.blob_value.dup.force_encoding("ASCII-8BIT"))

--- a/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
@@ -75,7 +75,7 @@ module Google
               Google::Cloud::Firestore::DocumentReference.from_path \
                 value.reference_value, client
             when :geo_point_value
-              value.geo_point_value.to_hash
+              value.geo_point_value.to_h
             when :array_value
               value.array_value.values.map { |v| value_to_raw v, client }
             when :map_value

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_query_test.rb
@@ -407,7 +407,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :partition_query, :mock_spanner 
       else
         partition.execute.params.must_equal params
       end
-      partition.execute.param_types.must_equal types.to_h
+      types_hash = Hash[Hash(types).map { |key, value| [key, value.to_h] }]
+      partition.execute.param_types.to_h.must_equal types_hash
 
       partition.read.must_be_nil
     end

--- a/grafeas-client/test/grafeas/v1/grafeas_client_test.rb
+++ b/grafeas-client/test/grafeas/v1/grafeas_client_test.rb
@@ -962,7 +962,7 @@ describe Grafeas::V1::GrafeasClient do
       mock_method = proc do |request|
         assert_instance_of(Grafeas::V1::BatchCreateNotesRequest, request)
         assert_equal(formatted_parent, request.parent)
-        assert_equal(notes, request.notes)
+        assert_equal(notes, request.notes.to_h)
         OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub_v1.new(:batch_create_notes, mock_method)
@@ -999,7 +999,7 @@ describe Grafeas::V1::GrafeasClient do
       mock_method = proc do |request|
         assert_instance_of(Grafeas::V1::BatchCreateNotesRequest, request)
         assert_equal(formatted_parent, request.parent)
-        assert_equal(notes, request.notes)
+        assert_equal(notes, request.notes.to_h)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v1.new(:batch_create_notes, mock_method)


### PR DESCRIPTION
The google-protobuf gem removed the #to_hash method.
The Bigtable, Datastore, and Firestore gems had calls to #to_hash.
This changes those calls to use the correct #to_h method instead.
This fixes these gems so they work with google-protobuf 3.9.0.

Some tests also expected #to_hash, and those tests are updated as well.