### PR TITLE
Release google-cloud-debugger 0.33.7

### DIFF
--- a/google-cloud-debugger/CHANGELOG.md
+++ b/google-cloud-debugger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-### 0.33.7 / 2019-07-30
+### 0.33.7 / 2019-07-31
 
 * Fix max threads setting in thread pools
   * Thread pools once again limit the number of threads allocated.

--- a/google-cloud-debugger/CHANGELOG.md
+++ b/google-cloud-debugger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.33.7 / 2019-07-30
+
+* Fix max threads setting in thread pools
+  * Thread pools once again limit the number of threads allocated.
+* Update documentation links
+
 ### 0.33.6 / 2019-07-08
 
 * Support overriding service host and port in the low-level client.

--- a/google-cloud-debugger/lib/google/cloud/debugger/version.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Debugger
-      VERSION = "0.33.6".freeze
+      VERSION = "0.33.7".freeze
     end
   end
 end


### PR DESCRIPTION
* Fix max threads setting in thread pools
  * Thread pools once again limit the number of threads allocated.
* Update documentation links

<details><summary>Commits since previous release</summary><pre><code>[33mcommit ac8ce21c294ea111e33142a7ba6da82786cc8935[m
Author: Graham Paye <paye@google.com>
Date:   Wed Jul 24 12:35:57 2019 -0700

    docs: update links to point to new docsite (#3684)

[33mcommit 3d79cbd111e300d0e73c2d55800c5ac39008bbff[m
Author: Mike Moore <mike@blowmage.com>
Date:   Thu Jul 18 14:09:50 2019 -0600

    fix: Fix max threads setting in thread pools
    
    Use ThreadPoolExecutor which honors the max threads setting.
    
    [pr #3682, fixes #3679]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
[1mdiff --git a/google-cloud-debugger/INSTRUMENTATION.md b/google-cloud-debugger/INSTRUMENTATION.md[m
[1mindex 42e85f3e6..5820bfcfb 100644[m
[1m--- a/google-cloud-debugger/INSTRUMENTATION.md[m
[1m+++ b/google-cloud-debugger/INSTRUMENTATION.md[m
[36m@@ -58,7 +58,7 @@[m [myou want to run on a non Google Cloud environment or you want to customize[m
 the default behavior.[m
 [m
 See the[m
[31m-[Configuration Guide](https://googleapis.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)[m
[32m+[m[32m[Configuration Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)[m
 for full configuration parameters.[m
 [m
 ### Using instrumentation with Ruby on Rails[m
[1mdiff --git a/google-cloud-debugger/LOGGING.md b/google-cloud-debugger/LOGGING.md[m
[1mindex 6afa8ef76..f64fd5b03 100644[m
[1m--- a/google-cloud-debugger/LOGGING.md[m
[1m+++ b/google-cloud-debugger/LOGGING.md[m
[36m@@ -5,7 +5,7 @@[m [mTo enable logging for this library, set the logger for the underlying[m
 that you set may be a Ruby stdlib[m
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as[m
 shown below, or a[m
[31m-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)[m
[32m+[m[32m[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
 that will write logs to [Stackdriver[m
 Logging](https://cloud.google.com/logging/). See[m
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
[1mdiff --git a/google-cloud-debugger/README.md b/google-cloud-debugger/README.md[m
[1mindex a64e3c817..f7a649a0d 100644[m
[1m--- a/google-cloud-debugger/README.md[m
[1m+++ b/google-cloud-debugger/README.md[m
[36m@@ -8,7 +8,7 @@[m [myour application, including test, development, and production. The Ruby[m
 debugger adds minimal request latency, typically less than 50ms, and only when[m
 application state is captured. In most cases, this is not noticeable by users.[m
 [m
[31m-- [google-cloud-debugger documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest)[m
[32m+[m[32m- [google-cloud-debugger documentation](https://googleapis.dev/ruby/google-cloud-debugger/latest)[m
 - [google-cloud-debugger on RubyGems](https://rubygems.org/gems/google-cloud-debugger)[m
 - [Stackdriver Debugger documentation](https://cloud.google.com/debugger/docs/)[m
 [m
[36m@@ -22,7 +22,7 @@[m [mAdd the `google-cloud-debugger` gem to your Gemfile:[m
 gem "google-cloud-debugger"[m
 ```[m
 [m
[31m-Alternatively, consider installing the [`stackdriver`](../stackdriver) gem. It[m
[32m+[m[32mAlternatively, consider installing the [`stackdriver`](https://googleapis.dev/ruby/stackdriver/latest) gem. It[m
 includes the `google-cloud-debugger` gem as a dependency, and automatically[m
 initializes it for some application frameworks.[m
 [m
[36m@@ -175,7 +175,7 @@[m [mGoogle::Cloud::Debugger.new(project_id: "your-project-id",[m
 [m
 This library also supports the other authentication methods provided by the[m
 `google-cloud-ruby` suite. Instructions and configuration options are covered[m
[31m-in the [Authentication Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.AUTHENTICATION).[m
[32m+[m[32min the [Authentication Guide](https://googleapis.dev/ruby/google-cloud-debugger/latest/file.AUTHENTICATION.html).[m
 [m
 ### Using the Debugger[m
 [m
[36m@@ -219,12 +219,12 @@[m [magent.[m
 You can customize the behavior of the Stackdriver Debugger agent. This includes[m
 setting the Google Cloud project and authentication, and customizing the[m
 behavior of the debugger itself, such as side effect protection and data[m
[31m-size limits. See [agent configuration](../stackdriver/INSTRUMENTATION_CONFIGURATION.md)[m
[32m+[m[32msize limits. See [agent configuration](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)[m
 for a list of possible configuration options.[m
 [m
 ## Enabling Logging[m
 [m
[31m-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
[32m+[m[32mTo enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
 [m
 Configuring a Ruby stdlib logger:[m
 [m
[36m@@ -264,18 +264,18 @@[m [mand the public API should not be considered stable.[m
 Contributions to this library are always welcome and highly encouraged.[m
 [m
 See the [Contributing[m
[31m-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.CONTRIBUTING)[m
[32m+[m[32mGuide](https://googleapis.dev/ruby/google-cloud-debugger/latest/file.CONTRIBUTING.html)[m
 for more information on how to get started.[m
 [m
 Please note that this project is released with a Contributor Code of Conduct. By[m
 participating in this project you agree to abide by its terms. See [Code of[m
[31m-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.CODE_OF_CONDUCT)[m
[32m+[m[32mConduct](https://googleapis.dev/ruby/google-cloud-debugger/latest/file.CODE_OF_CONDUCT.html)[m
 for more information.[m
 [m
 ## License[m
 [m
 This library is licensed under Apache 2.0. Full license text is available in[m
[31m-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.LICENSE).[m
[32m+[m[32m[LICENSE](https://googleapis.dev/ruby/google-cloud-debugger/latest/file.LICENSE.html).[m
 [m
 ## Support[m
 [m
[1mdiff --git a/google-cloud-debugger/lib/google/cloud/debugger.rb b/google-cloud-debugger/lib/google/cloud/debugger.rb[m
[1mindex e0d9822d3..cdee3d959 100644[m
[1m--- a/google-cloud-debugger/lib/google/cloud/debugger.rb[m
[1m+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb[m
[36m@@ -154,7 +154,7 @@[m [mmodule Google[m
       #   single argument.[m
       #[m
       # See the [Configuration[m
[31m-      # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)[m
[32m+[m[32m      # Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)[m
       # for full configuration parameters.[m
       #[m
       # @return [Google::Cloud::Config] The configuration object the[m
[1mdiff --git a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb[m
[1mindex 7a187efdb..b6a16b1a0 100644[m
[1m--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb[m
[1m+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb[m
[36m@@ -99,7 +99,7 @@[m [mmodule Google[m
         #   using the other parameters.[m
         # @param [Hash] kwargs Hash of configuration settings. Used for backward[m
         #   API compatibility. See the [Configuration[m
[31m-        #   Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)[m
[32m+[m[32m        #   Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)[m
         #   for the prefered way to set configuration parameters.[m
         #[m
         # @return [Google::Cloud::Debugger::Middleware] A new[m
[1mdiff --git a/google-cloud-debugger/lib/google/cloud/debugger/rails.rb b/google-cloud-debugger/lib/google/cloud/debugger/rails.rb[m
[1mindex b98cc78f7..d075759ac 100644[m
[1m--- a/google-cloud-debugger/lib/google/cloud/debugger/rails.rb[m
[1m+++ b/google-cloud-debugger/lib/google/cloud/debugger/rails.rb[m
[36m@@ -34,7 +34,7 @@[m [mmodule Google[m
       #[m
       # The Railtie should also initialize a debugger to be used by the[m
       # Middleware. See the [Configuration[m
[31m-      # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)[m
[32m+[m[32m      # Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)[m
       # on how to configure the Railtie and Middleware.[m
       #[m
       class Railtie < ::Rails::Railtie[m
[1mdiff --git a/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb b/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb[m
[1mindex a23acd3d4..3fb063f2c 100644[m
[1m--- a/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb[m
[1m+++ b/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb[m
[36m@@ -78,8 +78,8 @@[m [mmodule Google[m
           @max_queue = max_queue[m
           @threads   = threads[m
 [m
[31m-          @thread_pool = Concurrent::CachedThreadPool.new max_threads: @threads,[m
[31m-                                                          max_queue: @max_queue[m
[32m+[m[32m          @thread_pool = Concurrent::ThreadPoolExecutor.new \[m
[32m+[m[32m            max_threads: @threads, max_queue: @max_queue[m
 [m
           @error_callbacks = [][m
 [m
[1mdiff --git a/google-cloud-debugger/lib/google/cloud/debugger/v2.rb b/google-cloud-debugger/lib/google/cloud/debugger/v2.rb[m
[1mindex dd0811da2..ac8f6d8cb 100644[m
[1m--- a/google-cloud-debugger/lib/google/cloud/debugger/v2.rb[m
[1m+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2.rb[m
[36m@@ -36,7 +36,7 @@[m [mmodule Google[m
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)[m
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)[m
       # 3. [Enable the Stackdriver Debugger API.](https://console.cloud.google.com/apis/library/clouddebugger.googleapis.com)[m
[31m-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)[m
[32m+[m[32m      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-debugger/latest/file.AUTHENTICATION.html)[m
       #[m
       # ### Installation[m
       # ```[m
[36m@@ -55,7 +55,7 @@[m [mmodule Google[m
       #[m
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.[m
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,[m
[31m-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)[m
[32m+[m[32m      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
       #[m
[1mdiff --git a/google-cloud-debugger/synth.py b/google-cloud-debugger/synth.py[m
[1mindex d65499316..a4e924332 100644[m
[1m--- a/google-cloud-debugger/synth.py[m
[1m+++ b/google-cloud-debugger/synth.py[m
[36m@@ -153,3 +153,15 @@[m [ms.replace([m
     'Gem.loaded_specs\[.*\]\.version\.version',[m
     'Google::Cloud::Debugger::VERSION'[m
 )[m
[32m+[m
[32m+[m[32m# Fix links for devsite migration[m
[32m+[m[32ms.replace([m
[32m+[m[32m    'lib/**/*.rb',[m
[32m+[m[32m    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',[m
[32m+[m[32m    'https://googleapis.dev/ruby/google-cloud-debugger/latest/file.AUTHENTICATION.html'[m
[32m+[m[32m)[m
[32m+[m[32ms.replace([m
[32m+[m[32m    'lib/**/*.rb',[m
[32m+[m[32m    'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',[m
[32m+[m[32m    'https://googleapis.dev/ruby/google-cloud-logging/latest'[m
[32m+[m[32m)[m

```

</details>

This pull request was generated using releasetool.