### PR TITLE
Release google-cloud-pubsub 0.38.1

### DIFF
--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.38.1 / 2019-08-02
+
+* Add endpoint argument to constructor
+
 ### 0.38.0 / 2019-07-31
 
 * Allow persistence_regions to be set

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module PubSub
-      VERSION = "0.38.0".freeze
+      VERSION = "0.38.1".freeze
     end
 
     Pubsub = PubSub unless const_defined? :Pubsub


### PR DESCRIPTION
* Add endpoint argument to constructor

<details><summary>Commits since previous release</summary><pre><code>[33mcommit 0fbfd72085bbf075a2e21f8ffa8e671bf640be50[m
Author: Mike Moore <mike@blowmage.com>
Date:   Wed Jul 31 17:44:19 2019 -0600

    feat(pubsub): Add endpoint to constructor
    
    [pr #3723]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
[1mdiff --git a/google-cloud-pubsub/lib/google/cloud/pubsub.rb b/google-cloud-pubsub/lib/google/cloud/pubsub.rb[m
[1mindex fd116aa48..d1f13c242 100644[m
[1m--- a/google-cloud-pubsub/lib/google/cloud/pubsub.rb[m
[1m+++ b/google-cloud-pubsub/lib/google/cloud/pubsub.rb[m
[36m@@ -59,6 +59,8 @@[m [mmodule Google[m
       # @param [Integer] timeout Default timeout to use in requests. Optional.[m
       # @param [Hash] client_config A hash of values to override the default[m
       #   behavior of the API client. Optional.[m
[32m+[m[32m      # @param [String] endpoint Override of the endpoint host name. Optional.[m
[32m+[m[32m      #   If the param is nil, uses the default endpoint.[m
       # @param [String] emulator_host Pub/Sub emulator host. Optional.[m
       #   If the param is nil, uses the value of the `emulator_host` config.[m
       # @param [String] project Alias for the `project_id` argument. Deprecated.[m
[36m@@ -70,18 +72,19 @@[m [mmodule Google[m
       # @example[m
       #   require "google/cloud/pubsub"[m
       #[m
[31m-      #   pubsub = Google::Cloud.pubsub[m
[32m+[m[32m      #   pubsub = Google::Cloud::PubSub.new[m
       #[m
       #   topic = pubsub.topic "my-topic"[m
       #   topic.publish "task completed"[m
       #[m
       def self.new project_id: nil, credentials: nil, scope: nil, timeout: nil,[m
[31m-                   client_config: nil, emulator_host: nil, project: nil,[m
[31m-                   keyfile: nil[m
[32m+[m[32m                   client_config: nil, endpoint: nil, emulator_host: nil,[m
[32m+[m[32m                   project: nil, keyfile: nil[m
         project_id    ||= (project || default_project_id)[m
         scope         ||= configure.scope[m
         timeout       ||= configure.timeout[m
         client_config ||= configure.client_config[m
[32m+[m[32m        endpoint      ||= configure.endpoint[m
         emulator_host ||= configure.emulator_host[m
 [m
         if emulator_host[m
[36m@@ -111,7 +114,7 @@[m [mmodule Google[m
         PubSub::Project.new([m
           PubSub::Service.new([m
             project_id, credentials, timeout:       timeout,[m
[31m-                                     host:          configure.endpoint,[m
[32m+[m[32m                                     host:          endpoint,[m
                                      client_config: client_config[m
           )[m
         )[m
[1mdiff --git a/google-cloud-pubsub/test/google/cloud/pubsub_test.rb b/google-cloud-pubsub/test/google/cloud/pubsub_test.rb[m
[1mindex c24e49f4d..bb8d3078f 100644[m
[1m--- a/google-cloud-pubsub/test/google/cloud/pubsub_test.rb[m
[1m+++ b/google-cloud-pubsub/test/google/cloud/pubsub_test.rb[m
[36m@@ -102,6 +102,7 @@[m [mdescribe Google::Cloud do[m
         credentials.must_equal "pubsub-credentials"[m
         client_config.must_be :nil?[m
         timeout.must_be :nil?[m
[32m+[m[32m        host.must_be :nil?[m
         OpenStruct.new project: project[m
       }[m
 [m
[36m@@ -162,6 +163,7 @@[m [mdescribe Google::Cloud do[m
         project.must_equal "project-id"[m
         credentials.must_equal "pubsub-credentials"[m
         timeout.must_be :nil?[m
[32m+[m[32m        host.must_be :nil?[m
         client_config.must_be :nil?[m
         OpenStruct.new project: project[m
       }[m
[36m@@ -193,6 +195,7 @@[m [mdescribe Google::Cloud do[m
         project.must_equal "project-id"[m
         credentials.must_equal "pubsub-credentials"[m
         timeout.must_be :nil?[m
[32m+[m[32m        host.must_be :nil?[m
         client_config.must_be :nil?[m
         OpenStruct.new project: project[m
       }[m
[36m@@ -232,6 +235,34 @@[m [mdescribe Google::Cloud do[m
       end[m
     end[m
 [m
[32m+[m[32m    it "allows endpoint to be set" do[m
[32m+[m[32m      endpoint = "localhost:4567"[m
[32m+[m
[32m+[m[32m      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {[m
[32m+[m[32m        project.must_equal "project-id"[m
[32m+[m[32m        credentials.must_equal default_credentials[m
[32m+[m[32m        timeout.must_be :nil?[m
[32m+[m[32m        host.must_equal endpoint[m
[32m+[m[32m        client_config.must_be :nil?[m
[32m+[m[32m        OpenStruct.new project: project, credentials: credentials[m
[32m+[m[32m      }[m
[32m+[m
[32m+[m[32m      # Clear all environment variables[m
[32m+[m[32m      ENV.stub :[], nil do[m
[32m+[m[32m        # Get project_id from Google Compute Engine[m
[32m+[m[32m        Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do[m
[32m+[m[32m          Google::Cloud::PubSub::Credentials.stub :default, default_credentials do[m
[32m+[m[32m            Google::Cloud::PubSub::Service.stub :new, stubbed_service do[m
[32m+[m[32m              pubsub = Google::Cloud::PubSub.new endpoint: endpoint[m
[32m+[m[32m              pubsub.must_be_kind_of Google::Cloud::PubSub::Project[m
[32m+[m[32m              pubsub.project.must_equal "project-id"[m
[32m+[m[32m              pubsub.service.credentials.must_equal default_credentials[m
[32m+[m[32m            end[m
[32m+[m[32m          end[m
[32m+[m[32m        end[m
[32m+[m[32m      end[m
[32m+[m[32m    end[m
[32m+[m
     it "allows emulator_host to be set" do[m
       emulator_host = "localhost:4567"[m
       # Clear all environment variables[m
[36m@@ -260,6 +291,7 @@[m [mdescribe Google::Cloud do[m
         credentials.must_be_kind_of OpenStruct[m
         credentials.project_id.must_equal "project-id"[m
         timeout.must_be :nil?[m
[32m+[m[32m        host.must_be :nil?[m
         client_config.must_be :nil?[m
         OpenStruct.new project: project[m
       }[m
[36m@@ -307,6 +339,7 @@[m [mdescribe Google::Cloud do[m
         project.must_equal "project-id"[m
         credentials.must_equal "pubsub-credentials"[m
         timeout.must_be :nil?[m
[32m+[m[32m        host.must_be :nil?[m
         client_config.must_be :nil?[m
         OpenStruct.new project: project[m
       }[m
[36m@@ -344,6 +377,7 @@[m [mdescribe Google::Cloud do[m
         project.must_equal "project-id"[m
         credentials.must_equal "pubsub-credentials"[m
         timeout.must_be :nil?[m
[32m+[m[32m        host.must_be :nil?[m
         client_config.must_be :nil?[m
         OpenStruct.new project: project[m
       }[m

```

</details>

This pull request was generated using releasetool.