### PR TITLE
Release google-cloud-bigtable 0.4.3

### DIFF
--- a/google-cloud-bigtable/CHANGELOG.md
+++ b/google-cloud-bigtable/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.4.3 / 2019-07-12
+
+* Update #to_hash to #to_h for compatibility with google-protobuf >= 3.9.0
+
 ### 0.4.2 / 2019-07-09
 
 * Add IAM GetPolicyOptions in the lower-level interface.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/version.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigtable
-      VERSION = "0.4.2".freeze
+      VERSION = "0.4.3".freeze
     end
   end
 end


### PR DESCRIPTION
* Update #to_hash to #to_h for compatibility with google-protobuf >= 3.9.0

<details><summary>Commits since previous release</summary><pre><code>commit 70eeff8a2402ec48962ea3541629a6fa21046de7
Author: Mike Moore <mike@blowmage.com>
Date:   Fri Jul 12 15:30:21 2019 -0600

    fix: Update #to_hash to #to_h to fix for protobuf 3.9.0
    
    The google-protobuf gem removed the #to_hash method.
    The Bigtable, Datastore, and Firestore gems had calls to #to_hash.
    This changes those calls to use the correct #to_h method instead.
    This fixes these gems so they work with google-protobuf 3.9.0.
    Some tests also expected #to_hash, and those tests are updated as well.
    
    [pr  #3658]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/chunk_processor.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/chunk_processor.rb
index 15e505d62..815680830 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/chunk_processor.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/chunk_processor.rb
@@ -245,7 +245,7 @@ module Google
         # @raise [Google::Cloud::Bigtable::InvalidRowStateError]
         #
         def raise_if condition, message
-          raise InvalidRowStateError.new(message, chunk.to_hash) if condition
+          raise InvalidRowStateError.new(message, chunk.to_h) if condition
         end
       end
     end
diff --git a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
index c94165bcd..5322d2d93 100644
--- a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(instance_id, request.instance_id)
         assert_equal(Google::Gax::to_proto(instance, Google::Bigtable::Admin::V2::Instance), request.instance)
-        assert_equal(clusters, request.clusters)
+        assert_equal(clusters, request.clusters.to_h)
         OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub_v2.new(:create_instance, mock_method)
@@ -146,7 +146,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(instance_id, request.instance_id)
         assert_equal(Google::Gax::to_proto(instance, Google::Bigtable::Admin::V2::Instance), request.instance)
-        assert_equal(clusters, request.clusters)
+        assert_equal(clusters, request.clusters.to_h)
         OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub_v2.new(:create_instance, mock_method)
@@ -186,7 +186,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(instance_id, request.instance_id)
         assert_equal(Google::Gax::to_proto(instance, Google::Bigtable::Admin::V2::Instance), request.instance)
-        assert_equal(clusters, request.clusters)
+        assert_equal(clusters, request.clusters.to_h)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v2.new(:create_instance, mock_method)
@@ -386,7 +386,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_name, request.name)
         assert_equal(display_name, request.display_name)
         assert_equal(type, request.type)
-        assert_equal(labels, request.labels)
+        assert_equal(labels, request.labels.to_h)
         OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub_v2.new(:update_instance, mock_method)
@@ -437,7 +437,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_name, request.name)
         assert_equal(display_name, request.display_name)
         assert_equal(type, request.type)
-        assert_equal(labels, request.labels)
+        assert_equal(labels, request.labels.to_h)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v2.new(:update_instance, mock_method)
@@ -455,7 +455,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
               formatted_name,
               display_name,
               type,
-              labels
+              labels.to_h
             )
           end
 
@@ -1826,4 +1826,4 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
       end
     end
   end
-end
\ No newline at end of file
+end
diff --git a/google-cloud-bigtable/test/google/cloud/bigtable/instance_test.rb b/google-cloud-bigtable/test/google/cloud/bigtable/instance_test.rb
index a2902256e..79e3f3f05 100644
--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance_test.rb
@@ -53,13 +53,13 @@ describe Google::Cloud::Bigtable::Instance, :mock_bigtable do
 
     it "set labels using hash" do
       instance.labels = { "env" => "test1" }
-      instance.labels.must_equal({"env" => "test1"})
+      instance.labels.to_h.must_equal({"env" => "test1"})
 
       instance.labels = { :env => "test2" }
-      instance.labels.must_equal({"env" => "test2"})
+      instance.labels.to_h.must_equal({"env" => "test2"})
 
       instance.labels = { data: "users", appprofile: 12345 }
-      instance.labels.must_equal({ "data" => "users", "appprofile" => "12345" })
+      instance.labels.to_h.must_equal({ "data" => "users", "appprofile" => "12345" })
     end
 
     it "clear lables if labels value is nil" do

```

</details>

This pull request was generated using releasetool.