### PR TITLE
feat(pubsub): Service endpoint can be overridden from config

### DIFF
--- a/google-cloud-pubsub/lib/google-cloud-pubsub.rb
+++ b/google-cloud-pubsub/lib/google-cloud-pubsub.rb
@@ -143,4 +143,5 @@ Google::Cloud.configure.add_config! :pubsub do |config|
   config.add_field! :emulator_host, default_emulator,
                     match: String, allow_nil: true
   config.add_field! :on_error, nil, match: Proc
+  config.add_field! :endpoint, nil, match: String
 end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub.rb
@@ -111,6 +111,7 @@ module Google
         PubSub::Project.new(
           PubSub::Service.new(
             project_id, credentials, timeout:       timeout,
+                                     host:          configure.endpoint,
                                      client_config: client_config
           )
         )
@@ -136,6 +137,8 @@ module Google
       # * `timeout` - (Integer) Default timeout to use in requests.
       # * `client_config` - (Hash) A hash of values to override the default
       #   behavior of the API client.
+      # * `endpoint` - (String) Override of the endpoint host name, or `nil`
+      #   to use the default endpoint.
       # * `emulator_host` - (String) Host name of the emulator. Defaults to
       #   `ENV["PUBSUB_EMULATOR_HOST"]`
       # * `on_error` - (Proc) A Proc to be run when an error is encountered

--- a/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
@@ -97,7 +97,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "pubsub-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "pubsub-credentials"
         client_config.must_be :nil?
@@ -158,7 +158,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "pubsub-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "pubsub-credentials"
         timeout.must_be :nil?
@@ -189,7 +189,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "pubsub-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "pubsub-credentials"
         timeout.must_be :nil?
@@ -255,7 +255,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         OpenStruct.new project_id: "project-id"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_be_kind_of OpenStruct
         credentials.project_id.must_equal "project-id"
@@ -303,7 +303,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "pubsub-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "pubsub-credentials"
         timeout.must_be :nil?
@@ -340,7 +340,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "pubsub-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "pubsub-credentials"
         timeout.must_be :nil?
@@ -377,7 +377,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "pubsub-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "pubsub-credentials"
         timeout.must_equal 42
@@ -416,7 +416,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "pubsub-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "pubsub-credentials"
         timeout.must_equal 42


### PR DESCRIPTION
Adds an `endpoint` field to the config object, allowing the service endpoint to be overridden.