### PR TITLE
Release google-cloud-pubsub 0.38.0

### DIFF
--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-### 0.38.0 / 2019-07-30
+### 0.38.0 / 2019-07-31
 
 * Allow Service endpoint to be configured
   * Google::Cloud::PubSub.configure.endpoint

--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### 0.38.0 / 2019-07-31
 
+* Allow persistence_regions to be set
+  * Support setting persistence_regions on topic creation
+    and topic update.
 * Allow Service endpoint to be configured
   * Google::Cloud::PubSub.configure.endpoint
 * Fix max threads setting in thread pools

--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+### 0.38.0 / 2019-07-30
+
+* Allow Service endpoint to be configured
+  * Google::Cloud::PubSub.configure.endpoint
+* Fix max threads setting in thread pools
+  * Thread pools once again limit the number of threads allocated.
+* Reduce thread usage at startup
+  * Allocate threads in pool as needed, not all up front
+* Update documentation links
+
 ### 0.37.1 / 2019-07-09
 
 * Add IAM GetPolicyOptions in the lower-level interface.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module PubSub
-      VERSION = "0.37.1".freeze
+      VERSION = "0.38.0".freeze
     end
 
     Pubsub = PubSub unless const_defined? :Pubsub


### PR DESCRIPTION
* Allow Service endpoint to be configured
  * Google::Cloud::PubSub.configure.endpoint
* Fix max threads setting in thread pools
  * Thread pools once again limit the number of threads allocated.
* Reduce thread usage at startup
  * Allocate threads in pool as needed, not all up front
* Update documentation links

<details><summary>Commits since previous release</summary><pre><code>[33mcommit 58c2f51176955212838e6dfd585b212d86dab930[m
Author: Daniel Azuma <dazuma@google.com>
Date:   Mon Jul 29 16:32:40 2019 -0700

    feat(pubsub): Service endpoint can be overridden from config

[33mcommit aea767c02299e507dd1e0f3c4889604f7e031198[m
Author: Mike Moore <mike@blowmage.com>
Date:   Wed Jul 24 20:14:32 2019 -0600

    feat(pubsub): Allow persistence_regions to be set
    
    Support setting persistence_regions on topic creation and topic update.
    
    [pr #3686]

[33mcommit ac8ce21c294ea111e33142a7ba6da82786cc8935[m
Author: Graham Paye <paye@google.com>
Date:   Wed Jul 24 12:35:57 2019 -0700

    docs: update links to point to new docsite (#3684)

[33mcommit 3d79cbd111e300d0e73c2d55800c5ac39008bbff[m
Author: Mike Moore <mike@blowmage.com>
Date:   Thu Jul 18 14:09:50 2019 -0600

    fix: Fix max threads setting in thread pools
    
    Use ThreadPoolExecutor which honors the max threads setting.
    
    [pr #3682, fixes #3679]

[33mcommit 428dbcee5c740aa190f260a81788ff916be0dc19[m
Author: Atsushi Tanaka <bgpat@users.noreply.github.com>
Date:   Fri Jul 19 00:11:30 2019 +0900

    perf(pubsub): Honor max_threads in thread pools
    
    Use ThreadPoolExecutor instead of CachedThreadPool
    
    [pr #3678]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
[1mdiff --git a/google-cloud-pubsub/LOGGING.md b/google-cloud-pubsub/LOGGING.md[m
[1mindex 6afa8ef76..f64fd5b03 100644[m
[1m--- a/google-cloud-pubsub/LOGGING.md[m
[1m+++ b/google-cloud-pubsub/LOGGING.md[m
[36m@@ -5,7 +5,7 @@[m [mTo enable logging for this library, set the logger for the underlying[m
 that you set may be a Ruby stdlib[m
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as[m
 shown below, or a[m
[31m-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)[m
[32m+[m[32m[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
 that will write logs to [Stackdriver[m
 Logging](https://cloud.google.com/logging/). See[m
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
[1mdiff --git a/google-cloud-pubsub/README.md b/google-cloud-pubsub/README.md[m
[1mindex 58556099e..5d9b4b8ca 100644[m
[1m--- a/google-cloud-pubsub/README.md[m
[1m+++ b/google-cloud-pubsub/README.md[m
[36m@@ -2,7 +2,7 @@[m
 [m
 [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) ([docs](https://cloud.google.com/pubsub/docs/reference/rest/)) is designed to provide reliable, many-to-many, asynchronous messaging between applications. Publisher applications can send messages to a “topic” and other applications can subscribe to that topic to receive the messages. By decoupling senders and receivers, Google Cloud Pub/Sub allows developers to communicate between independently written applications.[m
 [m
[31m-- [google-cloud-pubsub API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-pubsub/latest)[m
[32m+[m[32m- [google-cloud-pubsub API documentation](https://googleapis.dev/ruby/google-cloud-pubsub/latest)[m
 - [google-cloud-pubsub on RubyGems](https://rubygems.org/gems/google-cloud-pubsub)[m
 - [Google Cloud Pub/Sub documentation](https://cloud.google.com/pubsub/docs)[m
 [m
[36m@@ -16,7 +16,7 @@[m [m$ gem install google-cloud-pubsub[m
 [m
 This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.[m
 [m
[31m-Instructions and configuration options are covered in the [Authentication Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-pubsub/latest/file.AUTHENTICATION).[m
[32m+[m[32mInstructions and configuration options are covered in the [Authentication Guide](https://googleapis.dev/ruby/google-cloud-pubsub/latest/file.AUTHENTICATION.html).[m
 [m
 ## Example[m
 [m
[36m@@ -52,7 +52,7 @@[m [msubscriber.stop.wait![m
 [m
 ## Enabling Logging[m
 [m
[31m-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
[32m+[m[32mTo enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
 [m
 Configuring a Ruby stdlib logger:[m
 [m
[36m@@ -95,18 +95,18 @@[m [mchange at any time and the public API should not be considered stable.[m
 Contributions to this library are always welcome and highly encouraged.[m
 [m
 See the [Contributing[m
[31m-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-pubsub/latest/file.CONTRIBUTING)[m
[32m+[m[32mGuide](https://googleapis.dev/ruby/google-cloud-pubsub/latest/file.CONTRIBUTING.html)[m
 for more information on how to get started.[m
 [m
 Please note that this project is released with a Contributor Code of Conduct. By[m
 participating in this project you agree to abide by its terms. See [Code of[m
[31m-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-pubsub/latest/file.CODE_OF_CONDUCT)[m
[32m+[m[32mConduct](https://googleapis.dev/ruby/google-cloud-pubsub/latest/file.CODE_OF_CONDUCT.html)[m
 for more information.[m
 [m
 ## License[m
 [m
 This library is licensed under Apache 2.0. Full license text is available in[m
[31m-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-pubsub/latest/file.LICENSE).[m
[32m+[m[32m[LICENSE](https://googleapis.dev/ruby/google-cloud-pubsub/latest/file.LICENSE.html).[m
 [m
 ## Support[m
 [m
[1mdiff --git a/google-cloud-pubsub/lib/google-cloud-pubsub.rb b/google-cloud-pubsub/lib/google-cloud-pubsub.rb[m
[1mindex bea169c67..62ca73655 100644[m
[1m--- a/google-cloud-pubsub/lib/google-cloud-pubsub.rb[m
[1m+++ b/google-cloud-pubsub/lib/google-cloud-pubsub.rb[m
[36m@@ -143,4 +143,5 @@[m [mGoogle::Cloud.configure.add_config! :pubsub do |config|[m
   config.add_field! :emulator_host, default_emulator,[m
                     match: String, allow_nil: true[m
   config.add_field! :on_error, nil, match: Proc[m
[32m+[m[32m  config.add_field! :endpoint, nil, match: String[m
 end[m
[1mdiff --git a/google-cloud-pubsub/lib/google/cloud/pubsub.rb b/google-cloud-pubsub/lib/google/cloud/pubsub.rb[m
[1mindex 68f5a380f..fd116aa48 100644[m
[1m--- a/google-cloud-pubsub/lib/google/cloud/pubsub.rb[m
[1m+++ b/google-cloud-pubsub/lib/google/cloud/pubsub.rb[m
[36m@@ -111,6 +111,7 @@[m [mmodule Google[m
         PubSub::Project.new([m
           PubSub::Service.new([m
             project_id, credentials, timeout:       timeout,[m
[32m+[m[32m                                     host:          configure.endpoint,[m
                                      client_config: client_config[m
           )[m
         )[m
[36m@@ -136,6 +137,8 @@[m [mmodule Google[m
       # * `timeout` - (Integer) Default timeout to use in requests.[m
       # * `client_config` - (Hash) A hash of values to override the default[m
       #   behavior of the API client.[m
[32m+[m[32m      # * `endpoint` - (String) Override of the endpoint host name, or `nil`[m
[32m+[m[32m      #   to use the default endpoint.[m
       # * `emulator_host` - (String) Host name of the emulator. Defaults to[m
       #   `ENV["PUBSUB_EMULATOR_HOST"]`[m
       # * `on_error` - (Proc) A Proc to be run when an error is encountered[m
[1mdiff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb[m
[1mindex b42ab780c..cd71d2329 100644[m
[1m--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb[m
[1m+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb[m
[36m@@ -193,9 +193,9 @@[m [mmodule Google[m
 [m
         def init_resources![m
           @first_published_at   ||= Time.now[m
[31m-          @publish_thread_pool  ||= Concurrent::CachedThreadPool.new \[m
[32m+[m[32m          @publish_thread_pool  ||= Concurrent::ThreadPoolExecutor.new \[m
             max_threads: @publish_threads[m
[31m-          @callback_thread_pool ||= Concurrent::CachedThreadPool.new \[m
[32m+[m[32m          @callback_thread_pool ||= Concurrent::ThreadPoolExecutor.new \[m
             max_threads: @callback_threads[m
           @thread ||= Thread.new { run_background }[m
         end[m
[1mdiff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb[m
[1mindex 076418cb2..7229d02b6 100644[m
[1m--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb[m
[1m+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb[m
[36m@@ -174,6 +174,9 @@[m [mmodule Google[m
         # @param [String] kms_key The Cloud KMS encryption key that will be used[m
         #   to protect access to messages published on this topic. Optional.[m
         #   For example: `projects/a/locations/b/keyRings/c/cryptoKeys/d`[m
[32m+[m[32m        # @param [Array<String>] persistence_regions The list of GCP region IDs[m
[32m+[m[32m        #   where messages that are published to the topic may be persisted in[m
[32m+[m[32m        #   storage. Optional.[m
         # @param [Hash] async A hash of values to configure the topic's[m
         #   {AsyncPublisher} that is created when {Topic#publish_async}[m
         #   is called. Optional.[m
[36m@@ -202,11 +205,13 @@[m [mmodule Google[m
         #   pubsub = Google::Cloud::PubSub.new[m
         #   topic = pubsub.create_topic "my-topic"[m
         #[m
[31m-        def create_topic topic_name, labels: nil, kms_key: nil, async: nil[m
[32m+[m[32m        def create_topic topic_name, labels: nil, kms_key: nil,[m
[32m+[m[32m                         persistence_regions: nil, async: nil[m
           ensure_service![m
           grpc = service.create_topic topic_name,[m
[31m-                                      labels:       labels,[m
[31m-                                      kms_key_name: kms_key[m
[32m+[m[32m                                      labels:              labels,[m
[32m+[m[32m                                      kms_key_name:        kms_key,[m
[32m+[m[32m                                      persistence_regions: persistence_regions[m
           Topic.from_grpc grpc, service, async: async[m
         end[m
         alias new_topic create_topic[m
[1mdiff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb[m
[1mindex 163ab3ad9..676d48fc3 100644[m
[1m--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb[m
[1m+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb[m
[36m@@ -126,12 +126,21 @@[m [mmodule Google[m
 [m
         ##[m
         # Creates the given topic with the given name.[m
[31m-        def create_topic topic_name, labels: nil, kms_key_name: nil, options: {}[m
[32m+[m[32m        def create_topic topic_name, labels: nil, kms_key_name: nil,[m
[32m+[m[32m                         persistence_regions: nil, options: {}[m
[32m+[m[32m          if persistence_regions[m
[32m+[m[32m            message_storage_policy = {[m
[32m+[m[32m              allowed_persistence_regions: Array(persistence_regions)[m
[32m+[m[32m            }[m
[32m+[m[32m          end[m
[32m+[m
           execute do[m
[31m-            publisher.create_topic topic_path(topic_name, options),[m
[31m-                                   labels:       labels,[m
[31m-                                   kms_key_name: kms_key_name,[m
[31m-                                   options:      default_options[m
[32m+[m[32m            publisher.create_topic \[m
[32m+[m[32m              topic_path(topic_name, options),[m
[32m+[m[32m              labels:                 labels,[m
[32m+[m[32m              kms_key_name:           kms_key_name,[m
[32m+[m[32m              message_storage_policy: message_storage_policy,[m
[32m+[m[32m              options:                default_options[m
           end[m
         end[m
 [m
[1mdiff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb[m
[1mindex 22da31b79..884325815 100644[m
[1m--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb[m
[1m+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb[m
[36m@@ -48,7 +48,7 @@[m [mmodule Google[m
             @pause_cond = new_cond[m
 [m
             @inventory = Inventory.new self, @subscriber.stream_inventory[m
[31m-            @callback_thread_pool = Concurrent::CachedThreadPool.new \[m
[32m+[m[32m            @callback_thread_pool = Concurrent::ThreadPoolExecutor.new \[m
               max_threads: @subscriber.callback_threads[m
 [m
             @stream_keepalive_task = Concurrent::TimerTask.new([m
[1mdiff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb[m
[1mindex 1abcaf2fa..a6d5a13e1 100644[m
[1m--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb[m
[1m+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb[m
[36m@@ -201,7 +201,7 @@[m [mmodule Google[m
           end[m
 [m
           def with_threadpool[m
[31m-            pool = Concurrent::CachedThreadPool.new \[m
[32m+[m[32m            pool = Concurrent::ThreadPoolExecutor.new \[m
               max_threads: @subscriber.push_threads[m
 [m
             yield pool[m
[1mdiff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb[m
[1mindex a29038400..55892fdfa 100644[m
[1m--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb[m
[1m+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb[m
[36m@@ -212,6 +212,30 @@[m [mmodule Google[m
           Array @grpc.message_storage_policy.allowed_persistence_regions[m
         end[m
 [m
[32m+[m[32m        ##[m
[32m+[m[32m        # Sets the list of GCP region IDs where messages that are published to[m
[32m+[m[32m        # the topic may be persisted in storage.[m
[32m+[m[32m        #[m
[32m+[m[32m        # @param [Array<String>] new_persistence_regions[m
[32m+[m[32m        #[m
[32m+[m[32m        # @example[m
[32m+[m[32m        #   require "google/cloud/pubsub"[m
[32m+[m[32m        #[m
[32m+[m[32m        #   pubsub = Google::Cloud::PubSub.new[m
[32m+[m[32m        #[m
[32m+[m[32m        #   topic = pubsub.topic "my-topic"[m
[32m+[m[32m        #[m
[32m+[m[32m        #   topic.persistence_regions = ["us-central1", "us-central2"][m
[32m+[m[32m        #[m
[32m+[m[32m        def persistence_regions= new_persistence_regions[m
[32m+[m[32m          update_grpc = Google::Cloud::PubSub::V1::Topic.new \[m
[32m+[m[32m            name: name, message_storage_policy: {[m
[32m+[m[32m              allowed_persistence_regions: Array(new_persistence_regions)[m
[32m+[m[32m            }[m
[32m+[m[32m          @grpc = service.update_topic update_grpc, :message_storage_policy[m
[32m+[m[32m          @resource_name = nil[m
[32m+[m[32m        end[m
[32m+[m
         ##[m
         # Permanently deletes the topic.[m
         #[m
[1mdiff --git a/google-cloud-pubsub/support/doctest_helper.rb b/google-cloud-pubsub/support/doctest_helper.rb[m
[1mindex 5de08094b..eb751552d 100644[m
[1m--- a/google-cloud-pubsub/support/doctest_helper.rb[m
[1m+++ b/google-cloud-pubsub/support/doctest_helper.rb[m
[36m@@ -497,6 +497,14 @@[m [mYARD::Doctest.configure do |doctest|[m
     end[m
   end[m
 [m
[32m+[m[32m  doctest.before "Google::Cloud::PubSub::Topic#persistence_regions=" do[m
[32m+[m[32m    mock_pubsub do |mock_publisher, mock_subscriber|[m
[32m+[m[32m      this_topic = topic_resp "my-topic", persistence_regions: ["us-central1", "us-central2"][m
[32m+[m[32m      mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/my-topic", Hash][m
[32m+[m[32m      mock_publisher.expect :update_topic, this_topic, [this_topic, Google::Protobuf::FieldMask.new(paths: ["message_storage_policy"]), Hash][m
[32m+[m[32m    end[m
[32m+[m[32m  end[m
[32m+[m
   doctest.before "Google::Cloud::PubSub::Topic#delete" do[m
     mock_pubsub do |mock_publisher, mock_subscriber|[m
       mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/my-topic", Hash][m
[1mdiff --git a/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb b/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb[m
[1mindex adf27dd17..d7ee21ede 100644[m
[1m--- a/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb[m
[1m+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb[m
[36m@@ -53,6 +53,7 @@[m [mdescribe Google::Cloud::PubSub::Project, :mock_pubsub do[m
   end[m
   let(:labels) { { "foo" => "bar" } }[m
   let(:kms_key) { "projects/a/locations/b/keyRings/c/cryptoKeys/d" }[m
[32m+[m[32m  let(:persistence_regions) { ["us-west1", "us-west2"] }[m
 [m
   it "knows the project identifier" do[m
     pubsub.project.must_equal project[m
[36m@@ -63,7 +64,7 @@[m [mdescribe Google::Cloud::PubSub::Project, :mock_pubsub do[m
 [m
     create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name)[m
     mock = Minitest::Mock.new[m
[31m-    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: nil, options: default_options][m
[32m+[m[32m    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: nil, message_storage_policy: nil, options: default_options][m
     pubsub.service.mocked_publisher = mock[m
 [m
     topic = pubsub.create_topic new_topic_name[m
[36m@@ -74,6 +75,7 @@[m [mdescribe Google::Cloud::PubSub::Project, :mock_pubsub do[m
     topic.labels.must_be :empty?[m
     topic.labels.must_be :frozen?[m
     topic.kms_key.must_be :empty?[m
[32m+[m[32m    topic.persistence_regions.must_be :empty?[m
   end[m
 [m
   it "creates a topic with new_topic_alias" do[m
[36m@@ -81,7 +83,7 @@[m [mdescribe Google::Cloud::PubSub::Project, :mock_pubsub do[m
 [m
     create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name)[m
     mock = Minitest::Mock.new[m
[31m-    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: nil, options: default_options][m
[32m+[m[32m    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: nil, message_storage_policy: nil, options: default_options][m
     pubsub.service.mocked_publisher = mock[m
 [m
     topic = pubsub.new_topic new_topic_name[m
[36m@@ -92,6 +94,7 @@[m [mdescribe Google::Cloud::PubSub::Project, :mock_pubsub do[m
     topic.labels.must_be :empty?[m
     topic.labels.must_be :frozen?[m
     topic.kms_key.must_be :empty?[m
[32m+[m[32m    topic.persistence_regions.must_be :empty?[m
   end[m
 [m
   it "creates a topic with labels" do[m
[36m@@ -99,7 +102,7 @@[m [mdescribe Google::Cloud::PubSub::Project, :mock_pubsub do[m
 [m
     create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name, labels: labels)[m
     mock = Minitest::Mock.new[m
[31m-    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: labels, kms_key_name: nil, options: default_options][m
[32m+[m[32m    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: labels, kms_key_name: nil, message_storage_policy: nil, options: default_options][m
     pubsub.service.mocked_publisher = mock[m
 [m
     topic = pubsub.create_topic new_topic_name, labels: labels[m
[36m@@ -110,6 +113,7 @@[m [mdescribe Google::Cloud::PubSub::Project, :mock_pubsub do[m
     topic.labels.must_equal labels[m
     topic.labels.must_be :frozen?[m
     topic.kms_key.must_be :empty?[m
[32m+[m[32m    topic.persistence_regions.must_be :empty?[m
   end[m
 [m
   it "creates a topic with kms_key" do[m
[36m@@ -117,7 +121,7 @@[m [mdescribe Google::Cloud::PubSub::Project, :mock_pubsub do[m
 [m
     create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name, kms_key_name: kms_key)[m
     mock = Minitest::Mock.new[m
[31m-    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: kms_key, options: default_options][m
[32m+[m[32m    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: kms_key, message_storage_policy: nil, options: default_options][m
     pubsub.service.mocked_publisher = mock[m
 [m
     topic = pubsub.create_topic new_topic_name, kms_key: kms_key[m
[36m@@ -128,6 +132,26 @@[m [mdescribe Google::Cloud::PubSub::Project, :mock_pubsub do[m
     topic.labels.must_be :empty?[m
     topic.labels.must_be :frozen?[m
     topic.kms_key.must_equal kms_key[m
[32m+[m[32m    topic.persistence_regions.must_be :empty?[m
[32m+[m[32m  end[m
[32m+[m
[32m+[m[32m  it "creates a topic with persistence_regions" do[m
[32m+[m[32m    new_topic_name = "new-topic-#{Time.now.to_i}"[m
[32m+[m
[32m+[m[32m    create_res = Google::Cloud::PubSub::V1::Topic.new topic_hash(new_topic_name, persistence_regions: persistence_regions)[m
[32m+[m[32m    mock = Minitest::Mock.new[m
[32m+[m[32m    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, kms_key_name: nil, message_storage_policy: { allowed_persistence_regions: persistence_regions }, options: default_options][m
[32m+[m[32m    pubsub.service.mocked_publisher = mock[m
[32m+[m
[32m+[m[32m    topic = pubsub.create_topic new_topic_name, persistence_regions: persistence_regions[m
[32m+[m
[32m+[m[32m    mock.verify[m
[32m+[m
[32m+[m[32m    topic.name.must_equal topic_path(new_topic_name)[m
[32m+[m[32m    topic.labels.must_be :empty?[m
[32m+[m[32m    topic.labels.must_be :frozen?[m
[32m+[m[32m    topic.kms_key.must_be :empty?[m
[32m+[m[32m    topic.persistence_regions.must_equal persistence_regions[m
   end[m
 [m
   it "gets a topic" do[m
[1mdiff --git a/google-cloud-pubsub/test/google/cloud/pubsub/topic/update_test.rb b/google-cloud-pubsub/test/google/cloud/pubsub/topic/update_test.rb[m
[1mindex 7bf1711e0..5a3bec721 100644[m
[1m--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/update_test.rb[m
[1m+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/update_test.rb[m
[36m@@ -25,6 +25,8 @@[m [mdescribe Google::Cloud::PubSub::Topic, :update, :mock_pubsub do[m
   end[m
   let(:kms_key_name) { "projects/a/locations/b/keyRings/c/cryptoKeys/d" }[m
   let(:new_kms_key_name) { "projects/d/locations/c/keyRings/b/cryptoKeys/a" }[m
[32m+[m[32m  let(:persistence_regions) { ["us-west1", "us-west2"] }[m
[32m+[m[32m  let(:new_persistence_regions) { ["us-central1", "us-central2"] }[m
   let(:topic_grpc) { Google::Cloud::PubSub::V1::Topic.new topic_hash(topic_name, labels: labels) }[m
   let(:topic) { Google::Cloud::PubSub::Topic.from_grpc topic_grpc, pubsub.service }[m
 [m
[36m@@ -129,6 +131,72 @@[m [mdescribe Google::Cloud::PubSub::Topic, :update, :mock_pubsub do[m
     topic.kms_key.must_be :empty?[m
   end[m
 [m
[32m+[m[32m  it "updates persistence_regions" do[m
[32m+[m[32m    topic_grpc.message_storage_policy = Google::Cloud::PubSub::V1::MessageStoragePolicy.new([m
[32m+[m[32m      allowed_persistence_regions: persistence_regions[m
[32m+[m[32m    )[m
[32m+[m[32m    topic.persistence_regions.must_equal persistence_regions[m
[32m+[m
[32m+[m[32m    update_grpc = Google::Cloud::PubSub::V1::Topic.new([m
[32m+[m[32m      name: topic_path(topic_name),[m
[32m+[m[32m      message_storage_policy: { allowed_persistence_regions: new_persistence_regions }[m
[32m+[m[32m    )[m
[32m+[m[32m    update_mask = Google::Protobuf::FieldMask.new paths: ["message_storage_policy"][m
[32m+[m[32m    mock = Minitest::Mock.new[m
[32m+[m[32m    mock.expect :update_topic, update_grpc, [update_grpc, update_mask, options: default_options][m
[32m+[m[32m    topic.service.mocked_publisher = mock[m
[32m+[m
[32m+[m[32m    topic.persistence_regions = new_persistence_regions[m
[32m+[m
[32m+[m[32m    mock.verify[m
[32m+[m
[32m+[m[32m    topic.persistence_regions.must_equal new_persistence_regions[m
[32m+[m[32m  end[m
[32m+[m
[32m+[m[32m  it "updates persistence_regions to empty array" do[m
[32m+[m[32m    topic_grpc.message_storage_policy = Google::Cloud::PubSub::V1::MessageStoragePolicy.new([m
[32m+[m[32m      allowed_persistence_regions: persistence_regions[m
[32m+[m[32m    )[m
[32m+[m[32m    topic.persistence_regions.must_equal persistence_regions[m
[32m+[m
[32m+[m[32m    update_grpc = Google::Cloud::PubSub::V1::Topic.new([m
[32m+[m[32m      name: topic_path(topic_name),[m
[32m+[m[32m      message_storage_policy: { allowed_persistence_regions: [] }[m
[32m+[m[32m    )[m
[32m+[m[32m    update_mask = Google::Protobuf::FieldMask.new paths: ["message_storage_policy"][m
[32m+[m[32m    mock = Minitest::Mock.new[m
[32m+[m[32m    mock.expect :update_topic, update_grpc, [update_grpc, update_mask, options: default_options][m
[32m+[m[32m    topic.service.mocked_publisher = mock[m
[32m+[m
[32m+[m[32m    topic.persistence_regions = [][m
[32m+[m
[32m+[m[32m    mock.verify[m
[32m+[m
[32m+[m[32m    topic.persistence_regions.must_be :empty?[m
[32m+[m[32m  end[m
[32m+[m
[32m+[m[32m  it "updates persistence_regions to nil" do[m
[32m+[m[32m    topic_grpc.message_storage_policy = Google::Cloud::PubSub::V1::MessageStoragePolicy.new([m
[32m+[m[32m      allowed_persistence_regions: persistence_regions[m
[32m+[m[32m    )[m
[32m+[m[32m    topic.persistence_regions.must_equal persistence_regions[m
[32m+[m
[32m+[m[32m    update_grpc = Google::Cloud::PubSub::V1::Topic.new([m
[32m+[m[32m      name: topic_path(topic_name),[m
[32m+[m[32m      message_storage_policy: { allowed_persistence_regions: [] }[m
[32m+[m[32m    )[m
[32m+[m[32m    update_mask = Google::Protobuf::FieldMask.new paths: ["message_storage_policy"][m
[32m+[m[32m    mock = Minitest::Mock.new[m
[32m+[m[32m    mock.expect :update_topic, update_grpc, [update_grpc, update_mask, options: default_options][m
[32m+[m[32m    topic.service.mocked_publisher = mock[m
[32m+[m
[32m+[m[32m    topic.persistence_regions = nil[m
[32m+[m
[32m+[m[32m    mock.verify[m
[32m+[m
[32m+[m[32m    topic.persistence_regions.must_be :empty?[m
[32m+[m[32m  end[m
[32m+[m
   describe :reference do[m
     let(:topic) { Google::Cloud::PubSub::Topic.from_name topic_name, pubsub.service }[m
 [m
[1mdiff --git a/google-cloud-pubsub/test/google/cloud/pubsub_test.rb b/google-cloud-pubsub/test/google/cloud/pubsub_test.rb[m
[1mindex 204b6203f..c24e49f4d 100644[m
[1m--- a/google-cloud-pubsub/test/google/cloud/pubsub_test.rb[m
[1m+++ b/google-cloud-pubsub/test/google/cloud/pubsub_test.rb[m
[36m@@ -97,7 +97,7 @@[m [mdescribe Google::Cloud do[m
         scope.must_be :nil?[m
         "pubsub-credentials"[m
       }[m
[31m-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {[m
[32m+[m[32m      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {[m
         project.must_equal "project-id"[m
         credentials.must_equal "pubsub-credentials"[m
         client_config.must_be :nil?[m
[36m@@ -158,7 +158,7 @@[m [mdescribe Google::Cloud do[m
         scope.must_be :nil?[m
         "pubsub-credentials"[m
       }[m
[31m-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {[m
[32m+[m[32m      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {[m
         project.must_equal "project-id"[m
         credentials.must_equal "pubsub-credentials"[m
         timeout.must_be :nil?[m
[36m@@ -189,7 +189,7 @@[m [mdescribe Google::Cloud do[m
         scope.must_be :nil?[m
         "pubsub-credentials"[m
       }[m
[31m-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {[m
[32m+[m[32m      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {[m
         project.must_equal "project-id"[m
         credentials.must_equal "pubsub-credentials"[m
         timeout.must_be :nil?[m
[36m@@ -255,7 +255,7 @@[m [mdescribe Google::Cloud do[m
         scope.must_be :nil?[m
         OpenStruct.new project_id: "project-id"[m
       }[m
[31m-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {[m
[32m+[m[32m      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {[m
         project.must_equal "project-id"[m
         credentials.must_be_kind_of OpenStruct[m
         credentials.project_id.must_equal "project-id"[m
[36m@@ -303,7 +303,7 @@[m [mdescribe Google::Cloud do[m
         scope.must_be :nil?[m
         "pubsub-credentials"[m
       }[m
[31m-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {[m
[32m+[m[32m      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {[m
         project.must_equal "project-id"[m
         credentials.must_equal "pubsub-credentials"[m
         timeout.must_be :nil?[m
[36m@@ -340,7 +340,7 @@[m [mdescribe Google::Cloud do[m
         scope.must_be :nil?[m
         "pubsub-credentials"[m
       }[m
[31m-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {[m
[32m+[m[32m      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {[m
         project.must_equal "project-id"[m
         credentials.must_equal "pubsub-credentials"[m
         timeout.must_be :nil?[m
[36m@@ -377,7 +377,7 @@[m [mdescribe Google::Cloud do[m
         scope.must_be :nil?[m
         "pubsub-credentials"[m
       }[m
[31m-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {[m
[32m+[m[32m      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {[m
         project.must_equal "project-id"[m
         credentials.must_equal "pubsub-credentials"[m
         timeout.must_equal 42[m
[36m@@ -416,7 +416,7 @@[m [mdescribe Google::Cloud do[m
         scope.must_be :nil?[m
         "pubsub-credentials"[m
       }[m
[31m-      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {[m
[32m+[m[32m      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {[m
         project.must_equal "project-id"[m
         credentials.must_equal "pubsub-credentials"[m
         timeout.must_equal 42[m

```

</details>

This pull request was generated using releasetool.