### PR TITLE
Add endpoint to constructor

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub.rb
@@ -59,6 +59,8 @@ module Google
       # @param [Integer] timeout Default timeout to use in requests. Optional.
       # @param [Hash] client_config A hash of values to override the default
       #   behavior of the API client. Optional.
+      # @param [String] endpoint Override of the endpoint host name. Optional.
+      #   If the param is nil, uses the default endpoint.
       # @param [String] emulator_host Pub/Sub emulator host. Optional.
       #   If the param is nil, uses the value of the `emulator_host` config.
       # @param [String] project Alias for the `project_id` argument. Deprecated.
@@ -70,18 +72,19 @@ module Google
       # @example
       #   require "google/cloud/pubsub"
       #
-      #   pubsub = Google::Cloud.pubsub
+      #   pubsub = Google::Cloud::PubSub.new
       #
       #   topic = pubsub.topic "my-topic"
       #   topic.publish "task completed"
       #
       def self.new project_id: nil, credentials: nil, scope: nil, timeout: nil,
-                   client_config: nil, emulator_host: nil, project: nil,
-                   keyfile: nil
+                   client_config: nil, endpoint: nil, emulator_host: nil,
+                   project: nil, keyfile: nil
         project_id    ||= (project || default_project_id)
         scope         ||= configure.scope
         timeout       ||= configure.timeout
         client_config ||= configure.client_config
+        endpoint      ||= configure.endpoint
         emulator_host ||= configure.emulator_host
 
         if emulator_host
@@ -111,7 +114,7 @@ module Google
         PubSub::Project.new(
           PubSub::Service.new(
             project_id, credentials, timeout:       timeout,
-                                     host:          configure.endpoint,
+                                     host:          endpoint,
                                      client_config: client_config
           )
         )

--- a/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
@@ -102,6 +102,7 @@ describe Google::Cloud do
         credentials.must_equal "pubsub-credentials"
         client_config.must_be :nil?
         timeout.must_be :nil?
+        host.must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -162,6 +163,7 @@ describe Google::Cloud do
         project.must_equal "project-id"
         credentials.must_equal "pubsub-credentials"
         timeout.must_be :nil?
+        host.must_be :nil?
         client_config.must_be :nil?
         OpenStruct.new project: project
       }
@@ -193,6 +195,7 @@ describe Google::Cloud do
         project.must_equal "project-id"
         credentials.must_equal "pubsub-credentials"
         timeout.must_be :nil?
+        host.must_be :nil?
         client_config.must_be :nil?
         OpenStruct.new project: project
       }
@@ -232,6 +235,34 @@ describe Google::Cloud do
       end
     end
 
+    it "allows endpoint to be set" do
+      endpoint = "localhost:4567"
+
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal default_credentials
+        timeout.must_be :nil?
+        host.must_equal endpoint
+        client_config.must_be :nil?
+        OpenStruct.new project: project, credentials: credentials
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Get project_id from Google Compute Engine
+        Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
+          Google::Cloud::PubSub::Credentials.stub :default, default_credentials do
+            Google::Cloud::PubSub::Service.stub :new, stubbed_service do
+              pubsub = Google::Cloud::PubSub.new endpoint: endpoint
+              pubsub.must_be_kind_of Google::Cloud::PubSub::Project
+              pubsub.project.must_equal "project-id"
+              pubsub.service.credentials.must_equal default_credentials
+            end
+          end
+        end
+      end
+    end
+
     it "allows emulator_host to be set" do
       emulator_host = "localhost:4567"
       # Clear all environment variables
@@ -260,6 +291,7 @@ describe Google::Cloud do
         credentials.must_be_kind_of OpenStruct
         credentials.project_id.must_equal "project-id"
         timeout.must_be :nil?
+        host.must_be :nil?
         client_config.must_be :nil?
         OpenStruct.new project: project
       }
@@ -307,6 +339,7 @@ describe Google::Cloud do
         project.must_equal "project-id"
         credentials.must_equal "pubsub-credentials"
         timeout.must_be :nil?
+        host.must_be :nil?
         client_config.must_be :nil?
         OpenStruct.new project: project
       }
@@ -344,6 +377,7 @@ describe Google::Cloud do
         project.must_equal "project-id"
         credentials.must_equal "pubsub-credentials"
         timeout.must_be :nil?
+        host.must_be :nil?
         client_config.must_be :nil?
         OpenStruct.new project: project
       }


### PR DESCRIPTION
This PR follows up on #3710 and adds `endpoint` as a constructor argument to `Google::Cloud::PubSub.new`.