### PR TITLE
docs(bigtable): Fix timestamp param documentation

### DIFF
--- a/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
@@ -47,7 +47,7 @@ describe "DataClient Mutate Row", :bigtable do
     postfix = random_str
     row_key = "setcell-#{postfix}"
     qualifier = "mutate-row-#{postfix}"
-    timestamp = (Time.now.to_f * 1000).to_i * 1000
+    timestamp = (Time.now.to_f * 1000000).round(-3)
 
     # Set cell
     entry = table.new_mutation_entry(row_key)
@@ -135,7 +135,7 @@ describe "DataClient Mutate Row", :bigtable do
     postfix = random_str
     row_key = "setcell-#{postfix}"
     qualifier = "mutate-row-#{postfix}"
-    timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
+    timestamp_micros = (Time.now.to_f * 1000000).round(-3)
 
     table.granularity.must_equal :MILLIS
 

--- a/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
@@ -95,8 +95,8 @@ describe "DataClient Mutate Row", :bigtable do
     postfix = random_str
     row_key = "setcell-#{postfix}"
     qualifier = "mutate-row-#{postfix}"
-    t = Time.now
-    timestamp_micros = t.to_i * 1000000 + t.usec
+    timestamp_micros = (Time.now.to_f * 1000000).round
+    timestamp_micros += 1 if (timestamp_micros % 10).zero?
 
     table.granularity.must_equal :MILLIS
 
@@ -115,8 +115,8 @@ describe "DataClient Mutate Row", :bigtable do
     postfix = random_str
     row_key = "setcell-#{postfix}"
     qualifier = "mutate-row-#{postfix}"
-    t = Time.now
     timestamp_millis = (Time.now.to_f * 1000).to_i
+    timestamp_millis += 1 if (timestamp_millis % 10).zero?
 
     table.granularity.must_equal :MILLIS
 

--- a/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
@@ -43,11 +43,11 @@ describe "DataClient Mutate Row", :bigtable do
     table.read_row(row_key).must_be :nil?
   end
 
-  it "set cell with timestamp and delete cells with timestamp range" do
+  it "set cell with timestamp and delete cells with integer timestamp range" do
     postfix = random_str
     row_key = "setcell-#{postfix}"
     qualifier = "mutate-row-#{postfix}"
-    timestamp = (Time.now.to_i * 1000).floor
+    timestamp = (Time.now.to_f * 1000).to_i * 1000
 
     # Set cell
     entry = table.new_mutation_entry(row_key)
@@ -72,6 +72,89 @@ describe "DataClient Mutate Row", :bigtable do
     table.mutate_row(entry)
     row = table.read_row(row_key)
     row.cells[family].select{|v| v.qualifier == qualifier}.length.must_equal 1
+  end
+
+  it "raises when set_cell with incorrect Time timestamp" do
+    postfix = random_str
+    row_key = "setcell-#{postfix}"
+    qualifier = "mutate-row-#{postfix}"
+
+    table.granularity.must_equal :MILLIS
+
+    # Set cell
+    entry = table.new_mutation_entry(row_key)
+    err = expect do
+      entry.set_cell(
+        family, qualifier, "mutatetest value #{postfix}", timestamp: Time.now
+      )
+    end.must_raise Google::Protobuf::TypeError
+    err.message.must_match "Expected number type for integral field 'timestamp_micros' (given Time)."
+  end
+
+  it "raises when set_cell with incorrect microsecond integer timestamp" do
+    postfix = random_str
+    row_key = "setcell-#{postfix}"
+    qualifier = "mutate-row-#{postfix}"
+    t = Time.now
+    timestamp_micros = t.to_i * 1000000 + t.usec
+
+    table.granularity.must_equal :MILLIS
+
+    # Set cell
+    entry = table.new_mutation_entry(row_key)
+    entry.set_cell(
+      family, qualifier, "mutatetest value #{postfix}", timestamp: timestamp_micros
+    )
+    err = expect do
+      table.mutate_row(entry)
+    end.must_raise Google::Gax::RetryError
+    err.message.must_match /Timestamp granularity mismatch. Expected a multiple of 1000 \(millisecond granularity\), but got #{timestamp_micros}/
+  end
+
+  it "raises when set_cell with incorrect millisecond integer timestamp" do
+    postfix = random_str
+    row_key = "setcell-#{postfix}"
+    qualifier = "mutate-row-#{postfix}"
+    t = Time.now
+    timestamp_millis = (Time.now.to_f * 1000).to_i
+
+    table.granularity.must_equal :MILLIS
+
+    # Set cell
+    entry = table.new_mutation_entry(row_key)
+    entry.set_cell(
+      family, qualifier, "mutatetest value #{postfix}", timestamp: timestamp_millis
+    )
+    err = expect do
+      table.mutate_row(entry)
+    end.must_raise Google::Gax::RetryError
+    err.message.must_match /Timestamp granularity mismatch. Expected a multiple of 1000 \(millisecond granularity\), but got #{timestamp_millis}/
+  end
+
+  it "set_cell with correct microseconds rounded to milliseconds integer timestamp" do
+    postfix = random_str
+    row_key = "setcell-#{postfix}"
+    qualifier = "mutate-row-#{postfix}"
+    timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
+
+    table.granularity.must_equal :MILLIS
+
+    # Set cell
+    entry = table.new_mutation_entry(row_key)
+    entry.set_cell(
+      family, qualifier, "mutatetest value #{postfix}", timestamp: timestamp_micros
+    )
+
+    table.mutate_row(entry).must_equal true
+    row = table.read_row(row_key)
+    cells = row.cells[family].select{|v| v.qualifier == qualifier}
+    cells.length.must_equal 1
+    cells.first.timestamp.must_equal timestamp_micros
+
+    # Delete cell
+    entry = table.new_mutation_entry(row_key)
+    entry.delete_cells family, qualifier
+    table.mutate_row(entry)
   end
 
   it "delete all cells from specified column family" do

--- a/google-cloud-bigtable/acceptance/bigtable/table/row_filter_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/row_filter_test.rb
@@ -112,18 +112,18 @@ describe "DataClient Read Rows Filters", :bigtable do
   end
 
   it "timestamp range filter" do
-    timestamp = Time.now.to_i * 1000
+    timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
     entry = table.new_mutation_entry("timestamp-#{random_str}")
-    entry.set_cell(family, "timestamp", "timestamp range test", timestamp: timestamp)
+    entry.set_cell(family, "timestamp", "timestamp range test", timestamp: timestamp_micros)
     table.mutate_row(entry)
 
-    filter = table.filter.timestamp_range(from: timestamp)
+    filter = table.filter.timestamp_range(from: timestamp_micros)
     rows = table.read_rows(filter: filter, limit: 2).to_a
     rows.wont_be :empty?
 
     rows.each do |row|
       row.cells[family].each do |cell|
-        cell.timestamp.must_be :>=, timestamp
+        cell.timestamp.must_be :>=, timestamp_micros
       end
     end
   end

--- a/google-cloud-bigtable/acceptance/bigtable/table/row_filter_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/row_filter_test.rb
@@ -112,7 +112,7 @@ describe "DataClient Read Rows Filters", :bigtable do
   end
 
   it "timestamp range filter" do
-    timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
+    timestamp_micros = (Time.now.to_f * 1000000).round(-3)
     entry = table.new_mutation_entry("timestamp-#{random_str}")
     entry.set_cell(family, "timestamp", "timestamp range test", timestamp: timestamp_micros)
     table.mutate_row(entry)

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
@@ -486,7 +486,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: (Time.now.to_f * 1000).to_i * 1000 # microseconds
+        #     timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
         #   ).delete_cells("cf2", "field02")
         #
         #   table.mutate_row(entry)

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
@@ -486,7 +486,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: Time.now.to_i * 1000 # Time stamp in milli seconds.
+        #     timestamp: (Time.now.to_f * 1000).to_i * 1000 # microseconds
         #   ).delete_cells("cf2", "field02")
         #
         #   table.mutate_row(entry)

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
@@ -31,13 +31,14 @@ module Google
       #
       # @example
       #   entry = Google::Cloud::Bigtable::MutationEntry.new("user-1")
+      #   timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
       #   entry.set_cell(
-      #     "cf1", "fiel01", "XYZ", timestamp: Time.now.to_i * 1000
+      #     "cf1", "fiel01", "XYZ", timestamp: timestamp_micros
       #   ).delete_cells(
       #     "cf2",
       #     "field02",
-      #     timestamp_from: (Time.now.to_i - 1800) * 1000,
-      #     timestamp_to: (Time.now.to_i * 1000)
+      #     timestamp_from: timestamp_micros - 5000000,
+      #     timestamp_to: timestamp_micros
       #   ).delete_from_family("cf3").delete_from_row
       #
       # @example Using table
@@ -47,8 +48,9 @@ module Google
       #   table = bigtable.table("my-instance", "my-table")
       #
       #   entry = table.new_mutation_entry("user-1")
+      #   timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
       #   entry.set_cell(
-      #     "cf1", "fiel01", "XYZ", timestamp: Time.now.to_i * 1000
+      #     "cf1", "fiel01", "XYZ", timestamp: timestamp_micros
       #   )
       #
       class MutationEntry
@@ -100,7 +102,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: Time.now.to_i * 1000 # Time stamp in millis seconds.
+        #     timestamp: (Time.now.to_f * 1000).to_i * 1000 # microseconds
         #   )
         #
         def set_cell family, qualifier, value, timestamp: nil
@@ -151,18 +153,20 @@ module Google
         #
         # @example With timestamp range
         #   entry = Google::Cloud::Bigtable::MutationEntry.new("user-1")
+        #   timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
         #   entry.delete_cells(
         #     "cf1",
         #     "field-1",
-        #     timestamp_from: (Time.now.to_i - 1800) * 1000,
-        #     timestamp_to: (Time.now.to_i * 1000)
+        #     timestamp_from: timestamp_micros - 5000000,
+        #     timestamp_to: timestamp_micros
         #   )
         # @example With timestamp range with lower boundary only
         #   entry = Google::Cloud::Bigtable::MutationEntry.new("user-1")
+        #   timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
         #   entry.delete_cells(
         #     "cf1",
         #     "field-1",
-        #     timestamp_from: (Time.now.to_i - 1800) * 1000
+        #     timestamp_from: timestamp_micros - 5000000
         #   )
         #
         def delete_cells \

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
@@ -31,7 +31,7 @@ module Google
       #
       # @example
       #   entry = Google::Cloud::Bigtable::MutationEntry.new("user-1")
-      #   timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
+      #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
       #   entry.set_cell(
       #     "cf1", "fiel01", "XYZ", timestamp: timestamp_micros
       #   ).delete_cells(
@@ -48,7 +48,7 @@ module Google
       #   table = bigtable.table("my-instance", "my-table")
       #
       #   entry = table.new_mutation_entry("user-1")
-      #   timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
+      #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
       #   entry.set_cell(
       #     "cf1", "fiel01", "XYZ", timestamp: timestamp_micros
       #   )
@@ -102,7 +102,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: (Time.now.to_f * 1000).to_i * 1000 # microseconds
+        #     timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
         #   )
         #
         def set_cell family, qualifier, value, timestamp: nil
@@ -153,7 +153,7 @@ module Google
         #
         # @example With timestamp range
         #   entry = Google::Cloud::Bigtable::MutationEntry.new("user-1")
-        #   timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
+        #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
         #   entry.delete_cells(
         #     "cf1",
         #     "field-1",
@@ -162,7 +162,7 @@ module Google
         #   )
         # @example With timestamp range with lower boundary only
         #   entry = Google::Cloud::Bigtable::MutationEntry.new("user-1")
-        #   timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
+        #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
         #   entry.delete_cells(
         #     "cf1",
         #     "field-1",

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
@@ -79,12 +79,15 @@ module Google
         #   Can be any byte string, including an empty string.
         # @param value [String, Integer] Cell value data.
         #   The value to be written into the specified cell.
-        # @param timestamp [Time, Integer] Timestamp value.
+        # @param timestamp [Integer] Timestamp value in microseconds.
         #   The timestamp of the cell into which new data should be written.
         #   Use -1 for current Bigtable server time.
         #   Otherwise, the client should set this value itself, noting that the
         #   default value is a timestamp of zero if the field is left unspecified.
-        #   Values must match the granularity of the table (micros or millis, for example).
+        #   Values are in microseconds but must match the granularity of the
+        #   table. Therefore, if {Table#granularity} is `MILLIS` (the default),
+        #   the given value must be a multiple of 1000 (millisecond
+        #   granularity). For example: `1564257960168000`.
         # @return [MutationEntry]  `self` object of entry for chaining.
         #
         # @example
@@ -128,10 +131,18 @@ module Google
         # @param qualifier [String] Column qualifier name.
         #   The qualifier of the column from which cells should be deleted.
         #   Can be any byte string, including an empty string.
-        # @param timestamp_from [Integer] Timestamp lower boundary. Optional.
-        #   The range of timestamps from which cells should be deleted.
-        # @param timestamp_to [Integer] Timestamp upper boundary. Optional.
-        #   The range of timestamps from which cells should be deleted.
+        # @param timestamp_from [Integer] Timestamp lower boundary in
+        #   microseconds. Optional. Begins the range of timestamps from which
+        #   cells should be deleted. Values are in microseconds but must match
+        #   the granularity of the table. Therefore, if {Table#granularity} is
+        #   `MILLIS` (the default), the given value must be a multiple of 1000
+        #   (millisecond granularity). For example: `1564257960168000`.
+        # @param timestamp_to [Integer] Timestamp upper boundary in
+        #   microseconds. Optional. Ends the range of timestamps from which
+        #   cells should be deleted. Values are in microseconds but must match
+        #   the granularity of the table. Therefore, if {Table#granularity} is
+        #   `MILLIS` (the default), the given value must be a multiple of 1000
+        #   (millisecond granularity). For example: `1564257960168000`.
         # @return [MutationEntry] `self` object of entry for chaining.
         #
         # @example Without timestamp range

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
@@ -67,7 +67,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: (Time.now.to_f * 1000).to_i * 1000 # microseconds
+        #     timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
         #   ).delete_cells("cf2", "field02")
         #
         #   table.mutate_row(entry)
@@ -216,7 +216,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: (Time.now.to_f * 1000).to_i * 1000 # microseconds
+        #     timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
         #   ).delete_cells("cf2", "field02")
         #
         #   otherwise_mutations = Google::Cloud::Bigtable::MutationEntry.new

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
@@ -67,7 +67,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: Time.now.to_i * 1000 # Time stamp in milli seconds.
+        #     timestamp: (Time.now.to_f * 1000).to_i * 1000 # microseconds
         #   ).delete_cells("cf2", "field02")
         #
         #   table.mutate_row(entry)
@@ -216,7 +216,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: Time.now.to_i * 1000 # Time stamp in micro seconds.
+        #     timestamp: (Time.now.to_f * 1000).to_i * 1000 # microseconds
         #   ).delete_cells("cf2", "field02")
         #
         #   otherwise_mutations = Google::Cloud::Bigtable::MutationEntry.new

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
@@ -360,7 +360,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: Time.now.to_i * 1000  # Timestamp in milliseconds.
+        #     timestamp: (Time.now.to_f * 1000).to_i * 1000 # microseconds
         #   ).delete_cells("cf2", "field02")
         #
         #   table.mutate_row(entry)

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
@@ -360,7 +360,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: (Time.now.to_f * 1000).to_i * 1000 # microseconds
+        #     timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
         #   ).delete_cells("cf2", "field02")
         #
         #   table.mutate_row(entry)

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/row.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/row.rb
@@ -32,7 +32,7 @@ module Google
           #
           # @param family [String] Column family name
           # @param qualifier [String] Column cell qualifier name
-          # @param timestamp [Integer] Timestamp in micro seconds
+          # @param timestamp [Integer] Timestamp in microseconds
           # @param value [String] Cell value
           # @param labels [Array<String>] List of label array
 

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter.rb
@@ -527,8 +527,9 @@ module Google
         #
         # @example
         #
-        #   from = (Time.now - 300).to_i * 1000
-        #   to = Time.now.to_f * 1000
+        #   timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
+        #   from = timestamp_micros - 300000000
+        #   to = timestamp_micros
         #
         #   filter = Google::Cloud::Bigtable::RowFilter.timestamp_range(from: from, to: to)
         #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter.rb
@@ -527,7 +527,7 @@ module Google
         #
         # @example
         #
-        #   timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
+        #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
         #   from = timestamp_micros - 300000000
         #   to = timestamp_micros
         #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/chain_filter.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/chain_filter.rb
@@ -433,7 +433,7 @@ module Google
           #
           # @example
           #
-          #   timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
+          #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
           #   from = timestamp_micros - 300000000
           #   to = timestamp_micros
           #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/chain_filter.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/chain_filter.rb
@@ -433,8 +433,9 @@ module Google
           #
           # @example
           #
-          #   from = (Time.now - 300).to_i * 1000 # 300 seconds ago
-          #   to = Time.now.to_f * 1000
+          #   timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
+          #   from = timestamp_micros - 300000000
+          #   to = timestamp_micros
           #
           #   filter = Google::Cloud::Bigtable::RowFilter.chain.timestamp_range(from: from, to: to)
           #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/interleave_filter.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/interleave_filter.rb
@@ -465,7 +465,7 @@ module Google
           #
           # @example
           #
-          #   timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
+          #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
           #   from = timestamp_micros - 300000000
           #   to = timestamp_micros
           #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/interleave_filter.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/interleave_filter.rb
@@ -465,8 +465,9 @@ module Google
           #
           # @example
           #
-          #   from = (Time.now - 300).to_f * 1000
-          #   to = Time.now.to_f * 1000
+          #   timestamp_micros = (Time.now.to_f * 1000).to_i * 1000
+          #   from = timestamp_micros - 300000000
+          #   to = timestamp_micros
           #
           #   filter = Google::Cloud::Bigtable::RowFilter.interleave.timestamp_range(from: from, to: to)
           #

--- a/google-cloud-bigtable/test/google/cloud/bigtable/mutation_entry_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/mutation_entry_test.rb
@@ -59,7 +59,7 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
     end
 
     it "add set cell mutation with timestamp" do
-      timestamp = Time.now.to_i * 1000
+      timestamp = timestamp_micros
       entry = Google::Cloud::Bigtable::MutationEntry.new(row_key)
       entry.set_cell(family, qualifier, cell_value, timestamp: timestamp)
       entry.mutations.length.must_equal 1
@@ -112,7 +112,7 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
     end
 
     it "add delete cells mutation with from timestamp" do
-      timestamp_from = Time.now.to_i * 1000
+      timestamp_from = timestamp_micros
 
       entry = Google::Cloud::Bigtable::MutationEntry.new(row_key)
       entry.delete_cells(family, qualifier, timestamp_from: timestamp_from)
@@ -130,7 +130,7 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
     end
 
     it "add delete cells mutation with to timestamp range" do
-      timestamp_to = Time.now.to_i * 1000
+      timestamp_to = timestamp_micros
 
       entry = Google::Cloud::Bigtable::MutationEntry.new(row_key)
       entry.delete_cells(family, qualifier, timestamp_to: timestamp_to)
@@ -148,8 +148,8 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
     end
 
     it "add delete cells mutation with timestamp range" do
-      timestamp_from = Time.now.to_i * 1000
-      timestamp_to = Time.now.to_i * 1000 + 1000
+      timestamp_from = timestamp_micros
+      timestamp_to = timestamp_micros + 1000000
 
       entry = Google::Cloud::Bigtable::MutationEntry.new(row_key)
       entry.delete_cells(family, qualifier, timestamp_from: timestamp_from, timestamp_to: timestamp_to)

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_filter_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_filter_test.rb
@@ -117,8 +117,8 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
 
   describe "timestamp_range" do
     it "create timestamp_range filter" do
-      from = (Time.now.to_i - 300) * 1000
-      to = Time.now.to_i * 1000
+      from = timestamp_micros - 3000000
+      to = timestamp_micros
 
       filter = Google::Cloud::Bigtable::RowFilter.timestamp_range(from: from, to: to)
 
@@ -131,7 +131,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     end
 
     it "create timestamp_range filter with only from range" do
-      from = (Time.now.to_i - 300) * 1000
+      from = timestamp_micros - 3000000
       filter = Google::Cloud::Bigtable::RowFilter.timestamp_range(from: from)
 
       filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
@@ -143,7 +143,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     end
 
     it "create timestamp_range filter with only to range" do
-      to = Time.now.to_i * 1000
+      to = timestamp_micros
       filter = Google::Cloud::Bigtable::RowFilter.timestamp_range(to: to)
 
       filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_rows_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_rows_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
   let(:family) {  "cf" }
   let(:qualifier) {  "field1" }
   let(:cell_value) { "xyz" }
-  let(:timestamp) { Time.now.to_i * 1000 }
+  let(:timestamp) { timestamp_micros }
   let(:mutation_gprc) {
     Google::Bigtable::V2::Mutation.new(set_cell: {
       family_name: family, column_qualifier: qualifier, value: cell_value, timestamp_micros: timestamp
@@ -42,7 +42,7 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
       mutation = Google::Bigtable::V2::Mutation.new(set_cell: {
         family_name: "cf#{i}",
         column_qualifier: "field01",
-        timestamp_micros: Time.now.to_i * 1000,
+        timestamp_micros: timestamp_micros,
         value: "XYZ-#{i}"
       })
       Google::Bigtable::V2::MutateRowsRequest::Entry.new(

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
@@ -21,7 +21,7 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable 
   let(:instance_id) { "test-instance" }
   let(:table_id) { "test-table" }
   let(:family_name) { "cf" }
-  let(:timestamp_micros) { 1527625039663 }
+  let(:timestamp) { 1564257960168000 }
   let(:labels) { ["test-labels"] }
   let(:qualifier) { "field01" }
   let(:cell_value) { "xyz" }
@@ -37,7 +37,7 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable 
 
     row_key = "user-1"
 
-    cell = { value: cell_value, timestamp_micros: timestamp_micros, labels: labels }
+    cell = { value: cell_value, timestamp_micros: timestamp, labels: labels }
     column = {
       qualifier: qualifier,
       cells: [cell]
@@ -71,7 +71,7 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable 
     cell.value.must_equal cell_value
     cell.family.must_equal family_name
     cell.qualifier.must_equal qualifier
-    cell.timestamp.must_equal timestamp_micros
+    cell.timestamp.must_equal timestamp
     cell.labels.must_equal labels
   end
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
   let(:family) {  "cf" }
   let(:qualifier) {  "field1" }
   let(:cell_value) { "xyz" }
-  let(:timestamp) { Time.now.to_i * 1000 }
+  let(:timestamp) { timestamp_micros }
 
   it "read rows" do
     mock = Minitest::Mock.new

--- a/google-cloud-bigtable/test/helper.rb
+++ b/google-cloud-bigtable/test/helper.rb
@@ -222,6 +222,11 @@ class MockBigtable < Minitest::Spec
   def paged_enum_struct response
     OpenStruct.new(page: OpenStruct.new(response: response))
   end
+
+# A microseconds integer rounded to the nearest millisecond. For example: `1564257960168000`.
+  def timestamp_micros
+    (Time.now.to_f * 1000).to_i * 1000
+  end
 end
 
 class MockPagedEnumerable
@@ -258,9 +263,4 @@ def read_rows_acceptance_test_data
   end
 
   tests
-end
-
-# A microseconds integer rounded to the nearest millisecond. For example: `1564257960168000`.
-def timestamp_micros
-  (Time.now.to_f * 1000).to_i * 1000
 end

--- a/google-cloud-bigtable/test/helper.rb
+++ b/google-cloud-bigtable/test/helper.rb
@@ -225,7 +225,7 @@ class MockBigtable < Minitest::Spec
 
 # A microseconds integer rounded to the nearest millisecond. For example: `1564257960168000`.
   def timestamp_micros
-    (Time.now.to_f * 1000).to_i * 1000
+    (Time.now.to_f * 1000000).round(-3)
   end
 end
 

--- a/google-cloud-bigtable/test/helper.rb
+++ b/google-cloud-bigtable/test/helper.rb
@@ -259,3 +259,8 @@ def read_rows_acceptance_test_data
 
   tests
 end
+
+# A microseconds integer rounded to the nearest millisecond. For example: `1564257960168000`.
+def timestamp_micros
+  (Time.now.to_f * 1000).to_i * 1000
+end


### PR DESCRIPTION
* Add tests demonstrating correct and incorrect timestamp arguments.
* Add param documentation to clarify that values are in microseconds but must match the granularity of the table, which is currently always milliseconds, meaning that the microsecond values must be rounded to the nearest `1000`.
* Remove `Time` type from `timestamp` parameter types list, since its use raises an error.


[closes #3676]