### PR TITLE
test: fix conformance file paths in bigtable, firestore and storage

### DIFF
--- a/google-cloud-bigtable/test/google/cloud/bigtable/conformance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/conformance_test.rb
@@ -95,7 +95,7 @@ class ReadRowsTest < MockBigtable
   end
 end
 
-file_path = "conformance/v2/readrows.json"
+file_path = File.expand_path "../../../../conformance/v2/readrows.json", __dir__
 test_file = Google::Cloud::Conformance::Bigtable::V2::TestFile.decode_json File.read(file_path)
 test_file.read_rows_tests.each_with_index do |test, index|
   ReadRowsTest.build_test_for test, index

--- a/google-cloud-firestore/test/google/cloud/firestore/conformance_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/conformance_test.rb
@@ -332,7 +332,7 @@ class ConformanceListen < ConformanceTest
   end
 end
 
-Dir.glob("conformance/v1/*.json").each do |file_path|
+Dir.glob("#{__dir__}/../../../../conformance/v1/*.json").each do |file_path|
   test_file = Google::Cloud::Conformance::Firestore::V1::TestFile.decode_json File.read(file_path)
   test_file.tests.each do |wrapper|
     case wrapper.test

--- a/google-cloud-storage/test/google/cloud/storage/file/signer_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file/signer_v4_test.rb
@@ -47,7 +47,7 @@ class SignerV4Test < MockStorage
   end
 end
 
-tests = SignerV4Test.load_json "../../../../data/signer_v4_test_data.json"
+tests = SignerV4Test.load_json "#{__dir__}/../../../../data/signer_v4_test_data.json"
 tests.each_with_index do |test, index|
   SignerV4Test.build_test_for test, index
 end


### PR DESCRIPTION
[fixes #3654]