### PR TITLE
Update Data#total assertions

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -338,7 +338,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     data.class.must_equal Google::Cloud::Bigquery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
-    [nil, 0].must_include data.total
+    data.total.wont_be :nil?
     data.count.wont_be :nil?
     data.all(request_limit: 2).each do |row|
       row.must_be_kind_of Hash
@@ -391,7 +391,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     data.class.must_equal Google::Cloud::Bigquery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
-    [nil, 0].must_include data.total
+    data.total.wont_be :nil?
     data.count.wont_be :nil?
     data.all(request_limit: 2).each do |row|
       row.must_be_kind_of Hash
@@ -412,7 +412,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     data.class.must_equal Google::Cloud::Bigquery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
-    [nil, 0].must_include data.total
+    data.total.wont_be :nil?
     data.count.wont_be :nil?
     data.all(request_limit: 2).each do |row|
       row.must_be_kind_of Hash
@@ -444,7 +444,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     data.class.must_equal Google::Cloud::Bigquery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
-    [nil, 0].must_include data.total
+    data.total.wont_be :nil?
     data.count.wont_be :nil?
     data.all(request_limit: 2).each do |row|
       row.must_be_kind_of Hash

--- a/google-cloud-bigquery/acceptance/bigquery/location_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/location_test.rb
@@ -79,7 +79,7 @@ describe Google::Cloud::Bigquery, :location, :bigquery do
     data.class.must_equal Google::Cloud::Bigquery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
-    [nil, 0].must_include data.total
+    data.total.wont_be :nil?
     data.count.wont_be :nil?
     data.all(request_limit: 2).each do |row|
       row.must_be_kind_of Hash

--- a/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
@@ -191,7 +191,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
 
     data = table.data max: 1
     data.class.must_equal Google::Cloud::Bigquery::Data
-    [nil, 0].must_include data.total
+    data.total.wont_be :nil?
     data.count.wont_be :nil?
     data.all(request_limit: 2).each do |row|
       row.must_be_kind_of Hash
@@ -230,7 +230,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
     data.class.must_equal Google::Cloud::Bigquery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
-    [nil, 0].must_include data.total
+    data.total.wont_be :nil?
     data.count.wont_be :nil?
     data.all(request_limit: 2).each do |row|
       row.must_be_kind_of Hash

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -537,7 +537,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     data.class.must_equal Google::Cloud::Bigquery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
-    [nil, 0].must_include data.total
+    data.total.wont_be :nil?
     data.count.wont_be :nil?
     data.all(request_limit: 2).each do |row|
       row.must_be_kind_of Hash
@@ -592,7 +592,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     data.class.must_equal Google::Cloud::Bigquery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
-    [nil, 0].must_include data.total
+    data.total.wont_be :nil?
     data.count.wont_be :nil?
     data.all(request_limit: 2).each do |row|
       row.must_be_kind_of Hash
@@ -684,7 +684,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     data.class.must_equal Google::Cloud::Bigquery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
-    [nil, 0].must_include data.total
+    data.total.wont_be :nil?
     data.count.wont_be :nil?
     data.all(request_limit: 2).each do |row|
       row.must_be_kind_of Hash
@@ -726,7 +726,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     data.class.must_equal Google::Cloud::Bigquery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
-    [nil, 0].must_include data.total
+    data.total.wont_be :nil?
     data.count.wont_be :nil?
     data.all(request_limit: 2).each do |row|
       row.must_be_kind_of Hash


### PR DESCRIPTION
When the acceptance tests originally implemented, `Data#total` was always returning `nil`. Now `Data#total` is returning the total rows count, and these checks are now failing. It looks like the client and API are behaving correctly, but the tests are specifying the wrong behavior. Update the total checks to match the other checks.

The way these tests were written goes back at least as far as 57c748d8c92cb3f41d6c3ea08d0254580189a481, and probably further.

[refs #3084]