### PR TITLE
chore: Update synth files so they don't revert to_h fixes

### DIFF
--- a/google-cloud-bigtable/synth.py
+++ b/google-cloud-bigtable/synth.py
@@ -137,6 +137,18 @@ s.replace(
     ],
     '/bigtable-admin\\.googleapis\\.com', '/bigtableadmin.googleapis.com')
 
+# Fix for tests that assume protos implement to_hash
+s.replace(
+    'test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb',
+    'assert_equal\\(clusters, request\\.clusters\\)',
+    'assert_equal(clusters, request.clusters.to_h)'
+)
+s.replace(
+    'test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb',
+    'assert_equal\\(labels, request\\.labels\\)',
+    'assert_equal(labels, request.labels.to_h)'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2232
 s.replace(
     [

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -97,6 +97,13 @@ s.replace(
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
     '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
 
+# Fix for tests that assume protos implement to_hash
+s.replace(
+    'test/google/cloud/container/v1*/cluster_manager_client_test.rb',
+    'assert_equal\\(resource_labels, request\\.resource_labels\\)',
+    'assert_equal(resource_labels, request.resource_labels.to_h)'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [

--- a/grafeas-client/synth.py
+++ b/grafeas-client/synth.py
@@ -141,6 +141,13 @@ s.replace(
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
     '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
 
+# Fix for tests that assume protos implement to_hash
+s.replace(
+    'test/grafeas/v1/grafeas_client_test.rb',
+    'assert_equal\\(notes, request\\.notes\\)',
+    'assert_equal(notes, request.notes.to_h)'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [


### PR DESCRIPTION
Prevents synth from reverting parts of #3658. (See #3662, #3663, #3664)