### PR TITLE
migrate to devsite

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -29,8 +29,6 @@ function set_failed_status {
 }
 
 if [ "$PACKAGE" = "post" ]; then
-    export DOCS_CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
-    python3 -m pip install gcp-docuploader
     (bundle update && bundle exec rake kokoro:post) || set_failed_status
 elif [ "$JOB_TYPE" = "nightly" ]; then
     for version in "${versions[@]}"; do
@@ -44,6 +42,7 @@ elif [ "$JOB_TYPE" = "continuous" ]; then
         (bundle update && bundle exec rake kokoro:continuous) || set_failed_status
     done
 elif [ "$JOB_TYPE" = "release" ]; then
+    export DOCS_CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
     git fetch --depth=10000
     python3 -m pip install git+https://github.com/googleapis/releasetool
     python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -13,7 +13,7 @@ recommended during development.
 
 General instructions, environment variables, and configuration options are
 covered in the general [Authentication
-guide](https://googleapis.github.io/google-cloud-ruby/docs/authentication)
+guide](./google-cloud/AUTHENTICATION.md)
 for the `google-cloud` umbrella package. Specific instructions and environment
 variables for each individual service are linked from the README documents
 listed below for each service.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ recommended during development.
 
 General instructions, environment variables, and configuration options are
 covered in the general [Authentication
-guide](https://googleapis.github.io/google-cloud-ruby/docs/authentication)
+guide](./google-cloud/AUTHENTICATION.md)
 for the `google-cloud` umbrella package. Specific instructions and environment
 variables for each individual service are linked from the README documents
 listed below for each service.
@@ -102,7 +102,7 @@ The preview examples below demonstrate how to provide the **Project ID** and
 ### Cloud Asset API (Beta)
 
 - [google-cloud-asset README](google-cloud-asset/README.md)
-- [google-cloud-asset API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-asset/latest)
+- [google-cloud-asset API documentation](https://googleapis.dev/ruby/google-cloud-asset/latest)
 - [google-cloud-asset on RubyGems](https://rubygems.org/gems/google-cloud-asset/)
 
 #### Quick Start
@@ -114,7 +114,7 @@ $ gem install google-cloud-asset
 ### BigQuery (GA)
 
 - [google-cloud-bigquery README](google-cloud-bigquery/README.md)
-- [google-cloud-bigquery API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigquery/latest)
+- [google-cloud-bigquery API documentation](https://googleapis.dev/ruby/google-cloud-bigquery/latest)
 - [google-cloud-bigquery on RubyGems](https://rubygems.org/gems/google-cloud-bigquery)
 - [Google BigQuery documentation](https://cloud.google.com/bigquery/docs)
 
@@ -156,7 +156,7 @@ end
 ### BigQuery Data Transfer API (Beta)
 
 - [google-bigquery-data_transfer README](google-cloud-bigquery-data_transfer/README.md)
-- [google-bigquery-data_transfer API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigquery-data_transfer/latest)
+- [google-bigquery-data_transfer API documentation](https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/latest)
 - [google-bigquery-data_transfer on RubyGems](https://rubygems.org/gems/google-cloud-bigquery-data_transfer/)
 - [Google BigQuery Data Transfer documentation](https://cloud.google.com/bigquery/transfer/)
 
@@ -191,7 +191,7 @@ end
 ### Cloud Bigtable (Beta)
 
 - [google-cloud-bigtable README](google-cloud-bigtable/README.md)
-- [google-cloud-bigtable API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigtable/latest)
+- [google-cloud-bigtable API documentation](https://googleapis.dev/ruby/google-cloud-bigtable/latest)
 - [google-cloud-bigtable on RubyGems](https://rubygems.org/gems/google-cloud-bigtable)
 - [Cloud Bigtable documentation](https://cloud.google.com/bigtable/docs)
 
@@ -224,7 +224,7 @@ table.mutate_row(entry)
 ### Cloud Datastore (GA)
 
 - [google-cloud-datastore README](google-cloud-datastore/README.md)
-- [google-cloud-datastore API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-datastore/latest)
+- [google-cloud-datastore API documentation](https://googleapis.dev/ruby/google-cloud-datastore/latest)
 - [google-cloud-datastore on RubyGems](https://rubygems.org/gems/google-cloud-datastore)
 - [Google Cloud Datastore documentation](https://cloud.google.com/datastore/docs)
 
@@ -266,7 +266,7 @@ tasks = datastore.run query
 ### Stackdriver Debugger (Beta)
 
 - [google-cloud-debugger README](google-cloud-debugger/README.md)
-- [google-cloud-debugger instrumentation documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.INSTRUMENTATION)
+- [google-cloud-debugger instrumentation documentation](./google-cloud-debugger/INSTRUMENTATION.md)
 - [google-cloud-debugger on RubyGems](https://rubygems.org/gems/google-cloud-debugger)
 - [Stackdriver Debugger documentation](https://cloud.google.com/debugger/docs)
 
@@ -288,7 +288,7 @@ debugger.start
 ### Cloud DNS (Alpha)
 
 - [google-cloud-dns README](google-cloud-dns/README.md)
-- [google-cloud-dns API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-dns/latest)
+- [google-cloud-dns API documentation](https://googleapis.dev/ruby/google-cloud-dns/latest)
 - [google-cloud-dns on RubyGems](https://rubygems.org/gems/google-cloud-dns)
 - [Google Cloud DNS documentation](https://cloud.google.com/dns/docs)
 
@@ -324,7 +324,7 @@ end
 ### Container Analysis (Alpha)
 
 - [google-cloud-container_analysis README](google-cloud-container_analysis/README.md)
-- [google-cloud-container_analysis API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-container_analysis/latest)
+- [google-cloud-container_analysis API documentation](https://googleapis.dev/ruby/google-cloud-container_analysis/latest)
 - [google-cloud-container_analysis on RubyGems](https://rubygems.org/gems/google-cloud-container_analysis)
 - [Container Analysis documentation](https://cloud.google.com/container-registry/docs/container-analysis/)
 
@@ -350,7 +350,7 @@ end
 ### Container Engine (Alpha)
 
 - [google-cloud-container README](google-cloud-container/README.md)
-- [google-cloud-container API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-container/latest)
+- [google-cloud-container API documentation](https://googleapis.dev/ruby/google-cloud-container/latest)
 - [google-cloud-container on RubyGems](https://rubygems.org/gems/google-cloud-container)
 - [Container Engine documentation](https://cloud.google.com/kubernetes-engine/docs/)
 
@@ -374,7 +374,7 @@ response = cluster_manager_client.list_clusters(project_id_2, zone)
 ### Cloud Dataproc (Alpha)
 
 - [google-cloud-dataproc README](google-cloud-dataproc/README.md)
-- [google-cloud-dataproc API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-dataproc/latest)
+- [google-cloud-dataproc API documentation](https://googleapis.dev/ruby/google-cloud-dataproc/latest)
 - [google-cloud-dataproc on RubyGems](https://rubygems.org/gems/google-cloud-dataproc)
 - [Google Cloud Dataproc documentation](https://cloud.google.com/dataproc/docs)
 
@@ -410,7 +410,7 @@ end
 ### Data Loss Prevention (Alpha)
 
 - [google-cloud-dlp README](google-cloud-dlp/README.md)
-- [google-cloud-dlp API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-dlp/latest)
+- [google-cloud-dlp API documentation](https://googleapis.dev/ruby/google-cloud-dlp/latest)
 - [google-cloud-dlp on RubyGems](https://rubygems.org/gems/google-cloud-dlp)
 - [Data Loss Prevention documentation](https://cloud.google.com/dlp/docs)
 
@@ -438,7 +438,7 @@ response = dlp_service_client.inspect_content(inspect_config, items)
 ### Dialogflow API (Alpha)
 
 - [google-cloud-dialogflow README](google-cloud-dialogflow/README.md)
-- [google-cloud-dialogflow API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-dialogflow/latest)
+- [google-cloud-dialogflow API documentation](https://googleapis.dev/ruby/google-cloud-dialogflow/latest)
 - [google-cloud-dialogflow on RubyGems](https://rubygems.org/gems/google-cloud-dialogflow)
 - [Dialogflow API documentation](https://cloud.google.com/dialogflow-enterprise/docs/)
 
@@ -451,7 +451,7 @@ $ gem install google-cloud-dialogflow
 ### Stackdriver Error Reporting (Beta)
 
 - [google-cloud-error_reporting README](google-cloud-error_reporting/README.md)
-- [google-cloud-error_reporting instrumentation documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-error_reporting/latest/file.INSTRUMENTATION)
+- [google-cloud-error_reporting instrumentation documentation](./google-cloud-error_reporting/INSTRUMENTATION.md)
 - [google-cloud-error_reporting on RubyGems](https://rubygems.org/gems/google-cloud-error_reporting)
 - [Stackdriver Error Reporting documentation](https://cloud.google.com/error-reporting/docs)
 
@@ -477,7 +477,7 @@ end
 ### Cloud Firestore (GA)
 
 - [google-cloud-firestore README](google-cloud-firestore/README.md)
-- [google-cloud-firestore API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-firestore/latest)
+- [google-cloud-firestore API documentation](https://googleapis.dev/ruby/google-cloud-firestore/latest)
 - [google-cloud-firestore on RubyGems](https://rubygems.org/gems/google-cloud-firestore)
 - [Google Cloud Firestore documentation](https://cloud.google.com/firestore/docs)
 
@@ -513,7 +513,7 @@ end
 ### Cloud Key Management Service (GA)
 
 - [google-cloud-kms README](google-cloud-kms/README.md)
-- [google-cloud-kms API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-kms/latest)
+- [google-cloud-kms API documentation](https://googleapis.dev/ruby/google-cloud-kms/latest)
 - [google-cloud-kms on RubyGems](https://rubygems.org/gems/google-cloud-kms)
 - [Google Cloud KMS documentation](https://cloud.google.com/kms/docs/)
 
@@ -547,7 +547,7 @@ end
 ### Stackdriver Logging (GA)
 
 - [google-cloud-logging README](google-cloud-logging/README.md)
-- [google-cloud-logging API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest)
+- [google-cloud-logging API documentation](https://googleapis.dev/ruby/google-cloud-logging/latest)
 - [google-cloud-logging on RubyGems](https://rubygems.org/gems/google-cloud-logging)
 - [Stackdriver Logging documentation](https://cloud.google.com/logging/docs/)
 
@@ -586,7 +586,7 @@ logging.write_entries entry
 ### Cloud Natural Language API (Alpha)
 
 - [google-cloud-language README](google-cloud-language/README.md)
-- [google-cloud-language API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-language/latest)
+- [google-cloud-language API documentation](https://googleapis.dev/ruby/google-cloud-language/latest)
 - [google-cloud-language on RubyGems](https://rubygems.org/gems/google-cloud-language)
 - [Google Cloud Natural Language API documentation](https://cloud.google.com/natural-language/docs)
 
@@ -620,7 +620,7 @@ annotation.tokens.count #=> 13
 ### Cloud OS Login (Alpha)
 
 - [google-cloud-os_login README](google-cloud-os_login/README.md)
-- [google-cloud-os_login API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-os_login/latest)
+- [google-cloud-os_login API documentation](https://googleapis.dev/ruby/google-cloud-os_login/latest)
 - [google-cloud-os_login on RubyGems](https://rubygems.org/gems/google-cloud-os_login)
 - [Google Cloud DNS documentation](https://cloud.google.com/compute/docs/oslogin/rest/)
 
@@ -633,7 +633,7 @@ $ gem install google-cloud-os_login
 ### Phishing Protection (Alpha)
 
 - [google-cloud-phishing_protection README](google-cloud-phishing_protection/README.md)
-- [google-cloud-phishing_protection API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-phishing_protection/latest)
+- [google-cloud-phishing_protection API documentation](https://googleapis.dev/ruby/google-cloud-phishing_protection/latest)
 - [google-cloud-phishing_protection on RubyGems](https://rubygems.org/gems/google-cloud-phishing_protection)
 - [Phishing Protection documentation](https://cloud.google.com/phishing-protection/docs/)
 
@@ -646,7 +646,7 @@ $ gem install google-cloud-phishing_protection
 ### Cloud Pub/Sub (Beta)
 
 - [google-cloud-pubsub README](google-cloud-pubsub/README.md)
-- [google-cloud-pubsub API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-pubsub/latest)
+- [google-cloud-pubsub API documentation](https://googleapis.dev/ruby/google-cloud-pubsub/latest)
 - [google-cloud-pubsub on RubyGems](https://rubygems.org/gems/google-cloud-pubsub)
 - [Google Cloud Pub/Sub documentation](https://cloud.google.com/pubsub/docs)
 
@@ -691,7 +691,7 @@ subscriber.stop.wait!
 ### Recaptcha Enterprise (Alpha)
 
 - [google-cloud-recaptcha_enterprise README](google-cloud-recaptcha_enterprise/README.md)
-- [google-cloud-recaptcha_enterprise API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-recaptcha_enterprise/latest)
+- [google-cloud-recaptcha_enterprise API documentation](https://googleapis.dev/ruby/google-cloud-recaptcha_enterprise/latest)
 - [google-cloud-recaptcha_enterprise on RubyGems](https://rubygems.org/gems/google-cloud-recaptcha_enterprise)
 - [Recaptcha Enterprise documentation](https://cloud.google.com/recaptcha-enterprise/docs/)
 
@@ -704,7 +704,7 @@ $ gem install google-cloud-recaptcha_enterprise
 ### Cloud Redis API (Alpha)
 
 - [google-cloud-redis README](google-cloud-redis/README.md)
-- [google-cloud-redis API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-redis/latest)
+- [google-cloud-redis API documentation](https://googleapis.dev/ruby/google-cloud-redis/latest)
 - [google-cloud-redis on RubyGems](https://rubygems.org/gems/google-cloud-redis)
 - [Cloud Redis API documentation](https://cloud.google.com/memorystore/docs/redis/)
 
@@ -718,7 +718,7 @@ $ gem install google-cloud-redis
 ### Cloud Resource Manager (Alpha)
 
 - [google-cloud-resource_manager README](google-cloud-resource_manager/README.md)
-- [google-cloud-resource_manager API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-resource_manager/latest)
+- [google-cloud-resource_manager API documentation](https://googleapis.dev/ruby/google-cloud-resource_manager/latest)
 - [google-cloud-resource_manager on RubyGems](https://rubygems.org/gems/google-cloud-resource_manager)
 - [Google Cloud Resource Manager documentation](https://cloud.google.com/resource-manager/)
 
@@ -753,7 +753,7 @@ projects = resource_manager.projects filter: "labels.env:production"
 ### Stackdriver Trace (Beta)
 
 - [google-cloud-trace README](google-cloud-trace/README.md)
-- [google-cloud-trace instrumentation documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest/file.INSTRUMENTATION)
+- [google-cloud-trace instrumentation documentation](./google-cloud-trace/INSTRUMENTATION.md)
 - [google-cloud-trace on RubyGems](https://rubygems.org/gems/google-cloud-trace)
 - [Stackdriver Trace documentation](https://cloud.google.com/trace/docs/)
 
@@ -779,7 +779,7 @@ end
 ### Cloud Spanner API (GA)
 
 - [google-cloud-spanner README](google-cloud-spanner/README.md)
-- [google-cloud-spanner API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-spanner/latest)
+- [google-cloud-spanner API documentation](https://googleapis.dev/ruby/google-cloud-spanner/latest)
 - [google-cloud-spanner on RubyGems](https://rubygems.org/gems/google-cloud-spanner)
 - [Google Cloud Speech API documentation](https://cloud.google.com/spanner/docs)
 
@@ -810,7 +810,7 @@ end
 ### Cloud Speech API (Alpha)
 
 - [google-cloud-speech README](google-cloud-speech/README.md)
-- [google-cloud-speech API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-speech/latest)
+- [google-cloud-speech API documentation](https://googleapis.dev/ruby/google-cloud-speech/latest)
 - [google-cloud-speech on RubyGems](https://rubygems.org/gems/google-cloud-speech)
 - [Google Cloud Speech API documentation](https://cloud.google.com/speech/docs)
 
@@ -848,7 +848,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Scheduler API.](https://console.cloud.google.com/apis/library/cloudscheduler.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./google-cloud-scheduler/AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -863,14 +863,14 @@ $ gem install google-cloud-scheduler
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-scheduler/latest/google/cloud/scheduler/v1beta1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-scheduler/latest
 [Product Documentation]: https://cloud.google.com/cloudscheduler
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
@@ -895,7 +895,7 @@ end
 ### Cloud Security Center API (Alpha)
 
 - [google-cloud-security_center README](google-cloud-security_center/README.md)
-- [google-cloud-security_center API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-security_center/latest)
+- [google-cloud-security_center API documentation](https://googleapis.dev/ruby/google-cloud-security_center/latest)
 - [google-cloud-security_center on RubyGems](https://rubygems.org/gems/google-cloud-security_center)
 - [Google Cloud Security Center API documentation](https://cloud.google.com/security-command-center/docs)
 
@@ -908,7 +908,7 @@ $ gem install google-cloud-security_center
 ### Cloud Storage (GA)
 
 - [google-cloud-storage README](google-cloud-storage/README.md)
-- [google-cloud-storage API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-storage/latest)
+- [google-cloud-storage API documentation](https://googleapis.dev/ruby/google-cloud-storage/latest)
 - [google-cloud-storage on RubyGems](https://rubygems.org/gems/google-cloud-storage)
 - [Google Cloud Storage documentation](https://cloud.google.com/storage/docs)
 
@@ -943,7 +943,7 @@ file.copy backup, file.name
 ### Cloud Talent Solutions API (Alpha)
 
 - [google-cloud-talent README](google-cloud-talent/README.md)
-- [google-cloud-talent API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-talent/latest)
+- [google-cloud-talent API documentation](https://googleapis.dev/ruby/google-cloud-talent/latest)
 - [google-cloud-talent on RubyGems](https://rubygems.org/gems/google-cloud-talent/)
 - [Google Cloud Talent Solutions documentation](https://cloud.google.com/talent-solution/docs)
 
@@ -981,7 +981,7 @@ $ gem install google-cloud-talent
 ### Cloud Tasks API (Alpha)
 
 - [google-cloud-tasks README](google-cloud-tasks/README.md)
-- [google-cloud-tasks API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-tasks/latest)
+- [google-cloud-tasks API documentation](https://googleapis.dev/ruby/google-cloud-tasks/latest)
 - [google-cloud-tasks on RubyGems](https://rubygems.org/gems/google-cloud-tasks/)
 
 #### Quick Start
@@ -1039,7 +1039,7 @@ File.write("example.mp3", response.audio_content, mode: "wb")
 ### Cloud Translation API (GA)
 
 - [google-cloud-translate README](google-cloud-translate/README.md)
-- [google-cloud-translate API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-translate/latest)
+- [google-cloud-translate API documentation](https://googleapis.dev/ruby/google-cloud-translate/latest)
 - [google-cloud-translate on RubyGems](https://rubygems.org/gems/google-cloud-translate)
 - [Google Cloud Translation API documentation](https://cloud.google.com/translation/docs)
 
@@ -1069,7 +1069,7 @@ translation.text #=> "Salve mundi!"
 ### Cloud Vision API (Alpha)
 
 - [google-cloud-vision README](google-cloud-vision/README.md)
-- [google-cloud-vision API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-vision/latest)
+- [google-cloud-vision API documentation](https://googleapis.dev/ruby/google-cloud-vision/latest)
 - [google-cloud-vision on RubyGems](https://rubygems.org/gems/google-cloud-vision)
 - [Google Cloud Vision API documentation](https://cloud.google.com/vision/docs)
 
@@ -1099,7 +1099,7 @@ response = image_annotator_client.batch_annotate_images(requests)
 ### Stackdriver Monitoring API (Beta)
 
 - [google-cloud-monitoring README](google-cloud-monitoring/README.md)
-- [google-cloud-monitoring API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-monitoring/latest)
+- [google-cloud-monitoring API documentation](https://googleapis.dev/ruby/google-cloud-monitoring/latest)
 - [google-cloud-monitoring on RubyGems](https://rubygems.org/gems/google-cloud-monitoring)
 - [Google Cloud Monitoring API documentation](https://cloud.google.com/monitoring/docs)
 
@@ -1135,7 +1135,7 @@ $ gem install google-cloud-monitoring
 ### Cloud Video Intelligence API (GA)
 
 - [google-cloud-video_intelligence README](google-cloud-video_intelligence/README.md)
-- [google-cloud-video_intelligence API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-video_intelligence/latest)
+- [google-cloud-video_intelligence API documentation](https://googleapis.dev/ruby/google-cloud-video_intelligence/latest)
 - [google-cloud-video_intelligence on RubyGems](https://rubygems.org/gems/google-cloud-video_intelligence)
 - [Google Cloud Video Intelligence API documentation](https://cloud.google.com/video-intelligence/docs)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -108,7 +108,7 @@ green, you may create a release as follows:
 
 1. Verify the [GitHub release summary](https://github.com/googleapis/google-cloud-ruby/releases), making sure that it fits the format of other releases, mirrors the changelog, is tagged to the appropriate commit hash, and is for the correct version.
 
-1. Verify that the new version is displayed on the [google-cloud-ruby doc site](https://googleapis.dev/ruby/#{gem_name}/latest). The docs are published from the staging bucket every 15 minutes, so it may a few minutes to update.
+1. Verify that the new version is displayed on the google-cloud-ruby doc site at googleapis.dev/ruby/#{gem_name}/latest. The docs are published from the staging bucket every 15 minutes, so it may a few minutes to update.
 
    If it's been 30 minutes and the docs have not updated, [inspect the Kokoro build logs](#checking-the-status-of-kokoro-builds) to confirm that the rake `release` task succeeded.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -108,7 +108,7 @@ green, you may create a release as follows:
 
 1. Verify the [GitHub release summary](https://github.com/googleapis/google-cloud-ruby/releases), making sure that it fits the format of other releases, mirrors the changelog, is tagged to the appropriate commit hash, and is for the correct version.
 
-1. Verify that the new version is displayed on the [google-cloud-ruby gh-pages doc site](https://http://googleapis.github.io/google-cloud-ruby/docs/). Or, to save time when releasing many gems at once, check out the gh-pages branch and pull repeatedly to confirm that it has received the new docs.
+1. Verify that the new version is displayed on the [google-cloud-ruby gh-pages doc site](https://googleapis.dev/ruby/#{gem_name}/latest). Or, to save time when releasing many gems at once, check out the gh-pages branch and pull repeatedly to confirm that it has received the new docs.
 
    If the gh-pages branch has not been updated, [inspect the Kokoro build logs](#checking-the-status-of-kokoro-builds) to confirm that the rake `post` task succeeded.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -89,9 +89,9 @@ green, you may create a release as follows:
 
     1. Releasetool will then ask you if your change is considered major, minor, or patch. This project uses [semantic versioning](http://semver.org).
 
-    1. Releasetool will then create and switch to a branch called "release-#{gem-name}-v#{version}", make all the necessary changes to the changelog and gem version, and open a [pull request](https://github.com/googleapis/google-cloud-ruby/pulls).
+    1. Releasetool will then create and switch to a branch called `release-#{gem-name}-v#{version}`, make all the necessary changes to the changelog and gem version, and open a [pull request](https://github.com/googleapis/google-cloud-ruby/pulls).
 
-1. Review the PR created by releasetool in the previous step, apply the appropriate label (i.e. "api: #{gem_name}"), and request a review from googleapis/yoshi-ruby.
+1. Review the PR created by releasetool in the previous step, apply the appropriate label (i.e. `api: #{gem_name}`), and request a review from googleapis/yoshi-ruby.
 
 1. Repeat steps 3 through 12 if you are releasing multiple gems.
 
@@ -108,7 +108,7 @@ green, you may create a release as follows:
 
 1. Verify the [GitHub release summary](https://github.com/googleapis/google-cloud-ruby/releases), making sure that it fits the format of other releases, mirrors the changelog, is tagged to the appropriate commit hash, and is for the correct version.
 
-1. Verify that the new version is displayed on the google-cloud-ruby doc site at googleapis.dev/ruby/#{gem_name}/latest. The docs are published from the staging bucket every 15 minutes, so it may a few minutes to update.
+1. Verify that the new version is displayed on the google-cloud-ruby doc site at `googleapis.dev/ruby/#{gem_name}/latest`. The docs are published from the staging bucket every 15 minutes, so it may a few minutes to update.
 
    If it's been 30 minutes and the docs have not updated, [inspect the Kokoro build logs](#checking-the-status-of-kokoro-builds) to confirm that the rake `release` task succeeded.
 
@@ -141,11 +141,11 @@ for the `google-cloud` gem.
 
 1. A modal will appear with the list of Kokoro builds. The build titled "Kokoro CI" can be ignored. To learn more about why a build failed or what it was testing for click "details" next to the build.
 
-1. The "details" link will take you to a page on https://source.cloud.google.com/. On the "TARGETS" tab, there will be a link to the logs. It will look like "cloud-devrel/client-libraries/google-cloud-ruby/#{job_type}-#{operating_system}". Click the link.
+1. The "details" link will take you to a page on https://source.cloud.google.com/. On the "TARGETS" tab, there will be a link to the logs. It will look like `cloud-devrel/client-libraries/google-cloud-ruby/#{job_type}-#{operating_system}`. Click the link.
 
 1. The next page will have a list of all the tasks carried out under the selected operating system. The top half will be a list of tasks and the links to their respective logs, the bottom half will be a list of tasks and their status (SUCCEEDED/FAILED). To learn more about why a task failed, clink the corresponding link on the top half of the screen.
 
-1. You will be greeted with a screen similar to the one in step 4. The link to your task should look like "cloud-devrel/client-libraries/google-cloud-ruby/#{job_type}/#{operating_system}/#{task_name}". Click it.
+1. You will be greeted with a screen similar to the one in step 4. The link to your task should look like `cloud-devrel/client-libraries/google-cloud-ruby/#{job_type}/#{operating_system}/#{task_name}`. Click it.
 
 1. The "TARGET LOG" tab should be pre-selected, and will contain the complete logs. Examine the logs to determine what went wrong. Before taking the steps below, check to see if the issue appears on [the list of known issues](https://github.com/googleapis/google-cloud-ruby/wiki/Known-Issues#kokoro-build-failures). If you see the error there, and you are confident that your release is unrelated, no further steps are necessary.
 
@@ -164,11 +164,11 @@ for the `google-cloud` gem.
 ## Writing a GitHub release summary manually
 1. [Draft a new GitHub release summary](https://github.com/googleapis/google-cloud-ruby/releases/new).
 
-1. Add a tag. The tag should be of the format "#{gem_name}/v#{version_number}".
+1. Add a tag. The tag should be of the format `#{gem_name}/v#{version_number}`.
 
 1. To the right of the tag and "@" symbol, there will be a dropdown with "Target: master. Click the dropdown, select the "Recent Commits" tab, and find and select the commit that was your merged PR.
 
-1. Add a title in the format "Release #{gem_name} #{version_number}".
+1. Add a title in the format `Release #{gem_name} #{version_number}`.
 
 1. Copy the content of the most recent update in the gem's `CHANGELOG.md` into the textarea with placeholder text "Describe this release".
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -108,9 +108,9 @@ green, you may create a release as follows:
 
 1. Verify the [GitHub release summary](https://github.com/googleapis/google-cloud-ruby/releases), making sure that it fits the format of other releases, mirrors the changelog, is tagged to the appropriate commit hash, and is for the correct version.
 
-1. Verify that the new version is displayed on the [google-cloud-ruby gh-pages doc site](https://googleapis.dev/ruby/#{gem_name}/latest). Or, to save time when releasing many gems at once, check out the gh-pages branch and pull repeatedly to confirm that it has received the new docs.
+1. Verify that the new version is displayed on the [google-cloud-ruby doc site](https://googleapis.dev/ruby/#{gem_name}/latest). The docs are published from the staging bucket every 15 minutes, so it may a few minutes to update.
 
-   If the gh-pages branch has not been updated, [inspect the Kokoro build logs](#checking-the-status-of-kokoro-builds) to confirm that the rake `post` task succeeded.
+   If it's been 30 minutes and the docs have not updated, [inspect the Kokoro build logs](#checking-the-status-of-kokoro-builds) to confirm that the rake `release` task succeeded.
 
 1. Verify that the correct version of the gem was published on [rubygems](https://rubygems.org/).
 

--- a/Rakefile
+++ b/Rakefile
@@ -227,8 +227,8 @@ namespace :docs do
   end
 
   desc "Builds documentation for all tags and current branch (assumes master)"
-  task :rebuild_all do
-    DevsiteBuilder.new(__dir__).rebuild_all
+  task :republish_all do
+    DevsiteBuilder.new(__dir__).republish_all
   end
 end
 
@@ -592,13 +592,8 @@ namespace :kokoro do
 
   desc "Runs post-build logic on kokoro."
   task :post do
-    require_relative "rakelib/devsite_builder.rb"
-
     Rake::Task["kokoro:load_env_vars"].invoke
-
-    DevsiteBuilder.new(__dir__).republish_all
-    Rake::Task["docs:build_master"].invoke
-
+    Rake::Task["docs:republish_all"].invoke
     Rake::Task["test:codecov"].invoke
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -592,7 +592,14 @@ namespace :kokoro do
 
   desc "Runs post-build logic on kokoro."
   task :post do
-    puts "Linkinator will run here"
+    require_relative "rakelib/devsite_builder.rb"
+
+    Rake::Task["kokoro:load_env_vars"].invoke
+
+    DevsiteBuilder.new(__dir__).republish_all
+    Rake::Task["docs:build_master"].invoke
+
+    Rake::Task["test:codecov"].invoke
   end
 
   task :nightly do

--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -21,7 +21,7 @@ $ gem install gcloud
 ## Authentication
 
 Instructions and configuration options are covered in the [Authentication
-Guide](./AUTHENTICATION.md).
+Guide](https://googleapis.dev/gcloud/latest/file.AUTHENTICATION.html).
 
 ## Example
 
@@ -60,18 +60,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://github.com/googleapis/google-cloud-ruby/blob/master/.github/CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://github.com/googleapis/google-cloud-ruby/blob/master/CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://github.com/googleapis/google-cloud-ruby/blob/master/LICENSE).
 
 ## Support
 

--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -9,7 +9,7 @@ repository](https://github.com/googleapis/google-cloud-ruby) for more
 information about using the `google-cloud` umbrella gem and the individual
 service gems.
 
-- [gcloud API documentation](https://googleapis.github.io/google-cloud-ruby/docs/gcloud/latest)
+- [gcloud API documentation](https://googleapis.dev/ruby/docs/gcloud/latest)
 - [gcloud on RubyGems](https://rubygems.org/gems/gcloud)
 
 ## Quick Start
@@ -21,7 +21,7 @@ $ gem install gcloud
 ## Authentication
 
 Instructions and configuration options are covered in the [Authentication
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/gcloud/latest/file.AUTHENTICATION).
+Guide](./AUTHENTICATION.md).
 
 ## Example
 
@@ -60,18 +60,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/gcloud/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/gcloud/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/gcloud/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud-asset/README.md
+++ b/google-cloud-asset/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Asset API.](https://console.cloud.google.com/apis/library/asset.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-asset/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-asset/README.md
+++ b/google-cloud-asset/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Asset API.](https://console.cloud.google.com/apis/library/asset.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -27,14 +27,14 @@ $ gem install google-cloud-asset
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-asset/latest/google/cloud/asset/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-asset/latest
 [Product Documentation]: https://cloud.google.com/asset
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-asset/lib/google/cloud/asset.rb
+++ b/google-cloud-asset/lib/google/cloud/asset.rb
@@ -34,7 +34,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Cloud Asset API.](https://console.cloud.google.com/apis/library/asset.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-asset/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -53,7 +53,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-asset/lib/google/cloud/asset/v1.rb
+++ b/google-cloud-asset/lib/google/cloud/asset/v1.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Asset API.](https://console.cloud.google.com/apis/library/asset.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-asset/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-asset/lib/google/cloud/asset/v1beta1.rb
+++ b/google-cloud-asset/lib/google/cloud/asset/v1beta1.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Asset API.](https://console.cloud.google.com/apis/library/asset.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-asset/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -208,6 +208,28 @@ for version in ['v1', 'v1beta1']:
         'Google::Cloud::Asset::VERSION'
     )
 
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-asset/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-asset/latest/.*$',
+    'dev/ruby/google-cloud-asset/latest'
+)
 
 # Generate the helper methods
 call('bundle update && bundle exec rake generate', shell=True)

--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -218,7 +218,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-asset/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-automl/README.md
+++ b/google-cloud-automl/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud AutoML API.](https://console.cloud.google.com/apis/library/automl.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-automl/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-automl/README.md
+++ b/google-cloud-automl/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud AutoML API.](https://console.cloud.google.com/apis/library/automl.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -28,14 +28,14 @@ $ gem install google-cloud-automl
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-automl/latest/google/cloud/automl/v1beta1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-automl/latest
 [Product Documentation]: https://cloud.google.com/automl
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-automl/lib/google/cloud/automl.rb
+++ b/google-cloud-automl/lib/google/cloud/automl.rb
@@ -35,7 +35,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Cloud AutoML API.](https://console.cloud.google.com/apis/library/automl.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-automl/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -54,7 +54,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-automl/lib/google/cloud/automl/v1beta1.rb
+++ b/google-cloud-automl/lib/google/cloud/automl/v1beta1.rb
@@ -38,7 +38,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud AutoML API.](https://console.cloud.google.com/apis/library/automl.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-automl/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -57,7 +57,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-automl/synth.py
+++ b/google-cloud-automl/synth.py
@@ -220,3 +220,26 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::AutoML::VERSION'
 )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-automl/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-automl/latest/.*$',
+    'dev/ruby/google-cloud-automl/latest'
+)

--- a/google-cloud-automl/synth.py
+++ b/google-cloud-automl/synth.py
@@ -231,7 +231,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-automl/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-bigquery-data_transfer/README.md
+++ b/google-cloud-bigquery-data_transfer/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the BigQuery Data Transfer API.](https://console.cloud.google.com/apis/library/bigquerydatatransfer.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -50,14 +50,14 @@ end
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-bigquery-data_transfer/latest/google/cloud/bigquery/datatransfer/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/latest
 [Product Documentation]: https://cloud.google.com/bigquery/transfer/
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-bigquery-data_transfer/README.md
+++ b/google-cloud-bigquery-data_transfer/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the BigQuery Data Transfer API.](https://console.cloud.google.com/apis/library/bigquerydatatransfer.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer.rb
@@ -36,7 +36,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the BigQuery Data Transfer API.](https://console.cloud.google.com/apis/library/bigquerydatatransfer.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -77,7 +77,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1.rb
@@ -36,7 +36,7 @@ module Google
         # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
         # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
         # 3. [Enable the BigQuery Data Transfer API.](https://console.cloud.google.com/apis/library/bigquerydatatransfer.googleapis.com)
-        # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+        # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/file.AUTHENTICATION.html)
         #
         # ### Installation
         # ```
@@ -77,7 +77,7 @@ module Google
         #
         # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
         # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
         # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
         # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
         #

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/data_transfer/v1/data_transfer.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/data_transfer/v1/data_transfer.rb
@@ -25,8 +25,7 @@ module Google
         # | [DataTransferServiceClient][] | The Google BigQuery Data Transfer Service API enables BigQuery users to configure the transfer of their data from other Google Products into BigQuery. |
         # | [Data Types][] | Data types for Google::Cloud::Bigquery::DataTransfer::V1 |
         #
-        # [DataTransferServiceClient]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-bigquery-data_transfer/latest/google/cloud/bigquery/datatransfer/v1/datatransferserviceclient
-        # [Data Types]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-bigquery-data_transfer/latest/google/cloud/bigquery/datatransfer/v1/datatypes
+        # [DataTransferServiceClient]: https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/latest/Google/Cloud/Bigquery/DataTransfer/V1/DataTransferServiceClient.html
         #
         module V1
           # Represents a data source parameter with validation rules, so that

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -188,3 +188,26 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Bigquery::DataTransfer::VERSION'
 )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-bigquery-data_transfer/latest/.*$',
+    'dev/ruby/google-cloud-bigquery-data_transfer/latest'
+)

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -199,7 +199,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-bigquery/LOGGING.md
+++ b/google-cloud-bigquery/LOGGING.md
@@ -6,7 +6,7 @@ Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#l
 library. The logger that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/).
 

--- a/google-cloud-bigquery/README.md
+++ b/google-cloud-bigquery/README.md
@@ -2,7 +2,7 @@
 
 [Google BigQuery](https://cloud.google.com/bigquery/) ([docs](https://cloud.google.com/bigquery/docs)) enables super-fast, SQL-like queries against append-only tables, using the processing power of Google's infrastructure. Simply move your data into BigQuery and let it handle the hard work. You can control access to both the project and your data based on your business needs, such as giving others the ability to view or query your data.
 
-- [google-cloud-bigquery API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigquery/latest)
+- [google-cloud-bigquery API documentation](https://googleapis.dev/ruby/google-cloud-bigquery/latest)
 - [google-cloud-bigquery on RubyGems](https://rubygems.org/gems/google-cloud-bigquery)
 - [Google BigQuery documentation](https://cloud.google.com/bigquery/docs)
 
@@ -16,7 +16,7 @@ $ gem install google-cloud-bigquery
 
 This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.
 
-Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigquery/latest/file.AUTHENTICATION).
+Instructions and configuration options are covered in the [Authentication Guide](./AUTHENTICATION.md).
 
 ## Example
 
@@ -49,7 +49,7 @@ end
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [Google API Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/).
+To enable logging for this library, set the logger for the underlying [Google API Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/).
 
 If you do not set the logger explicitly and your application is running in a Rails environment, it will default to `Rails.logger`. Otherwise, if you do not set the logger and you are not using Rails, logging is disabled by default.
 
@@ -88,18 +88,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigquery/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigquery/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigquery/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 
@@ -109,4 +109,4 @@ hesitate to [ask
 questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby)
 about the client or APIs on [StackOverflow](http://stackoverflow.com). For more
 see the [Troubleshooting
-guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigquery/latest/file.TROUBLESHOOTING)
+guide](./TROUBLESHOOTING.md)

--- a/google-cloud-bigquery/README.md
+++ b/google-cloud-bigquery/README.md
@@ -16,7 +16,7 @@ $ gem install google-cloud-bigquery
 
 This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.
 
-Instructions and configuration options are covered in the [Authentication Guide](./AUTHENTICATION.md).
+Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.dev/ruby/google-cloud-bigquery/latest/file.AUTHENTICATION.html).
 
 ## Example
 
@@ -88,18 +88,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud-bigquery/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud-bigquery/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud-bigquery/latest/file.LICENSE.html).
 
 ## Support
 
@@ -109,4 +109,4 @@ hesitate to [ask
 questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby)
 about the client or APIs on [StackOverflow](http://stackoverflow.com). For more
 see the [Troubleshooting
-guide](./TROUBLESHOOTING.md)
+guide](https://googleapis.dev/ruby/google-cloud-bigquery/latest/file.TROUBLESHOOTING.html)

--- a/google-cloud-bigtable/LOGGING.md
+++ b/google-cloud-bigtable/LOGGING.md
@@ -5,7 +5,7 @@ To enable logging for this library, set the logger for the underlying
 that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/). See
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)

--- a/google-cloud-bigtable/OVERVIEW.md
+++ b/google-cloud-bigtable/OVERVIEW.md
@@ -14,7 +14,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Bigtable API.](https://console.cloud.google.com/apis/library/bigtable.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud/latest/file.AUTHENTICATION)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Next Steps
 - Read the [Cloud Bigtable API Product documentation][Product Documentation]

--- a/google-cloud-bigtable/OVERVIEW.md
+++ b/google-cloud-bigtable/OVERVIEW.md
@@ -14,7 +14,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Bigtable API.](https://console.cloud.google.com/apis/library/bigtable.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigtable/latest/file.AUTHENTICATION.html)
 
 ### Next Steps
 - Read the [Cloud Bigtable API Product documentation][Product Documentation]

--- a/google-cloud-bigtable/README.md
+++ b/google-cloud-bigtable/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Bigtable API.](https://console.cloud.google.com/apis/api/bigtable)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigtable/latest/file.AUTHENTICATION)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -30,7 +30,7 @@ $ gem install google-cloud-bigtable
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:
 
@@ -61,5 +61,5 @@ and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigtable/latest
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-bigtable/latest
 [Product Documentation]: https://cloud.google.com/bigtable

--- a/google-cloud-bigtable/README.md
+++ b/google-cloud-bigtable/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Bigtable API.](https://console.cloud.google.com/apis/api/bigtable)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigtable/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Bigtable Admin API.](https://console.cloud.google.com/apis/library/bigtableadmin.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigtable/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2.rb
@@ -38,7 +38,7 @@ module Google
         # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
         # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
         # 3. [Enable the Cloud Bigtable Admin API.](https://console.cloud.google.com/apis/library/bigtableadmin.googleapis.com)
-        # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+        # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigtable/file.AUTHENTICATION.html)
         #
         # ### Installation
         # ```
@@ -57,7 +57,7 @@ module Google
         #
         # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
         # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
         # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
         # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
         #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Bigtable API.](https://console.cloud.google.com/apis/library/bigtable.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigtable/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-bigtable/samples/README.md
+++ b/google-cloud-bigtable/samples/README.md
@@ -23,7 +23,7 @@
 ## Before you begin
 
 Before running the samples, make sure you've followed the steps in the
-[Before you begin section](../README.md#before-you-begin) of the client
+[Before you begin section](https://github.com/googleapis/google-cloud-ruby/tree/master/google-cloud-bigtable/samples#before-you-begin) of the client
 library's README.
 
 ## Samples

--- a/google-cloud-bigtable/synth.py
+++ b/google-cloud-bigtable/synth.py
@@ -219,3 +219,15 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Bigtable::VERSION'
 )
+
+# Fix links for devsite migration
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+    'https://googleapis.dev/ruby/google-cloud-logging/latest'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-bigtable/latest/file.AUTHENTICATION.html'
+)

--- a/google-cloud-container/README.md
+++ b/google-cloud-container/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Kubernetes Engine API.](https://console.cloud.google.com/apis/library/container.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-container/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-container/README.md
+++ b/google-cloud-container/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Kubernetes Engine API.](https://console.cloud.google.com/apis/library/container.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -39,14 +39,14 @@ response = cluster_manager_client.list_clusters(project_id_2, zone)
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-container/latest/google/container/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-container/latest
 [Product Documentation]: https://cloud.google.com/kubernetes-engine
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-container/lib/google/cloud/container.rb
+++ b/google-cloud-container/lib/google/cloud/container.rb
@@ -35,7 +35,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Kubernetes Engine API.](https://console.cloud.google.com/apis/library/container.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-container/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -65,7 +65,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-container/lib/google/cloud/container/v1.rb
+++ b/google-cloud-container/lib/google/cloud/container/v1.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Kubernetes Engine API.](https://console.cloud.google.com/apis/library/container.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-container/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -65,7 +65,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-container/lib/google/cloud/container/v1beta1.rb
+++ b/google-cloud-container/lib/google/cloud/container/v1beta1.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Kubernetes Engine API.](https://console.cloud.google.com/apis/library/container.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-container/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -65,7 +65,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -201,7 +201,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-container/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -190,3 +190,26 @@ for version in ['v1', 'v1beta1']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Container::VERSION'
     )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-container/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-container/latest/.*$',
+    'dev/ruby/google-cloud-container/latest'
+)

--- a/google-cloud-container_analysis/README.md
+++ b/google-cloud-container_analysis/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Container Analysis API.](https://console.cloud.google.com/apis/library/containeranalysis.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -40,14 +40,14 @@ end
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-container_analysis/latest/google/devtools/containeranalysis/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-container_analysis/latest
 [Product Documentation]: https://cloud.google.com/container-registry/docs/container-analysis
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-container_analysis/README.md
+++ b/google-cloud-container_analysis/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Container Analysis API.](https://console.cloud.google.com/apis/library/containeranalysis.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-container_analysis/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-container_analysis/lib/google/cloud/container_analysis.rb
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis.rb
@@ -36,7 +36,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Container Analysis API.](https://console.cloud.google.com/apis/library/containeranalysis.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-container_analysis/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -55,7 +55,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1.rb
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Container Analysis API.](https://console.cloud.google.com/apis/library/containeranalysis.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-container_analysis/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-container_analysis/synth.py
+++ b/google-cloud-container_analysis/synth.py
@@ -220,3 +220,15 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::ContainerAnalysis::VERSION'
 )
+
+# Fix links for devsite migration
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+    'https://googleapis.dev/ruby/google-cloud-logging/latest'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-container_analysis/latest/file.AUTHENTICATION.html'
+)

--- a/google-cloud-core/README.md
+++ b/google-cloud-core/README.md
@@ -30,18 +30,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud-core/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud-core/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud-core/latest/file.LICENSE.html).
 
 ## Support
 

--- a/google-cloud-core/README.md
+++ b/google-cloud-core/README.md
@@ -5,7 +5,7 @@ project. Please see the [GitHub
 repository](https://github.com/googleapis/google-cloud-ruby) for more
 information about the individual google-cloud gems.
 
-- [google-cloud-core API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-core/latest)
+- [google-cloud-core API documentation](https://googleapis.dev/ruby/google-cloud-core/latest)
 
 ## Supported Ruby Versions
 
@@ -30,18 +30,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-core/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-core/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-core/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud-dataproc/README.md
+++ b/google-cloud-dataproc/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Google Cloud Dataproc API.](https://console.cloud.google.com/apis/library/dataproc.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-dataproc/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-dataproc/README.md
+++ b/google-cloud-dataproc/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Google Cloud Dataproc API.](https://console.cloud.google.com/apis/library/dataproc.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -50,14 +50,14 @@ end
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-dataproc/latest/google/cloud/dataproc/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-dataproc/latest
 [Product Documentation]: https://cloud.google.com/dataproc
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-dataproc/lib/google/cloud/dataproc.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc.rb
@@ -34,7 +34,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Google Cloud Dataproc API.](https://console.cloud.google.com/apis/library/dataproc.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-dataproc/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -76,7 +76,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1.rb
@@ -39,7 +39,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Google Cloud Dataproc API.](https://console.cloud.google.com/apis/library/dataproc.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-dataproc/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -81,7 +81,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2.rb
@@ -40,7 +40,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Google Cloud Dataproc API.](https://console.cloud.google.com/apis/library/dataproc.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-dataproc/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -82,7 +82,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -238,3 +238,26 @@ for version in ['v1', 'v1beta2']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Dataproc::VERSION'
     )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-dataproc/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-dataproc/latest/.*$',
+    'dev/ruby/google-cloud-dataproc/latest'
+)

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -249,7 +249,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-dataproc/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-datastore/LOGGING.md
+++ b/google-cloud-datastore/LOGGING.md
@@ -5,7 +5,7 @@ To enable logging for this library, set the logger for the underlying
 that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/). See
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)

--- a/google-cloud-datastore/README.md
+++ b/google-cloud-datastore/README.md
@@ -18,7 +18,7 @@ $ gem install google-cloud-datastore
 
 This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.
 
-Instructions and configuration options are covered in the [Authentication Guide](./AUTHENTICATION.md).
+Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.dev/ruby/google-cloud-datastore/latest/file.AUTHENTICATION.html).
 
 ## Example
 
@@ -89,18 +89,18 @@ This library follows [Semantic Versioning](http://semver.org/).
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud-datastore/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud-datastore/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud-datastore/latest/file.LICENSE.html).
 
 ## Support
 

--- a/google-cloud-datastore/README.md
+++ b/google-cloud-datastore/README.md
@@ -4,7 +4,7 @@
 
 Follow the [activation instructions](https://cloud.google.com/datastore/docs/activate) to use the Google Cloud Datastore API with your project.
 
-- [google-cloud-datastore API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-datastore/latest)
+- [google-cloud-datastore API documentation](https://googleapis.dev/ruby/google-cloud-datastore/latest)
 - [google-cloud-datastore on RubyGems](https://rubygems.org/gems/google-cloud-datastore)
 - [Google Cloud Datastore documentation](https://cloud.google.com/datastore/docs)
 
@@ -18,7 +18,7 @@ $ gem install google-cloud-datastore
 
 This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.
 
-Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-datastore/latest/file.AUTHENTICATION).
+Instructions and configuration options are covered in the [Authentication Guide](./AUTHENTICATION.md).
 
 ## Example
 
@@ -49,7 +49,7 @@ tasks = datastore.run query
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:
 
@@ -89,18 +89,18 @@ This library follows [Semantic Versioning](http://semver.org/).
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-datastore/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-datastore/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-datastore/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud-debugger/INSTRUMENTATION.md
+++ b/google-cloud-debugger/INSTRUMENTATION.md
@@ -58,7 +58,7 @@ you want to run on a non Google Cloud environment or you want to customize
 the default behavior.
 
 See the
-[Configuration Guide](../stackdriver/INSTRUMENTATION_CONFIGURATION.md)
+[Configuration Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
 for full configuration parameters.
 
 ### Using instrumentation with Ruby on Rails

--- a/google-cloud-debugger/INSTRUMENTATION.md
+++ b/google-cloud-debugger/INSTRUMENTATION.md
@@ -58,7 +58,7 @@ you want to run on a non Google Cloud environment or you want to customize
 the default behavior.
 
 See the
-[Configuration Guide](https://googleapis.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
+[Configuration Guide](../stackdriver/INSTRUMENTATION_CONFIGURATION.md)
 for full configuration parameters.
 
 ### Using instrumentation with Ruby on Rails

--- a/google-cloud-debugger/LOGGING.md
+++ b/google-cloud-debugger/LOGGING.md
@@ -5,7 +5,7 @@ To enable logging for this library, set the logger for the underlying
 that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/). See
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)

--- a/google-cloud-debugger/README.md
+++ b/google-cloud-debugger/README.md
@@ -22,7 +22,7 @@ Add the `google-cloud-debugger` gem to your Gemfile:
 gem "google-cloud-debugger"
 ```
 
-Alternatively, consider installing the [`stackdriver`](../stackdriver) gem. It
+Alternatively, consider installing the [`stackdriver`](https://googleapis.dev/ruby/stackdriver/latest) gem. It
 includes the `google-cloud-debugger` gem as a dependency, and automatically
 initializes it for some application frameworks.
 
@@ -175,7 +175,7 @@ Google::Cloud::Debugger.new(project_id: "your-project-id",
 
 This library also supports the other authentication methods provided by the
 `google-cloud-ruby` suite. Instructions and configuration options are covered
-in the [Authentication Guide](./AUTHENTICATION.md).
+in the [Authentication Guide](https://googleapis.dev/ruby/google-cloud-debugger/latest/file.AUTHENTICATION.html).
 
 ### Using the Debugger
 
@@ -219,7 +219,7 @@ agent.
 You can customize the behavior of the Stackdriver Debugger agent. This includes
 setting the Google Cloud project and authentication, and customizing the
 behavior of the debugger itself, such as side effect protection and data
-size limits. See [agent configuration](../stackdriver/INSTRUMENTATION_CONFIGURATION.md)
+size limits. See [agent configuration](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
 for a list of possible configuration options.
 
 ## Enabling Logging
@@ -264,18 +264,18 @@ and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud-debugger/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud-debugger/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud-debugger/latest/file.LICENSE.html).
 
 ## Support
 

--- a/google-cloud-debugger/README.md
+++ b/google-cloud-debugger/README.md
@@ -8,7 +8,7 @@ your application, including test, development, and production. The Ruby
 debugger adds minimal request latency, typically less than 50ms, and only when
 application state is captured. In most cases, this is not noticeable by users.
 
-- [google-cloud-debugger documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest)
+- [google-cloud-debugger documentation](https://googleapis.dev/ruby/google-cloud-debugger/latest)
 - [google-cloud-debugger on RubyGems](https://rubygems.org/gems/google-cloud-debugger)
 - [Stackdriver Debugger documentation](https://cloud.google.com/debugger/docs/)
 
@@ -175,7 +175,7 @@ Google::Cloud::Debugger.new(project_id: "your-project-id",
 
 This library also supports the other authentication methods provided by the
 `google-cloud-ruby` suite. Instructions and configuration options are covered
-in the [Authentication Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.AUTHENTICATION).
+in the [Authentication Guide](./AUTHENTICATION.md).
 
 ### Using the Debugger
 
@@ -224,7 +224,7 @@ for a list of possible configuration options.
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:
 
@@ -264,18 +264,18 @@ and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud-debugger/lib/google/cloud/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb
@@ -154,7 +154,7 @@ module Google
       #   single argument.
       #
       # See the [Configuration
-      # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
+      # Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
       # for full configuration parameters.
       #
       # @return [Google::Cloud::Config] The configuration object the

--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
@@ -99,7 +99,7 @@ module Google
         #   using the other parameters.
         # @param [Hash] kwargs Hash of configuration settings. Used for backward
         #   API compatibility. See the [Configuration
-        #   Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
+        #   Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
         #   for the prefered way to set configuration parameters.
         #
         # @return [Google::Cloud::Debugger::Middleware] A new

--- a/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
@@ -34,7 +34,7 @@ module Google
       #
       # The Railtie should also initialize a debugger to be used by the
       # Middleware. See the [Configuration
-      # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
+      # Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
       # on how to configure the Railtie and Middleware.
       #
       class Railtie < ::Rails::Railtie

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2.rb
@@ -36,7 +36,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Stackdriver Debugger API.](https://console.cloud.google.com/apis/library/clouddebugger.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-debugger/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -55,7 +55,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-debugger/synth.py
+++ b/google-cloud-debugger/synth.py
@@ -153,3 +153,15 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Debugger::VERSION'
 )
+
+# Fix links for devsite migration
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-debugger/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+    'https://googleapis.dev/ruby/google-cloud-logging/latest'
+)

--- a/google-cloud-dialogflow/README.md
+++ b/google-cloud-dialogflow/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Dialogflow API.](https://console.cloud.google.com/apis/library/dialogflow.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-dialogflow/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-dialogflow/README.md
+++ b/google-cloud-dialogflow/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Dialogflow API.](https://console.cloud.google.com/apis/library/dialogflow.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -28,14 +28,14 @@ $ gem install google-cloud-dialogflow
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-dialogflow/latest/google/cloud/dialogflow/v2
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-dialogflow/latest
 [Product Documentation]: https://cloud.google.com/dialogflow
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow.rb
@@ -35,7 +35,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Dialogflow API.](https://console.cloud.google.com/apis/library/dialogflow.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-dialogflow/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -54,7 +54,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2.rb
@@ -44,7 +44,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Dialogflow API.](https://console.cloud.google.com/apis/library/dialogflow.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-dialogflow/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -63,7 +63,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -170,3 +170,26 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Dialogflow::VERSION'
 )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-dialogflow/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-dialogflow/latest/.*$',
+    'dev/ruby/google-cloud-dialogflow/latest'
+)

--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -181,7 +181,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-dialogflow/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-dlp/README.md
+++ b/google-cloud-dlp/README.md
@@ -14,7 +14,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Data Loss Prevention (DLP) API.](https://console.cloud.google.com/apis/library/dlp.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -29,14 +29,14 @@ $ gem install google-cloud-dlp
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-dlp/latest/google/privacy/dlp/v2
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-dlp/latest
 [Product Documentation]: https://cloud.google.com/dlp
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-dlp/README.md
+++ b/google-cloud-dlp/README.md
@@ -14,7 +14,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Data Loss Prevention (DLP) API.](https://console.cloud.google.com/apis/library/dlp.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-dlp/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-dlp/lib/google/cloud/dlp.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp.rb
@@ -36,7 +36,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Cloud Data Loss Prevention (DLP) API.](https://console.cloud.google.com/apis/library/dlp.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-dlp/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -55,7 +55,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2.rb
@@ -36,7 +36,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Data Loss Prevention (DLP) API.](https://console.cloud.google.com/apis/library/dlp.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-dlp/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -55,7 +55,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -172,3 +172,26 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Dlp::VERSION'
 )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-dlp/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-dlp/latest/.*$',
+    'dev/ruby/google-cloud-dlp/latest'
+)

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -183,7 +183,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-dlp/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-dns/LOGGING.md
+++ b/google-cloud-dns/LOGGING.md
@@ -6,7 +6,7 @@ Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#l
 library. The logger that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/).
 

--- a/google-cloud-dns/README.md
+++ b/google-cloud-dns/README.md
@@ -2,7 +2,7 @@
 
 [Google Cloud DNS](https://cloud.google.com/dns/) ([docs](https://cloud.google.com/dns/docs)) is a high-performance, resilient, global DNS service that provides a cost-effective way to make your applications and services available to your users. This programmable, authoritative DNS service can be used to easily publish and manage DNS records using the same infrastructure relied upon by Google. To learn more, read [What is Google Cloud DNS?](https://cloud.google.com/dns/what-is-cloud-dns).
 
-- [google-cloud-dns API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-dns/latest)
+- [google-cloud-dns API documentation](https://googleapis.dev/ruby/google-cloud-dns/latest)
 - [google-cloud-dns on RubyGems](https://rubygems.org/gems/google-cloud-dns)
 - [Google Cloud DNS documentation](https://cloud.google.com/dns/docs)
 
@@ -16,7 +16,7 @@ $ gem install google-cloud-dns
 
 This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.
 
-Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-dns/latest/file.AUTHENTICATION).
+Instructions and configuration options are covered in the [Authentication Guide](./AUTHENTICATION.md).
 
 ## Example
 
@@ -42,7 +42,7 @@ end
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [Google API Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/).
+To enable logging for this library, set the logger for the underlying [Google API Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/).
 
 If you do not set the logger explicitly and your application is running in a Rails environment, it will default to `Rails.logger`. Otherwise, if you do not set the logger and you are not using Rails, logging is disabled by default.
 
@@ -81,18 +81,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-dns/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-dns/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-dns/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud-dns/README.md
+++ b/google-cloud-dns/README.md
@@ -16,7 +16,7 @@ $ gem install google-cloud-dns
 
 This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.
 
-Instructions and configuration options are covered in the [Authentication Guide](./AUTHENTICATION.md).
+Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.dev/ruby/google-cloud-dns/latest/file.AUTHENTICATION.html).
 
 ## Example
 
@@ -81,18 +81,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud-dns/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud-dns/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud-dns/latest/file.LICENSE.html).
 
 ## Support
 

--- a/google-cloud-env/README.md
+++ b/google-cloud-env/README.md
@@ -28,18 +28,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud-env/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud-env/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud-env/latest/file.LICENSE.html).
 
 ## Support
 

--- a/google-cloud-env/README.md
+++ b/google-cloud-env/README.md
@@ -3,7 +3,7 @@
 This library provides information on the application hosting environment for
 apps running on Google Cloud Platform.
 
-- [google-cloud-env API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-env/latest)
+- [google-cloud-env API documentation](https://googleapis.dev/ruby/google-cloud-env/latest)
 
 ## Supported Ruby Versions
 
@@ -28,18 +28,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-env/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-env/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-env/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud-error_reporting/INSTRUMENTATION.md
+++ b/google-cloud-error_reporting/INSTRUMENTATION.md
@@ -26,7 +26,7 @@ you want to run on a non Google Cloud environment or you want to customize  the
 default behavior.
 
 See the [Configuration
-Guide](../stackdriver/INSTRUMENTATION_CONFIGURATION)
+Guide](https://googleapis.dev/ruby/stackdriver/INSTRUMENTATION_CONFIGURATION/latest)
 for full configuration parameters.
 
 ## Rack Middleware and Railtie
@@ -48,7 +48,7 @@ require "google/cloud/error_reporting/rails"
 ```
 
 Alternatively, check out the
-[stackdriver](../stackdriver/README.md
+[stackdriver](https://googleapis.dev/ruby/stackdriver/latest/file.README.html
 gem, which enables this Railtie by default.
 
 ### Rack Integration

--- a/google-cloud-error_reporting/INSTRUMENTATION.md
+++ b/google-cloud-error_reporting/INSTRUMENTATION.md
@@ -26,7 +26,7 @@ you want to run on a non Google Cloud environment or you want to customize  the
 default behavior.
 
 See the [Configuration
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
+Guide](../stackdriver/INSTRUMENTATION_CONFIGURATION)
 for full configuration parameters.
 
 ## Rack Middleware and Railtie
@@ -48,7 +48,7 @@ require "google/cloud/error_reporting/rails"
 ```
 
 Alternatively, check out the
-[stackdriver](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest)
+[stackdriver](../stackdriver/README.md
 gem, which enables this Railtie by default.
 
 ### Rack Integration

--- a/google-cloud-error_reporting/LOGGING.md
+++ b/google-cloud-error_reporting/LOGGING.md
@@ -5,7 +5,7 @@ To enable logging for this library, set the logger for the underlying
 that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/). See
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)

--- a/google-cloud-error_reporting/README.md
+++ b/google-cloud-error_reporting/README.md
@@ -7,8 +7,8 @@ filtering capabilities. A dedicated view shows the error details: time chart,
 occurrences, affected user count, first and last seen dates and a cleaned
 exception stack trace. Opt-in to receive email and mobile alerts on new errors.
 
-- [google-cloud-error_reporting API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-error_reporting/latest)
-- [google-cloud-error_reporting instrumentation documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-error_reporting/latest/file.INSTRUMENTATION)
+- [google-cloud-error_reporting API documentation](https://googleapis.dev/ruby/google-cloud-error_reporting/latest)
+- [google-cloud-error_reporting instrumentation documentation](./INSTRUMENTATION.md)
 - [google-cloud-error_reporting on RubyGems](https://rubygems.org/gems/google-cloud-error_reporting)
 - [Stackdriver ErrorReporting documentation](https://cloud.google.com/error-reporting/docs/)
 
@@ -35,7 +35,7 @@ $ bundle install
 ```
 
 Alternatively, check out the
-[`stackdriver`](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest)
+[`stackdriver`](../stackdriver/README.md
 gem that includes the `google-cloud-error_reporting` gem.
 
 ## Enable Stackdriver Error Reporting API
@@ -92,7 +92,7 @@ end
 
 You can customize the behavior of the Stackdriver Error Reporting library for
 Ruby. See the [configuration
-guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
+guide](../stackdriver/INSTRUMENTATION_CONFIGURATION)
 for a list of possible configuration options.
 
 ## Running on Google Cloud Platform
@@ -177,7 +177,7 @@ end
 This library also supports the other authentication methods provided by the
 `google-cloud-ruby` suite. Instructions and configuration options are covered in
 the [Authentication
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.AUTHENTCATION).
+Guide](./AUTHENTCATION.md).
 
 ## Enabling Logging
 
@@ -186,7 +186,7 @@ To enable logging for this library, set the logger for the underlying
 that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/). See
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
@@ -235,18 +235,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud-error_reporting/README.md
+++ b/google-cloud-error_reporting/README.md
@@ -8,7 +8,7 @@ occurrences, affected user count, first and last seen dates and a cleaned
 exception stack trace. Opt-in to receive email and mobile alerts on new errors.
 
 - [google-cloud-error_reporting API documentation](https://googleapis.dev/ruby/google-cloud-error_reporting/latest)
-- [google-cloud-error_reporting instrumentation documentation](./INSTRUMENTATION.md)
+- [google-cloud-error_reporting instrumentation documentation](https://googleapis.dev/ruby/google-cloud-error_reporting/latest/file.INSTRUMENTATION.html)
 - [google-cloud-error_reporting on RubyGems](https://rubygems.org/gems/google-cloud-error_reporting)
 - [Stackdriver ErrorReporting documentation](https://cloud.google.com/error-reporting/docs/)
 
@@ -35,7 +35,7 @@ $ bundle install
 ```
 
 Alternatively, check out the
-[`stackdriver`](../stackdriver/README.md
+[`stackdriver`](https://googleapis.dev/ruby/stackdriver/latest/file.README.html
 gem that includes the `google-cloud-error_reporting` gem.
 
 ## Enable Stackdriver Error Reporting API
@@ -92,7 +92,7 @@ end
 
 You can customize the behavior of the Stackdriver Error Reporting library for
 Ruby. See the [configuration
-guide](../stackdriver/INSTRUMENTATION_CONFIGURATION)
+guide](https://googleapis.dev/ruby/stackdriver/INSTRUMENTATION_CONFIGURATION/latest)
 for a list of possible configuration options.
 
 ## Running on Google Cloud Platform
@@ -177,7 +177,7 @@ end
 This library also supports the other authentication methods provided by the
 `google-cloud-ruby` suite. Instructions and configuration options are covered in
 the [Authentication
-Guide](./AUTHENTCATION.md).
+Guide](https://googleapis.dev/ruby/google-cloud-error_reporting/latest/file.AUTHENTCATION.html).
 
 ## Enabling Logging
 
@@ -235,18 +235,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud-error_reporting/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud-error_reporting/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud-error_reporting/latest/file.LICENSE.html).
 
 ## Support
 

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
@@ -136,7 +136,7 @@ module Google
       #   ErrorReporting.
       #
       # See the [Configuration
-      # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
+      # Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
       # for full configuration parameters.
       #
       # @example

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -39,7 +39,7 @@ module Google
         #   exceptions
         # @param [Hash] kwargs Hash of configuration settings. Used for backward
         #   API compatibility. See the [Configuration
-        #   Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
+        #   Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
         #   for the prefered way to set configuration parameters.
         #
         # @return [Google::Cloud::ErrorReporting::Middleware] A new instance of

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -35,7 +35,7 @@ module Google
       # and handle all Exceptions without interfering with Rails's normal error
       # pages.
       # See the [Configuration
-      # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
+      # Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
       # on how to configure the Railtie and Middleware.
       #
       class Railtie < ::Rails::Railtie

--- a/google-cloud-firestore/LOGGING.md
+++ b/google-cloud-firestore/LOGGING.md
@@ -5,7 +5,7 @@ To enable logging for this library, set the logger for the underlying
 that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/). See
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)

--- a/google-cloud-firestore/README.md
+++ b/google-cloud-firestore/README.md
@@ -11,7 +11,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable the Google Cloud Firestore API.](https://console.cloud.google.com/apis/api/firestore)
-3. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-firestore/latest/file.AUTHENTICATION)
+3. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -28,7 +28,7 @@ $ gem install google-cloud-firestore
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:
 
@@ -59,5 +59,5 @@ and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-firestore/latest
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-firestore/latest
 [Product Documentation]: https://cloud.google.com/firestore

--- a/google-cloud-firestore/README.md
+++ b/google-cloud-firestore/README.md
@@ -11,7 +11,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable the Google Cloud Firestore API.](https://console.cloud.google.com/apis/api/firestore)
-3. [Setup Authentication.](./AUTHENTICATION.md)
+3. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-firestore/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1.rb
@@ -34,7 +34,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Google Cloud Firestore API.](https://console.cloud.google.com/apis/library/firestore.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-firestore/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -53,7 +53,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1.rb
@@ -34,7 +34,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Google Cloud Firestore API.](https://console.cloud.google.com/apis/library/firestore.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-firestore/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -53,7 +53,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-firestore/synth.py
+++ b/google-cloud-firestore/synth.py
@@ -164,7 +164,15 @@ for version in ['v1', 'v1beta1']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Firestore::VERSION'
     )
+
+# Fix links for devsite migration
 s.replace(
-    'lib/google/cloud/firestore/v1beta1.rb',
-    '\[Beta\]',
-    '[GA]')
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+    'https://googleapis.dev/ruby/google-cloud-logging/latest'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-firestore/latest/file.AUTHENTICATION.html'
+)

--- a/google-cloud-irm/README.md
+++ b/google-cloud-irm/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Stackdriver Incident Response & Management API.](https://console.cloud.google.com/apis/library/irm.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-irm/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-irm/README.md
+++ b/google-cloud-irm/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Stackdriver Incident Response & Management API.](https://console.cloud.google.com/apis/library/irm.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -27,14 +27,14 @@ $ gem install google-cloud-irm
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-irm/latest/google/cloud/irm/v1alpha2
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-irm/latest
 [Product Documentation]: https://cloud.google.com/irm
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-irm/lib/google/cloud/irm.rb
+++ b/google-cloud-irm/lib/google/cloud/irm.rb
@@ -34,7 +34,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Stackdriver Incident Response & Management API.](https://console.cloud.google.com/apis/library/irm.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-irm/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -53,7 +53,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-irm/lib/google/cloud/irm/v1alpha2.rb
+++ b/google-cloud-irm/lib/google/cloud/irm/v1alpha2.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Stackdriver Incident Response & Management API.](https://console.cloud.google.com/apis/library/irm.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-irm/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-irm/synth.py
+++ b/google-cloud-irm/synth.py
@@ -166,5 +166,28 @@ s.replace(
     'Google::Cloud::Irm::VERSION'
 )
 
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-irm/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-irm/latest/.*$',
+    'dev/ruby/google-cloud-irm/latest'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-irm/synth.py
+++ b/google-cloud-irm/synth.py
@@ -176,7 +176,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-irm/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-kms/README.md
+++ b/google-cloud-kms/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Key Management Service (KMS) API.](https://console.cloud.google.com/apis/library/cloudkms.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-kms/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-kms/README.md
+++ b/google-cloud-kms/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Key Management Service (KMS) API.](https://console.cloud.google.com/apis/library/cloudkms.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -49,14 +49,14 @@ end
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-kms/latest/google/cloud/kms/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-kms/latest
 [Product Documentation]: https://cloud.google.com/kms
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-kms/lib/google/cloud/kms.rb
+++ b/google-cloud-kms/lib/google/cloud/kms.rb
@@ -35,7 +35,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Cloud Key Management Service (KMS) API.](https://console.cloud.google.com/apis/library/cloudkms.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-kms/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -54,7 +54,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-kms/lib/google/cloud/kms/v1.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1.rb
@@ -37,7 +37,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Key Management Service (KMS) API.](https://console.cloud.google.com/apis/library/cloudkms.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-kms/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -56,7 +56,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -218,5 +218,28 @@ s.replace(
     'Google::Cloud::Kms::VERSION'
 )
 
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-kms/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-kms/latest/.*$',
+    'dev/ruby/google-cloud-kms/latest'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -228,7 +228,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-kms/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-language/README.md
+++ b/google-cloud-language/README.md
@@ -14,7 +14,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Natural Language API.](https://console.cloud.google.com/apis/library/language.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-language/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-language/README.md
+++ b/google-cloud-language/README.md
@@ -14,7 +14,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Natural Language API.](https://console.cloud.google.com/apis/library/language.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -29,14 +29,14 @@ $ gem install google-cloud-language
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-language/latest/google/cloud/language/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-language/latest
 [Product Documentation]: https://cloud.google.com/natural-language
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-language/lib/google/cloud/language.rb
+++ b/google-cloud-language/lib/google/cloud/language.rb
@@ -36,7 +36,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Cloud Natural Language API.](https://console.cloud.google.com/apis/library/language.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-language/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -55,7 +55,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-language/lib/google/cloud/language/v1.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1.rb
@@ -36,7 +36,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Natural Language API.](https://console.cloud.google.com/apis/library/language.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-language/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -55,7 +55,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-language/lib/google/cloud/language/v1beta2.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2.rb
@@ -36,7 +36,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Google Cloud Natural Language API.](https://console.cloud.google.com/apis/library/language.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-language/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -67,7 +67,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -194,3 +194,26 @@ for version in ['v1', 'v1beta2']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Language::VERSION'
     )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-language/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-language/latest/.*$',
+    'dev/ruby/google-cloud-language/latest'
+)

--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -205,7 +205,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-language/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-logging/INSTRUMENTATION.md
+++ b/google-cloud-logging/INSTRUMENTATION.md
@@ -16,7 +16,7 @@ if you want to run on a non Google Cloud environment or you want to customize
 the default behavior.
 
 See the 
-[Configuration Guide](../stackdriver/INSTRUMENTATION_CONFIGURATION.md)
+[Configuration Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
 for full configuration parameters.
 
 ## Using instrumentation with Ruby on Rails

--- a/google-cloud-logging/INSTRUMENTATION.md
+++ b/google-cloud-logging/INSTRUMENTATION.md
@@ -16,7 +16,7 @@ if you want to run on a non Google Cloud environment or you want to customize
 the default behavior.
 
 See the 
-[Configuration Guide](https://googleapis.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
+[Configuration Guide](../stackdriver/INSTRUMENTATION_CONFIGURATION.md)
 for full configuration parameters.
 
 ## Using instrumentation with Ruby on Rails

--- a/google-cloud-logging/LOGGING.md
+++ b/google-cloud-logging/LOGGING.md
@@ -5,7 +5,7 @@ To enable logging for this library, set the logger for the underlying
 that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/). See
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)

--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -2,7 +2,7 @@
 
 [Stackdriver Logging](https://cloud.google.com/logging/) ([docs](https://cloud.google.com/logging/docs/)) allows you to store, search, analyze, monitor, and alert on log data and events from Google Cloud Platform and Amazon Web Services (AWS). It supports ingestion of any custom log data from any source. Stackdriver Logging is a fully-managed service that performs at scale and can ingest application and system log data from thousands of VMs. Even better, you can analyze all that log data in real-time.
 
-- [google-cloud-logging API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest)
+- [google-cloud-logging API documentation](https://googleapis.dev/ruby/google-cloud-logging/latest)
 - [google-cloud-logging on RubyGems](https://rubygems.org/gems/google-cloud-logging)
 - [Stackdriver Logging documentation](https://cloud.google.com/logging/docs/)
 
@@ -153,12 +153,12 @@ end
 ```
 
 See the [Authentication
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/file.AUTHENTICATION).
+Guide](./AUTHENTICATION.md).
 for more ways to authenticate the client library.
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:
 
@@ -198,18 +198,18 @@ This library follows [Semantic Versioning](http://semver.org/).
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -28,7 +28,7 @@ gem "google-cloud-logging"
 $ bundle install
 ```
 
-Alternatively, check out the [`stackdriver`](../stackdriver) gem that includes
+Alternatively, check out the [`stackdriver`](https://googleapis.dev/ruby/stackdriver/latest) gem that includes
 the `google-cloud-logging` gem.
 
 ## Logging using client library
@@ -112,7 +112,7 @@ logger.
 ### Configuring the framework integration
 
 You can customize the behavior of the Stackdriver Logging framework integration
-for Ruby. See the [configuration guide](../stackdriver/INSTRUMENTATION_CONFIGURATION.md) for a
+for Ruby. See the [configuration guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html) for a
 list of possible configuration options.
 
 ## Authentication
@@ -153,7 +153,7 @@ end
 ```
 
 See the [Authentication
-Guide](./AUTHENTICATION.md).
+Guide](https://googleapis.dev/ruby/google-cloud-logging/latest/file.AUTHENTICATION.html).
 for more ways to authenticate the client library.
 
 ## Enabling Logging
@@ -198,18 +198,18 @@ This library follows [Semantic Versioning](http://semver.org/).
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud-logging/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud-logging/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud-logging/latest/file.LICENSE.html).
 
 ## Support
 

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -152,7 +152,7 @@ module Google
       #   single argument. (See {AsyncWriter.on_error}.)
       #
       # See the [Configuration
-      # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
+      # Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
       # for full configuration parameters.
       #
       # @return [Google::Cloud::Config] The configuration object

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -48,7 +48,7 @@ module Google
         #   initialized. The callback takes no arguments. Optional.
         # @param [Hash] kwargs Hash of configuration settings. Used for
         #   backward API compatibility. See the [Configuration
-        #   Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
+        #   Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
         #   for the prefered way to set configuration parameters.
         #
         # @return [Google::Cloud::Logging::Middleware] A new

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -41,7 +41,7 @@ module Google
       # before the `Rails::Rack::Logger Middleware`, which allows it to set the
       # `env['rack.logger']` in place of Rails's default logger.
       # See the [Configuration
-      # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
+      # Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
       # on how to configure the Railtie and Middleware.
       #
       class Railtie < ::Rails::Railtie

--- a/google-cloud-monitoring/README.md
+++ b/google-cloud-monitoring/README.md
@@ -14,7 +14,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Stackdriver Monitoring API.](https://console.cloud.google.com/apis/library/monitoring.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -51,14 +51,14 @@ end
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-monitoring/latest/google/monitoring/v3
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-monitoring/latest
 [Product Documentation]: https://cloud.google.com/monitoring
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-monitoring/README.md
+++ b/google-cloud-monitoring/README.md
@@ -14,7 +14,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Stackdriver Monitoring API.](https://console.cloud.google.com/apis/library/monitoring.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-monitoring/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-monitoring/lib/google/cloud/monitoring.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring.rb
@@ -36,7 +36,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Stackdriver Monitoring API.](https://console.cloud.google.com/apis/library/monitoring.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-monitoring/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -77,7 +77,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3.rb
@@ -42,7 +42,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Stackdriver Monitoring API.](https://console.cloud.google.com/apis/library/monitoring.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-monitoring/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -83,7 +83,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -172,3 +172,26 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Monitoring::VERSION'
 )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-monitoring/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-monitoring/latest/.*$',
+    'dev/ruby/google-cloud-monitoring/latest'
+)

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -183,7 +183,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-monitoring/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-os_login/README.md
+++ b/google-cloud-os_login/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Google Cloud OS Login API.](https://console.cloud.google.com/apis/library/oslogin.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -27,14 +27,14 @@ $ gem install google-cloud-os_login
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-os_login/latest/google/cloud/oslogin/
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-os_login/latest
 [Product Documentation]: https://cloud.google.com/compute/docs/oslogin/rest/
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-os_login/README.md
+++ b/google-cloud-os_login/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Google Cloud OS Login API.](https://console.cloud.google.com/apis/library/oslogin.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-os_login/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-os_login/lib/google/cloud/os_login.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login.rb
@@ -34,7 +34,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Google Cloud OS Login API.](https://console.cloud.google.com/apis/library/oslogin.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-os_login/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -53,7 +53,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1.rb
@@ -34,7 +34,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Google Cloud OS Login API.](https://console.cloud.google.com/apis/library/oslogin.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-os_login/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -53,7 +53,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1beta.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1beta.rb
@@ -34,7 +34,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Google Cloud OS Login API.](https://console.cloud.google.com/apis/library/oslogin.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-os_login/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -53,7 +53,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -205,3 +205,26 @@ for version in ['v1', 'v1beta']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::OsLogin::VERSION'
     )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-os_login/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-os_login/latest/.*$',
+    'dev/ruby/google-cloud-os_login/latest'
+)

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -216,7 +216,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-os_login/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-phishing_protection/README.md
+++ b/google-cloud-phishing_protection/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Phishing Protection API.](https://console.cloud.google.com/apis/library/phishingprotection.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -27,14 +27,14 @@ $ gem install google-cloud-phishing_protection
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-phishing_protection/latest/google/cloud/phishingprotection/v1beta1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-phishing_protection/latest
 [Product Documentation]: https://cloud.google.com/phishingprotection
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-phishing_protection/README.md
+++ b/google-cloud-phishing_protection/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Phishing Protection API.](https://console.cloud.google.com/apis/library/phishingprotection.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-phishing_protection/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-phishing_protection/lib/google/cloud/phishing_protection.rb
+++ b/google-cloud-phishing_protection/lib/google/cloud/phishing_protection.rb
@@ -34,7 +34,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Phishing Protection API.](https://console.cloud.google.com/apis/library/phishingprotection.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-phishing_protection/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -53,7 +53,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/v1beta1.rb
+++ b/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/v1beta1.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Phishing Protection API.](https://console.cloud.google.com/apis/library/phishingprotection.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-phishing_protection/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-phishing_protection/synth.py
+++ b/google-cloud-phishing_protection/synth.py
@@ -233,5 +233,28 @@ s.replace(
     'Google::Cloud::PhishingProtection::VERSION'
 )
 
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-phishing_protection/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-phishing_protection/latest/.*$',
+    'dev/ruby/google-cloud-phishing_protection/latest'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-phishing_protection/synth.py
+++ b/google-cloud-phishing_protection/synth.py
@@ -243,7 +243,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-phishing_protection/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-pubsub/LOGGING.md
+++ b/google-cloud-pubsub/LOGGING.md
@@ -5,7 +5,7 @@ To enable logging for this library, set the logger for the underlying
 that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/). See
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)

--- a/google-cloud-pubsub/README.md
+++ b/google-cloud-pubsub/README.md
@@ -16,7 +16,7 @@ $ gem install google-cloud-pubsub
 
 This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.
 
-Instructions and configuration options are covered in the [Authentication Guide](./AUTHENTICATION.md).
+Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.dev/ruby/google-cloud-pubsub/latest/file.AUTHENTICATION.html).
 
 ## Example
 
@@ -95,18 +95,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud-pubsub/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud-pubsub/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud-pubsub/latest/file.LICENSE.html).
 
 ## Support
 

--- a/google-cloud-pubsub/README.md
+++ b/google-cloud-pubsub/README.md
@@ -2,7 +2,7 @@
 
 [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) ([docs](https://cloud.google.com/pubsub/docs/reference/rest/)) is designed to provide reliable, many-to-many, asynchronous messaging between applications. Publisher applications can send messages to a “topic” and other applications can subscribe to that topic to receive the messages. By decoupling senders and receivers, Google Cloud Pub/Sub allows developers to communicate between independently written applications.
 
-- [google-cloud-pubsub API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-pubsub/latest)
+- [google-cloud-pubsub API documentation](https://googleapis.dev/ruby/google-cloud-pubsub/latest)
 - [google-cloud-pubsub on RubyGems](https://rubygems.org/gems/google-cloud-pubsub)
 - [Google Cloud Pub/Sub documentation](https://cloud.google.com/pubsub/docs)
 
@@ -16,7 +16,7 @@ $ gem install google-cloud-pubsub
 
 This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.
 
-Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-pubsub/latest/file.AUTHENTICATION).
+Instructions and configuration options are covered in the [Authentication Guide](./AUTHENTICATION.md).
 
 ## Example
 
@@ -52,7 +52,7 @@ subscriber.stop.wait!
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:
 
@@ -95,18 +95,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-pubsub/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-pubsub/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-pubsub/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud-recaptcha_enterprise/README.md
+++ b/google-cloud-recaptcha_enterprise/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the reCAPTCHA Enterprise API.](https://console.cloud.google.com/apis/library/recaptchaenterprise.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -27,14 +27,14 @@ $ gem install google-cloud-recaptcha_enterprise
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-recaptcha_enterprise/latest/google/cloud/recaptchaenterprise/v1beta1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-recaptcha_enterprise/latest
 [Product Documentation]: https://cloud.google.com/recaptchaenterprise
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-recaptcha_enterprise/README.md
+++ b/google-cloud-recaptcha_enterprise/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the reCAPTCHA Enterprise API.](https://console.cloud.google.com/apis/library/recaptchaenterprise.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-recaptcha_enterprise/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise.rb
+++ b/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise.rb
@@ -34,7 +34,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the reCAPTCHA Enterprise API.](https://console.cloud.google.com/apis/library/recaptchaenterprise.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-recaptcha_enterprise/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -53,7 +53,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise/v1beta1.rb
+++ b/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise/v1beta1.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the reCAPTCHA Enterprise API.](https://console.cloud.google.com/apis/library/recaptchaenterprise.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-recaptcha_enterprise/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-recaptcha_enterprise/synth.py
+++ b/google-cloud-recaptcha_enterprise/synth.py
@@ -227,5 +227,28 @@ s.replace(
     'Google::Cloud::RecaptchaEnterprise::VERSION'
 )
 
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-recaptcha_enterprise/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-recaptcha_enterprise/latest/.*$',
+    'dev/ruby/google-cloud-recaptcha_enterprise/latest'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-recaptcha_enterprise/synth.py
+++ b/google-cloud-recaptcha_enterprise/synth.py
@@ -237,7 +237,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-recaptcha_enterprise/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-redis/README.md
+++ b/google-cloud-redis/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Google Cloud Memorystore for Redis API.](https://console.cloud.google.com/apis/library/redis.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-redis/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-redis/README.md
+++ b/google-cloud-redis/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Google Cloud Memorystore for Redis API.](https://console.cloud.google.com/apis/library/redis.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -27,14 +27,14 @@ $ gem install google-cloud-redis
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-redis/latest/google/cloud/redis/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-redis/latest
 [Product Documentation]: https://cloud.google.com/memorystore
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-redis/lib/google/cloud/redis.rb
+++ b/google-cloud-redis/lib/google/cloud/redis.rb
@@ -34,7 +34,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Google Cloud Memorystore for Redis API.](https://console.cloud.google.com/apis/library/redis.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-redis/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -53,7 +53,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-redis/lib/google/cloud/redis/v1.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Google Cloud Memorystore for Redis API.](https://console.cloud.google.com/apis/library/redis.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-redis/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Google Cloud Memorystore for Redis API.](https://console.cloud.google.com/apis/library/redis.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-redis/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -204,3 +204,26 @@ for version in ['v1', 'v1beta1']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Redis::VERSION'
     )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-redis/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-redis/latest/.*$',
+    'dev/ruby/google-cloud-redis/latest'
+)

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -215,7 +215,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-redis/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-resource_manager/LOGGING.md
+++ b/google-cloud-resource_manager/LOGGING.md
@@ -6,7 +6,7 @@ Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#l
 library. The logger that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/).
 

--- a/google-cloud-resource_manager/README.md
+++ b/google-cloud-resource_manager/README.md
@@ -9,7 +9,7 @@ programmatically manage  container resources such as Organizations and Projects,
 * Delete projects
 * Undelete, or recover, projects that you don't want to delete
 
-- [google-cloud-resource_manager API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-resource_manager/latest)
+- [google-cloud-resource_manager API documentation](https://googleapis.dev/ruby/google-cloud-resource_manager/latest)
 - [google-cloud-resource_manager on RubyGems](https://rubygems.org/gems/google-cloud-resource_manager)
 - [Google Cloud Resource Manager documentation](https://cloud.google.com/resource-manager/)
 
@@ -36,7 +36,7 @@ Also make sure all environment variables are cleared of any
 service account credentials. Then google-cloud-resource_manager will be able to detect the user
 authentication and connect with those credentials.
 
-Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-resource_manager/latest/file.AUTHENTICATION).
+Instructions and configuration options are covered in the [Authentication Guide](./AUTHENTICATION.md).
 
 ## Example
 
@@ -62,7 +62,7 @@ projects = resource_manager.projects filter: "labels.env:production"
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [Google API Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/).
+To enable logging for this library, set the logger for the underlying [Google API Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/).
 
 If you do not set the logger explicitly and your application is running in a Rails environment, it will default to `Rails.logger`. Otherwise, if you do not set the logger and you are not using Rails, logging is disabled by default.
 
@@ -101,18 +101,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-resource_manager/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-resource_manager/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-resource_manager/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud-resource_manager/README.md
+++ b/google-cloud-resource_manager/README.md
@@ -36,7 +36,7 @@ Also make sure all environment variables are cleared of any
 service account credentials. Then google-cloud-resource_manager will be able to detect the user
 authentication and connect with those credentials.
 
-Instructions and configuration options are covered in the [Authentication Guide](./AUTHENTICATION.md).
+Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.dev/ruby/google-cloud-resource_manager/latest/file.AUTHENTICATION.html).
 
 ## Example
 
@@ -101,18 +101,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud-resource_manager/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud-resource_manager/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud-resource_manager/latest/file.LICENSE.html).
 
 ## Support
 

--- a/google-cloud-scheduler/README.md
+++ b/google-cloud-scheduler/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Scheduler API.](https://console.cloud.google.com/apis/library/cloudscheduler.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-scheduler/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-scheduler/README.md
+++ b/google-cloud-scheduler/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Scheduler API.](https://console.cloud.google.com/apis/library/cloudscheduler.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -27,14 +27,14 @@ $ gem install google-cloud-scheduler
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-scheduler/latest/google/cloud/scheduler/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-scheduler/latest
 [Product Documentation]: https://cloud.google.com/cloudscheduler
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-scheduler/lib/google/cloud/scheduler.rb
+++ b/google-cloud-scheduler/lib/google/cloud/scheduler.rb
@@ -34,7 +34,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Cloud Scheduler API.](https://console.cloud.google.com/apis/library/cloudscheduler.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-scheduler/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -53,7 +53,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-scheduler/lib/google/cloud/scheduler/v1.rb
+++ b/google-cloud-scheduler/lib/google/cloud/scheduler/v1.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Scheduler API.](https://console.cloud.google.com/apis/library/cloudscheduler.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-scheduler/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-scheduler/lib/google/cloud/scheduler/v1beta1.rb
+++ b/google-cloud-scheduler/lib/google/cloud/scheduler/v1beta1.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Scheduler API.](https://console.cloud.google.com/apis/library/cloudscheduler.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-scheduler/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-scheduler/synth.py
+++ b/google-cloud-scheduler/synth.py
@@ -179,5 +179,28 @@ for version in ['v1', 'v1beta1']:
         'Google::Cloud::Scheduler::VERSION'
     )
 
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-scheduler/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-scheduler/latest/.*$',
+    'dev/ruby/google-cloud-scheduler/latest'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-scheduler/synth.py
+++ b/google-cloud-scheduler/synth.py
@@ -189,7 +189,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-scheduler/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-security_center/README.md
+++ b/google-cloud-security_center/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Security Command Center API.](https://console.cloud.google.com/apis/library/securitycenter.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-security_center/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-security_center/README.md
+++ b/google-cloud-security_center/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Security Command Center API.](https://console.cloud.google.com/apis/library/securitycenter.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -28,14 +28,14 @@ $ gem install google-cloud-security_center
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-security_center/latest/google/cloud/securitycenter/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-security_center/latest
 [Product Documentation]: https://cloud.google.com/security-command-center/
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-security_center/lib/google/cloud/security_center.rb
+++ b/google-cloud-security_center/lib/google/cloud/security_center.rb
@@ -35,7 +35,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Cloud Security Command Center API.](https://console.cloud.google.com/apis/library/securitycenter.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-security_center/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -54,7 +54,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-security_center/lib/google/cloud/security_center/v1.rb
+++ b/google-cloud-security_center/lib/google/cloud/security_center/v1.rb
@@ -37,7 +37,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Security Command Center API.](https://console.cloud.google.com/apis/library/securitycenter.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-security_center/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -56,7 +56,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-security_center/synth.py
+++ b/google-cloud-security_center/synth.py
@@ -209,6 +209,29 @@ s.replace(
     'Google::Cloud::SecurityCenter::VERSION'
 )
 
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-security_center/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-security_center/latest/.*$',
+    'dev/ruby/google-cloud-security_center/latest'
+)
+
 # Generate the helper methods
 subprocess.call('bundle update && bundle exec rake generate_partials', shell=True)
 

--- a/google-cloud-security_center/synth.py
+++ b/google-cloud-security_center/synth.py
@@ -219,7 +219,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-security_center/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-spanner/LOGGING.md
+++ b/google-cloud-spanner/LOGGING.md
@@ -5,7 +5,7 @@ To enable logging for this library, set the logger for the underlying
 that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/). See
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)

--- a/google-cloud-spanner/OVERVIEW.md
+++ b/google-cloud-spanner/OVERVIEW.md
@@ -21,7 +21,7 @@ When you first use Cloud Spanner, you must create an instance, which is an
 allocation of resources that are used by Cloud Spanner databases. When you
 create an instance, you choose where your data is stored and how many nodes are
 used for your data. (For more information, see [Configuration
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)).
+Guide](../stackdriver/INSTRUMENTATION_CONFIGURATION)).
 
 Use {Google::Cloud::Spanner::Project#create_instance Project#create_instance} to
 create an instance:

--- a/google-cloud-spanner/OVERVIEW.md
+++ b/google-cloud-spanner/OVERVIEW.md
@@ -21,7 +21,7 @@ When you first use Cloud Spanner, you must create an instance, which is an
 allocation of resources that are used by Cloud Spanner databases. When you
 create an instance, you choose where your data is stored and how many nodes are
 used for your data. (For more information, see [Configuration
-Guide](../stackdriver/INSTRUMENTATION_CONFIGURATION)).
+Guide](https://googleapis.dev/ruby/stackdriver/INSTRUMENTATION_CONFIGURATION)/latest).
 
 Use {Google::Cloud::Spanner::Project#create_instance Project#create_instance} to
 create an instance:

--- a/google-cloud-spanner/README.md
+++ b/google-cloud-spanner/README.md
@@ -2,7 +2,7 @@
 
 [Google Cloud Spanner API](https://cloud.google.com/spanner/) ([docs](https://cloud.google.com/spanner/docs)) provides a fully managed, mission-critical, relational database service that offers transactional consistency at global scale, schemas, SQL (ANSI 2011 with extensions), and automatic, synchronous replication for high availability.
 
-- [google-cloud-spanner API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-spanner/latest)
+- [google-cloud-spanner API documentation](https://googleapis.dev/ruby/google-cloud-spanner/latest)
 - [google-cloud-spanner on RubyGems](https://rubygems.org/gems/google-cloud-spanner)
 - [Google Cloud Spanner API documentation](https://cloud.google.com/spanner/docs)
 
@@ -16,7 +16,7 @@ $ gem install google-cloud-spanner
 
 This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.
 
-Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-spanner/latest/file.AUTHENTICATION).
+Instructions and configuration options are covered in the [Authentication Guide](./AUTHENTICATION.md).
 
 ## Example
 
@@ -38,7 +38,7 @@ end
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:
 
@@ -78,18 +78,18 @@ This library follows [Semantic Versioning](http://semver.org/).
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-spanner/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-spanner/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-spanner/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud-spanner/README.md
+++ b/google-cloud-spanner/README.md
@@ -16,7 +16,7 @@ $ gem install google-cloud-spanner
 
 This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.
 
-Instructions and configuration options are covered in the [Authentication Guide](./AUTHENTICATION.md).
+Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.AUTHENTICATION.html).
 
 ## Example
 
@@ -78,18 +78,18 @@ This library follows [Semantic Versioning](http://semver.org/).
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.LICENSE.html).
 
 ## Support
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database.rb
@@ -36,7 +36,7 @@ module Google
         # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
         # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
         # 3. [Enable the Cloud Spanner Database Admin API.](https://console.cloud.google.com/apis/library/spanner.googleapis.com)
-        # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+        # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.AUTHENTICATION.html)
         #
         # ### Installation
         # ```
@@ -55,7 +55,7 @@ module Google
         #
         # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
         # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
         # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
         # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
         #

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1.rb
@@ -37,7 +37,7 @@ module Google
           # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
           # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
           # 3. [Enable the Cloud Spanner Database Admin API.](https://console.cloud.google.com/apis/library/spanner.googleapis.com)
-          # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+          # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.AUTHENTICATION.html)
           #
           # ### Installation
           # ```
@@ -56,7 +56,7 @@ module Google
           #
           # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
           # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-          # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+          # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
           # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
           # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
           #

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb
@@ -36,7 +36,7 @@ module Google
         # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
         # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
         # 3. [Enable the Cloud Spanner Instance Admin API.](https://console.cloud.google.com/apis/library/spanner.googleapis.com)
-        # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+        # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.AUTHENTICATION.html)
         #
         # ### Installation
         # ```
@@ -55,7 +55,7 @@ module Google
         #
         # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
         # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
         # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
         # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
         #

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1.rb
@@ -37,7 +37,7 @@ module Google
           # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
           # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
           # 3. [Enable the Cloud Spanner Instance Admin API.](https://console.cloud.google.com/apis/library/spanner.googleapis.com)
-          # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+          # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.AUTHENTICATION.html)
           #
           # ### Installation
           # ```
@@ -56,7 +56,7 @@ module Google
           #
           # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
           # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-          # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+          # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
           # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
           # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
           #

--- a/google-cloud-spanner/synth.py
+++ b/google-cloud-spanner/synth.py
@@ -221,3 +221,15 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Spanner::VERSION'
 )
+
+# Fix links for devsite migration
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+    'https://googleapis.dev/ruby/google-cloud-logging/latest'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-spanner/latest/file.AUTHENTICATION.html'
+)

--- a/google-cloud-speech/README.md
+++ b/google-cloud-speech/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Speech API.](https://console.cloud.google.com/apis/library/speech.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-speech/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-speech/README.md
+++ b/google-cloud-speech/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Speech API.](https://console.cloud.google.com/apis/library/speech.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -53,14 +53,14 @@ response = speech_client.recognize(config, audio)
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-speech/latest/google/cloud/speech/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-speech/latest
 [Product Documentation]: https://cloud.google.com/speech
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-speech/lib/google/cloud/speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech.rb
@@ -34,7 +34,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Cloud Speech API.](https://console.cloud.google.com/apis/library/speech.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-speech/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -79,7 +79,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-speech/lib/google/cloud/speech/v1.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1.rb
@@ -36,7 +36,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Speech API.](https://console.cloud.google.com/apis/library/speech.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-speech/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -74,7 +74,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Speech API.](https://console.cloud.google.com/apis/library/speech.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-speech/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -73,7 +73,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -255,3 +255,26 @@ for version in ['v1', 'v1p1beta1']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Speech::VERSION'
     )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-speech/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-speech/latest/.*$',
+    'dev/ruby/google-cloud-speech/latest'
+)

--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -266,7 +266,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-speech/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-storage/LOGGING.md
+++ b/google-cloud-storage/LOGGING.md
@@ -6,7 +6,7 @@ Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#l
 library. The logger that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/).
 

--- a/google-cloud-storage/README.md
+++ b/google-cloud-storage/README.md
@@ -16,7 +16,7 @@ $ gem install google-cloud-storage
 
 This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.
 
-Instructions and configuration options are covered in the [Authentication Guide](./AUTHENTICATION.md).
+Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.dev/ruby/google-cloud-storage/latest/file.AUTHENTICATION.html).
 
 ## Example
 
@@ -78,18 +78,18 @@ This library follows [Semantic Versioning](http://semver.org/).
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud-storage/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud-storage/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud-storage/latest/file.LICENSE.html).
 
 ## Support
 

--- a/google-cloud-storage/README.md
+++ b/google-cloud-storage/README.md
@@ -2,7 +2,7 @@
 
 [Google Cloud Storage](https://cloud.google.com/storage/) ([docs](https://cloud.google.com/storage/docs/json_api/)) allows you to store data on Google infrastructure with very high reliability, performance and availability, and can be used to distribute large data objects to users via direct download.
 
-- [google-cloud-storage API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-storage/latest)
+- [google-cloud-storage API documentation](https://googleapis.dev/ruby/google-cloud-storage/latest)
 - [google-cloud-storage on RubyGems](https://rubygems.org/gems/google-cloud-storage)
 - [Google Cloud Storage documentation](https://cloud.google.com/storage/docs)
 
@@ -16,7 +16,7 @@ $ gem install google-cloud-storage
 
 This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.
 
-Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-storage/latest/file.AUTHENTICATION).
+Instructions and configuration options are covered in the [Authentication Guide](./AUTHENTICATION.md).
 
 ## Example
 
@@ -42,7 +42,7 @@ file.copy backup, file.name
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [Google API Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/).
+To enable logging for this library, set the logger for the underlying [Google API Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/).
 
 If you do not set the logger explicitly and your application is running in a Rails environment, it will default to `Rails.logger`. Otherwise, if you do not set the logger and you are not using Rails, logging is disabled by default.
 
@@ -78,18 +78,18 @@ This library follows [Semantic Versioning](http://semver.org/).
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-storage/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-storage/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-storage/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud-talent/README.md
+++ b/google-cloud-talent/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Talent Solution API.](https://console.cloud.google.com/apis/library/talent.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-talent/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-talent/README.md
+++ b/google-cloud-talent/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Talent Solution API.](https://console.cloud.google.com/apis/library/talent.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -28,14 +28,14 @@ $ gem install google-cloud-talent
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-talent/latest/google/cloud/talent/v4beta1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-talent/latest
 [Product Documentation]: https://cloud.google.com/talent-solution
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-talent/lib/google/cloud/talent.rb
+++ b/google-cloud-talent/lib/google/cloud/talent.rb
@@ -35,7 +35,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Cloud Talent Solution API.](https://console.cloud.google.com/apis/library/talent.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-talent/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -54,7 +54,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-talent/lib/google/cloud/talent/v4beta1.rb
+++ b/google-cloud-talent/lib/google/cloud/talent/v4beta1.rb
@@ -43,7 +43,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Talent Solution API.](https://console.cloud.google.com/apis/library/talent.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-talent/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -62,7 +62,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-talent/synth.py
+++ b/google-cloud-talent/synth.py
@@ -202,5 +202,28 @@ s.replace(
     'Google::Cloud::Talent::VERSION'
 )
 
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-talent/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-talent/latest/.*$',
+    'dev/ruby/google-cloud-talent/latest'
+)
+
 # Generate the helper methods
 call(f'bundle update && bundle exec rake generate_partials TALENT_SERVICES={",".join(services)}', shell=True)

--- a/google-cloud-talent/synth.py
+++ b/google-cloud-talent/synth.py
@@ -212,7 +212,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-talent/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-tasks/README.md
+++ b/google-cloud-tasks/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Tasks API.](https://console.cloud.google.com/apis/library/tasks.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-tasks/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-tasks/README.md
+++ b/google-cloud-tasks/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Tasks API.](https://console.cloud.google.com/apis/library/tasks.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -27,14 +27,14 @@ $ gem install google-cloud-tasks
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-tasks/latest/google/cloud/tasks/v2
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-tasks/latest
 [Product Documentation]: https://cloud.google.com/tasks
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-tasks/lib/google/cloud/tasks.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks.rb
@@ -34,7 +34,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Cloud Tasks API.](https://console.cloud.google.com/apis/library/tasks.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-tasks/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -53,7 +53,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Tasks API.](https://console.cloud.google.com/apis/library/tasks.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-tasks/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Tasks API.](https://console.cloud.google.com/apis/library/tasks.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-tasks/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta3.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta3.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Tasks API.](https://console.cloud.google.com/apis/library/tasks.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-tasks/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -212,5 +212,28 @@ for version in ['v2', 'v2beta2', 'v2beta3']:
         'Google::Cloud::Tasks::VERSION'
     )
 
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-tasks/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-tasks/latest/.*$',
+    'dev/ruby/google-cloud-tasks/latest'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -222,7 +222,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-tasks/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-text_to_speech/README.md
+++ b/google-cloud-text_to_speech/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Text-to-Speech API.](https://console.cloud.google.com/apis/library/texttospeech.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-text_to_speech/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-text_to_speech/README.md
+++ b/google-cloud-text_to_speech/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Text-to-Speech API.](https://console.cloud.google.com/apis/library/texttospeech.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -44,14 +44,14 @@ File.write("example.mp3", response.audio_content, mode: "wb")
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-text_to_speech/latest/google/cloud/texttospeech/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-text_to_speech/latest
 [Product Documentation]: https://cloud.google.com/texttospeech
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech.rb
@@ -35,7 +35,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Cloud Text-to-Speech API.](https://console.cloud.google.com/apis/library/texttospeech.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-text_to_speech/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -69,7 +69,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Text-to-Speech API.](https://console.cloud.google.com/apis/library/texttospeech.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-text_to_speech/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -69,7 +69,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Text-to-Speech API.](https://console.cloud.google.com/apis/library/texttospeech.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-text_to_speech/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -69,7 +69,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -170,3 +170,26 @@ s.replace(
     'response = text_to_speech_client.synthesize_speech\(input, voice, audio_config\)\n',
     'response = text_to_speech_client.synthesize_speech(input, voice, audio_config)\nFile.write("example.mp3", response.audio_content, mode: "wb")\n'
 )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-text_to_speech/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-text_to_speech/latest/.*$',
+    'dev/ruby/google-cloud-text_to_speech/latest'
+)

--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -181,7 +181,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-text_to_speech/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-trace/INSTRUMENTATION.md
+++ b/google-cloud-trace/INSTRUMENTATION.md
@@ -16,7 +16,7 @@ you want to run on a non Google Cloud environment or you want to customize  the
 default behavior.
 
 See the [Configuration
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
+Guide](../stackdriver/INSTRUMENTATION_CONFIGURATION)
 for full configuration parameters.
 
 ## Rails Integration
@@ -29,7 +29,7 @@ require "google/cloud/trace/rails"
 ```
 
 Alternatively, check out the
-[stackdriver](https://googleapis.github.io/google-cloud-ruby/#/docs/stackdriver)
+[stackdriver](../stackdriver/README.md)
 gem, which enables this Railtie by default.
 
 ## Rack Integration

--- a/google-cloud-trace/INSTRUMENTATION.md
+++ b/google-cloud-trace/INSTRUMENTATION.md
@@ -16,7 +16,7 @@ you want to run on a non Google Cloud environment or you want to customize  the
 default behavior.
 
 See the [Configuration
-Guide](../stackdriver/INSTRUMENTATION_CONFIGURATION)
+Guide](https://googleapis.dev/ruby/stackdriver/INSTRUMENTATION_CONFIGURATION/latest)
 for full configuration parameters.
 
 ## Rails Integration
@@ -29,7 +29,7 @@ require "google/cloud/trace/rails"
 ```
 
 Alternatively, check out the
-[stackdriver](../stackdriver/README.md)
+[stackdriver](https://googleapis.dev/ruby/stackdriver/latest/file.README.html)
 gem, which enables this Railtie by default.
 
 ## Rack Integration

--- a/google-cloud-trace/LOGGING.md
+++ b/google-cloud-trace/LOGGING.md
@@ -5,7 +5,7 @@ To enable logging for this library, set the logger for the underlying
 that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/). See
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)

--- a/google-cloud-trace/README.md
+++ b/google-cloud-trace/README.md
@@ -8,8 +8,8 @@ Stackdriver Trace automatically analyzes all of your application's traces to
 generate in-depth latency reports to surface performance degradations, and can
 capture traces from all of your VMs, containers, or Google App Engine projects.
 
-- [google-cloud-trace API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest)
-- [google-cloud-trace instrumentation documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest/file.INSTRUMENTATION)
+- [google-cloud-trace API documentation](https://googleapis.dev/ruby/google-cloud-trace/latest)
+- [google-cloud-trace instrumentation documentation](./INSTRUMENTATION.md)
 - [google-cloud-trace on RubyGems](https://rubygems.org/gems/google-cloud-trace)
 - [Stackdriver Trace documentation](https://cloud.google.com/trace/docs/)
 
@@ -181,11 +181,11 @@ end
 
 This library also supports the other authentication methods provided by the
 `google-cloud-ruby` suite. Instructions and configuration options are covered
-in the [Authentication Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest/file.AUTHENTICATION).
+in the [Authentication Guide](./AUTHENTICATION.md).
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:
 
@@ -228,18 +228,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud-trace/README.md
+++ b/google-cloud-trace/README.md
@@ -9,7 +9,7 @@ generate in-depth latency reports to surface performance degradations, and can
 capture traces from all of your VMs, containers, or Google App Engine projects.
 
 - [google-cloud-trace API documentation](https://googleapis.dev/ruby/google-cloud-trace/latest)
-- [google-cloud-trace instrumentation documentation](./INSTRUMENTATION.md)
+- [google-cloud-trace instrumentation documentation](https://googleapis.dev/ruby/google-cloud-trace/latest/file.INSTRUMENTATION.html)
 - [google-cloud-trace on RubyGems](https://rubygems.org/gems/google-cloud-trace)
 - [Stackdriver Trace documentation](https://cloud.google.com/trace/docs/)
 
@@ -35,7 +35,7 @@ gem "google-cloud-trace"
 $ bundle install
 ```
 
-Alternatively, check out the [`stackdriver`](../stackdriver) gem that includes
+Alternatively, check out the [`stackdriver`](https://googleapis.dev/ruby/stackdriver/latest) gem that includes
 the `google-cloud-trace` gem.
 
 ## Enable Stackdriver Trace API
@@ -94,7 +94,7 @@ end
 ### Configuring the library
 
 You can customize the behavior of the Stackdriver Trace library for Ruby. See
-the [configuration guide](../stackdriver/INSTRUMENTATION_CONFIGURATION.md) for a list of
+the [configuration guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html) for a list of
 possible configuration options.
 
 ## Running on Google Cloud Platform
@@ -181,7 +181,7 @@ end
 
 This library also supports the other authentication methods provided by the
 `google-cloud-ruby` suite. Instructions and configuration options are covered
-in the [Authentication Guide](./AUTHENTICATION.md).
+in the [Authentication Guide](https://googleapis.dev/ruby/google-cloud-trace/latest/file.AUTHENTICATION.html).
 
 ## Enabling Logging
 
@@ -228,18 +228,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud-trace/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud-trace/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud-trace/latest/file.LICENSE.html).
 
 ## Support
 

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -148,7 +148,7 @@ module Google
         # @param [Hash] kwargs Hash of configuration settings. Used for backward
         #   API compatibility. See the {file:INSTRUMENTATION.md Instrumentation
         #   Guide} and [Configuration
-        #   Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
+        #   Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
         #   for the prefered way to set configuration parameters.
         #
         def initialize app, service: nil, **kwargs

--- a/google-cloud-trace/lib/google/cloud/trace/rails.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/rails.rb
@@ -46,7 +46,7 @@ module Google
       #
       # See the {file:INSTRUMENTATION.md Instrumentation Guide} and
       # [Configuration
-      # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)
+      # Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
       # on how to configure the Railtie and Middleware.
       #
       # ## Measuring custom functionality

--- a/google-cloud-trace/lib/google/cloud/trace/v2.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2.rb
@@ -35,7 +35,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Stackdriver Trace API.](https://console.cloud.google.com/apis/api/trace)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-trace/latest/file.AUTHENTICATION.html)
     #
     # ### Preview
     # #### TraceServiceClient

--- a/google-cloud-translate/README.md
+++ b/google-cloud-translate/README.md
@@ -21,7 +21,7 @@ authentication using a project ID and OAuth 2.0 credentials. In addition,
 it supports authentication using a public API access key. (If both the API
 key and the project and OAuth 2.0 credentials are provided, the API key
 will be used.) Instructions and configuration options are covered in the
-[Authentication Guide](./AUTHENTICATION.md).
+[Authentication Guide](https://googleapis.dev/ruby/google-cloud-translate/latest/file.AUTHENTICATION.html).
 
 ## Example
 
@@ -82,18 +82,18 @@ This library follows [Semantic Versioning](http://semver.org/).
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud-translate/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud-translate/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud-translate/latest/file.LICENSE.html).
 
 ## Support
 

--- a/google-cloud-translate/README.md
+++ b/google-cloud-translate/README.md
@@ -4,7 +4,7 @@
 
 Translation API supports more than one hundred different languages, from Afrikaans to Zulu. Used in combination, this enables translation between thousands of language pairs. Also, you can send in HTML and receive HTML with translated text back. You don't need to extract your source text or reassemble the translated content.
 
-- [google-cloud-translate API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-translate/latest)
+- [google-cloud-translate API documentation](https://googleapis.dev/ruby/google-cloud-translate/latest)
 - [google-cloud-translate on RubyGems](https://rubygems.org/gems/google-cloud-translate)
 - [Google Cloud Translation API documentation](https://cloud.google.com/translation/docs)
 
@@ -21,7 +21,7 @@ authentication using a project ID and OAuth 2.0 credentials. In addition,
 it supports authentication using a public API access key. (If both the API
 key and the project and OAuth 2.0 credentials are provided, the API key
 will be used.) Instructions and configuration options are covered in the
-[Authentication Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-translate/latest/file.AUTHENTICATION).
+[Authentication Guide](./AUTHENTICATION.md).
 
 ## Example
 
@@ -42,7 +42,7 @@ translation.text #=> "Salve mundi!"
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:
 
@@ -82,18 +82,18 @@ This library follows [Semantic Versioning](http://semver.org/).
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-translate/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-translate/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-translate/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud-video_intelligence/README.md
+++ b/google-cloud-video_intelligence/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Video Intelligence API.](https://console.cloud.google.com/apis/library/videointelligence.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-video_intelligence/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-video_intelligence/README.md
+++ b/google-cloud-video_intelligence/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Video Intelligence API.](https://console.cloud.google.com/apis/library/videointelligence.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -65,14 +65,14 @@ operation.wait_until_done!
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-video_intelligence/latest/google/cloud/videointelligence/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-video_intelligence/latest
 [Product Documentation]: https://cloud.google.com/video-intelligence
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence.rb
@@ -34,7 +34,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Cloud Video Intelligence API.](https://console.cloud.google.com/apis/library/videointelligence.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-video_intelligence/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -91,7 +91,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1.rb
@@ -36,7 +36,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Video Intelligence API.](https://console.cloud.google.com/apis/library/videointelligence.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-video_intelligence/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -93,7 +93,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1.rb
@@ -36,7 +36,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Google Cloud Video Intelligence API.](https://console.cloud.google.com/apis/library/videointelligence.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-video_intelligence/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -55,7 +55,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
@@ -36,7 +36,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Google Cloud Video Intelligence API.](https://console.cloud.google.com/apis/library/videointelligence.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-video_intelligence/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -55,7 +55,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1.rb
@@ -36,7 +36,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Video Intelligence API.](https://console.cloud.google.com/apis/library/videointelligence.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-video_intelligence/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -93,7 +93,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1.rb
@@ -36,7 +36,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Video Intelligence API.](https://console.cloud.google.com/apis/library/videointelligence.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-video_intelligence/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -93,7 +93,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -241,3 +241,26 @@ s.replace(
     '\nmodule Google::Cloud::VideoIntelligence::V(\\w+)\n',
     '\nmodule Google\n  module Cloud\n    module VideoIntelligence\n    end\n    Videointelligence = VideoIntelligence unless const_defined? :Videointelligence\n  end\nend\nmodule Google::Cloud::VideoIntelligence::V\\1\n',
 )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-video_intelligence/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-video_intelligence/latest/.*$',
+    'dev/ruby/google-cloud-video_intelligence/latest'
+)

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -252,7 +252,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-video_intelligence/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-vision/README.md
+++ b/google-cloud-vision/README.md
@@ -14,7 +14,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Vision API.](https://console.cloud.google.com/apis/library/vision.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-vision/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-vision/README.md
+++ b/google-cloud-vision/README.md
@@ -14,7 +14,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Vision API.](https://console.cloud.google.com/apis/library/vision.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -53,14 +53,14 @@ response = image_annotator_client.batch_annotate_images(requests)
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-vision/latest/google/cloud/vision/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-vision/latest
 [Product Documentation]: https://cloud.google.com/vision
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-vision/lib/google/cloud/vision.rb
+++ b/google-cloud-vision/lib/google/cloud/vision.rb
@@ -36,7 +36,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Cloud Vision API.](https://console.cloud.google.com/apis/library/vision.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-vision/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -79,7 +79,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-vision/lib/google/cloud/vision/v1.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1.rb
@@ -40,7 +40,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Vision API.](https://console.cloud.google.com/apis/library/vision.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-vision/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -76,7 +76,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-vision/lib/google/cloud/vision/v1p3beta1.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1p3beta1.rb
@@ -40,7 +40,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Vision API.](https://console.cloud.google.com/apis/library/vision.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-vision/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -76,7 +76,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -222,5 +222,28 @@ for version in ['v1', 'v1p3beta1']:
         'Google::Cloud::Vision::VERSION'
     )
 
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-vision/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-vision/latest/.*$',
+    'dev/ruby/google-cloud-vision/latest'
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -232,7 +232,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-vision/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud-webrisk/README.md
+++ b/google-cloud-webrisk/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Web Risk API.](https://console.cloud.google.com/apis/library/webrisk.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -27,14 +27,14 @@ $ gem install google-cloud-webrisk
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-webrisk/latest/google/cloud/webrisk/v1beta1
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-webrisk/latest
 [Product Documentation]: https://cloud.google.com/web-risk
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/google-cloud-webrisk/README.md
+++ b/google-cloud-webrisk/README.md
@@ -12,7 +12,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Web Risk API.](https://console.cloud.google.com/apis/library/webrisk.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-webrisk/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/google-cloud-webrisk/lib/google/cloud/webrisk.rb
+++ b/google-cloud-webrisk/lib/google/cloud/webrisk.rb
@@ -34,7 +34,7 @@ module Google
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
     # 3. [Enable the Web Risk API.](https://console.cloud.google.com/apis/library/webrisk.googleapis.com)
-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-webrisk/latest/file.AUTHENTICATION.html)
     #
     # ### Installation
     # ```
@@ -53,7 +53,7 @@ module Google
     #
     # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
     # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
     # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
     # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #

--- a/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1.rb
+++ b/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1.rb
@@ -34,7 +34,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Web Risk API.](https://console.cloud.google.com/apis/library/webrisk.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-webrisk/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -53,7 +53,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #

--- a/google-cloud-webrisk/synth.py
+++ b/google-cloud-webrisk/synth.py
@@ -152,3 +152,26 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Webrisk::VERSION'
 )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-webrisk/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/google-cloud-webrisk/latest/.*$',
+    'dev/ruby/google-cloud-webrisk/latest'
+)

--- a/google-cloud-webrisk/synth.py
+++ b/google-cloud-webrisk/synth.py
@@ -163,7 +163,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/google-cloud-webrisk/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/google-cloud/AUTHENTICATION.md
+++ b/google-cloud/AUTHENTICATION.md
@@ -36,6 +36,3 @@ Here are the environment variables (in the order they are checked) for credentia
 
 1. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
 2. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
-
-
-

--- a/google-cloud/README.md
+++ b/google-cloud/README.md
@@ -7,43 +7,43 @@ Because there are now so many google-cloud-* gems, instead of using this gem in
 your production application, we encourage you to directly require only the
 individual google-cloud-* gems that you need.
 
-- [google-cloud API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud/latest)
+- [google-cloud API documentation](https://googleapis.dev/ruby/google-cloud/latest)
 - [google-cloud on RubyGems](https://rubygems.org/gems/google-cloud)
 
 ## List of dependencies
 
 This gem depends on and lazily loads the following google-cloud-* gems:
 
-- [google-cloud-asset](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-asset)
-- [google-cloud-bigquery](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigquery)
-- [google-cloud-bigquery-data_transfer](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigquery-data_transfer)
-- [google-cloud-bigtable](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigtable)
-- [google-cloud-container](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-container)
-- [google-cloud-dataproc](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-dataproc)
-- [google-cloud-datastore](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-datastore)
-- [google-cloud-dialogflow](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-dialogflow)
-- [google-cloud-dlp](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-dlp)
-- [google-cloud-dns](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-dns)
-- [google-cloud-error_reporting](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-error_reporting)
-- [google-cloud-firestore](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-firestore)
-- [google-cloud-kms](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-kms)
-- [google-cloud-language](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-language)
-- [google-cloud-logging](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging)
-- [google-cloud-monitoring](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-monitoring)
-- [google-cloud-os_login](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-os_login)
-- [google-cloud-pubsub](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-pubsub)
-- [google-cloud-redis](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-redis)
-- [google-cloud-resource_manager](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-resource_manager)
-- [google-cloud-scheduler](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-scheduler)
-- [google-cloud-spanner](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-spanner)
-- [google-cloud-speech](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-speech)
-- [google-cloud-storage](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-storage)
-- [google-cloud-tasks](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-tasks)
-- [google-cloud-text_to_speech](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-text_to_speech)
-- [google-cloud-trace](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace)
-- [google-cloud-translate](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-translate)
-- [google-cloud-video_intelligence](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-video_intelligence)
-- [google-cloud-vision](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-vision)
+- [google-cloud-asset](../google-cloud-asset/README.md
+- [google-cloud-bigquery](../google-cloud-bigquery/README.md
+- [google-cloud-bigquery-data_transfer](../google-cloud-bigquery-data_transfer/README.md
+- [google-cloud-bigtable](../google-cloud-bigtable/README.md
+- [google-cloud-container](../google-cloud-container/README.md
+- [google-cloud-dataproc](../google-cloud-dataproc/README.md
+- [google-cloud-datastore](../google-cloud-datastore/README.md
+- [google-cloud-dialogflow](../google-cloud-dialogflow/README.md
+- [google-cloud-dlp](../google-cloud-dlp/README.md
+- [google-cloud-dns](../google-cloud-dns/README.md
+- [google-cloud-error_reporting](../google-cloud-error_reporting/README.md
+- [google-cloud-firestore](../google-cloud-firestore/README.md
+- [google-cloud-kms](../google-cloud-kms/README.md
+- [google-cloud-language](../google-cloud-language/README.md
+- [google-cloud-logging](../google-cloud-logging/README.md
+- [google-cloud-monitoring](../google-cloud-monitoring/README.md
+- [google-cloud-os_login](../google-cloud-os_login/README.md
+- [google-cloud-pubsub](../google-cloud-pubsub/README.md
+- [google-cloud-redis](../google-cloud-redis/README.md
+- [google-cloud-resource_manager](../google-cloud-resource_manager/README.md
+- [google-cloud-scheduler](../google-cloud-scheduler/README.md
+- [google-cloud-spanner](../google-cloud-spanner/README.md
+- [google-cloud-speech](../google-cloud-speech/README.md
+- [google-cloud-storage](../google-cloud-storage/README.md
+- [google-cloud-tasks](../google-cloud-tasks/README.md
+- [google-cloud-text_to_speech](../google-cloud-text_to_speech/README.md
+- [google-cloud-trace](../google-cloud-trace/README.md
+- [google-cloud-translate](../google-cloud-translate/README.md
+- [google-cloud-video_intelligence](../google-cloud-video_intelligence/README.md
+- [google-cloud-vision](../google-cloud-vision/README.md
 
 ## Quick Start
 
@@ -54,7 +54,7 @@ $ gem install google-cloud
 ## Authentication
 
 Instructions and configuration options are covered in the [Authentication
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud/latest/file.AUTHENTICATION).
+Guide](./AUTHENTICATION.md).
 
 ## Example
 
@@ -103,18 +103,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/google-cloud/README.md
+++ b/google-cloud/README.md
@@ -14,36 +14,36 @@ individual google-cloud-* gems that you need.
 
 This gem depends on and lazily loads the following google-cloud-* gems:
 
-- [google-cloud-asset](../google-cloud-asset/README.md
-- [google-cloud-bigquery](../google-cloud-bigquery/README.md
-- [google-cloud-bigquery-data_transfer](../google-cloud-bigquery-data_transfer/README.md
-- [google-cloud-bigtable](../google-cloud-bigtable/README.md
-- [google-cloud-container](../google-cloud-container/README.md
-- [google-cloud-dataproc](../google-cloud-dataproc/README.md
-- [google-cloud-datastore](../google-cloud-datastore/README.md
-- [google-cloud-dialogflow](../google-cloud-dialogflow/README.md
-- [google-cloud-dlp](../google-cloud-dlp/README.md
-- [google-cloud-dns](../google-cloud-dns/README.md
-- [google-cloud-error_reporting](../google-cloud-error_reporting/README.md
-- [google-cloud-firestore](../google-cloud-firestore/README.md
-- [google-cloud-kms](../google-cloud-kms/README.md
-- [google-cloud-language](../google-cloud-language/README.md
-- [google-cloud-logging](../google-cloud-logging/README.md
-- [google-cloud-monitoring](../google-cloud-monitoring/README.md
-- [google-cloud-os_login](../google-cloud-os_login/README.md
-- [google-cloud-pubsub](../google-cloud-pubsub/README.md
-- [google-cloud-redis](../google-cloud-redis/README.md
-- [google-cloud-resource_manager](../google-cloud-resource_manager/README.md
-- [google-cloud-scheduler](../google-cloud-scheduler/README.md
-- [google-cloud-spanner](../google-cloud-spanner/README.md
-- [google-cloud-speech](../google-cloud-speech/README.md
-- [google-cloud-storage](../google-cloud-storage/README.md
-- [google-cloud-tasks](../google-cloud-tasks/README.md
-- [google-cloud-text_to_speech](../google-cloud-text_to_speech/README.md
-- [google-cloud-trace](../google-cloud-trace/README.md
-- [google-cloud-translate](../google-cloud-translate/README.md
-- [google-cloud-video_intelligence](../google-cloud-video_intelligence/README.md
-- [google-cloud-vision](../google-cloud-vision/README.md
+- [google-cloud-asset](https://github.com/googleapis/google-cloud-ruby/google-cloud-asset
+- [google-cloud-bigquery](https://github.com/googleapis/google-cloud-ruby/google-cloud-bigquery
+- [google-cloud-bigquery-data_transfer](https://github.com/googleapis/google-cloud-ruby/google-cloud-bigquery-data_transfer
+- [google-cloud-bigtable](https://github.com/googleapis/google-cloud-ruby/google-cloud-bigtable
+- [google-cloud-container](https://github.com/googleapis/google-cloud-ruby/google-cloud-container
+- [google-cloud-dataproc](https://github.com/googleapis/google-cloud-ruby/google-cloud-dataproc
+- [google-cloud-datastore](https://github.com/googleapis/google-cloud-ruby/google-cloud-datastore
+- [google-cloud-dialogflow](https://github.com/googleapis/google-cloud-ruby/google-cloud-dialogflow
+- [google-cloud-dlp](https://github.com/googleapis/google-cloud-ruby/google-cloud-dlp
+- [google-cloud-dns](https://github.com/googleapis/google-cloud-ruby/google-cloud-dns
+- [google-cloud-error_reporting](https://github.com/googleapis/google-cloud-ruby/google-cloud-error_reporting
+- [google-cloud-firestore](https://github.com/googleapis/google-cloud-ruby/google-cloud-firestore
+- [google-cloud-kms](https://github.com/googleapis/google-cloud-ruby/google-cloud-kms
+- [google-cloud-language](https://github.com/googleapis/google-cloud-ruby/google-cloud-language
+- [google-cloud-logging](https://github.com/googleapis/google-cloud-ruby/google-cloud-logging
+- [google-cloud-monitoring](https://github.com/googleapis/google-cloud-ruby/google-cloud-monitoring
+- [google-cloud-os_login](https://github.com/googleapis/google-cloud-ruby/google-cloud-os_login
+- [google-cloud-pubsub](https://github.com/googleapis/google-cloud-ruby/google-cloud-pubsub
+- [google-cloud-redis](https://github.com/googleapis/google-cloud-ruby/google-cloud-redis
+- [google-cloud-resource_manager](https://github.com/googleapis/google-cloud-ruby/google-cloud-resource_manager
+- [google-cloud-scheduler](https://github.com/googleapis/google-cloud-ruby/google-cloud-scheduler
+- [google-cloud-spanner](https://github.com/googleapis/google-cloud-ruby/google-cloud-spanner
+- [google-cloud-speech](https://github.com/googleapis/google-cloud-ruby/google-cloud-speech
+- [google-cloud-storage](https://github.com/googleapis/google-cloud-ruby/google-cloud-storage
+- [google-cloud-tasks](https://github.com/googleapis/google-cloud-ruby/google-cloud-tasks
+- [google-cloud-text_to_speech](https://github.com/googleapis/google-cloud-ruby/google-cloud-text_to_speech
+- [google-cloud-trace](https://github.com/googleapis/google-cloud-ruby/google-cloud-trace
+- [google-cloud-translate](https://github.com/googleapis/google-cloud-ruby/google-cloud-translate
+- [google-cloud-video_intelligence](https://github.com/googleapis/google-cloud-ruby/google-cloud-video_intelligence
+- [google-cloud-vision](https://github.com/googleapis/google-cloud-ruby/google-cloud-vision
 
 ## Quick Start
 
@@ -54,7 +54,7 @@ $ gem install google-cloud
 ## Authentication
 
 Instructions and configuration options are covered in the [Authentication
-Guide](./AUTHENTICATION.md).
+Guide](https://googleapis.dev/ruby/google-cloud/latest/file.AUTHENTICATION.html).
 
 ## Example
 
@@ -103,18 +103,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/google-cloud/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/google-cloud/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/google-cloud/latest/file.LICENSE.html).
 
 ## Support
 

--- a/grafeas-client/README.md
+++ b/grafeas-client/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Container Analysis API.](https://console.cloud.google.com/apis/library/grafeas.googleapis.com)
-4. [Setup Authentication.](./AUTHENTICATION.md)
+4. [Setup Authentication.](https://googleapis.dev/ruby/grafeas-client/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```

--- a/grafeas-client/README.md
+++ b/grafeas-client/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Container Analysis API.](https://console.cloud.google.com/apis/library/grafeas.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+4. [Setup Authentication.](./AUTHENTICATION.md)
 
 ### Installation
 ```
@@ -28,14 +28,14 @@ $ gem install grafeas-client
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/grafeas/latest/grafeas/v1
+[Client Library Documentation]: https://googleapis.dev/ruby/grafeas/latest
 [Product Documentation]: https://grafeas.io/
 
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 

--- a/grafeas-client/lib/grafeas.rb
+++ b/grafeas-client/lib/grafeas.rb
@@ -33,7 +33,7 @@ require "pathname"
 # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 # 3. [Enable the Container Analysis API.](https://console.cloud.google.com/apis/library/grafeas.googleapis.com)
-# 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+# 4. [Setup Authentication.](https://googleapis.dev/ruby/grafeas-client/latest/file.AUTHENTICATION.html)
 #
 # ### Installation
 # ```
@@ -52,7 +52,7 @@ require "pathname"
 #
 # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-# or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+# or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 #

--- a/grafeas-client/lib/grafeas/v1.rb
+++ b/grafeas-client/lib/grafeas/v1.rb
@@ -33,7 +33,7 @@ module Grafeas
   # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
   # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
   # 3. [Enable the Container Analysis API.](https://console.cloud.google.com/apis/library/grafeas.googleapis.com)
-  # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+  # 4. [Setup Authentication.](https://googleapis.dev/ruby/grafeas-client/latest/file.AUTHENTICATION.html)
   #
   # ### Installation
   # ```
@@ -52,7 +52,7 @@ module Grafeas
   #
   # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
   # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-  # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+  # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
   # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
   # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
   #

--- a/grafeas-client/synth.py
+++ b/grafeas-client/synth.py
@@ -251,7 +251,7 @@ for file in ['lib/**/*.rb', '*.md']:
 s.replace(
     '*.md',
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
-    './AUTHENTICATION.md'
+    'https://googleapis.dev/ruby/grafeas-client/latest/file.AUTHENTICATION.html'
 )
 s.replace(
     'lib/**/*.rb',

--- a/grafeas-client/synth.py
+++ b/grafeas-client/synth.py
@@ -240,3 +240,26 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Grafeas::VERSION'
 )
+
+# Fix links for devsite migration
+for file in ['lib/**/*.rb', '*.md']:
+    s.replace(
+        file,
+        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+        'https://googleapis.dev/ruby/google-cloud-logging/latest'
+    )
+s.replace(
+    '*.md',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    './AUTHENTICATION.md'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/grafeas-client/latest/file.AUTHENTICATION.html'
+)
+s.replace(
+    'README.md',
+    'github.io/google-cloud-ruby/#/docs/grafeas/latest/.*$',
+    'dev/ruby/grafeas/latest'
+)

--- a/rakelib/devsite_builder.rb
+++ b/rakelib/devsite_builder.rb
@@ -16,7 +16,7 @@ class DevsiteBuilder < YardBuilder
       input_dir = "#{master_dir + gem}"
       output_dir = "#{gh_pages_dir + 'docs' + gem + 'master'}"
       build_gem_docs input_dir, output_dir
-      puts "Build #{gem} documentation for commit #{git_ref}"
+      puts "Built #{gem} documentation for commit #{git_ref}"
     end
   end
 
@@ -35,8 +35,17 @@ class DevsiteBuilder < YardBuilder
     gem, version = split_tag tag
     add_release gem, version
     publish_docs_for_tag tag
-    ensure_gem_latest_dir gem
-    puts "Add #{gem} documentation for #{version} release"
+    puts "Added #{gem} documentation for #{version} release"
+  end
+
+  def rebuild_tag *tags
+    return if case_insensitive_check!
+
+    tags.flatten.each do |tag|
+      gem, version = split_tag tag
+      publish_docs_for_tag tag
+      puts "Rebuilt #{gem} documentation for #{version} version"
+    end
   end
 
   def republish_all

--- a/rakelib/devsite_builder.rb
+++ b/rakelib/devsite_builder.rb
@@ -34,6 +34,8 @@ class DevsiteBuilder < YardBuilder
 
     gem, version = split_tag tag
     add_release gem, version
+    commit_changes gh_pages_dir, "Add #{gem}: #{version}"
+    push_changes gh_pages_dir
     publish_docs_for_tag tag
     puts "Added #{gem} documentation for #{version} release"
   end

--- a/rakelib/devsite_builder.rb
+++ b/rakelib/devsite_builder.rb
@@ -1,6 +1,6 @@
 require_relative "repo_metadata.rb"
 require_relative "gem_version_doc.rb"
-require_relative "repo_metadata.rb"
+require_relative "yard_builder.rb"
 
 class DevsiteBuilder < YardBuilder
   def initialize master_dir = "."

--- a/rakelib/gem_version_doc.rb
+++ b/rakelib/gem_version_doc.rb
@@ -55,4 +55,17 @@ class GemVersionDoc < RepoDocCommon
     build
     upload
   end
+
+  def fix_relative_links
+    Dir.chdir @input_dir do
+      files = Dir.glob("**/*.md")
+      files.each do |file|
+        content = File.read file
+        content.gsub! %r{\.\./(.*)/(.*).md}, "https://googleapis.dev/ruby/\\1/latest/file.\\2.html"
+        content.gsub! %r{\./(.*).md}, "https://googleapis.dev/ruby/#{@input_dir.split('/').last}/latest/file.\\1.html"
+        content.gsub! %r{\.\./(.*)\)}, "https://googleapis.dev/ruby/\\1/latest)"
+        File.write file, content
+      end
+    end
+  end
 end

--- a/stackdriver-core/README.md
+++ b/stackdriver-core/README.md
@@ -30,18 +30,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/stackdriver-core/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/stackdriver-core/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](./LICENSE.md).
+[LICENSE](https://googleapis.dev/ruby/stackdriver-core/latest/file.LICENSE.html).
 
 ## Support
 

--- a/stackdriver-core/README.md
+++ b/stackdriver-core/README.md
@@ -5,7 +5,7 @@ libraries. Please see the [GitHub
 repository](https://github.com/googleapis/google-cloud-ruby) for more
 information about the individual google-cloud gems.
 
-- [stackdriver-core API documentation](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver-core/latest)
+- [stackdriver-core API documentation](https://googleapis.dev/ruby/stackdriver-core/latest)
 
 ## Supported Ruby Versions
 
@@ -30,18 +30,18 @@ change at any time and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver-core/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver-core/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is available in
-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver-core/latest/file.LICENSE).
+[LICENSE](./LICENSE.md).
 
 ## Support
 

--- a/stackdriver/OVERVIEW.md
+++ b/stackdriver/OVERVIEW.md
@@ -7,18 +7,18 @@ your application.
 
 Specifically, this gem is a convenience package that loads the following gems:
 
-- [google-cloud-debugger](../google-cloud-debugger/README.md
-- [google-cloud-error_reporting](../google-cloud-error_reporting/README.md
-- [google-cloud-logging](../google-cloud-logging/README.md
-- [google-cloud-trace](../google-cloud-trace/README.md
+- [google-cloud-debugger](https://googleapis.dev/ruby/google-cloud-debugger/latest
+- [google-cloud-error_reporting](https://googleapis.dev/ruby/google-cloud-error_reporting/latest
+- [google-cloud-logging](https://googleapis.dev/ruby/google-cloud-logging/latest
+- [google-cloud-trace](https://googleapis.dev/ruby/google-cloud-trace/latest
 
 On top of that, stackdriver gem automatically activates the following
 instrumentation features:
 
-- [google-cloud-debugger instrumentation](../google-cloud-debugger/INSTRUMENTATION.md
-- [google-cloud-error_reporting strumentation](../google-cloud-error_reporting/INSTRUMENTATION.md
-- [google-cloud-logging instrumentation](../google-cloud-logging/INSTRUMENTATION.md
-- [google-cloud-trace instrumentation](../google-cloud-trace/INSTRUMENTATION.md
+- [google-cloud-debugger instrumentation](https://googleapis.dev/ruby/google-cloud-debugger/latest/file.INSTRUMENTATION.html
+- [google-cloud-error_reporting strumentation](https://googleapis.dev/ruby/google-cloud-error_reporting/latest/file.INSTRUMENTATION.html
+- [google-cloud-logging instrumentation](https://googleapis.dev/ruby/google-cloud-logging/latest/file.INSTRUMENTATION.html
+- [google-cloud-trace instrumentation](https://googleapis.dev/ruby/google-cloud-trace/latest/file.INSTRUMENTATION.html
 
 ## Usage
 

--- a/stackdriver/OVERVIEW.md
+++ b/stackdriver/OVERVIEW.md
@@ -7,18 +7,18 @@ your application.
 
 Specifically, this gem is a convenience package that loads the following gems:
 
-- [google-cloud-debugger](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger)
-- [google-cloud-error_reporting](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-error_reporting)
-- [google-cloud-logging](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging)
-- [google-cloud-trace](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace)
+- [google-cloud-debugger](../google-cloud-debugger/README.md
+- [google-cloud-error_reporting](../google-cloud-error_reporting/README.md
+- [google-cloud-logging](../google-cloud-logging/README.md
+- [google-cloud-trace](../google-cloud-trace/README.md
 
 On top of that, stackdriver gem automatically activates the following
 instrumentation features:
 
-- [google-cloud-debugger instrumentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.INSTRUMENTATION)
-- [google-cloud-error_reporting strumentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-error_reporting/latest/file.INSTRUMENTATION)
-- [google-cloud-logging instrumentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/file.INSTRUMENTATION)
-- [google-cloud-trace instrumentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest/file.INSTRUMENTATION)
+- [google-cloud-debugger instrumentation](../google-cloud-debugger/INSTRUMENTATION.md
+- [google-cloud-error_reporting strumentation](../google-cloud-error_reporting/INSTRUMENTATION.md
+- [google-cloud-logging instrumentation](../google-cloud-logging/INSTRUMENTATION.md
+- [google-cloud-trace instrumentation](../google-cloud-trace/INSTRUMENTATION.md
 
 ## Usage
 

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -126,12 +126,12 @@ and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.CONTRIBUTING)
+Guide](./CONTRIBUTING.md)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.CODE_OF_CONDUCT)
+Conduct](./CODE_OF_CONDUCT.md)
 for more information.
 
 ## License

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -8,14 +8,14 @@ application.
 Specifically, this gem is a convenience package that loads and automatically
 activates the instrumentation features of the following gems:
 
-*   [google-cloud-debugger](../google-cloud-debugger) which enables remote
+*   [google-cloud-debugger](https://googleapis.dev/ruby/google-cloud-debugger/latest) which enables remote
     debugging using [Stackdriver Debugger](https://cloud.google.com/debugger/)
-*   [google-cloud-error_reporting](../google-cloud-error_reporting) which
+*   [google-cloud-error_reporting](https://googleapis.dev/ruby/google-cloud-error_reporting/latest) which
     reports unhandled exceptions and other errors to
     [Stackdriver Error Reporting](https://cloud.google.com/error-reporting/)
-*   [google-cloud-logging](../google-cloud-logging) which collects application
+*   [google-cloud-logging](https://googleapis.dev/ruby/google-cloud-logging/latest) which collects application
     logs in [Stackdriver logging](https://cloud.google.com/logging/)
-*   [google-cloud-trace](../google-cloud-trace) which reports distributed
+*   [google-cloud-trace](https://googleapis.dev/ruby/google-cloud-trace/latest) which reports distributed
     latency traces to [Stackdriver Trace](https://cloud.google.com/trace/)
 
 ## Quick Start
@@ -126,12 +126,12 @@ and the public API should not be considered stable.
 Contributions to this library are always welcome and highly encouraged.
 
 See the [Contributing
-Guide](./CONTRIBUTING.md)
+Guide](https://googleapis.dev/ruby/stackdriver/latest/file.CONTRIBUTING.html)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See [Code of
-Conduct](./CODE_OF_CONDUCT.md)
+Conduct](https://googleapis.dev/ruby/stackdriver/latest/file.CODE_OF_CONDUCT.html)
 for more information.
 
 ## License

--- a/stackdriver/lib/stackdriver.rb
+++ b/stackdriver/lib/stackdriver.rb
@@ -40,18 +40,18 @@ end
 #
 # Specifically, this gem is a convenience package that loads the following gems:
 #
-# - [google-cloud-debugger](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger)
-# - [google-cloud-error_reporting](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-error_reporting)
-# - [google-cloud-logging](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging)
-# - [google-cloud-trace](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace)
+# - [google-cloud-debugger](https://googleapis.dev/ruby/google-cloud-debugger/latest)
+# - [google-cloud-error_reporting](https://googleapis.dev/ruby/google-cloud-error_reporting/latest)
+# - [google-cloud-logging](https://googleapis.dev/ruby/google-cloud-logging/latest)
+# - [google-cloud-trace](https://googleapis.dev/ruby/google-cloud-trace/latest)
 #
 # On top of that, stackdriver gem automatically activates the following
 # instrumentation features:
 #
-# - [google-cloud-debugger instrumentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.INSTRUMENTATION)
-# - [google-cloud-error_reporting instrumentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-error_reporting/latest/file.INSTRUMENTATION)
-# - [google-cloud-logging instrumentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/file.INSTRUMENTATION)
-# - [google-cloud-trace instrumentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest/file.INSTRUMENTATION)
+# - [google-cloud-debugger instrumentation](https://googleapis.dev/ruby/google-cloud-debugger/latest/file.INSTRUMENTATION.html)
+# - [google-cloud-error_reporting instrumentation](https://googleapis.dev/ruby/google-cloud-error_reporting/latest/file.INSTRUMENTATION.html)
+# - [google-cloud-logging instrumentation](https://googleapis.dev/ruby/google-cloud-logging/latest/file.INSTRUMENTATION.html)
+# - [google-cloud-trace instrumentation](https://googleapis.dev/ruby/google-cloud-trace/latest/file.INSTRUMENTATION.html)
 #
 # ## Usage
 #


### PR DESCRIPTION
- Links in \*.md files that pointed to https://googleapis.github.io/**/file.* now point to the file within the github repo (https://googleapis.github.io/google-cloud-ruby/docs/authentication becomes ../google-cloud/AUTHENTICATION.md)
- Links in \*.md files that refer to other gems now link to that gem's README, unless the context requires the api documentation.
- Relative links in \*.md files will be changed to their googleapis.dev equivalent prior to publishing.
- Links in \*.rb files that pointed to https://googleapis.github.io/**/file.* now point to the devsite equivalent.
- All links to Authentication guides have been routed to the gem specific one unless the context was specifically mentioning the google-cloud/AUTHENTICATION.md
- Add replacements in all appropriate synth.py's re-routing links to googleapis.dev
- kokoro:post will republish_all until https://github.com/googleapis/google-cloud-ruby/pull/3690
