### PR TITLE
Release google-cloud-error_reporting 0.31.7

### DIFF
--- a/google-cloud-error_reporting/CHANGELOG.md
+++ b/google-cloud-error_reporting/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.31.7 / 2019-07-30
+
+* Fix max threads setting in thread pools
+  * Thread pools once again limit the number of threads allocated.
+* Update documentation links
+
 ### 0.31.6 / 2019-07-08
 
 * Support overriding service host and port in the low-level interface.

--- a/google-cloud-error_reporting/CHANGELOG.md
+++ b/google-cloud-error_reporting/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-### 0.31.7 / 2019-07-30
+### 0.31.7 / 2019-07-31
 
 * Fix max threads setting in thread pools
   * Thread pools once again limit the number of threads allocated.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module ErrorReporting
-      VERSION = "0.31.6".freeze
+      VERSION = "0.31.7".freeze
     end
   end
 end


### PR DESCRIPTION
* Fix max threads setting in thread pools
  * Thread pools once again limit the number of threads allocated.
* Update documentation links

<details><summary>Commits since previous release</summary><pre><code>[33mcommit ac8ce21c294ea111e33142a7ba6da82786cc8935[m
Author: Graham Paye <paye@google.com>
Date:   Wed Jul 24 12:35:57 2019 -0700

    docs: update links to point to new docsite (#3684)

[33mcommit 3d79cbd111e300d0e73c2d55800c5ac39008bbff[m
Author: Mike Moore <mike@blowmage.com>
Date:   Thu Jul 18 14:09:50 2019 -0600

    fix: Fix max threads setting in thread pools
    
    Use ThreadPoolExecutor which honors the max threads setting.
    
    [pr #3682, fixes #3679]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
[1mdiff --git a/google-cloud-error_reporting/INSTRUMENTATION.md b/google-cloud-error_reporting/INSTRUMENTATION.md[m
[1mindex ab00f9d43..84778e5ad 100644[m
[1m--- a/google-cloud-error_reporting/INSTRUMENTATION.md[m
[1m+++ b/google-cloud-error_reporting/INSTRUMENTATION.md[m
[36m@@ -26,7 +26,7 @@[m [myou want to run on a non Google Cloud environment or you want to customize  the[m
 default behavior.[m
 [m
 See the [Configuration[m
[31m-Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)[m
[32m+[m[32mGuide](https://googleapis.dev/ruby/stackdriver/INSTRUMENTATION_CONFIGURATION/latest)[m
 for full configuration parameters.[m
 [m
 ## Rack Middleware and Railtie[m
[36m@@ -48,7 +48,7 @@[m [mrequire "google/cloud/error_reporting/rails"[m
 ```[m
 [m
 Alternatively, check out the[m
[31m-[stackdriver](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest)[m
[32m+[m[32m[stackdriver](https://googleapis.dev/ruby/stackdriver/latest/file.README.html[m
 gem, which enables this Railtie by default.[m
 [m
 ### Rack Integration[m
[1mdiff --git a/google-cloud-error_reporting/LOGGING.md b/google-cloud-error_reporting/LOGGING.md[m
[1mindex 6afa8ef76..f64fd5b03 100644[m
[1m--- a/google-cloud-error_reporting/LOGGING.md[m
[1m+++ b/google-cloud-error_reporting/LOGGING.md[m
[36m@@ -5,7 +5,7 @@[m [mTo enable logging for this library, set the logger for the underlying[m
 that you set may be a Ruby stdlib[m
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as[m
 shown below, or a[m
[31m-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)[m
[32m+[m[32m[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
 that will write logs to [Stackdriver[m
 Logging](https://cloud.google.com/logging/). See[m
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
[1mdiff --git a/google-cloud-error_reporting/README.md b/google-cloud-error_reporting/README.md[m
[1mindex a250aadb8..6e13991bd 100644[m
[1m--- a/google-cloud-error_reporting/README.md[m
[1m+++ b/google-cloud-error_reporting/README.md[m
[36m@@ -7,8 +7,8 @@[m [mfiltering capabilities. A dedicated view shows the error details: time chart,[m
 occurrences, affected user count, first and last seen dates and a cleaned[m
 exception stack trace. Opt-in to receive email and mobile alerts on new errors.[m
 [m
[31m-- [google-cloud-error_reporting API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-error_reporting/latest)[m
[31m-- [google-cloud-error_reporting instrumentation documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-error_reporting/latest/file.INSTRUMENTATION)[m
[32m+[m[32m- [google-cloud-error_reporting API documentation](https://googleapis.dev/ruby/google-cloud-error_reporting/latest)[m
[32m+[m[32m- [google-cloud-error_reporting instrumentation documentation](https://googleapis.dev/ruby/google-cloud-error_reporting/latest/file.INSTRUMENTATION.html)[m
 - [google-cloud-error_reporting on RubyGems](https://rubygems.org/gems/google-cloud-error_reporting)[m
 - [Stackdriver ErrorReporting documentation](https://cloud.google.com/error-reporting/docs/)[m
 [m
[36m@@ -35,7 +35,7 @@[m [m$ bundle install[m
 ```[m
 [m
 Alternatively, check out the[m
[31m-[`stackdriver`](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest)[m
[32m+[m[32m[`stackdriver`](https://googleapis.dev/ruby/stackdriver/latest/file.README.html[m
 gem that includes the `google-cloud-error_reporting` gem.[m
 [m
 ## Enable Stackdriver Error Reporting API[m
[36m@@ -92,7 +92,7 @@[m [mend[m
 [m
 You can customize the behavior of the Stackdriver Error Reporting library for[m
 Ruby. See the [configuration[m
[31m-guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)[m
[32m+[m[32mguide](https://googleapis.dev/ruby/stackdriver/INSTRUMENTATION_CONFIGURATION/latest)[m
 for a list of possible configuration options.[m
 [m
 ## Running on Google Cloud Platform[m
[36m@@ -177,7 +177,7 @@[m [mend[m
 This library also supports the other authentication methods provided by the[m
 `google-cloud-ruby` suite. Instructions and configuration options are covered in[m
 the [Authentication[m
[31m-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.AUTHENTCATION).[m
[32m+[m[32mGuide](https://googleapis.dev/ruby/google-cloud-error_reporting/latest/file.AUTHENTCATION.html).[m
 [m
 ## Enabling Logging[m
 [m
[36m@@ -186,7 +186,7 @@[m [mTo enable logging for this library, set the logger for the underlying[m
 that you set may be a Ruby stdlib[m
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as[m
 shown below, or a[m
[31m-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)[m
[32m+[m[32m[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
 that will write logs to [Stackdriver[m
 Logging](https://cloud.google.com/logging/). See[m
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
[36m@@ -235,18 +235,18 @@[m [mchange at any time and the public API should not be considered stable.[m
 Contributions to this library are always welcome and highly encouraged.[m
 [m
 See the [Contributing[m
[31m-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.CONTRIBUTING)[m
[32m+[m[32mGuide](https://googleapis.dev/ruby/google-cloud-error_reporting/latest/file.CONTRIBUTING.html)[m
 for more information on how to get started.[m
 [m
 Please note that this project is released with a Contributor Code of Conduct. By[m
 participating in this project you agree to abide by its terms. See [Code of[m
[31m-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.CODE_OF_CONDUCT)[m
[32m+[m[32mConduct](https://googleapis.dev/ruby/google-cloud-error_reporting/latest/file.CODE_OF_CONDUCT.html)[m
 for more information.[m
 [m
 ## License[m
 [m
 This library is licensed under Apache 2.0. Full license text is available in[m
[31m-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-debugger/latest/file.LICENSE).[m
[32m+[m[32m[LICENSE](https://googleapis.dev/ruby/google-cloud-error_reporting/latest/file.LICENSE.html).[m
 [m
 ## Support[m
 [m
[1mdiff --git a/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb b/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb[m
[1mindex 324585f39..9b0a01f5c 100644[m
[1m--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb[m
[1m+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb[m
[36m@@ -136,7 +136,7 @@[m [mmodule Google[m
       #   ErrorReporting.[m
       #[m
       # See the [Configuration[m
[31m-      # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)[m
[32m+[m[32m      # Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)[m
       # for full configuration parameters.[m
       #[m
       # @example[m
[1mdiff --git a/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb b/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb[m
[1mindex 8acb53d9a..b402db1db 100644[m
[1m--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb[m
[1m+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb[m
[36m@@ -78,8 +78,8 @@[m [mmodule Google[m
           @max_queue = max_queue[m
           @threads   = threads[m
 [m
[31m-          @thread_pool = Concurrent::CachedThreadPool.new max_threads: @threads,[m
[31m-                                                          max_queue: @max_queue[m
[32m+[m[32m          @thread_pool = Concurrent::ThreadPoolExecutor.new \[m
[32m+[m[32m            max_threads: @threads, max_queue: @max_queue[m
 [m
           @error_callbacks = [][m
 [m
[1mdiff --git a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb[m
[1mindex decb8fa62..0ee179dfe 100644[m
[1m--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb[m
[1m+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb[m
[36m@@ -39,7 +39,7 @@[m [mmodule Google[m
         #   exceptions[m
         # @param [Hash] kwargs Hash of configuration settings. Used for backward[m
         #   API compatibility. See the [Configuration[m
[31m-        #   Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)[m
[32m+[m[32m        #   Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)[m
         #   for the prefered way to set configuration parameters.[m
         #[m
         # @return [Google::Cloud::ErrorReporting::Middleware] A new instance of[m
[1mdiff --git a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb[m
[1mindex b86b64569..5da231a1e 100644[m
[1m--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb[m
[1m+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb[m
[36m@@ -35,7 +35,7 @@[m [mmodule Google[m
       # and handle all Exceptions without interfering with Rails's normal error[m
       # pages.[m
       # See the [Configuration[m
[31m-      # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)[m
[32m+[m[32m      # Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)[m
       # on how to configure the Railtie and Middleware.[m
       #[m
       class Railtie < ::Rails::Railtie[m

```

</details>

This pull request was generated using releasetool.