### PR TITLE
Release google-cloud-bigtable 0.5.0

### DIFF
--- a/google-cloud-bigtable/CHANGELOG.md
+++ b/google-cloud-bigtable/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.5.0 / 2019-08-05
+
+* Accept nil gc_rule arguments for column_family create/update
+* Update documentation
+
 ### 0.4.3 / 2019-07-12
 
 * Update #to_hash to #to_h for compatibility with google-protobuf >= 3.9.0

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/version.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigtable
-      VERSION = "0.4.3".freeze
+      VERSION = "0.5.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Accept nil gc_rule arguments for column_family create/update
* Update documentation

<details><summary>Commits since previous release</summary><pre><code>commit eb61b62df9130c8a3d48df535db147350a35336b
Author: Chris Smith <quartzmo@gmail.com>
Date:   Tue Jul 30 13:09:40 2019 -0600

    feat(bigtable): Accept nil gc_rule arguments for column_family create/update
    
    [pr #3694]

commit ef5ee59d52834d845f9871aa13f50a436ae8213e
Author: Chris Smith <quartzmo@gmail.com>
Date:   Mon Jul 29 16:10:55 2019 -0600

    docs(bigtable): Fix timestamp param documentation

commit f6b43c5f656bf98487b9fd6325eb337e2e43371d
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Thu Jul 25 14:01:46 2019 -0700

    docs(bigtable): Update links to googleapis.dev

commit ac8ce21c294ea111e33142a7ba6da82786cc8935
Author: Graham Paye <paye@google.com>
Date:   Wed Jul 24 12:35:57 2019 -0700

    docs: update links to point to new docsite (#3684)

commit 1b31c4237ceda21abed2f0a3d6db423afcece024
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Jul 24 11:58:04 2019 -0700

    perf(bigtable): Update retry config in lower-level client

commit 258793b2a040b661abd03655d9ab4a93d819163d
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Jul 17 08:18:41 2019 -0700

    test(bigtable): Use #to_h for compatibility with google-protobuf >= 3.9.0

commit a90634efde846bc4a248bcbdc6e958007f03cdd6
Author: Chris Smith <quartzmo@gmail.com>
Date:   Tue Jul 16 14:12:44 2019 -0600

    test: fix conformance file paths in bigtable, firestore and storage
    
    [fixes #3654]

commit 7d697bd28b5f60735d35a75e8e1554457d0c73b9
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Jul 16 10:16:19 2019 -0700

    chore: Update synth files so they don't revert to_h fixes (#3668)
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-bigtable/LOGGING.md b/google-cloud-bigtable/LOGGING.md
index 6afa8ef76..f64fd5b03 100644
--- a/google-cloud-bigtable/LOGGING.md
+++ b/google-cloud-bigtable/LOGGING.md
@@ -5,7 +5,7 @@ To enable logging for this library, set the logger for the underlying
 that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
-[`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger)
+[`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/). See
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
diff --git a/google-cloud-bigtable/OVERVIEW.md b/google-cloud-bigtable/OVERVIEW.md
index 80146c61f..26e2589e8 100644
--- a/google-cloud-bigtable/OVERVIEW.md
+++ b/google-cloud-bigtable/OVERVIEW.md
@@ -14,7 +14,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Bigtable API.](https://console.cloud.google.com/apis/library/bigtable.googleapis.com)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud/latest/file.AUTHENTICATION)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigtable/latest/file.AUTHENTICATION.html)
 
 ### Next Steps
 - Read the [Cloud Bigtable API Product documentation][Product Documentation]
diff --git a/google-cloud-bigtable/README.md b/google-cloud-bigtable/README.md
index 4593a54e3..a88dc50e1 100644
--- a/google-cloud-bigtable/README.md
+++ b/google-cloud-bigtable/README.md
@@ -13,7 +13,7 @@ steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 3. [Enable the Cloud Bigtable API.](https://console.cloud.google.com/apis/api/bigtable)
-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigtable/latest/file.AUTHENTICATION)
+4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigtable/latest/file.AUTHENTICATION.html)
 
 ### Installation
 ```
@@ -30,7 +30,7 @@ $ gem install google-cloud-bigtable
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-logging/latest/Google/Cloud/Logging/Logger) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:
 
@@ -61,5 +61,5 @@ and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.
 
-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/docs/google-cloud-bigtable/latest
+[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-bigtable/latest
 [Product Documentation]: https://cloud.google.com/bigtable
diff --git a/google-cloud-bigtable/acceptance/bigtable/column_family_test.rb b/google-cloud-bigtable/acceptance/bigtable/column_family_test.rb
index e1fe467bd..5f3fce35b 100644
--- a/google-cloud-bigtable/acceptance/bigtable/column_family_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/column_family_test.rb
@@ -35,10 +35,33 @@ describe "Table ColumnFamily", :bigtable do
 
     cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
     cf.name.must_equal "cfcreate"
+    cf.gc_rule.wont_be :nil?
     cf.gc_rule.max_versions.must_equal 1
 
     table.reload!
-    table.column_families.find{|cf| cf.name == "cfcreate"}.wont_be :nil?
+    cf = table.column_families.find{|cf| cf.name == "cfcreate"}
+    cf.wont_be :nil?
+
+    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    cf.name.must_equal "cfcreate"
+    cf.gc_rule.max_versions.must_equal 1
+  end
+
+  it "create column family without gc_rule" do
+    gc_rule = Google::Cloud::Bigtable::GcRule.max_versions(1)
+    cf = table.column_family("cfcreate").create
+
+    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    cf.name.must_equal "cfcreate"
+    cf.gc_rule.must_be :nil?
+
+    table.reload!
+    cf = table.column_families.find{|cf| cf.name == "cfcreate"}
+    cf.wont_be :nil?
+
+    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    cf.name.must_equal "cfcreate"
+    cf.gc_rule.must_be :nil?
   end
 
   it "update column family" do
@@ -53,6 +76,19 @@ describe "Table ColumnFamily", :bigtable do
     cf.gc_rule.max_age.must_equal 300
   end
 
+  it "update column family without gc_rule" do
+    cf = table.column_families.find{|cf| cf.name == "cf1"}
+    cf.gc_rule.wont_be :nil?
+    cf.gc_rule = nil
+    updated_cf = cf.save
+    updated_cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    updated_cf.gc_rule.must_be :nil?
+
+    table.reload!
+    cf = table.column_families.find{|cf| cf.name == "cf1"}
+    cf.gc_rule.must_be :nil?
+  end
+
   it "delete column family" do
     cf = table.column_families.find{|cf| cf.name == "cf2"}
     cf.delete.must_equal true
diff --git a/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb b/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
index 05bff610b..ce564ceef 100644
--- a/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
@@ -43,11 +43,11 @@ describe "DataClient Mutate Row", :bigtable do
     table.read_row(row_key).must_be :nil?
   end
 
-  it "set cell with timestamp and delete cells with timestamp range" do
+  it "set cell with timestamp and delete cells with integer timestamp range" do
     postfix = random_str
     row_key = "setcell-#{postfix}"
     qualifier = "mutate-row-#{postfix}"
-    timestamp = (Time.now.to_i * 1000).floor
+    timestamp = (Time.now.to_f * 1000000).round(-3)
 
     # Set cell
     entry = table.new_mutation_entry(row_key)
@@ -74,6 +74,89 @@ describe "DataClient Mutate Row", :bigtable do
     row.cells[family].select{|v| v.qualifier == qualifier}.length.must_equal 1
   end
 
+  it "raises when set_cell with incorrect Time timestamp" do
+    postfix = random_str
+    row_key = "setcell-#{postfix}"
+    qualifier = "mutate-row-#{postfix}"
+
+    table.granularity.must_equal :MILLIS
+
+    # Set cell
+    entry = table.new_mutation_entry(row_key)
+    err = expect do
+      entry.set_cell(
+        family, qualifier, "mutatetest value #{postfix}", timestamp: Time.now
+      )
+    end.must_raise Google::Protobuf::TypeError
+    err.message.must_match "Expected number type for integral field 'timestamp_micros' (given Time)."
+  end
+
+  it "raises when set_cell with incorrect microsecond integer timestamp" do
+    postfix = random_str
+    row_key = "setcell-#{postfix}"
+    qualifier = "mutate-row-#{postfix}"
+    timestamp_micros = (Time.now.to_f * 1000000).round
+    timestamp_micros += 1 if (timestamp_micros % 10).zero?
+
+    table.granularity.must_equal :MILLIS
+
+    # Set cell
+    entry = table.new_mutation_entry(row_key)
+    entry.set_cell(
+      family, qualifier, "mutatetest value #{postfix}", timestamp: timestamp_micros
+    )
+    err = expect do
+      table.mutate_row(entry)
+    end.must_raise Google::Gax::RetryError
+    err.message.must_match /Timestamp granularity mismatch. Expected a multiple of 1000 \(millisecond granularity\), but got #{timestamp_micros}/
+  end
+
+  it "raises when set_cell with incorrect millisecond integer timestamp" do
+    postfix = random_str
+    row_key = "setcell-#{postfix}"
+    qualifier = "mutate-row-#{postfix}"
+    timestamp_millis = (Time.now.to_f * 1000).to_i
+    timestamp_millis += 1 if (timestamp_millis % 10).zero?
+
+    table.granularity.must_equal :MILLIS
+
+    # Set cell
+    entry = table.new_mutation_entry(row_key)
+    entry.set_cell(
+      family, qualifier, "mutatetest value #{postfix}", timestamp: timestamp_millis
+    )
+    err = expect do
+      table.mutate_row(entry)
+    end.must_raise Google::Gax::RetryError
+    err.message.must_match /Timestamp granularity mismatch. Expected a multiple of 1000 \(millisecond granularity\), but got #{timestamp_millis}/
+  end
+
+  it "set_cell with correct microseconds rounded to milliseconds integer timestamp" do
+    postfix = random_str
+    row_key = "setcell-#{postfix}"
+    qualifier = "mutate-row-#{postfix}"
+    timestamp_micros = (Time.now.to_f * 1000000).round(-3)
+
+    table.granularity.must_equal :MILLIS
+
+    # Set cell
+    entry = table.new_mutation_entry(row_key)
+    entry.set_cell(
+      family, qualifier, "mutatetest value #{postfix}", timestamp: timestamp_micros
+    )
+
+    table.mutate_row(entry).must_equal true
+    row = table.read_row(row_key)
+    cells = row.cells[family].select{|v| v.qualifier == qualifier}
+    cells.length.must_equal 1
+    cells.first.timestamp.must_equal timestamp_micros
+
+    # Delete cell
+    entry = table.new_mutation_entry(row_key)
+    entry.delete_cells family, qualifier
+    table.mutate_row(entry)
+  end
+
   it "delete all cells from specified column family" do
     postfix = random_str
     row_key = "deletecells-#{postfix}"
diff --git a/google-cloud-bigtable/acceptance/bigtable/table/row_filter_test.rb b/google-cloud-bigtable/acceptance/bigtable/table/row_filter_test.rb
index 2a9e99126..3bf5c11a4 100644
--- a/google-cloud-bigtable/acceptance/bigtable/table/row_filter_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/row_filter_test.rb
@@ -112,18 +112,18 @@ describe "DataClient Read Rows Filters", :bigtable do
   end
 
   it "timestamp range filter" do
-    timestamp = Time.now.to_i * 1000
+    timestamp_micros = (Time.now.to_f * 1000000).round(-3)
     entry = table.new_mutation_entry("timestamp-#{random_str}")
-    entry.set_cell(family, "timestamp", "timestamp range test", timestamp: timestamp)
+    entry.set_cell(family, "timestamp", "timestamp range test", timestamp: timestamp_micros)
     table.mutate_row(entry)
 
-    filter = table.filter.timestamp_range(from: timestamp)
+    filter = table.filter.timestamp_range(from: timestamp_micros)
     rows = table.read_rows(filter: filter, limit: 2).to_a
     rows.wont_be :empty?
 
     rows.each do |row|
       row.cells[family].each do |cell|
-        cell.timestamp.must_be :>=, timestamp
+        cell.timestamp.must_be :>=, timestamp_micros
       end
     end
   end
diff --git a/google-cloud-bigtable/acceptance/bigtable/table_test.rb b/google-cloud-bigtable/acceptance/bigtable/table_test.rb
index 3fb174c88..f05d33e45 100644
--- a/google-cloud-bigtable/acceptance/bigtable/table_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table_test.rb
@@ -77,7 +77,7 @@ describe "Instance Tables", :bigtable do
     table_id = "test-table-#{random_str}"
 
     table = bigtable.create_table(instance_id, table_id) do |cfs|
-      cfs.add("cf1", Google::Cloud::Bigtable::GcRule.max_versions(1))
+      cfs.add("cf1") # default service value for GcRule
       cfs.add("cf2", Google::Cloud::Bigtable::GcRule.max_versions(1))
     end
 
@@ -87,10 +87,10 @@ describe "Instance Tables", :bigtable do
     )
 
     modifications << Google::Cloud::Bigtable::ColumnFamily.update_modification(
-      "cf1", Google::Cloud::Bigtable::GcRule.max_versions(5)
+      "cf2", Google::Cloud::Bigtable::GcRule.max_versions(5)
     )
 
-    modifications << Google::Cloud::Bigtable::ColumnFamily.drop_modification("cf2")
+    modifications << Google::Cloud::Bigtable::ColumnFamily.drop_modification("cf1")
 
     updated_table = table.modify_column_families(modifications)
     updated_table.must_be_kind_of Google::Cloud::Bigtable::Table
@@ -100,10 +100,10 @@ describe "Instance Tables", :bigtable do
     cf3.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
     cf3.gc_rule.max_age.must_equal 600
 
-    cf1 = column_families.find{|c| c.name == "cf1"}
-    cf1.gc_rule.max_versions.must_equal 5
+    cf2 = column_families.find{|c| c.name == "cf2"}
+    cf2.gc_rule.max_versions.must_equal 5
 
-    column_families.find{|c| c.name == "cf2"}.must_be :nil?
+    column_families.find{|c| c.name == "cf1"}.must_be :nil?
 
     table.delete
   end
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/admin.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/admin.rb
index 573adb00e..738c93fbc 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Bigtable Admin API.](https://console.cloud.google.com/apis/library/bigtableadmin.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigtable/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2.rb
index 26a859e98..d0d4de8f0 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2.rb
@@ -38,7 +38,7 @@ module Google
         # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
         # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
         # 3. [Enable the Cloud Bigtable Admin API.](https://console.cloud.google.com/apis/library/bigtableadmin.googleapis.com)
-        # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+        # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigtable/latest/file.AUTHENTICATION.html)
         #
         # ### Installation
         # ```
@@ -57,7 +57,7 @@ module Google
         #
         # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
         # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
         # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
         # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
         #
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_config.json b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_config.json
index 0b7bb1a19..45c2a50da 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_config.json
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_config.json
@@ -6,116 +6,132 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
-        "default": {
-          "initial_retry_delay_millis": 5,
+        "idempotent_params": {
+          "initial_retry_delay_millis": 1000,
           "retry_delay_multiplier": 2.0,
           "max_retry_delay_millis": 60000,
           "initial_rpc_timeout_millis": 60000,
           "rpc_timeout_multiplier": 1.0,
           "max_rpc_timeout_millis": 60000,
           "total_timeout_millis": 600000
+        },
+        "non_idempotent_params": {
+          "initial_retry_delay_millis": 0,
+          "retry_delay_multiplier": 1.0,
+          "max_retry_delay_millis": 0,
+          "initial_rpc_timeout_millis": 60000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 60000,
+          "total_timeout_millis": 60000
+        },
+        "non_idempotent_heavy_params": {
+          "initial_retry_delay_millis": 0,
+          "retry_delay_multiplier": 1.0,
+          "max_retry_delay_millis": 0,
+          "initial_rpc_timeout_millis": 300000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 300000,
+          "total_timeout_millis": 300000
         }
       },
       "methods": {
         "CreateInstance": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_heavy_params"
         },
         "GetInstance": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "ListInstances": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "UpdateInstance": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "PartialUpdateInstance": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "DeleteInstance": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_params"
         },
         "CreateCluster": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_params"
         },
         "GetCluster": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "ListClusters": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "UpdateCluster": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "DeleteCluster": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_params"
         },
         "CreateAppProfile": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_params"
         },
         "GetAppProfile": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "ListAppProfiles": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "UpdateAppProfile": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "DeleteAppProfile": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_params"
         },
         "GetIamPolicy": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "SetIamPolicy": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_params"
         },
         "TestIamPermissions": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         }
       }
     }
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_config.json b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_config.json
index bfdf2d119..5c77c8215 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_config.json
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_config.json
@@ -9,81 +9,108 @@
         "non_idempotent": []
       },
       "retry_params": {
-        "default": {
-          "initial_retry_delay_millis": 100,
-          "retry_delay_multiplier": 1.3,
+        "idempotent_params": {
+          "initial_retry_delay_millis": 1000,
+          "retry_delay_multiplier": 2.0,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 60000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
+          "max_rpc_timeout_millis": 60000,
           "total_timeout_millis": 600000
+        },
+        "non_idempotent_params": {
+          "initial_retry_delay_millis": 0,
+          "retry_delay_multiplier": 1.0,
+          "max_retry_delay_millis": 0,
+          "initial_rpc_timeout_millis": 60000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 60000,
+          "total_timeout_millis": 60000
+        },
+        "non_idempotent_heavy_params": {
+          "initial_retry_delay_millis": 0,
+          "retry_delay_multiplier": 1.0,
+          "max_retry_delay_millis": 0,
+          "initial_rpc_timeout_millis": 300000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 300000,
+          "total_timeout_millis": 300000
+        },
+        "drop_row_range_params": {
+          "initial_retry_delay_millis": 0,
+          "retry_delay_multiplier": 1.0,
+          "max_retry_delay_millis": 0,
+          "initial_rpc_timeout_millis": 3600000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {
         "CreateTable": {
           "timeout_millis": 130000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_heavy_params"
         },
         "CreateTableFromSnapshot": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_params"
         },
         "ListTables": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "GetTable": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "DeleteTable": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_params"
         },
         "ModifyColumnFamilies": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_heavy_params"
         },
         "DropRowRange": {
           "timeout_millis": 900000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "drop_row_range_params"
         },
         "GenerateConsistencyToken": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "CheckConsistency": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "SnapshotTable": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_params"
         },
         "GetSnapshot": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "ListSnapshots": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "DeleteSnapshot": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_params"
         }
       }
     }
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/column_family.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/column_family.rb
index 5cfc521d4..17200b67f 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/column_family.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/column_family.rb
@@ -34,7 +34,7 @@ module Google
       #
       #   # Create
       #   gc_rule = Google::Cloud::Bigtable::GcRule.max_versions(5)
-      #   column_family = table.column_families.create("cf1", gc_rule: gc_rule)
+      #   column_family = table.column_families.add("cf1", gc_rule)
       #
       #   # Update
       #   column_family = table.column_families.find_by_name("cf2")
@@ -74,10 +74,11 @@ module Google
 
         # Set Column Family garbage collection rules
         #
-        # @param rule [Google::Cloud::Bigtable::GcRule]
+        # @param rule [Google::Cloud::Bigtable::GcRule, nil] the new rule, or
+        #   `nil` for the service default value.
         #
         def gc_rule= rule
-          @grpc.gc_rule = rule.to_grpc
+          @grpc.gc_rule = rule.nil? ? nil : rule.to_grpc
         end
 
         # Get garbage collection rule
@@ -151,7 +152,9 @@ module Google
         # Create gPRC instance to create column family modification
         #
         # @param name [String] Column family name
-        # @param gc_rule [Google::Cloud::Bigtable::GcRule] GC Rule
+        # @param gc_rule [Google::Cloud::Bigtable::GcRule] The garbage
+        #   collection rule to be used for the column family. Optional. The
+        #   service default value will be used when not specified.
         # @return [Google::Bigtable::Admin::V2::ModifyColumnFamiliesRequest::Modification]
         #
         # @example
@@ -168,7 +171,9 @@ module Google
         # Create update column family modification gPRC instance
         #
         # @param name [String] Column family name
-        # @param gc_rule [Google::Cloud::Bigtable::GcRule] GC Rule
+        # @param gc_rule [Google::Cloud::Bigtable::GcRule] The garbage
+        #   collection rule to be used for the column family. Optional. The
+        #   service default value will be used when not specified.
         # @return [Google::Bigtable::Admin::V2::ModifyColumnFamiliesRequest::Modification]
         #
         # @example
@@ -227,8 +232,9 @@ module Google
         # @param type [Symbol] Type of modification.
         #   Valid values are `:create`, `:update`, `drop`
         # @param family_name [String] Column family name
-        # @param gc_rule [Google::Cloud::Bigtable::GcRule]
-        #   Required for only create and update modification type.
+        # @param gc_rule [Google::Cloud::Bigtable::GcRule] The garbage
+        #   collection rule to be used for the column family. Optional. The
+        #   service default value will be used when not specified.
         # @return [Google::Bigtable::Admin::V2::ModifyColumnFamiliesRequest::Modification]
         #
         def self.column_modification_grpc type, family_name, gc_rule = nil
@@ -237,9 +243,9 @@ module Google
           attrs[type] = if type == :drop
                           true
                         else
-                          Google::Bigtable::Admin::V2::ColumnFamily.new(
-                            gc_rule: gc_rule.to_grpc
-                          )
+                          cf = Google::Bigtable::Admin::V2::ColumnFamily.new
+                          cf.gc_rule = gc_rule.to_grpc if gc_rule
+                          cf
                         end
 
           Google::Bigtable::Admin::V2::ModifyColumnFamiliesRequest:: \
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
index c9e82257d..d7e720cfc 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
@@ -486,7 +486,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: Time.now.to_i * 1000 # Time stamp in milli seconds.
+        #     timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
         #   ).delete_cells("cf2", "field02")
         #
         #   table.mutate_row(entry)
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
index 86b8bd782..742fa9ccd 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
@@ -31,13 +31,14 @@ module Google
       #
       # @example
       #   entry = Google::Cloud::Bigtable::MutationEntry.new("user-1")
+      #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
       #   entry.set_cell(
-      #     "cf1", "fiel01", "XYZ", timestamp: Time.now.to_i * 1000
+      #     "cf1", "fiel01", "XYZ", timestamp: timestamp_micros
       #   ).delete_cells(
       #     "cf2",
       #     "field02",
-      #     timestamp_from: (Time.now.to_i - 1800) * 1000,
-      #     timestamp_to: (Time.now.to_i * 1000)
+      #     timestamp_from: timestamp_micros - 5000000,
+      #     timestamp_to: timestamp_micros
       #   ).delete_from_family("cf3").delete_from_row
       #
       # @example Using table
@@ -47,8 +48,9 @@ module Google
       #   table = bigtable.table("my-instance", "my-table")
       #
       #   entry = table.new_mutation_entry("user-1")
+      #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
       #   entry.set_cell(
-      #     "cf1", "fiel01", "XYZ", timestamp: Time.now.to_i * 1000
+      #     "cf1", "fiel01", "XYZ", timestamp: timestamp_micros
       #   )
       #
       class MutationEntry
@@ -79,12 +81,15 @@ module Google
         #   Can be any byte string, including an empty string.
         # @param value [String, Integer] Cell value data.
         #   The value to be written into the specified cell.
-        # @param timestamp [Time, Integer] Timestamp value.
+        # @param timestamp [Integer] Timestamp value in microseconds.
         #   The timestamp of the cell into which new data should be written.
         #   Use -1 for current Bigtable server time.
         #   Otherwise, the client should set this value itself, noting that the
         #   default value is a timestamp of zero if the field is left unspecified.
-        #   Values must match the granularity of the table (micros or millis, for example).
+        #   Values are in microseconds but must match the granularity of the
+        #   table. Therefore, if {Table#granularity} is `MILLIS` (the default),
+        #   the given value must be a multiple of 1000 (millisecond
+        #   granularity). For example: `1564257960168000`.
         # @return [MutationEntry]  `self` object of entry for chaining.
         #
         # @example
@@ -97,7 +102,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: Time.now.to_i * 1000 # Time stamp in millis seconds.
+        #     timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
         #   )
         #
         def set_cell family, qualifier, value, timestamp: nil
@@ -128,10 +133,18 @@ module Google
         # @param qualifier [String] Column qualifier name.
         #   The qualifier of the column from which cells should be deleted.
         #   Can be any byte string, including an empty string.
-        # @param timestamp_from [Integer] Timestamp lower boundary. Optional.
-        #   The range of timestamps from which cells should be deleted.
-        # @param timestamp_to [Integer] Timestamp upper boundary. Optional.
-        #   The range of timestamps from which cells should be deleted.
+        # @param timestamp_from [Integer] Timestamp lower boundary in
+        #   microseconds. Optional. Begins the range of timestamps from which
+        #   cells should be deleted. Values are in microseconds but must match
+        #   the granularity of the table. Therefore, if {Table#granularity} is
+        #   `MILLIS` (the default), the given value must be a multiple of 1000
+        #   (millisecond granularity). For example: `1564257960168000`.
+        # @param timestamp_to [Integer] Timestamp upper boundary in
+        #   microseconds. Optional. Ends the range of timestamps from which
+        #   cells should be deleted. Values are in microseconds but must match
+        #   the granularity of the table. Therefore, if {Table#granularity} is
+        #   `MILLIS` (the default), the given value must be a multiple of 1000
+        #   (millisecond granularity). For example: `1564257960168000`.
         # @return [MutationEntry] `self` object of entry for chaining.
         #
         # @example Without timestamp range
@@ -140,18 +153,20 @@ module Google
         #
         # @example With timestamp range
         #   entry = Google::Cloud::Bigtable::MutationEntry.new("user-1")
+        #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
         #   entry.delete_cells(
         #     "cf1",
         #     "field-1",
-        #     timestamp_from: (Time.now.to_i - 1800) * 1000,
-        #     timestamp_to: (Time.now.to_i * 1000)
+        #     timestamp_from: timestamp_micros - 5000000,
+        #     timestamp_to: timestamp_micros
         #   )
         # @example With timestamp range with lower boundary only
         #   entry = Google::Cloud::Bigtable::MutationEntry.new("user-1")
+        #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
         #   entry.delete_cells(
         #     "cf1",
         #     "field-1",
-        #     timestamp_from: (Time.now.to_i - 1800) * 1000
+        #     timestamp_from: timestamp_micros - 5000000
         #   )
         #
         def delete_cells \
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
index 850ef3e98..033157f61 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
@@ -67,7 +67,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: Time.now.to_i * 1000 # Time stamp in milli seconds.
+        #     timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
         #   ).delete_cells("cf2", "field02")
         #
         #   table.mutate_row(entry)
@@ -216,7 +216,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: Time.now.to_i * 1000 # Time stamp in micro seconds.
+        #     timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
         #   ).delete_cells("cf2", "field02")
         #
         #   otherwise_mutations = Google::Cloud::Bigtable::MutationEntry.new
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
index 187b4fa6e..70c829b8b 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
@@ -360,7 +360,7 @@ module Google
         #     "cf-1",
         #     "field-1",
         #     "XYZ",
-        #     timestamp: Time.now.to_i * 1000  # Timestamp in milliseconds.
+        #     timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
         #   ).delete_cells("cf2", "field02")
         #
         #   table.mutate_row(entry)
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/row.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/row.rb
index 27b4b1868..fe64a7b40 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/row.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/row.rb
@@ -32,7 +32,7 @@ module Google
           #
           # @param family [String] Column family name
           # @param qualifier [String] Column cell qualifier name
-          # @param timestamp [Integer] Timestamp in micro seconds
+          # @param timestamp [Integer] Timestamp in microseconds
           # @param value [String] Cell value
           # @param labels [Array<String>] List of label array
 
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter.rb
index 2d0c714c2..6cd6cce67 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter.rb
@@ -527,8 +527,9 @@ module Google
         #
         # @example
         #
-        #   from = (Time.now - 300).to_i * 1000
-        #   to = Time.now.to_f * 1000
+        #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
+        #   from = timestamp_micros - 300000000
+        #   to = timestamp_micros
         #
         #   filter = Google::Cloud::Bigtable::RowFilter.timestamp_range(from: from, to: to)
         #
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/chain_filter.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/chain_filter.rb
index 162046811..88420a448 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/chain_filter.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/chain_filter.rb
@@ -433,8 +433,9 @@ module Google
           #
           # @example
           #
-          #   from = (Time.now - 300).to_i * 1000 # 300 seconds ago
-          #   to = Time.now.to_f * 1000
+          #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
+          #   from = timestamp_micros - 300000000
+          #   to = timestamp_micros
           #
           #   filter = Google::Cloud::Bigtable::RowFilter.chain.timestamp_range(from: from, to: to)
           #
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/interleave_filter.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/interleave_filter.rb
index 09f7d74ce..71fd68101 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/interleave_filter.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/row_filter/interleave_filter.rb
@@ -465,8 +465,9 @@ module Google
           #
           # @example
           #
-          #   from = (Time.now - 300).to_f * 1000
-          #   to = Time.now.to_f * 1000
+          #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
+          #   from = timestamp_micros - 300000000
+          #   to = timestamp_micros
           #
           #   filter = Google::Cloud::Bigtable::RowFilter.interleave.timestamp_range(from: from, to: to)
           #
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
index 8216bc3a2..65e983e31 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
@@ -238,8 +238,9 @@ module Google
         # update, or delete operations.
         #
         # @param name [String] Name of the column family
-        # @param gc_rule [Google::Cloud::Bigtable::GcRule] Optional.
-        #   Required for create and update operations.
+        # @param gc_rule [Google::Cloud::Bigtable::GcRule] The garbage
+        #   collection rule to be used for the column family. Optional. The
+        #   service default value will be used when not specified.
         #
         # @example Create column family
         #   require "google/cloud/bigtable"
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/table/column_family_map.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/table/column_family_map.rb
index d02f0d045..7b786e006 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/table/column_family_map.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/table/column_family_map.rb
@@ -37,7 +37,9 @@ module Google
           # Adds a column family.
           #
           # @param name [String] Column family name
-          # @param gc_rule [Google::Bigtable::GcRule] GC Rule
+          # @param gc_rule [Google::Cloud::Bigtable::GcRule] The garbage
+          #   collection rule to be used for the column family. Optional. The
+          #   service default value will be used when not specified.
           # @example
           #  column_families = Google::Cloud::Bigtable::Instance::ColumnFamilyMap.new
           #
@@ -47,10 +49,10 @@ module Google
           #  gc_rule = Google::Cloud::Bigtable::GcRule.max_age(1800)
           #  column_families.add('cf2', gc_rule)
 
-          def add name, gc_rule
-            self[name] = Google::Bigtable::Admin::V2::ColumnFamily.new(
-              gc_rule: gc_rule.to_grpc
-            )
+          def add name, gc_rule = nil
+            cf = Google::Bigtable::Admin::V2::ColumnFamily.new
+            cf.gc_rule = gc_rule.to_grpc if gc_rule
+            self[name] = cf
           end
 
           # Removes a column family from the map.
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/v2.rb b/google-cloud-bigtable/lib/google/cloud/bigtable/v2.rb
index cc83904b5..d4c865f5d 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2.rb
@@ -35,7 +35,7 @@ module Google
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
       # 3. [Enable the Cloud Bigtable API.](https://console.cloud.google.com/apis/library/bigtable.googleapis.com)
-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigtable/latest/file.AUTHENTICATION.html)
       #
       # ### Installation
       # ```
@@ -54,7 +54,7 @@ module Google
       #
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
       #
diff --git a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/bigtable_client_config.json b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/bigtable_client_config.json
index 0ff37cedb..51f325943 100644
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/bigtable_client_config.json
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/bigtable_client_config.json
@@ -9,55 +9,73 @@
         "non_idempotent": []
       },
       "retry_params": {
-        "default": {
-          "initial_retry_delay_millis": 100,
-          "retry_delay_multiplier": 1.3,
+        "idempotent_params": {
+          "initial_retry_delay_millis": 10,
+          "retry_delay_multiplier": 2.0,
           "max_retry_delay_millis": 60000,
           "initial_rpc_timeout_millis": 20000,
           "rpc_timeout_multiplier": 1.0,
           "max_rpc_timeout_millis": 20000,
           "total_timeout_millis": 600000
         },
-        "streaming": {
-          "initial_retry_delay_millis": 100,
-          "retry_delay_multiplier": 1.3,
+        "non_idempotent_params": {
+          "initial_retry_delay_millis": 10,
+          "retry_delay_multiplier": 2.0,
           "max_retry_delay_millis": 60000,
           "initial_rpc_timeout_millis": 20000,
           "rpc_timeout_multiplier": 1.0,
           "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 3600000
+          "total_timeout_millis": 20000
+        },
+        "read_rows_params": {
+          "initial_retry_delay_millis": 10,
+          "retry_delay_multiplier": 2.0,
+          "max_retry_delay_millis": 60000,
+          "initial_rpc_timeout_millis": 300000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 300000,
+          "total_timeout_millis": 43200000
+        },
+        "mutate_rows_params": {
+          "initial_retry_delay_millis": 10,
+          "retry_delay_multiplier": 2.0,
+          "max_retry_delay_millis": 60000,
+          "initial_rpc_timeout_millis": 60000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 60000,
+          "total_timeout_millis": 600000
         }
       },
       "methods": {
         "ReadRows": {
-          "timeout_millis": 3600000,
+          "timeout_millis": 43200000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "streaming"
+          "retry_params_name": "read_rows_params"
         },
         "SampleRowKeys": {
-          "timeout_millis": 60000,
+          "timeout_millis": 20000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "MutateRow": {
-          "timeout_millis": 60000,
+          "timeout_millis": 20000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "idempotent_params"
         },
         "MutateRows": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "mutate_rows_params"
         },
         "CheckAndMutateRow": {
-          "timeout_millis": 60000,
+          "timeout_millis": 20000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_params"
         },
         "ReadModifyWriteRow": {
-          "timeout_millis": 60000,
+          "timeout_millis": 20000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "non_idempotent_params"
         }
       }
     }
diff --git a/google-cloud-bigtable/samples/README.md b/google-cloud-bigtable/samples/README.md
index dd6461dc2..1a4f41ab9 100644
--- a/google-cloud-bigtable/samples/README.md
+++ b/google-cloud-bigtable/samples/README.md
@@ -23,7 +23,7 @@
 ## Before you begin
 
 Before running the samples, make sure you've followed the steps in the
-[Before you begin section](../README.md#before-you-begin) of the client
+[Before you begin section](https://github.com/googleapis/google-cloud-ruby/tree/master/google-cloud-bigtable/samples#before-you-begin) of the client
 library's README.
 
 ## Samples
diff --git a/google-cloud-bigtable/synth.metadata b/google-cloud-bigtable/synth.metadata
index d5f38a859..9bdfc0243 100644
--- a/google-cloud-bigtable/synth.metadata
+++ b/google-cloud-bigtable/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-07-02T10:37:52.742266Z",
+  "updateTime": "2019-07-25T10:38:22.875538Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.29.3",
-        "dockerImage": "googleapis/artman@sha256:8900f94a81adaab0238965aa8a7b3648791f4f3a95ee65adc6a56cfcc3753101"
+        "version": "0.31.0",
+        "dockerImage": "googleapis/artman@sha256:9aed6bbde54e26d2fcde7aa86d9f64c0278f741e58808c46573e488cbf6098f0"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "5322233f8cbec4d3f8c17feca2507ef27d4a07c9",
-        "internalRef": "256042411"
+        "sha": "4b12afe72950f36bef6f196a05f4430e4421a873",
+        "internalRef": "259790363"
       }
     }
   ],
diff --git a/google-cloud-bigtable/synth.py b/google-cloud-bigtable/synth.py
index 902f4269d..6737ebd93 100644
--- a/google-cloud-bigtable/synth.py
+++ b/google-cloud-bigtable/synth.py
@@ -137,6 +137,18 @@ s.replace(
     ],
     '/bigtable-admin\\.googleapis\\.com', '/bigtableadmin.googleapis.com')
 
+# Fix for tests that assume protos implement to_hash
+s.replace(
+    'test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb',
+    'assert_equal\\(clusters, request\\.clusters\\)',
+    'assert_equal(clusters, request.clusters.to_h)'
+)
+s.replace(
+    'test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb',
+    'assert_equal\\(labels, request\\.labels\\)',
+    'assert_equal(labels, request.labels.to_h)'
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2232
 s.replace(
     [
@@ -207,3 +219,15 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::Bigtable::VERSION'
 )
+
+# Fix links for devsite migration
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
+    'https://googleapis.dev/ruby/google-cloud-logging/latest'
+)
+s.replace(
+    'lib/**/*.rb',
+    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
+    'https://googleapis.dev/ruby/google-cloud-bigtable/latest/file.AUTHENTICATION.html'
+)
diff --git a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
index 5322d2d93..a96b35e27 100644
--- a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
@@ -455,7 +455,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
               formatted_name,
               display_name,
               type,
-              labels.to_h
+              labels
             )
           end
 
@@ -1826,4 +1826,4 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
       end
     end
   end
-end
+end
\ No newline at end of file
diff --git a/google-cloud-bigtable/test/google/cloud/bigtable/column_family/modifications_test.rb b/google-cloud-bigtable/test/google/cloud/bigtable/column_family/modifications_test.rb
index c54047493..e8087dc62 100644
--- a/google-cloud-bigtable/test/google/cloud/bigtable/column_family/modifications_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/column_family/modifications_test.rb
@@ -93,6 +93,38 @@ describe Google::Cloud::Bigtable::ColumnFamily, :create, :mock_bigtable do
     mock.verify
   end
 
+  it "create column family with nil gc_rule" do
+    new_cf_name = "new-cf"
+
+    get_res = Google::Bigtable::Admin::V2::Table.new(
+      name: table_path(instance_id, table_id),
+      column_families: {
+        new_cf_name => Google::Bigtable::Admin::V2::ColumnFamily.new
+      }
+    )
+    modifications = [
+      Google::Bigtable::Admin::V2::ModifyColumnFamiliesRequest::Modification.new(
+        id: new_cf_name,
+        create: Google::Bigtable::Admin::V2::ColumnFamily.new
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :modify_column_families, get_res, [
+                                         table_path(instance_id, table_id),
+                                         modifications
+                                       ]
+    bigtable.service.mocked_tables = mock
+
+    column_family = table.column_family(new_cf_name)
+    column_family.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+
+    created_column = column_family.create
+    created_column.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+
+    mock.verify
+  end
+
   it "update column family" do
     cf_name = "cf"
     cf_grpc = Google::Bigtable::Admin::V2::ColumnFamily.new(
@@ -137,7 +169,51 @@ describe Google::Cloud::Bigtable::ColumnFamily, :create, :mock_bigtable do
     mock.verify
   end
 
-  it "delelte column family" do
+  it "update column family with nil gc_rule" do
+    cf_name = "cf"
+    cf_grpc = Google::Bigtable::Admin::V2::ColumnFamily.new(
+      gc_rule: Google::Bigtable::Admin::V2::GcRule.new(max_num_versions: 3)
+    )
+    column_family = Google::Cloud::Bigtable::ColumnFamily.from_grpc(
+      cf_grpc,
+      bigtable.service,
+      name: cf_name,
+      instance_id: instance_id,
+      table_id: table_id
+    )
+
+    get_res = Google::Bigtable::Admin::V2::Table.new(
+      name: table_path(instance_id, table_id),
+      column_families: {
+        cf_name => Google::Bigtable::Admin::V2::ColumnFamily.new(
+          gc_rule: nil
+        )
+      }
+    )
+    modifications = [
+      Google::Bigtable::Admin::V2::ModifyColumnFamiliesRequest::Modification.new(
+        id: cf_name,
+        update: Google::Bigtable::Admin::V2::ColumnFamily.new(
+          gc_rule: nil
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :modify_column_families, get_res, [
+                                         table_path(instance_id, table_id),
+                                         modifications
+                                       ]
+    bigtable.service.mocked_tables = mock
+
+    column_family.gc_rule = nil
+    updated_cf = column_family.save
+    updated_cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+
+    mock.verify
+  end
+
+  it "delete column family" do
     cf_name = "cf"
     cf_grpc = Google::Bigtable::Admin::V2::ColumnFamily.new(
       gc_rule: Google::Bigtable::Admin::V2::GcRule.new(max_num_versions: 3)
diff --git a/google-cloud-bigtable/test/google/cloud/bigtable/conformance_test.rb b/google-cloud-bigtable/test/google/cloud/bigtable/conformance_test.rb
index 7b7936498..b77beff01 100644
--- a/google-cloud-bigtable/test/google/cloud/bigtable/conformance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/conformance_test.rb
@@ -95,7 +95,7 @@ class ReadRowsTest < MockBigtable
   end
 end
 
-file_path = "conformance/v2/readrows.json"
+file_path = File.expand_path "../../../../conformance/v2/readrows.json", __dir__
 test_file = Google::Cloud::Conformance::Bigtable::V2::TestFile.decode_json File.read(file_path)
 test_file.read_rows_tests.each_with_index do |test, index|
   ReadRowsTest.build_test_for test, index
diff --git a/google-cloud-bigtable/test/google/cloud/bigtable/mutation_entry_test.rb b/google-cloud-bigtable/test/google/cloud/bigtable/mutation_entry_test.rb
index 56b65cd59..9e02b25b0 100644
--- a/google-cloud-bigtable/test/google/cloud/bigtable/mutation_entry_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/mutation_entry_test.rb
@@ -59,7 +59,7 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
     end
 
     it "add set cell mutation with timestamp" do
-      timestamp = Time.now.to_i * 1000
+      timestamp = timestamp_micros
       entry = Google::Cloud::Bigtable::MutationEntry.new(row_key)
       entry.set_cell(family, qualifier, cell_value, timestamp: timestamp)
       entry.mutations.length.must_equal 1
@@ -112,7 +112,7 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
     end
 
     it "add delete cells mutation with from timestamp" do
-      timestamp_from = Time.now.to_i * 1000
+      timestamp_from = timestamp_micros
 
       entry = Google::Cloud::Bigtable::MutationEntry.new(row_key)
       entry.delete_cells(family, qualifier, timestamp_from: timestamp_from)
@@ -130,7 +130,7 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
     end
 
     it "add delete cells mutation with to timestamp range" do
-      timestamp_to = Time.now.to_i * 1000
+      timestamp_to = timestamp_micros
 
       entry = Google::Cloud::Bigtable::MutationEntry.new(row_key)
       entry.delete_cells(family, qualifier, timestamp_to: timestamp_to)
@@ -148,8 +148,8 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
     end
 
     it "add delete cells mutation with timestamp range" do
-      timestamp_from = Time.now.to_i * 1000
-      timestamp_to = Time.now.to_i * 1000 + 1000
+      timestamp_from = timestamp_micros
+      timestamp_to = timestamp_micros + 1000000
 
       entry = Google::Cloud::Bigtable::MutationEntry.new(row_key)
       entry.delete_cells(family, qualifier, timestamp_from: timestamp_from, timestamp_to: timestamp_to)
diff --git a/google-cloud-bigtable/test/google/cloud/bigtable/project/modify_column_families_test.rb b/google-cloud-bigtable/test/google/cloud/bigtable/project/modify_column_families_test.rb
index c38a39017..db155f2c9 100644
--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/modify_column_families_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/modify_column_families_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::Bigtable::Project, :modify_column_families, :mock_bigtab
 
     column_families = Google::Cloud::Bigtable::Table::ColumnFamilyMap.new.tap do |cfs|
       cfs.add('cf1', Google::Cloud::Bigtable::GcRule.max_age(300))
-      cfs.add('cf2', Google::Cloud::Bigtable::GcRule.max_versions(3))
+      cfs.add('cf2') # service default GcRule
     end
     cluster_states = clusters_state_grpc(num: 1)
     res_table = Google::Bigtable::Admin::V2::Table.new(
@@ -60,9 +60,8 @@ describe Google::Cloud::Bigtable::Project, :modify_column_families, :mock_bigtab
     table.granularity.must_equal :MILLIS
   
     table.column_families.map(&:name).sort.must_equal column_families.keys
-    table.column_families.each do |cf|
-      cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
-    end
+    table.column_families[0].gc_rule.to_grpc.must_equal Google::Cloud::Bigtable::GcRule.max_age(300).to_grpc
+    table.column_families[1].gc_rule.must_be :nil?
   end
 
   it "modify single column family in table" do
diff --git a/google-cloud-bigtable/test/google/cloud/bigtable/row_filter_test.rb b/google-cloud-bigtable/test/google/cloud/bigtable/row_filter_test.rb
index 8cdbe6923..00991f180 100644
--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_filter_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_filter_test.rb
@@ -117,8 +117,8 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
 
   describe "timestamp_range" do
     it "create timestamp_range filter" do
-      from = (Time.now.to_i - 300) * 1000
-      to = Time.now.to_i * 1000
+      from = timestamp_micros - 3000000
+      to = timestamp_micros
 
       filter = Google::Cloud::Bigtable::RowFilter.timestamp_range(from: from, to: to)
 
@@ -131,7 +131,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     end
 
     it "create timestamp_range filter with only from range" do
-      from = (Time.now.to_i - 300) * 1000
+      from = timestamp_micros - 3000000
       filter = Google::Cloud::Bigtable::RowFilter.timestamp_range(from: from)
 
       filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
@@ -143,7 +143,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     end
 
     it "create timestamp_range filter with only to range" do
-      to = Time.now.to_i * 1000
+      to = timestamp_micros
       filter = Google::Cloud::Bigtable::RowFilter.timestamp_range(to: to)
 
       filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
diff --git a/google-cloud-bigtable/test/google/cloud/bigtable/table/column_family_map_test.rb b/google-cloud-bigtable/test/google/cloud/bigtable/table/column_family_map_test.rb
index e853baef2..f3ad9cbe6 100644
--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/column_family_map_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/column_family_map_test.rb
@@ -18,7 +18,7 @@
 require "helper"
 
 describe Google::Cloud::Bigtable::Table::ColumnFamilyMap, :mock_bigtable do
-  it "add column family to map" do
+  it "adds a column family" do
     cfs_map = Google::Cloud::Bigtable::Table::ColumnFamilyMap.new
     cfs_map.must_be :empty?
 
@@ -32,4 +32,17 @@ describe Google::Cloud::Bigtable::Table::ColumnFamilyMap, :mock_bigtable do
     cfs_map.gc_rule.must_be_kind_of Google::Bigtable::Admin::V2::GcRule
     cfs_map.gc_rule.must_equal gc_rule.to_grpc
   end
+
+  it "adds a column family without gc_rule" do
+    cfs_map = Google::Cloud::Bigtable::Table::ColumnFamilyMap.new
+    cfs_map.must_be :empty?
+
+    cf_name = "new-cf"
+    cfs_map.add(cf_name)
+
+    cfs_map.length.must_equal 1
+    cfs_map = cfs_map[cf_name]
+    cfs_map.must_be_kind_of Google::Bigtable::Admin::V2::ColumnFamily
+    cfs_map.gc_rule.must_be :nil?
+  end
 end
diff --git a/google-cloud-bigtable/test/google/cloud/bigtable/table/modify_column_families_test.rb b/google-cloud-bigtable/test/google/cloud/bigtable/table/modify_column_families_test.rb
index 22fb7ea0b..c7e9ffdd9 100644
--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/modify_column_families_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/modify_column_families_test.rb
@@ -46,7 +46,7 @@ describe Google::Cloud::Bigtable::Table, :modify_column_families, :mock_bigtable
 
     column_families = Google::Cloud::Bigtable::Table::ColumnFamilyMap.new.tap do |cfs|
       cfs.add('cf1', Google::Cloud::Bigtable::GcRule.max_age(300))
-      cfs.add('cf2', Google::Cloud::Bigtable::GcRule.max_versions(3))
+      cfs.add('cf2') # service default GcRule
     end
     cluster_states = clusters_state_grpc(num: 1)
     res_table = Google::Bigtable::Admin::V2::Table.new(
@@ -74,8 +74,7 @@ describe Google::Cloud::Bigtable::Table, :modify_column_families, :mock_bigtable
     updated_table.path.must_equal table_path(instance_id, table_id)
     updated_table.granularity.must_equal :MILLIS
     updated_table.column_families.map(&:name).sort.must_equal column_families.keys
-    updated_table.column_families.each do |cf|
-      cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
-    end
+    updated_table.column_families[0].gc_rule.to_grpc.must_equal Google::Cloud::Bigtable::GcRule.max_age(300).to_grpc
+    updated_table.column_families[1].gc_rule.must_be :nil?
   end
 end
diff --git a/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_rows_test.rb b/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_rows_test.rb
index 20463be2c..adff6e777 100644
--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_rows_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_rows_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
   let(:family) {  "cf" }
   let(:qualifier) {  "field1" }
   let(:cell_value) { "xyz" }
-  let(:timestamp) { Time.now.to_i * 1000 }
+  let(:timestamp) { timestamp_micros }
   let(:mutation_gprc) {
     Google::Bigtable::V2::Mutation.new(set_cell: {
       family_name: family, column_qualifier: qualifier, value: cell_value, timestamp_micros: timestamp
@@ -42,7 +42,7 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
       mutation = Google::Bigtable::V2::Mutation.new(set_cell: {
         family_name: "cf#{i}",
         column_qualifier: "field01",
-        timestamp_micros: Time.now.to_i * 1000,
+        timestamp_micros: timestamp_micros,
         value: "XYZ-#{i}"
       })
       Google::Bigtable::V2::MutateRowsRequest::Entry.new(
diff --git a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
index 6dd4d9a6f..725969918 100644
--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
@@ -21,7 +21,7 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable
   let(:instance_id) { "test-instance" }
   let(:table_id) { "test-table" }
   let(:family_name) { "cf" }
-  let(:timestamp_micros) { 1527625039663 }
+  let(:timestamp) { 1564257960168000 }
   let(:labels) { ["test-labels"] }
   let(:qualifier) { "field01" }
   let(:cell_value) { "xyz" }
@@ -37,7 +37,7 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable
 
     row_key = "user-1"
 
-    cell = { value: cell_value, timestamp_micros: timestamp_micros, labels: labels }
+    cell = { value: cell_value, timestamp_micros: timestamp, labels: labels }
     column = {
       qualifier: qualifier,
       cells: [cell]
@@ -71,7 +71,7 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable
     cell.value.must_equal cell_value
     cell.family.must_equal family_name
     cell.qualifier.must_equal qualifier
-    cell.timestamp.must_equal timestamp_micros
+    cell.timestamp.must_equal timestamp
     cell.labels.must_equal labels
   end
 
diff --git a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
index 78d6c4c69..5064c22b6 100644
--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
   let(:family) {  "cf" }
   let(:qualifier) {  "field1" }
   let(:cell_value) { "xyz" }
-  let(:timestamp) { Time.now.to_i * 1000 }
+  let(:timestamp) { timestamp_micros }
 
   it "read rows" do
     mock = Minitest::Mock.new
diff --git a/google-cloud-bigtable/test/helper.rb b/google-cloud-bigtable/test/helper.rb
index 35fa5ae0e..0486c56f7 100644
--- a/google-cloud-bigtable/test/helper.rb
+++ b/google-cloud-bigtable/test/helper.rb
@@ -222,6 +222,11 @@ class MockBigtable < Minitest::Spec
   def paged_enum_struct response
     OpenStruct.new(page: OpenStruct.new(response: response))
   end
+
+# A microseconds integer rounded to the nearest millisecond. For example: `1564257960168000`.
+  def timestamp_micros
+    (Time.now.to_f * 1000000).round(-3)
+  end
 end
 
 class MockPagedEnumerable

```

</details>

This pull request was generated using releasetool.