### PR TITLE
Release google-cloud-datastore 1.5.5

### DIFF
--- a/google-cloud-datastore/CHANGELOG.md
+++ b/google-cloud-datastore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.5.5 / 2019-07-12
+
+* Update #to_hash to #to_h for compatibility with google-protobuf >= 3.9.0
+
 ### 1.5.4 / 2019-07-08
 
 * Support overriding service host and port for low-level API.

--- a/google-cloud-datastore/lib/google/cloud/datastore/version.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Datastore
-      VERSION = "1.5.4".freeze
+      VERSION = "1.5.5".freeze
     end
   end
 end


### PR DESCRIPTION
* Update #to_hash to #to_h for compatibility with google-protobuf >= 3.9.0

<details><summary>Commits since previous release</summary><pre><code>commit 70eeff8a2402ec48962ea3541629a6fa21046de7
Author: Mike Moore <mike@blowmage.com>
Date:   Fri Jul 12 15:30:21 2019 -0600

    fix: Update #to_hash to #to_h to fix for protobuf 3.9.0
    
    The google-protobuf gem removed the #to_hash method.
    The Bigtable, Datastore, and Firestore gems had calls to #to_hash.
    This changes those calls to use the correct #to_h method instead.
    This fixes these gems so they work with google-protobuf 3.9.0.
    Some tests also expected #to_hash, and those tests are updated as well.
    
    [pr  #3658]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-datastore/lib/google/cloud/datastore/convert.rb b/google-cloud-datastore/lib/google/cloud/datastore/convert.rb
index 7044911f3..01b4cb0b8 100644
--- a/google-cloud-datastore/lib/google/cloud/datastore/convert.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/convert.rb
@@ -100,7 +100,7 @@ module Google
             return Time.at grpc_value.timestamp_value.seconds,
                            grpc_value.timestamp_value.nanos/1000.0
           elsif grpc_value.value_type == :geo_point_value
-            return grpc_value.geo_point_value.to_hash
+            return grpc_value.geo_point_value.to_h
           elsif grpc_value.value_type == :blob_value
             return StringIO.new(
               grpc_value.blob_value.dup.force_encoding("ASCII-8BIT"))

```

</details>

This pull request was generated using releasetool.