### PR TITLE
Release google-cloud-spanner 1.9.5

### DIFF
--- a/google-cloud-spanner/CHANGELOG.md
+++ b/google-cloud-spanner/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-### 1.9.5 / 2019-07-30
+### 1.9.5 / 2019-07-31
 
 * Reduce thread usage at startup
   * Allocate threads in pool as needed, not all up front

--- a/google-cloud-spanner/CHANGELOG.md
+++ b/google-cloud-spanner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 1.9.5 / 2019-07-30
+
+* Reduce thread usage at startup
+  * Allocate threads in pool as needed, not all up front
+* Update documentation links
+
 ### 1.9.4 / 2019-07-08
 
 * Add IAM GetPolicyOptions in the lower-level API.

--- a/google-cloud-spanner/lib/google/cloud/spanner/version.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Spanner
-      VERSION = "1.9.4".freeze
+      VERSION = "1.9.5".freeze
     end
   end
 end


### PR DESCRIPTION
* Reduce thread usage at startup
  * Allocate threads in pool as needed, not all up front
* Update documentation links

<details><summary>Commits since previous release</summary><pre><code>[33mcommit ac8ce21c294ea111e33142a7ba6da82786cc8935[m
Author: Graham Paye <paye@google.com>
Date:   Wed Jul 24 12:35:57 2019 -0700

    docs: update links to point to new docsite (#3684)

[33mcommit 6ba581af165167cb9a8ea57cb34a00afad5251a8[m
Author: Mike Moore <mike@blowmage.com>
Date:   Thu Jul 18 14:08:40 2019 -0600

    perf: Reduce thread allocations
    
    Lower thread allocations by switching from FixedThreadPool to
    ThreadPoolExecutor which only add threads when needed vs.
    creating all threads on thread pool initialization.
    
    [pr #3683, refs #3679]

[33mcommit 70eeff8a2402ec48962ea3541629a6fa21046de7[m
Author: Mike Moore <mike@blowmage.com>
Date:   Fri Jul 12 15:30:21 2019 -0600

    fix: Update #to_hash to #to_h to fix for protobuf 3.9.0
    
    The google-protobuf gem removed the #to_hash method.
    The Bigtable, Datastore, and Firestore gems had calls to #to_hash.
    This changes those calls to use the correct #to_h method instead.
    This fixes these gems so they work with google-protobuf 3.9.0.
    Some tests also expected #to_hash, and those tests are updated as well.
    
    [pr  #3658]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
[1mdiff --git a/google-cloud-spanner/LOGGING.md b/google-cloud-spanner/LOGGING.md[m
[1mindex 6afa8ef76..f64fd5b03 100644[m
[1m--- a/google-cloud-spanner/LOGGING.md[m
[1m+++ b/google-cloud-spanner/LOGGING.md[m
[36m@@ -5,7 +5,7 @@[m [mTo enable logging for this library, set the logger for the underlying[m
 that you set may be a Ruby stdlib[m
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as[m
 shown below, or a[m
[31m-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)[m
[32m+[m[32m[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
 that will write logs to [Stackdriver[m
 Logging](https://cloud.google.com/logging/). See[m
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
[1mdiff --git a/google-cloud-spanner/OVERVIEW.md b/google-cloud-spanner/OVERVIEW.md[m
[1mindex f5f1100f5..4becca898 100644[m
[1m--- a/google-cloud-spanner/OVERVIEW.md[m
[1m+++ b/google-cloud-spanner/OVERVIEW.md[m
[36m@@ -21,7 +21,7 @@[m [mWhen you first use Cloud Spanner, you must create an instance, which is an[m
 allocation of resources that are used by Cloud Spanner databases. When you[m
 create an instance, you choose where your data is stored and how many nodes are[m
 used for your data. (For more information, see [Configuration[m
[31m-Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)).[m
[32m+[m[32mGuide](https://googleapis.dev/ruby/stackdriver/INSTRUMENTATION_CONFIGURATION)/latest).[m
 [m
 Use {Google::Cloud::Spanner::Project#create_instance Project#create_instance} to[m
 create an instance:[m
[1mdiff --git a/google-cloud-spanner/README.md b/google-cloud-spanner/README.md[m
[1mindex fdcb1a18f..608be4d1a 100644[m
[1m--- a/google-cloud-spanner/README.md[m
[1m+++ b/google-cloud-spanner/README.md[m
[36m@@ -2,7 +2,7 @@[m
 [m
 [Google Cloud Spanner API](https://cloud.google.com/spanner/) ([docs](https://cloud.google.com/spanner/docs)) provides a fully managed, mission-critical, relational database service that offers transactional consistency at global scale, schemas, SQL (ANSI 2011 with extensions), and automatic, synchronous replication for high availability.[m
 [m
[31m-- [google-cloud-spanner API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-spanner/latest)[m
[32m+[m[32m- [google-cloud-spanner API documentation](https://googleapis.dev/ruby/google-cloud-spanner/latest)[m
 - [google-cloud-spanner on RubyGems](https://rubygems.org/gems/google-cloud-spanner)[m
 - [Google Cloud Spanner API documentation](https://cloud.google.com/spanner/docs)[m
 [m
[36m@@ -16,7 +16,7 @@[m [m$ gem install google-cloud-spanner[m
 [m
 This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.[m
 [m
[31m-Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-spanner/latest/file.AUTHENTICATION).[m
[32m+[m[32mInstructions and configuration options are covered in the [Authentication Guide](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.AUTHENTICATION.html).[m
 [m
 ## Example[m
 [m
[36m@@ -38,7 +38,7 @@[m [mend[m
 [m
 ## Enabling Logging[m
 [m
[31m-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
[32m+[m[32mTo enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
 [m
 Configuring a Ruby stdlib logger:[m
 [m
[36m@@ -78,18 +78,18 @@[m [mThis library follows [Semantic Versioning](http://semver.org/).[m
 Contributions to this library are always welcome and highly encouraged.[m
 [m
 See the [Contributing[m
[31m-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-spanner/latest/file.CONTRIBUTING)[m
[32m+[m[32mGuide](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.CONTRIBUTING.html)[m
 for more information on how to get started.[m
 [m
 Please note that this project is released with a Contributor Code of Conduct. By[m
 participating in this project you agree to abide by its terms. See [Code of[m
[31m-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-spanner/latest/file.CODE_OF_CONDUCT)[m
[32m+[m[32mConduct](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.CODE_OF_CONDUCT.html)[m
 for more information.[m
 [m
 ## License[m
 [m
 This library is licensed under Apache 2.0. Full license text is available in[m
[31m-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-spanner/latest/file.LICENSE).[m
[32m+[m[32m[LICENSE](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.LICENSE.html).[m
 [m
 ## Support[m
 [m
[1mdiff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/database.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/database.rb[m
[1mindex 34d52da8b..356ffe2b1 100644[m
[1m--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database.rb[m
[1m+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database.rb[m
[36m@@ -36,7 +36,7 @@[m [mmodule Google[m
         # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)[m
         # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)[m
         # 3. [Enable the Cloud Spanner Database Admin API.](https://console.cloud.google.com/apis/library/spanner.googleapis.com)[m
[31m-        # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)[m
[32m+[m[32m        # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.AUTHENTICATION.html)[m
         #[m
         # ### Installation[m
         # ```[m
[36m@@ -55,7 +55,7 @@[m [mmodule Google[m
         #[m
         # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.[m
         # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,[m
[31m-        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)[m
[32m+[m[32m        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
         # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
         # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
         #[m
[1mdiff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1.rb[m
[1mindex d54de44c9..fb5111fec 100644[m
[1m--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1.rb[m
[1m+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1.rb[m
[36m@@ -37,7 +37,7 @@[m [mmodule Google[m
           # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)[m
           # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)[m
           # 3. [Enable the Cloud Spanner Database Admin API.](https://console.cloud.google.com/apis/library/spanner.googleapis.com)[m
[31m-          # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)[m
[32m+[m[32m          # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.AUTHENTICATION.html)[m
           #[m
           # ### Installation[m
           # ```[m
[36m@@ -56,7 +56,7 @@[m [mmodule Google[m
           #[m
           # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.[m
           # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,[m
[31m-          # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)[m
[32m+[m[32m          # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
           # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
           # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
           #[m
[1mdiff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb[m
[1mindex 7afc66baf..21859bccb 100644[m
[1m--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb[m
[1m+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb[m
[36m@@ -36,7 +36,7 @@[m [mmodule Google[m
         # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)[m
         # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)[m
         # 3. [Enable the Cloud Spanner Instance Admin API.](https://console.cloud.google.com/apis/library/spanner.googleapis.com)[m
[31m-        # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)[m
[32m+[m[32m        # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.AUTHENTICATION.html)[m
         #[m
         # ### Installation[m
         # ```[m
[36m@@ -55,7 +55,7 @@[m [mmodule Google[m
         #[m
         # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.[m
         # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,[m
[31m-        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)[m
[32m+[m[32m        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
         # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
         # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
         #[m
[1mdiff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1.rb[m
[1mindex 82b63b186..f3be0ea67 100644[m
[1m--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1.rb[m
[1m+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1.rb[m
[36m@@ -37,7 +37,7 @@[m [mmodule Google[m
           # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)[m
           # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)[m
           # 3. [Enable the Cloud Spanner Instance Admin API.](https://console.cloud.google.com/apis/library/spanner.googleapis.com)[m
[31m-          # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)[m
[32m+[m[32m          # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-spanner/latest/file.AUTHENTICATION.html)[m
           #[m
           # ### Installation[m
           # ```[m
[36m@@ -56,7 +56,7 @@[m [mmodule Google[m
           #[m
           # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.[m
           # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,[m
[31m-          # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)[m
[32m+[m[32m          # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
           # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
           # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
           #[m
[1mdiff --git a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb[m
[1mindex 8b511c94a..a8ec05bfc 100644[m
[1m--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb[m
[1m+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb[m
[36m@@ -200,7 +200,8 @@[m [mmodule Google[m
 [m
         def init[m
           # init the thread pool[m
[31m-          @thread_pool = Concurrent::FixedThreadPool.new @threads[m
[32m+[m[32m          @thread_pool = Concurrent::ThreadPoolExecutor.new \[m
[32m+[m[32m            max_threads: @threads[m
           # init the queues[m
           @new_sessions_in_process = 0[m
           @all_sessions = [][m
[1mdiff --git a/google-cloud-spanner/synth.py b/google-cloud-spanner/synth.py[m
[1mindex 4a9fee6f0..ca91b62dc 100644[m
[1m--- a/google-cloud-spanner/synth.py[m
[1m+++ b/google-cloud-spanner/synth.py[m
[36m@@ -221,3 +221,15 @@[m [ms.replace([m
     'Gem.loaded_specs\[.*\]\.version\.version',[m
     'Google::Cloud::Spanner::VERSION'[m
 )[m
[32m+[m
[32m+[m[32m# Fix links for devsite migration[m
[32m+[m[32ms.replace([m
[32m+[m[32m    'lib/**/*.rb',[m
[32m+[m[32m    'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',[m
[32m+[m[32m    'https://googleapis.dev/ruby/google-cloud-logging/latest'[m
[32m+[m[32m)[m
[32m+[m[32ms.replace([m
[32m+[m[32m    'lib/**/*.rb',[m
[32m+[m[32m    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',[m
[32m+[m[32m    'https://googleapis.dev/ruby/google-cloud-spanner/latest/file.AUTHENTICATION.html'[m
[32m+[m[32m)[m
[1mdiff --git a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_query_test.rb b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_query_test.rb[m
[1mindex b8c407a3c..234ceb2b8 100644[m
[1m--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_query_test.rb[m
[1m+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_query_test.rb[m
[36m@@ -407,7 +407,8 @@[m [mdescribe Google::Cloud::Spanner::BatchSnapshot, :partition_query, :mock_spanner[m
       else[m
         partition.execute.params.must_equal params[m
       end[m
[31m-      partition.execute.param_types.must_equal types.to_h[m
[32m+[m[32m      types_hash = Hash[Hash(types).map { |key, value| [key, value.to_h] }][m
[32m+[m[32m      partition.execute.param_types.to_h.must_equal types_hash[m
 [m
       partition.read.must_be_nil[m
     end[m

```

</details>

This pull request was generated using releasetool.