### PR TITLE
Release google-cloud-logging 1.6.6

### DIFF
--- a/google-cloud-logging/CHANGELOG.md
+++ b/google-cloud-logging/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-### 1.6.6 / 2019-07-30
+### 1.6.6 / 2019-07-31
 
 * Fix max threads setting in thread pools
   * Thread pools once again limit the number of threads allocated.

--- a/google-cloud-logging/CHANGELOG.md
+++ b/google-cloud-logging/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 1.6.6 / 2019-07-30
+
+* Fix max threads setting in thread pools
+  * Thread pools once again limit the number of threads allocated.
+* Update documentation links
+
 ### 1.6.5 / 2019-07-08
 
 * Support overriding service host and port in the low-level interface.

--- a/google-cloud-logging/lib/google/cloud/logging/version.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Logging
-      VERSION = "1.6.5".freeze
+      VERSION = "1.6.6".freeze
     end
   end
 end


### PR DESCRIPTION
* Fix max threads setting in thread pools
  * Thread pools once again limit the number of threads allocated.
* Update documentation links

<details><summary>Commits since previous release</summary><pre><code>[33mcommit ac8ce21c294ea111e33142a7ba6da82786cc8935[m
Author: Graham Paye <paye@google.com>
Date:   Wed Jul 24 12:35:57 2019 -0700

    docs: update links to point to new docsite (#3684)

[33mcommit 3d79cbd111e300d0e73c2d55800c5ac39008bbff[m
Author: Mike Moore <mike@blowmage.com>
Date:   Thu Jul 18 14:09:50 2019 -0600

    fix: Fix max threads setting in thread pools
    
    Use ThreadPoolExecutor which honors the max threads setting.
    
    [pr #3682, fixes #3679]

[33mcommit b1cb205a4fd4734980bc2d6c9a82b10298497f4a[m
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Jul 10 15:08:38 2019 -0700

    refactor(logging): Add path helpers to lower-level client
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
[1mdiff --git a/google-cloud-logging/INSTRUMENTATION.md b/google-cloud-logging/INSTRUMENTATION.md[m
[1mindex 5c3853277..d9b570c2f 100644[m
[1m--- a/google-cloud-logging/INSTRUMENTATION.md[m
[1m+++ b/google-cloud-logging/INSTRUMENTATION.md[m
[36m@@ -16,7 +16,7 @@[m [mif you want to run on a non Google Cloud environment or you want to customize[m
 the default behavior.[m
 [m
 See the [m
[31m-[Configuration Guide](https://googleapis.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)[m
[32m+[m[32m[Configuration Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)[m
 for full configuration parameters.[m
 [m
 ## Using instrumentation with Ruby on Rails[m
[1mdiff --git a/google-cloud-logging/LOGGING.md b/google-cloud-logging/LOGGING.md[m
[1mindex 6afa8ef76..f64fd5b03 100644[m
[1m--- a/google-cloud-logging/LOGGING.md[m
[1m+++ b/google-cloud-logging/LOGGING.md[m
[36m@@ -5,7 +5,7 @@[m [mTo enable logging for this library, set the logger for the underlying[m
 that you set may be a Ruby stdlib[m
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as[m
 shown below, or a[m
[31m-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)[m
[32m+[m[32m[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
 that will write logs to [Stackdriver[m
 Logging](https://cloud.google.com/logging/). See[m
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
[1mdiff --git a/google-cloud-logging/README.md b/google-cloud-logging/README.md[m
[1mindex a1459aa05..6960d0b83 100644[m
[1m--- a/google-cloud-logging/README.md[m
[1m+++ b/google-cloud-logging/README.md[m
[36m@@ -2,7 +2,7 @@[m
 [m
 [Stackdriver Logging](https://cloud.google.com/logging/) ([docs](https://cloud.google.com/logging/docs/)) allows you to store, search, analyze, monitor, and alert on log data and events from Google Cloud Platform and Amazon Web Services (AWS). It supports ingestion of any custom log data from any source. Stackdriver Logging is a fully-managed service that performs at scale and can ingest application and system log data from thousands of VMs. Even better, you can analyze all that log data in real-time.[m
 [m
[31m-- [google-cloud-logging API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest)[m
[32m+[m[32m- [google-cloud-logging API documentation](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
 - [google-cloud-logging on RubyGems](https://rubygems.org/gems/google-cloud-logging)[m
 - [Stackdriver Logging documentation](https://cloud.google.com/logging/docs/)[m
 [m
[36m@@ -28,7 +28,7 @@[m [mgem "google-cloud-logging"[m
 $ bundle install[m
 ```[m
 [m
[31m-Alternatively, check out the [`stackdriver`](../stackdriver) gem that includes[m
[32m+[m[32mAlternatively, check out the [`stackdriver`](https://googleapis.dev/ruby/stackdriver/latest) gem that includes[m
 the `google-cloud-logging` gem.[m
 [m
 ## Logging using client library[m
[36m@@ -112,7 +112,7 @@[m [mlogger.[m
 ### Configuring the framework integration[m
 [m
 You can customize the behavior of the Stackdriver Logging framework integration[m
[31m-for Ruby. See the [configuration guide](../stackdriver/INSTRUMENTATION_CONFIGURATION.md) for a[m
[32m+[m[32mfor Ruby. See the [configuration guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html) for a[m
 list of possible configuration options.[m
 [m
 ## Authentication[m
[36m@@ -153,12 +153,12 @@[m [mend[m
 ```[m
 [m
 See the [Authentication[m
[31m-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/file.AUTHENTICATION).[m
[32m+[m[32mGuide](https://googleapis.dev/ruby/google-cloud-logging/latest/file.AUTHENTICATION.html).[m
 for more ways to authenticate the client library.[m
 [m
 ## Enabling Logging[m
 [m
[31m-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
[32m+[m[32mTo enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
 [m
 Configuring a Ruby stdlib logger:[m
 [m
[36m@@ -198,18 +198,18 @@[m [mThis library follows [Semantic Versioning](http://semver.org/).[m
 Contributions to this library are always welcome and highly encouraged.[m
 [m
 See the [Contributing[m
[31m-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/file.CONTRIBUTING)[m
[32m+[m[32mGuide](https://googleapis.dev/ruby/google-cloud-logging/latest/file.CONTRIBUTING.html)[m
 for more information on how to get started.[m
 [m
 Please note that this project is released with a Contributor Code of Conduct. By[m
 participating in this project you agree to abide by its terms. See [Code of[m
[31m-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/file.CODE_OF_CONDUCT)[m
[32m+[m[32mConduct](https://googleapis.dev/ruby/google-cloud-logging/latest/file.CODE_OF_CONDUCT.html)[m
 for more information.[m
 [m
 ## License[m
 [m
 This library is licensed under Apache 2.0. Full license text is available in[m
[31m-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/file.LICENSE).[m
[32m+[m[32m[LICENSE](https://googleapis.dev/ruby/google-cloud-logging/latest/file.LICENSE.html).[m
 [m
 ## Support[m
 [m
[1mdiff --git a/google-cloud-logging/lib/google/cloud/logging.rb b/google-cloud-logging/lib/google/cloud/logging.rb[m
[1mindex 31cc02e5c..7839a1c6c 100644[m
[1m--- a/google-cloud-logging/lib/google/cloud/logging.rb[m
[1m+++ b/google-cloud-logging/lib/google/cloud/logging.rb[m
[36m@@ -152,7 +152,7 @@[m [mmodule Google[m
       #   single argument. (See {AsyncWriter.on_error}.)[m
       #[m
       # See the [Configuration[m
[31m-      # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)[m
[32m+[m[32m      # Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)[m
       # for full configuration parameters.[m
       #[m
       # @return [Google::Cloud::Config] The configuration object[m
[1mdiff --git a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb[m
[1mindex fcdcefc48..9b29cbd43 100644[m
[1m--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb[m
[1m+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb[m
[36m@@ -151,9 +151,8 @@[m [mmodule Google[m
               @batch.add entry[m
             end[m
 [m
[31m-            @thread_pool ||= \[m
[31m-              Concurrent::CachedThreadPool.new max_threads: @threads,[m
[31m-                                               max_queue:   @max_queue[m
[32m+[m[32m            @thread_pool ||= Concurrent::ThreadPoolExecutor.new \[m
[32m+[m[32m              max_threads: @threads, max_queue: @max_queue[m
             @thread ||= Thread.new { run_background }[m
 [m
             publish_batch! if @batch.ready?[m
[1mdiff --git a/google-cloud-logging/lib/google/cloud/logging/middleware.rb b/google-cloud-logging/lib/google/cloud/logging/middleware.rb[m
[1mindex edd993b88..d14c622dc 100644[m
[1m--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb[m
[1m+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb[m
[36m@@ -48,7 +48,7 @@[m [mmodule Google[m
         #   initialized. The callback takes no arguments. Optional.[m
         # @param [Hash] kwargs Hash of configuration settings. Used for[m
         #   backward API compatibility. See the [Configuration[m
[31m-        #   Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)[m
[32m+[m[32m        #   Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)[m
         #   for the prefered way to set configuration parameters.[m
         #[m
         # @return [Google::Cloud::Logging::Middleware] A new[m
[1mdiff --git a/google-cloud-logging/lib/google/cloud/logging/rails.rb b/google-cloud-logging/lib/google/cloud/logging/rails.rb[m
[1mindex 48cfafc1d..f5efcbcfc 100644[m
[1m--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb[m
[1m+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb[m
[36m@@ -41,7 +41,7 @@[m [mmodule Google[m
       # before the `Rails::Rack::Logger Middleware`, which allows it to set the[m
       # `env['rack.logger']` in place of Rails's default logger.[m
       # See the [Configuration[m
[31m-      # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)[m
[32m+[m[32m      # Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)[m
       # on how to configure the Railtie and Middleware.[m
       #[m
       class Railtie < ::Rails::Railtie[m
[1mdiff --git a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb[m
[1mindex 16c7ef5b9..19b62eca5 100644[m
[1m--- a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb[m
[1m+++ b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb[m
[36m@@ -77,12 +77,66 @@[m [mmodule Google[m
           ].freeze[m
 [m
 [m
[32m+[m[32m          BILLING_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "billingAccounts/{billing_account}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :BILLING_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m          BILLING_EXCLUSION_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "billingAccounts/{billing_account}/exclusions/{exclusion}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :BILLING_EXCLUSION_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m          BILLING_SINK_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "billingAccounts/{billing_account}/sinks/{sink}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :BILLING_SINK_PATH_TEMPLATE[m
[32m+[m
           EXCLUSION_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
             "projects/{project}/exclusions/{exclusion}"[m
           )[m
 [m
           private_constant :EXCLUSION_PATH_TEMPLATE[m
 [m
[32m+[m[32m          FOLDER_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "folders/{folder}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :FOLDER_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m          FOLDER_EXCLUSION_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "folders/{folder}/exclusions/{exclusion}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :FOLDER_EXCLUSION_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m          FOLDER_SINK_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "folders/{folder}/sinks/{sink}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :FOLDER_SINK_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m          ORGANIZATION_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "organizations/{organization}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :ORGANIZATION_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m          ORGANIZATION_EXCLUSION_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "organizations/{organization}/exclusions/{exclusion}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :ORGANIZATION_EXCLUSION_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m          ORGANIZATION_SINK_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "organizations/{organization}/sinks/{sink}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :ORGANIZATION_SINK_PATH_TEMPLATE[m
[32m+[m
           PROJECT_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
             "projects/{project}"[m
           )[m
[36m@@ -95,6 +149,37 @@[m [mmodule Google[m
 [m
           private_constant :SINK_PATH_TEMPLATE[m
 [m
[32m+[m[32m          # Returns a fully-qualified billing resource name string.[m
[32m+[m[32m          # @param billing_account [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.billing_path billing_account[m
[32m+[m[32m            BILLING_PATH_TEMPLATE.render([m
[32m+[m[32m              :"billing_account" => billing_account[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
[32m+[m[32m          # Returns a fully-qualified billing_exclusion resource name string.[m
[32m+[m[32m          # @param billing_account [String][m
[32m+[m[32m          # @param exclusion [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.billing_exclusion_path billing_account, exclusion[m
[32m+[m[32m            BILLING_EXCLUSION_PATH_TEMPLATE.render([m
[32m+[m[32m              :"billing_account" => billing_account,[m
[32m+[m[32m              :"exclusion" => exclusion[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
[32m+[m[32m          # Returns a fully-qualified billing_sink resource name string.[m
[32m+[m[32m          # @param billing_account [String][m
[32m+[m[32m          # @param sink [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.billing_sink_path billing_account, sink[m
[32m+[m[32m            BILLING_SINK_PATH_TEMPLATE.render([m
[32m+[m[32m              :"billing_account" => billing_account,[m
[32m+[m[32m              :"sink" => sink[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
           # Returns a fully-qualified exclusion resource name string.[m
           # @param project [String][m
           # @param exclusion [String][m
[36m@@ -106,6 +191,68 @@[m [mmodule Google[m
             )[m
           end[m
 [m
[32m+[m[32m          # Returns a fully-qualified folder resource name string.[m
[32m+[m[32m          # @param folder [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.folder_path folder[m
[32m+[m[32m            FOLDER_PATH_TEMPLATE.render([m
[32m+[m[32m              :"folder" => folder[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
[32m+[m[32m          # Returns a fully-qualified folder_exclusion resource name string.[m
[32m+[m[32m          # @param folder [String][m
[32m+[m[32m          # @param exclusion [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.folder_exclusion_path folder, exclusion[m
[32m+[m[32m            FOLDER_EXCLUSION_PATH_TEMPLATE.render([m
[32m+[m[32m              :"folder" => folder,[m
[32m+[m[32m              :"exclusion" => exclusion[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
[32m+[m[32m          # Returns a fully-qualified folder_sink resource name string.[m
[32m+[m[32m          # @param folder [String][m
[32m+[m[32m          # @param sink [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.folder_sink_path folder, sink[m
[32m+[m[32m            FOLDER_SINK_PATH_TEMPLATE.render([m
[32m+[m[32m              :"folder" => folder,[m
[32m+[m[32m              :"sink" => sink[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
[32m+[m[32m          # Returns a fully-qualified organization resource name string.[m
[32m+[m[32m          # @param organization [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.organization_path organization[m
[32m+[m[32m            ORGANIZATION_PATH_TEMPLATE.render([m
[32m+[m[32m              :"organization" => organization[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
[32m+[m[32m          # Returns a fully-qualified organization_exclusion resource name string.[m
[32m+[m[32m          # @param organization [String][m
[32m+[m[32m          # @param exclusion [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.organization_exclusion_path organization, exclusion[m
[32m+[m[32m            ORGANIZATION_EXCLUSION_PATH_TEMPLATE.render([m
[32m+[m[32m              :"organization" => organization,[m
[32m+[m[32m              :"exclusion" => exclusion[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
[32m+[m[32m          # Returns a fully-qualified organization_sink resource name string.[m
[32m+[m[32m          # @param organization [String][m
[32m+[m[32m          # @param sink [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.organization_sink_path organization, sink[m
[32m+[m[32m            ORGANIZATION_SINK_PATH_TEMPLATE.render([m
[32m+[m[32m              :"organization" => organization,[m
[32m+[m[32m              :"sink" => sink[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
           # Returns a fully-qualified project resource name string.[m
           # @param project [String][m
           # @return [String][m
[1mdiff --git a/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb b/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb[m
[1mindex ed86daa09..1b08ca39d 100644[m
[1m--- a/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb[m
[1m+++ b/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb[m
[36m@@ -92,18 +92,94 @@[m [mmodule Google[m
           ].freeze[m
 [m
 [m
[32m+[m[32m          BILLING_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "billingAccounts/{billing_account}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :BILLING_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m          BILLING_LOG_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "billingAccounts/{billing_account}/logs/{log}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :BILLING_LOG_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m          FOLDER_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "folders/{folder}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :FOLDER_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m          FOLDER_LOG_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "folders/{folder}/logs/{log}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :FOLDER_LOG_PATH_TEMPLATE[m
[32m+[m
           LOG_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
             "projects/{project}/logs/{log}"[m
           )[m
 [m
           private_constant :LOG_PATH_TEMPLATE[m
 [m
[32m+[m[32m          ORGANIZATION_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "organizations/{organization}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :ORGANIZATION_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m          ORGANIZATION_LOG_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "organizations/{organization}/logs/{log}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :ORGANIZATION_LOG_PATH_TEMPLATE[m
[32m+[m
           PROJECT_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
             "projects/{project}"[m
           )[m
 [m
           private_constant :PROJECT_PATH_TEMPLATE[m
 [m
[32m+[m[32m          # Returns a fully-qualified billing resource name string.[m
[32m+[m[32m          # @param billing_account [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.billing_path billing_account[m
[32m+[m[32m            BILLING_PATH_TEMPLATE.render([m
[32m+[m[32m              :"billing_account" => billing_account[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
[32m+[m[32m          # Returns a fully-qualified billing_log resource name string.[m
[32m+[m[32m          # @param billing_account [String][m
[32m+[m[32m          # @param log [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.billing_log_path billing_account, log[m
[32m+[m[32m            BILLING_LOG_PATH_TEMPLATE.render([m
[32m+[m[32m              :"billing_account" => billing_account,[m
[32m+[m[32m              :"log" => log[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
[32m+[m[32m          # Returns a fully-qualified folder resource name string.[m
[32m+[m[32m          # @param folder [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.folder_path folder[m
[32m+[m[32m            FOLDER_PATH_TEMPLATE.render([m
[32m+[m[32m              :"folder" => folder[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
[32m+[m[32m          # Returns a fully-qualified folder_log resource name string.[m
[32m+[m[32m          # @param folder [String][m
[32m+[m[32m          # @param log [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.folder_log_path folder, log[m
[32m+[m[32m            FOLDER_LOG_PATH_TEMPLATE.render([m
[32m+[m[32m              :"folder" => folder,[m
[32m+[m[32m              :"log" => log[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
           # Returns a fully-qualified log resource name string.[m
           # @param project [String][m
           # @param log [String][m
[36m@@ -115,6 +191,26 @@[m [mmodule Google[m
             )[m
           end[m
 [m
[32m+[m[32m          # Returns a fully-qualified organization resource name string.[m
[32m+[m[32m          # @param organization [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.organization_path organization[m
[32m+[m[32m            ORGANIZATION_PATH_TEMPLATE.render([m
[32m+[m[32m              :"organization" => organization[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
[32m+[m[32m          # Returns a fully-qualified organization_log resource name string.[m
[32m+[m[32m          # @param organization [String][m
[32m+[m[32m          # @param log [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.organization_log_path organization, log[m
[32m+[m[32m            ORGANIZATION_LOG_PATH_TEMPLATE.render([m
[32m+[m[32m              :"organization" => organization,[m
[32m+[m[32m              :"log" => log[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
           # Returns a fully-qualified project resource name string.[m
           # @param project [String][m
           # @return [String][m
[1mdiff --git a/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb b/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb[m
[1mindex 0425321b2..d510a2115 100644[m
[1m--- a/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb[m
[1m+++ b/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb[m
[36m@@ -72,18 +72,54 @@[m [mmodule Google[m
           ].freeze[m
 [m
 [m
[32m+[m[32m          BILLING_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "billingAccounts/{billing_account}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :BILLING_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m          FOLDER_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "folders/{folder}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :FOLDER_PATH_TEMPLATE[m
[32m+[m
           METRIC_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
             "projects/{project}/metrics/{metric}"[m
           )[m
 [m
           private_constant :METRIC_PATH_TEMPLATE[m
 [m
[32m+[m[32m          ORGANIZATION_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m            "organizations/{organization}"[m
[32m+[m[32m          )[m
[32m+[m
[32m+[m[32m          private_constant :ORGANIZATION_PATH_TEMPLATE[m
[32m+[m
           PROJECT_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
             "projects/{project}"[m
           )[m
 [m
           private_constant :PROJECT_PATH_TEMPLATE[m
 [m
[32m+[m[32m          # Returns a fully-qualified billing resource name string.[m
[32m+[m[32m          # @param billing_account [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.billing_path billing_account[m
[32m+[m[32m            BILLING_PATH_TEMPLATE.render([m
[32m+[m[32m              :"billing_account" => billing_account[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
[32m+[m[32m          # Returns a fully-qualified folder resource name string.[m
[32m+[m[32m          # @param folder [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.folder_path folder[m
[32m+[m[32m            FOLDER_PATH_TEMPLATE.render([m
[32m+[m[32m              :"folder" => folder[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
           # Returns a fully-qualified metric resource name string.[m
           # @param project [String][m
           # @param metric [String][m
[36m@@ -95,6 +131,15 @@[m [mmodule Google[m
             )[m
           end[m
 [m
[32m+[m[32m          # Returns a fully-qualified organization resource name string.[m
[32m+[m[32m          # @param organization [String][m
[32m+[m[32m          # @return [String][m
[32m+[m[32m          def self.organization_path organization[m
[32m+[m[32m            ORGANIZATION_PATH_TEMPLATE.render([m
[32m+[m[32m              :"organization" => organization[m
[32m+[m[32m            )[m
[32m+[m[32m          end[m
[32m+[m
           # Returns a fully-qualified project resource name string.[m
           # @param project [String][m
           # @return [String][m
[1mdiff --git a/google-cloud-logging/synth.metadata b/google-cloud-logging/synth.metadata[m
[1mindex 90d80e016..4daad0cab 100644[m
[1m--- a/google-cloud-logging/synth.metadata[m
[1m+++ b/google-cloud-logging/synth.metadata[m
[36m@@ -1,19 +1,19 @@[m
 {[m
[31m-  "updateTime": "2019-07-01T10:42:02.835095Z",[m
[32m+[m[32m  "updateTime": "2019-07-10T10:40:26.018439Z",[m
   "sources": [[m
     {[m
       "generator": {[m
         "name": "artman",[m
[31m-        "version": "0.29.2",[m
[31m-        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"[m
[32m+[m[32m        "version": "0.29.4",[m
[32m+[m[32m        "dockerImage": "googleapis/artman@sha256:63f21e83cb92680b7001dc381069e962c9e6dee314fd8365ac554c07c89221fb"[m
       }[m
     },[m
     {[m
       "git": {[m
         "name": "googleapis",[m
         "remote": "https://github.com/googleapis/googleapis.git",[m
[31m-        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",[m
[31m-        "internalRef": "255474859"[m
[32m+[m[32m        "sha": "16c0ea3cde17a897ba04b7b94d9bf4dd57e3227e",[m
[32m+[m[32m        "internalRef": "257239177"[m
       }[m
     }[m
   ],[m

```

</details>

This pull request was generated using releasetool.