### PR TITLE
Remove cache_hit? acceptance checks

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -140,7 +140,6 @@ describe Google::Cloud::Bigquery, :bigquery do
     rows.total.must_equal 100
 
     # @gapi.statistics.query
-    job.cache_hit?.must_equal true
     job.bytes_processed.must_equal 0
     job.query_plan.must_be :nil?
     # Sometimes values are nil in the returned job, so currently comment out unreliable expectations

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -498,7 +498,6 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     query_job.large_results?.must_equal false
     query_job.cache?.must_equal true
     query_job.flatten?.must_equal true
-    query_job.cache_hit?.must_equal false
     query_job.bytes_processed.wont_be :nil?
     query_job.destination.wont_be :nil?
     query_job.data.class.must_equal Google::Cloud::Bigquery::Data
@@ -645,7 +644,6 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     query_job.large_results?.must_equal false
     query_job.cache?.must_equal true
     query_job.flatten?.must_equal true
-    query_job.cache_hit?.must_equal false
     query_job.bytes_processed.wont_be :nil?
     query_job.destination.wont_be :nil?
     query_job.data.class.must_equal Google::Cloud::Bigquery::Data


### PR DESCRIPTION
These checks occasionally fail. The API's use of cache is not deterministic.

[refs #3084]