### PR TITLE
Release google-cloud-firestore 0.26.2

### DIFF
--- a/google-cloud-firestore/CHANGELOG.md
+++ b/google-cloud-firestore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.26.2 / 2019-07-12
+
+* Update #to_hash to #to_h for compatibility with google-protobuf >= 3.9.0
+
 ### 0.26.1 / 2019-07-08
 
 * Support overriding service host and port in the low-level interface.

--- a/google-cloud-firestore/lib/google/cloud/firestore/version.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Firestore
-      VERSION = "0.26.1".freeze
+      VERSION = "0.26.2".freeze
     end
   end
 end


### PR DESCRIPTION
* Update #to_hash to #to_h for compatibility with google-protobuf >= 3.9.0

<details><summary>Commits since previous release</summary><pre><code>commit 70eeff8a2402ec48962ea3541629a6fa21046de7
Author: Mike Moore <mike@blowmage.com>
Date:   Fri Jul 12 15:30:21 2019 -0600

    fix: Update #to_hash to #to_h to fix for protobuf 3.9.0
    
    The google-protobuf gem removed the #to_hash method.
    The Bigtable, Datastore, and Firestore gems had calls to #to_hash.
    This changes those calls to use the correct #to_h method instead.
    This fixes these gems so they work with google-protobuf 3.9.0.
    Some tests also expected #to_hash, and those tests are updated as well.
    
    [pr  #3658]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-firestore/lib/google/cloud/firestore/convert.rb b/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
index b09171f87..36ecd9e06 100644
--- a/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
@@ -75,7 +75,7 @@ module Google
               Google::Cloud::Firestore::DocumentReference.from_path \
                 value.reference_value, client
             when :geo_point_value
-              value.geo_point_value.to_hash
+              value.geo_point_value.to_h
             when :array_value
               value.array_value.values.map { |v| value_to_raw v, client }
             when :map_value

```

</details>

This pull request was generated using releasetool.