### PR TITLE
Reduce thread allocations

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -86,7 +86,8 @@ module Google
 
             @batch = nil
 
-            @thread_pool = Concurrent::FixedThreadPool.new @threads
+            @thread_pool = Concurrent::ThreadPoolExecutor.new \
+              max_threads: @threads
 
             @cond = new_cond
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -200,7 +200,8 @@ module Google
 
         def init
           # init the thread pool
-          @thread_pool = Concurrent::FixedThreadPool.new @threads
+          @thread_pool = Concurrent::ThreadPoolExecutor.new \
+            max_threads: @threads
           # init the queues
           @new_sessions_in_process = 0
           @all_sessions = []


### PR DESCRIPTION
Lower thread allocations by switching from FixedThreadPool to
ThreadPoolExecutor which only add threads when needed vs.
creating all threads on thread pool initialization.

[refs #3679]