### PR TITLE
Release google-cloud-trace 0.34.5

### DIFF
--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-### 0.34.5 / 2019-07-30
+### 0.34.5 / 2019-07-31
 
 * Fix max threads setting in thread pools
   * Thread pools once again limit the number of threads allocated.

--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.34.5 / 2019-07-30
+
+* Fix max threads setting in thread pools
+  * Thread pools once again limit the number of threads allocated.
+* Update documentation links
+
 ### 0.34.4 / 2019-07-08
 
 * Support overriding service host and port in the low-level interface.

--- a/google-cloud-trace/lib/google/cloud/trace/version.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Trace
-      VERSION = "0.34.4".freeze
+      VERSION = "0.34.5".freeze
     end
   end
 end


### PR DESCRIPTION
* Fix max threads setting in thread pools
  * Thread pools once again limit the number of threads allocated.
* Update documentation links

<details><summary>Commits since previous release</summary><pre><code>[33mcommit ac8ce21c294ea111e33142a7ba6da82786cc8935[m
Author: Graham Paye <paye@google.com>
Date:   Wed Jul 24 12:35:57 2019 -0700

    docs: update links to point to new docsite (#3684)

[33mcommit 3d79cbd111e300d0e73c2d55800c5ac39008bbff[m
Author: Mike Moore <mike@blowmage.com>
Date:   Thu Jul 18 14:09:50 2019 -0600

    fix: Fix max threads setting in thread pools
    
    Use ThreadPoolExecutor which honors the max threads setting.
    
    [pr #3682, fixes #3679]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
[1mdiff --git a/google-cloud-trace/INSTRUMENTATION.md b/google-cloud-trace/INSTRUMENTATION.md[m
[1mindex 3ae8a6acc..27ca3a490 100644[m
[1m--- a/google-cloud-trace/INSTRUMENTATION.md[m
[1m+++ b/google-cloud-trace/INSTRUMENTATION.md[m
[36m@@ -16,7 +16,7 @@[m [myou want to run on a non Google Cloud environment or you want to customize  the[m
 default behavior.[m
 [m
 See the [Configuration[m
[31m-Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)[m
[32m+[m[32mGuide](https://googleapis.dev/ruby/stackdriver/INSTRUMENTATION_CONFIGURATION/latest)[m
 for full configuration parameters.[m
 [m
 ## Rails Integration[m
[36m@@ -29,7 +29,7 @@[m [mrequire "google/cloud/trace/rails"[m
 ```[m
 [m
 Alternatively, check out the[m
[31m-[stackdriver](https://googleapis.github.io/google-cloud-ruby/#/docs/stackdriver)[m
[32m+[m[32m[stackdriver](https://googleapis.dev/ruby/stackdriver/latest/file.README.html)[m
 gem, which enables this Railtie by default.[m
 [m
 ## Rack Integration[m
[1mdiff --git a/google-cloud-trace/LOGGING.md b/google-cloud-trace/LOGGING.md[m
[1mindex 6afa8ef76..f64fd5b03 100644[m
[1m--- a/google-cloud-trace/LOGGING.md[m
[1m+++ b/google-cloud-trace/LOGGING.md[m
[36m@@ -5,7 +5,7 @@[m [mTo enable logging for this library, set the logger for the underlying[m
 that you set may be a Ruby stdlib[m
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as[m
 shown below, or a[m
[31m-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)[m
[32m+[m[32m[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
 that will write logs to [Stackdriver[m
 Logging](https://cloud.google.com/logging/). See[m
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
[1mdiff --git a/google-cloud-trace/README.md b/google-cloud-trace/README.md[m
[1mindex 48fa05779..3d8695a9d 100644[m
[1m--- a/google-cloud-trace/README.md[m
[1m+++ b/google-cloud-trace/README.md[m
[36m@@ -8,8 +8,8 @@[m [mStackdriver Trace automatically analyzes all of your application's traces to[m
 generate in-depth latency reports to surface performance degradations, and can[m
 capture traces from all of your VMs, containers, or Google App Engine projects.[m
 [m
[31m-- [google-cloud-trace API documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest)[m
[31m-- [google-cloud-trace instrumentation documentation](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest/file.INSTRUMENTATION)[m
[32m+[m[32m- [google-cloud-trace API documentation](https://googleapis.dev/ruby/google-cloud-trace/latest)[m
[32m+[m[32m- [google-cloud-trace instrumentation documentation](https://googleapis.dev/ruby/google-cloud-trace/latest/file.INSTRUMENTATION.html)[m
 - [google-cloud-trace on RubyGems](https://rubygems.org/gems/google-cloud-trace)[m
 - [Stackdriver Trace documentation](https://cloud.google.com/trace/docs/)[m
 [m
[36m@@ -35,7 +35,7 @@[m [mgem "google-cloud-trace"[m
 $ bundle install[m
 ```[m
 [m
[31m-Alternatively, check out the [`stackdriver`](../stackdriver) gem that includes[m
[32m+[m[32mAlternatively, check out the [`stackdriver`](https://googleapis.dev/ruby/stackdriver/latest) gem that includes[m
 the `google-cloud-trace` gem.[m
 [m
 ## Enable Stackdriver Trace API[m
[36m@@ -94,7 +94,7 @@[m [mend[m
 ### Configuring the library[m
 [m
 You can customize the behavior of the Stackdriver Trace library for Ruby. See[m
[31m-the [configuration guide](../stackdriver/INSTRUMENTATION_CONFIGURATION.md) for a list of[m
[32m+[m[32mthe [configuration guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html) for a list of[m
 possible configuration options.[m
 [m
 ## Running on Google Cloud Platform[m
[36m@@ -181,11 +181,11 @@[m [mend[m
 [m
 This library also supports the other authentication methods provided by the[m
 `google-cloud-ruby` suite. Instructions and configuration options are covered[m
[31m-in the [Authentication Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest/file.AUTHENTICATION).[m
[32m+[m[32min the [Authentication Guide](https://googleapis.dev/ruby/google-cloud-trace/latest/file.AUTHENTICATION.html).[m
 [m
 ## Enabling Logging[m
 [m
[31m-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
[32m+[m[32mTo enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
 [m
 Configuring a Ruby stdlib logger:[m
 [m
[36m@@ -228,18 +228,18 @@[m [mchange at any time and the public API should not be considered stable.[m
 Contributions to this library are always welcome and highly encouraged.[m
 [m
 See the [Contributing[m
[31m-Guide](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest/file.CONTRIBUTING)[m
[32m+[m[32mGuide](https://googleapis.dev/ruby/google-cloud-trace/latest/file.CONTRIBUTING.html)[m
 for more information on how to get started.[m
 [m
 Please note that this project is released with a Contributor Code of Conduct. By[m
 participating in this project you agree to abide by its terms. See [Code of[m
[31m-Conduct](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest/file.CODE_OF_CONDUCT)[m
[32m+[m[32mConduct](https://googleapis.dev/ruby/google-cloud-trace/latest/file.CODE_OF_CONDUCT.html)[m
 for more information.[m
 [m
 ## License[m
 [m
 This library is licensed under Apache 2.0. Full license text is available in[m
[31m-[LICENSE](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-trace/latest/file.LICENSE).[m
[32m+[m[32m[LICENSE](https://googleapis.dev/ruby/google-cloud-trace/latest/file.LICENSE.html).[m
 [m
 ## Support[m
 [m
[1mdiff --git a/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb b/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb[m
[1mindex 781f70a01..df0017404 100644[m
[1m--- a/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb[m
[1m+++ b/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb[m
[36m@@ -199,9 +199,8 @@[m [mmodule Google[m
         protected[m
 [m
         def init_resources![m
[31m-          @thread_pool ||= \[m
[31m-            Concurrent::CachedThreadPool.new max_threads: @threads,[m
[31m-                                             max_queue: @max_queue[m
[32m+[m[32m          @thread_pool ||= Concurrent::ThreadPoolExecutor.new \[m
[32m+[m[32m            max_threads: @threads, max_queue: @max_queue[m
           @thread ||= Thread.new { run_background }[m
           nil # returning nil because of rubocop...[m
         end[m
[1mdiff --git a/google-cloud-trace/lib/google/cloud/trace/middleware.rb b/google-cloud-trace/lib/google/cloud/trace/middleware.rb[m
[1mindex b56884291..f6f6c272f 100644[m
[1m--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb[m
[1m+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb[m
[36m@@ -148,7 +148,7 @@[m [mmodule Google[m
         # @param [Hash] kwargs Hash of configuration settings. Used for backward[m
         #   API compatibility. See the {file:INSTRUMENTATION.md Instrumentation[m
         #   Guide} and [Configuration[m
[31m-        #   Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)[m
[32m+[m[32m        #   Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)[m
         #   for the prefered way to set configuration parameters.[m
         #[m
         def initialize app, service: nil, **kwargs[m
[1mdiff --git a/google-cloud-trace/lib/google/cloud/trace/rails.rb b/google-cloud-trace/lib/google/cloud/trace/rails.rb[m
[1mindex 008f2763b..cbcda4f4f 100644[m
[1m--- a/google-cloud-trace/lib/google/cloud/trace/rails.rb[m
[1m+++ b/google-cloud-trace/lib/google/cloud/trace/rails.rb[m
[36m@@ -46,7 +46,7 @@[m [mmodule Google[m
       #[m
       # See the {file:INSTRUMENTATION.md Instrumentation Guide} and[m
       # [Configuration[m
[31m-      # Guide](https://googleapis.github.io/google-cloud-ruby/docs/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION)[m
[32m+[m[32m      # Guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)[m
       # on how to configure the Railtie and Middleware.[m
       #[m
       # ## Measuring custom functionality[m
[1mdiff --git a/google-cloud-trace/lib/google/cloud/trace/v2.rb b/google-cloud-trace/lib/google/cloud/trace/v2.rb[m
[1mindex 2ddc830e6..f2f628656 100644[m
[1m--- a/google-cloud-trace/lib/google/cloud/trace/v2.rb[m
[1m+++ b/google-cloud-trace/lib/google/cloud/trace/v2.rb[m
[36m@@ -35,7 +35,7 @@[m [mmodule Google[m
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)[m
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)[m
     # 3. [Enable the Stackdriver Trace API.](https://console.cloud.google.com/apis/api/trace)[m
[31m-    # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)[m
[32m+[m[32m    # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-trace/latest/file.AUTHENTICATION.html)[m
     #[m
     # ### Preview[m
     # #### TraceServiceClient[m

```

</details>

This pull request was generated using releasetool.