### PR TITLE
Add Table#require_partition_filter

### DIFF
--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-api-client", "~> 0.23"
+  gem.add_dependency "google-api-client", "~> 0.26"
   gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_dependency "mime-types", "~> 3.0"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -326,6 +326,52 @@ module Google
         end
 
         ###
+        # Whether queries over this table require a partition filter that can be
+        # used for partition elimination to be specified. See [Partitioned
+        # Tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
+        #
+        # @return [Boolean, nil] `true` when a partition filter will be
+        #   required, `false` otherwise, or `nil` if the object is a reference
+        #   (see {#reference?}).
+        #
+        # @!group Attributes
+        #
+        def require_partition_filter
+          return nil if reference?
+          ensure_full_data!
+          @gapi.require_partition_filter
+        end
+
+        ##
+        # Sets whether queries over this table require a partition filter. See
+        # [Partitioned
+        # Tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
+        #
+        # If the table is not a full resource representation (see
+        # {#resource_full?}), the full representation will be retrieved before
+        # the update to comply with ETag-based optimistic concurrency control.
+        #
+        # @param [Boolean] new_require Whether queries over this table require a
+        #   partition filter.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.create_table "my_table" do |table|
+        #     table.require_partition_filter = true
+        #   end
+        #
+        # @!group Attributes
+        #
+        def require_partition_filter= new_require
+          reload! unless resource_full?
+          @gapi.require_partition_filter = new_require
+          patch_gapi! :require_partition_filter
+        end
+
+        ###
         # Checks if the table is clustered.
         #
         # @see https://cloud.google.com/bigquery/docs/clustered-tables

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -226,6 +226,26 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     table.clustering_fields.must_equal clustering_fields
   end
 
+  it "creates a table with require_partition_filter in a block" do
+    mock = Minitest::Mock.new
+    insert_table = Google::Apis::BigqueryV2::Table.new(
+      table_reference: Google::Apis::BigqueryV2::TableReference.new(
+        project_id: project, dataset_id: dataset_id, table_id: table_id),
+      require_partition_filter: true)
+    mock.expect :insert_table, insert_table, [project, dataset_id, insert_table]
+    dataset.service.mocked_service = mock
+
+    table = dataset.create_table table_id do |t|
+      t.require_partition_filter = true
+    end
+
+    mock.verify
+
+    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.table_id.must_equal table_id
+    table.require_partition_filter.must_equal true
+  end
+
   it "creates a table with a schema inline" do
     mock = Minitest::Mock.new
     insert_table = Google::Apis::BigqueryV2::Table.new(

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
@@ -49,6 +49,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.location.must_equal location_code
     table.labels.must_equal labels
     table.labels.must_be :frozen?
+    table.require_partition_filter.must_equal true
   end
 
   it "knows its fully-qualified ID" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
@@ -45,6 +45,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.time_partitioning_type.must_be_nil
     table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
+    table.require_partition_filter.must_equal true
     table.clustering_fields.must_be_nil
 
     table.name = new_table_name
@@ -55,6 +56,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.time_partitioning_type.must_be_nil
     table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
+    table.require_partition_filter.must_equal true
     table.clustering_fields.must_be_nil
 
     mock.verify
@@ -77,6 +79,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.time_partitioning_type.must_be_nil
     table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
+    table.require_partition_filter.must_equal true
 
     table.description = new_description
 
@@ -86,6 +89,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.time_partitioning_type.must_be_nil
     table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
+    table.require_partition_filter.must_equal true
 
     mock.verify
   end
@@ -111,6 +115,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.time_partitioning_type.must_be_nil
     table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
+    table.require_partition_filter.must_equal true
 
     table.time_partitioning_type = type
 
@@ -119,6 +124,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.schema.fields.count.must_equal schema.fields.count
     table.time_partitioning_type.must_equal type
     table.time_partitioning_expiration.must_be_nil
+    table.require_partition_filter.must_equal true
 
     mock.verify
   end
@@ -144,6 +150,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.time_partitioning_type.must_be_nil
     table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
+    table.require_partition_filter.must_equal true
 
     table.time_partitioning_field = field
 
@@ -153,6 +160,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.time_partitioning_type.must_be_nil
     table.time_partitioning_field.must_equal field
     table.time_partitioning_expiration.must_be_nil
+    table.require_partition_filter.must_equal true
 
     mock.verify
   end
@@ -179,6 +187,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.time_partitioning_type.must_be_nil
     table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
+    table.require_partition_filter.must_equal true
 
     table.time_partitioning_expiration = expiration
 
@@ -188,6 +197,38 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.time_partitioning_type.must_be_nil
     table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_equal expiration
+    table.require_partition_filter.must_equal true
+
+    mock.verify
+  end
+
+  it "updates require_partition_filter" do
+    mock = Minitest::Mock.new
+    table_hash = random_table_hash dataset_id, table_id, table_name, description
+    table_hash["requirePartitionFilter"] = false
+    request_table_gapi = Google::Apis::BigqueryV2::Table.new require_partition_filter: false, etag: etag
+    mock.expect :patch_table, return_table(table_hash),
+      [project, dataset_id, table_id, request_table_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
+    table.service.mocked_service = mock
+
+    table.name.must_equal table_name
+    table.description.must_equal description
+    table.schema.fields.count.must_equal schema.fields.count
+    table.time_partitioning_type.must_be_nil
+    table.time_partitioning_field.must_be_nil
+    table.time_partitioning_expiration.must_be_nil
+    table.require_partition_filter.must_equal true
+
+    table.require_partition_filter = false
+
+    table.name.must_equal table_name
+    table.description.must_equal description
+    table.schema.fields.count.must_equal schema.fields.count
+    table.time_partitioning_type.must_be_nil
+    table.time_partitioning_field.must_be_nil
+    table.time_partitioning_expiration.must_be_nil
+    table.require_partition_filter.must_equal false
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -250,7 +250,8 @@ class MockBigquery < Minitest::Spec
         "estimatedBytes" => "2000", # String per google/google-api-ruby-client
         "estimatedRows" => "200", # String per google/google-api-ruby-client
         "oldestEntryTime" => time_millis
-      }
+      },
+      "requirePartitionFilter" => true
     }
   end
 


### PR DESCRIPTION
Add getter and setter methods for the `require_partition_filter` value.

Although there are no acceptance tests for this change, this has been verified manually on a table where time partitioning has been configured.

The following error is raised when setting this value on a table that has not been configured for time partitioning: `Google::Cloud::InvalidArgumentError (invalid: Either interval partition or range partition should be specified.)`

[closes #3671]