### PR TITLE
feat(bigquery): Support overriding of service endpoint

### DIFF
--- a/google-cloud-bigquery/lib/google-cloud-bigquery.rb
+++ b/google-cloud-bigquery/lib/google-cloud-bigquery.rb
@@ -43,8 +43,6 @@ module Google
     # @param [Integer] retries Number of times to retry requests on server
     #   error. The default value is `5`. Optional.
     # @param [Integer] timeout Default request timeout in seconds. Optional.
-    # @param [String] endpoint Override of the endpoint host name. Optional.
-    #   If the param is nil, uses the default endpoint.
     #
     # @return [Google::Cloud::Bigquery::Project]
     #
@@ -66,12 +64,10 @@ module Google
     #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
     #   bigquery = gcloud.bigquery scope: platform_scope
     #
-    def bigquery scope: nil, retries: nil, timeout: nil, endpoint: nil
-      Google::Cloud.bigquery @project, @keyfile,
-                             scope:    scope,
-                             retries:  (retries || @retries),
-                             timeout:  (timeout || @timeout),
-                             endpoint: endpoint
+    def bigquery scope: nil, retries: nil, timeout: nil
+      Google::Cloud.bigquery @project, @keyfile, scope:   scope,
+                                                 retries: (retries || @retries),
+                                                 timeout: (timeout || @timeout)
     end
 
     ##
@@ -97,8 +93,6 @@ module Google
     # @param [Integer] retries Number of times to retry requests on server
     #   error. The default value is `5`. Optional.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
-    # @param [String] endpoint Override of the endpoint host name. Optional.
-    #   If the param is nil, uses the default endpoint.
     #
     # @return [Google::Cloud::Bigquery::Project]
     #
@@ -110,12 +104,12 @@ module Google
     #   table = dataset.table "my_table"
     #
     def self.bigquery project_id = nil, credentials = nil, scope: nil,
-                      retries: nil, timeout: nil, endpoint: nil
+                      retries: nil, timeout: nil
       require "google/cloud/bigquery"
       Google::Cloud::Bigquery.new project_id: project_id,
                                   credentials: credentials,
                                   scope: scope, retries: retries,
-                                  timeout: timeout, endpoint: endpoint
+                                  timeout: timeout
     end
   end
 end

--- a/google-cloud-bigquery/lib/google-cloud-bigquery.rb
+++ b/google-cloud-bigquery/lib/google-cloud-bigquery.rb
@@ -43,6 +43,8 @@ module Google
     # @param [Integer] retries Number of times to retry requests on server
     #   error. The default value is `5`. Optional.
     # @param [Integer] timeout Default request timeout in seconds. Optional.
+    # @param [String] endpoint Override of the endpoint host name. Optional.
+    #   If the param is nil, uses the default endpoint.
     #
     # @return [Google::Cloud::Bigquery::Project]
     #
@@ -64,10 +66,12 @@ module Google
     #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
     #   bigquery = gcloud.bigquery scope: platform_scope
     #
-    def bigquery scope: nil, retries: nil, timeout: nil
-      Google::Cloud.bigquery @project, @keyfile, scope:   scope,
-                                                 retries: (retries || @retries),
-                                                 timeout: (timeout || @timeout)
+    def bigquery scope: nil, retries: nil, timeout: nil, endpoint: nil
+      Google::Cloud.bigquery @project, @keyfile,
+                             scope:    scope,
+                             retries:  (retries || @retries),
+                             timeout:  (timeout || @timeout),
+                             endpoint: endpoint
     end
 
     ##
@@ -93,6 +97,8 @@ module Google
     # @param [Integer] retries Number of times to retry requests on server
     #   error. The default value is `5`. Optional.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
+    # @param [String] endpoint Override of the endpoint host name. Optional.
+    #   If the param is nil, uses the default endpoint.
     #
     # @return [Google::Cloud::Bigquery::Project]
     #
@@ -104,12 +110,12 @@ module Google
     #   table = dataset.table "my_table"
     #
     def self.bigquery project_id = nil, credentials = nil, scope: nil,
-                      retries: nil, timeout: nil
+                      retries: nil, timeout: nil, endpoint: nil
       require "google/cloud/bigquery"
       Google::Cloud::Bigquery.new project_id: project_id,
                                   credentials: credentials,
                                   scope: scope, retries: retries,
-                                  timeout: timeout
+                                  timeout: timeout, endpoint: endpoint
     end
   end
 end
@@ -135,4 +141,5 @@ Google::Cloud.configure.add_config! :bigquery do |config|
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :retries, nil, match: Integer
   config.add_field! :timeout, nil, match: Integer
+  config.add_field! :endpoint, nil, match: String
 end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -84,7 +84,7 @@ module Google
         Bigquery::Project.new(
           Bigquery::Service.new(
             project_id, credentials,
-            retries: retries, timeout: timeout, endpoint: endpoint
+            retries: retries, timeout: timeout, host: endpoint
           )
         )
       end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -39,15 +39,17 @@ module Google
         attr_accessor :credentials
 
         # @private
-        attr_reader :retries, :timeout
+        attr_reader :retries, :timeout, :endpoint
 
         ##
         # Creates a new Service instance.
-        def initialize project, credentials, retries: nil, timeout: nil
+        def initialize project, credentials,
+                       retries: nil, timeout: nil, endpoint: nil
           @project = project
           @credentials = credentials
           @retries = retries
           @timeout = timeout
+          @endpoint = endpoint
         end
 
         def service
@@ -65,6 +67,7 @@ module Google
             service.request_options.header["x-goog-api-client"] = \
               "gl-ruby/#{RUBY_VERSION} gccl/#{Google::Cloud::Bigquery::VERSION}"
             service.authorization = @credentials.client
+            service.root_url = endpoint if endpoint
             service
           end
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -39,17 +39,17 @@ module Google
         attr_accessor :credentials
 
         # @private
-        attr_reader :retries, :timeout, :endpoint
+        attr_reader :retries, :timeout, :host
 
         ##
         # Creates a new Service instance.
         def initialize project, credentials,
-                       retries: nil, timeout: nil, endpoint: nil
+                       retries: nil, timeout: nil, host: nil
           @project = project
           @credentials = credentials
           @retries = retries
           @timeout = timeout
-          @endpoint = endpoint
+          @host = host
         end
 
         def service
@@ -67,7 +67,7 @@ module Google
             service.request_options.header["x-goog-api-client"] = \
               "gl-ruby/#{RUBY_VERSION} gccl/#{Google::Cloud::Bigquery::VERSION}"
             service.authorization = @credentials.client
-            service.root_url = endpoint if endpoint
+            service.root_url = host if host
             service
           end
         end

--- a/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
@@ -165,13 +165,11 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
-          Google::Cloud::Bigquery::Credentials.stub :new, default_credentials do
-            Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
-              bigquery = Google::Cloud::Bigquery.new endpoint: "bigquery-endpoint2.example.com"
-              bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
-              bigquery.project.must_equal "project-id"
-              bigquery.service.must_be_kind_of OpenStruct
-            end
+          Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
+            bigquery = Google::Cloud::Bigquery.new credentials: default_credentials, endpoint: "bigquery-endpoint2.example.com"
+            bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
+            bigquery.project.must_equal "project-id"
+            bigquery.service.must_be_kind_of OpenStruct
           end
         end
       end

--- a/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
@@ -19,12 +19,13 @@ describe Google::Cloud do
   describe "#bigquery" do
     it "calls out to Google::Cloud.bigquery" do
       gcloud = Google::Cloud.new
-      stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, endpoint: nil) {
         project.must_be :nil?
         keyfile.must_be :nil?
         scope.must_be :nil?
         retries.must_be :nil?
         timeout.must_be :nil?
+        endpoint.must_be :nil?
         "bigquery-project-object-empty"
       }
       Google::Cloud.stub :bigquery, stubbed_bigquery do
@@ -35,12 +36,13 @@ describe Google::Cloud do
 
     it "passes project and keyfile to Google::Cloud.bigquery" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, endpoint: nil) {
         project.must_equal "project-id"
         keyfile.must_equal "keyfile-path"
         scope.must_be :nil?
         retries.must_be :nil?
         timeout.must_be :nil?
+        endpoint.must_be :nil?
         "bigquery-project-object"
       }
       Google::Cloud.stub :bigquery, stubbed_bigquery do
@@ -51,17 +53,35 @@ describe Google::Cloud do
 
     it "passes project and keyfile and options to Google::Cloud.bigquery" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, endpoint: nil) {
         project.must_equal "project-id"
         keyfile.must_equal "keyfile-path"
         scope.must_equal "http://example.com/scope"
         retries.must_equal 5
         timeout.must_equal 60
+        endpoint.must_be :nil?
         "bigquery-project-object-scoped"
       }
       Google::Cloud.stub :bigquery, stubbed_bigquery do
         project = gcloud.bigquery scope: "http://example.com/scope", retries: 5, timeout: 60
         project.must_equal "bigquery-project-object-scoped"
+      end
+    end
+
+    it "passes endpoint to Google::Cloud.bigquery" do
+      gcloud = Google::Cloud.new
+      stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, endpoint: nil) {
+        project.must_be :nil?
+        keyfile.must_be :nil?
+        scope.must_be :nil?
+        retries.must_be :nil?
+        timeout.must_be :nil?
+        endpoint.must_equal "bigquery-endpoint2.example.com"
+        "bigquery-endpoint-object"
+      }
+      Google::Cloud.stub :bigquery, stubbed_bigquery do
+        project = gcloud.bigquery endpoint: "bigquery-endpoint2.example.com"
+        project.must_equal "bigquery-endpoint-object"
       end
     end
   end
@@ -97,11 +117,12 @@ describe Google::Cloud do
         scope.must_be :nil?
         "bigquery-credentials"
       }
-      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, endpoint: nil) {
         project.must_equal "project-id"
         credentials.must_equal "bigquery-credentials"
         retries.must_be :nil?
         timeout.must_be :nil?
+        endpoint.must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -154,11 +175,12 @@ describe Google::Cloud do
         scope.must_be :nil?
         "bigquery-credentials"
       }
-      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, endpoint: nil) {
         project.must_equal "project-id"
         credentials.must_equal "bigquery-credentials"
         retries.must_be :nil?
         timeout.must_be :nil?
+        endpoint.must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -185,11 +207,12 @@ describe Google::Cloud do
         scope.must_be :nil?
         "bigquery-credentials"
       }
-      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, endpoint: nil) {
         project.must_equal "project-id"
         credentials.must_equal "bigquery-credentials"
         retries.must_be :nil?
         timeout.must_be :nil?
+        endpoint.must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -216,12 +239,13 @@ describe Google::Cloud do
         scope.must_be :nil?
         OpenStruct.new project_id: "project-id"
       }
-      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, endpoint: nil) {
         project.must_equal "project-id"
         credentials.must_be_kind_of OpenStruct
         credentials.project_id.must_equal "project-id"
         retries.must_be :nil?
         timeout.must_be :nil?
+        endpoint.must_be :nil?
         OpenStruct.new project: project
       }
       empty_env = OpenStruct.new
@@ -259,11 +283,12 @@ describe Google::Cloud do
         scope.must_be :nil?
         "bigquery-credentials"
       }
-      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, endpoint: nil) {
         project.must_equal "project-id"
         credentials.must_equal "bigquery-credentials"
         retries.must_be :nil?
         timeout.must_be :nil?
+        endpoint.must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -296,11 +321,12 @@ describe Google::Cloud do
         scope.must_be :nil?
         "bigquery-credentials"
       }
-      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, endpoint: nil) {
         project.must_equal "project-id"
         credentials.must_equal "bigquery-credentials"
         retries.must_be :nil?
         timeout.must_be :nil?
+        endpoint.must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -333,11 +359,12 @@ describe Google::Cloud do
         scope.must_be :nil?
         "bigquery-credentials"
       }
-      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, endpoint: nil) {
         project.must_equal "project-id"
         credentials.must_equal "bigquery-credentials"
         retries.must_equal 3
         timeout.must_equal 42
+        endpoint.must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -372,11 +399,12 @@ describe Google::Cloud do
         scope.must_be :nil?
         "bigquery-credentials"
       }
-      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, endpoint: nil) {
         project.must_equal "project-id"
         credentials.must_equal "bigquery-credentials"
         retries.must_equal 3
         timeout.must_equal 42
+        endpoint.must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -388,6 +416,47 @@ describe Google::Cloud do
           config.credentials = "path/to/keyfile.json"
           config.retries = 3
           config.timeout = 42
+        end
+
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
+                bigquery = Google::Cloud::Bigquery.new
+                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
+                bigquery.project.must_equal "project-id"
+                bigquery.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
+
+    it "uses bigquery config for endpoint" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        "bigquery-credentials"
+      }
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, endpoint: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "bigquery-credentials"
+        retries.must_equal 3
+        timeout.must_equal 42
+        endpoint.must_equal "bigquery-endpoint2.example.com"
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Set new configuration
+        Google::Cloud::Bigquery.configure do |config|
+          config.project = "project-id"
+          config.keyfile = "path/to/keyfile.json"
+          config.retries = 3
+          config.timeout = 42
+          config.endpoint = "bigquery-endpoint2.example.com"
         end
 
         File.stub :file?, true, ["path/to/keyfile.json"] do


### PR DESCRIPTION
Support overriding of the service endpoint from the veneer layer in google-cloud-bigquery. Both config and constructor arguments are provided. This is the bigquery equivalent of #3710 and #3723 for pubsub.