### PR TITLE
Allow persistence_regions to be set

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -174,6 +174,9 @@ module Google
         # @param [String] kms_key The Cloud KMS encryption key that will be used
         #   to protect access to messages published on this topic. Optional.
         #   For example: `projects/a/locations/b/keyRings/c/cryptoKeys/d`
+        # @param [Array<String>] persistence_regions The list of GCP region IDs
+        #   where messages that are published to the topic may be persisted in
+        #   storage. Optional.
         # @param [Hash] async A hash of values to configure the topic's
         #   {AsyncPublisher} that is created when {Topic#publish_async}
         #   is called. Optional.
@@ -202,11 +205,13 @@ module Google
         #   pubsub = Google::Cloud::PubSub.new
         #   topic = pubsub.create_topic "my-topic"
         #
-        def create_topic topic_name, labels: nil, kms_key: nil, async: nil
+        def create_topic topic_name, labels: nil, kms_key: nil,
+                         persistence_regions: nil, async: nil
           ensure_service!
           grpc = service.create_topic topic_name,
-                                      labels:       labels,
-                                      kms_key_name: kms_key
+                                      labels:              labels,
+                                      kms_key_name:        kms_key,
+                                      persistence_regions: persistence_regions
           Topic.from_grpc grpc, service, async: async
         end
         alias new_topic create_topic

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -126,12 +126,21 @@ module Google
 
         ##
         # Creates the given topic with the given name.
-        def create_topic topic_name, labels: nil, kms_key_name: nil, options: {}
+        def create_topic topic_name, labels: nil, kms_key_name: nil,
+                         persistence_regions: nil, options: {}
+          if persistence_regions
+            message_storage_policy = {
+              allowed_persistence_regions: Array(persistence_regions)
+            }
+          end
+
           execute do
-            publisher.create_topic topic_path(topic_name, options),
-                                   labels:       labels,
-                                   kms_key_name: kms_key_name,
-                                   options:      default_options
+            publisher.create_topic \
+              topic_path(topic_name, options),
+              labels:                 labels,
+              kms_key_name:           kms_key_name,
+              message_storage_policy: message_storage_policy,
+              options:                default_options
           end
         end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -213,6 +213,30 @@ module Google
         end
 
         ##
+        # Sets the list of GCP region IDs where messages that are published to
+        # the topic may be persisted in storage.
+        #
+        # @param [Array<String>] new_persistence_regions
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   topic = pubsub.topic "my-topic"
+        #
+        #   topic.persistence_regions = ["us-central1", "us-central2"]
+        #
+        def persistence_regions= new_persistence_regions
+          update_grpc = Google::Cloud::PubSub::V1::Topic.new \
+            name: name, message_storage_policy: {
+              allowed_persistence_regions: Array(new_persistence_regions)
+            }
+          @grpc = service.update_topic update_grpc, :message_storage_policy
+          @resource_name = nil
+        end
+
+        ##
         # Permanently deletes the topic.
         #
         # @return [Boolean] Returns `true` if the topic was deleted.

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -497,6 +497,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::PubSub::Topic#persistence_regions=" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      this_topic = topic_resp "my-topic", persistence_regions: ["us-central1", "us-central2"]
+      mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/my-topic", Hash]
+      mock_publisher.expect :update_topic, this_topic, [this_topic, Google::Protobuf::FieldMask.new(paths: ["message_storage_policy"]), Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::PubSub::Topic#delete" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/my-topic", Hash]

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
@@ -53,6 +53,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
   end
   let(:labels) { { "foo" => "bar" } }
   let(:kms_key) { "projects/a/locations/b/keyRings/c/cryptoKeys/d" }
+  let(:persistence_regions) { ["us-west1", "us-west2"] }
 
   it "knows the project identifier" do
     pubsub.project.must_equal project
@@ -63,7 +64,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name)
     mock = Minitest::Mock.new
-    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: nil, options: default_options]
+    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: nil, message_storage_policy: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic = pubsub.create_topic new_topic_name
@@ -74,6 +75,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
     topic.labels.must_be :empty?
     topic.labels.must_be :frozen?
     topic.kms_key.must_be :empty?
+    topic.persistence_regions.must_be :empty?
   end
 
   it "creates a topic with new_topic_alias" do
@@ -81,7 +83,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name)
     mock = Minitest::Mock.new
-    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: nil, options: default_options]
+    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: nil, message_storage_policy: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic = pubsub.new_topic new_topic_name
@@ -92,6 +94,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
     topic.labels.must_be :empty?
     topic.labels.must_be :frozen?
     topic.kms_key.must_be :empty?
+    topic.persistence_regions.must_be :empty?
   end
 
   it "creates a topic with labels" do
@@ -99,7 +102,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name, labels: labels)
     mock = Minitest::Mock.new
-    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: labels, kms_key_name: nil, options: default_options]
+    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: labels, kms_key_name: nil, message_storage_policy: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic = pubsub.create_topic new_topic_name, labels: labels
@@ -110,6 +113,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
     topic.labels.must_equal labels
     topic.labels.must_be :frozen?
     topic.kms_key.must_be :empty?
+    topic.persistence_regions.must_be :empty?
   end
 
   it "creates a topic with kms_key" do
@@ -117,7 +121,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name, kms_key_name: kms_key)
     mock = Minitest::Mock.new
-    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: kms_key, options: default_options]
+    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: kms_key, message_storage_policy: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic = pubsub.create_topic new_topic_name, kms_key: kms_key
@@ -128,6 +132,26 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
     topic.labels.must_be :empty?
     topic.labels.must_be :frozen?
     topic.kms_key.must_equal kms_key
+    topic.persistence_regions.must_be :empty?
+  end
+
+  it "creates a topic with persistence_regions" do
+    new_topic_name = "new-topic-#{Time.now.to_i}"
+
+    create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name, persistence_regions: persistence_regions)
+    mock = Minitest::Mock.new
+    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: nil, message_storage_policy: { allowed_persistence_regions: persistence_regions }, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    topic = pubsub.create_topic new_topic_name, persistence_regions: persistence_regions
+
+    mock.verify
+
+    topic.name.must_equal topic_path(new_topic_name)
+    topic.labels.must_be :empty?
+    topic.labels.must_be :frozen?
+    topic.kms_key.must_be :empty?
+    topic.persistence_regions.must_equal persistence_regions
   end
 
   it "gets a topic" do


### PR DESCRIPTION
Support setting persistence_regions on topic creation and topic update.

[closes #3638]