### PR TITLE
Use MiniMime to detect content types

### DIFF
--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-api-client", "~> 0.26"
   gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
-  gem.add_dependency "mime-types", "~> 3.0"
+  gem.add_dependency "mini_mime", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -480,7 +480,7 @@ module Google
         end
 
         def mime_type_for file
-          mime_type = MiniMime.lookup_by_filename(Pathname(file).to_path)
+          mime_type = MiniMime.lookup_by_filename Pathname(file).to_path
           return nil if mime_type.nil?
           mime_type.content_type
         rescue StandardError

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -19,7 +19,7 @@ require "google/cloud/errors"
 require "google/apis/bigquery_v2"
 require "pathname"
 require "securerandom"
-require "mime/types"
+require "mini_mime"
 require "date"
 
 module Google
@@ -480,9 +480,9 @@ module Google
         end
 
         def mime_type_for file
-          mime_type = MIME::Types.of(Pathname(file).to_path).first.to_s
-          return nil if mime_type.empty?
-          mime_type
+          mime_type = MiniMime.lookup_by_filename(Pathname(file).to_path)
+          return nil if mime_type.nil?
+          mime_type.content_type
         rescue StandardError
           nil
         end

--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
   gem.add_dependency "digest-crc", "~> 0.4"
   gem.add_dependency "addressable", "~> 2.5"
-  gem.add_dependency "mime-types", "~> 3.0"
+  gem.add_dependency "mini_mime", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -16,7 +16,7 @@
 require "google/cloud/storage/version"
 require "google/apis/storage_v1"
 require "digest"
-require "mime/types"
+require "mini_mime"
 require "pathname"
 
 module Google
@@ -455,7 +455,9 @@ module Google
         # Retrieves the mime-type for a file path.
         # An empty string is returned if no mime-type can be found.
         def mime_type_for path
-          MIME::Types.of(path).first.to_s
+          mime_type = MiniMime.lookup_by_filename path
+          return "" if mime_type.nil?
+          mime_type.content_type
         end
 
         # @private


### PR DESCRIPTION
This dependency uses less resources that mime-types.

[closes #3408]