### PR TITLE
Release google-cloud-firestore 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Availability (GA)](#versioning) quality level:
 
 * [BigQuery](#bigquery-ga) (GA)
 * [Cloud Datastore](#cloud-datastore-ga) (GA)
+* [Cloud Firestore](#cloud-firestore-ga) (GA)
 * [Cloud Key Management Service](#cloud-key-management-service-ga) (GA)
 * [Stackdriver Logging](#stackdriver-logging-ga) (GA)
 * [Cloud Spanner API](#cloud-spanner-api-ga) (GA)
@@ -31,7 +32,6 @@ This client supports the following Google Cloud Platform services at a
 * [Cloud Bigtable](#cloud-bigtable-beta) (Beta)
 * [Stackdriver Debugger](#stackdriver-debugger-beta) (Beta)
 * [Stackdriver Error Reporting](#stackdriver-error-reporting-beta) (Beta)
-* [Cloud Firestore](#cloud-firestore-beta) (Beta)
 * [Cloud Pub/Sub](#cloud-pubsub-beta) (Beta)
 * [Stackdriver Monitoring API](#stackdriver-monitoring-api-beta) (Beta)
 * [Stackdriver Trace](#stackdriver-trace-beta) (Beta)
@@ -474,7 +474,7 @@ rescue => exception
 end
 ```
 
-### Cloud Firestore (Beta)
+### Cloud Firestore (GA)
 
 - [google-cloud-firestore README](google-cloud-firestore/README.md)
 - [google-cloud-firestore API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-firestore/latest)

--- a/google-cloud-firestore/CHANGELOG.md
+++ b/google-cloud-firestore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.0 / 2019-07-15
+
+* Bump release level to GA.
+
 ### 0.26.2 / 2019-07-12
 
 * Update #to_hash to #to_h for compatibility with google-protobuf >= 3.9.0

--- a/google-cloud-firestore/README.md
+++ b/google-cloud-firestore/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Google Cloud Firestore API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Google Cloud Firestore API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
 
 [Google Cloud Firestore API][Product Documentation]:
 

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Google Cloud Firestore API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Google Cloud Firestore API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
       #
       # [Google Cloud Firestore API][Product Documentation]:
       #

--- a/google-cloud-firestore/lib/google/cloud/firestore/version.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Firestore
-      VERSION = "0.26.2".freeze
+      VERSION = "1.0.0".freeze
     end
   end
 end

--- a/google-cloud-firestore/synth.metadata
+++ b/google-cloud-firestore/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-07-01T10:40:54.695501Z",
+  "updateTime": "2019-07-15T20:38:57.627614Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.29.2",
-        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
+        "version": "0.29.4",
+        "dockerImage": "googleapis/artman@sha256:63f21e83cb92680b7001dc381069e962c9e6dee314fd8365ac554c07c89221fb"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
-        "internalRef": "255474859"
+        "sha": "47bd0c2ba33c28dd624a65dad382e02bb61d1618",
+        "internalRef": "257690259"
       }
     }
   ],

--- a/google-cloud-firestore/synth.py
+++ b/google-cloud-firestore/synth.py
@@ -164,3 +164,7 @@ for version in ['v1', 'v1beta1']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Firestore::VERSION'
     )
+s.replace(
+    'lib/google/cloud/firestore/v1beta1.rb',
+    '\[Beta\]',
+    '[GA]')

--- a/google-cloud/google-cloud.gemspec
+++ b/google-cloud/google-cloud.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-dlp", "~> 0.4"
   gem.add_dependency "google-cloud-dns", "~> 0.28"
   gem.add_dependency "google-cloud-error_reporting", "~> 0.30"
-  gem.add_dependency "google-cloud-firestore", "~> 0.21"
+  gem.add_dependency "google-cloud-firestore", "~> 1.0"
   gem.add_dependency "google-cloud-kms", "~> 1.0"
   gem.add_dependency "google-cloud-language", "~> 0.30"
   gem.add_dependency "google-cloud-logging", "~> 1.5"


### PR DESCRIPTION
* Bump release level to GA.
* Update READMEs for Firestore GA.
* Update synth.py for Firestore GA in doc link.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff

```

</details>

This pull request was generated using releasetool.