### PR TITLE
test(storage): Fix incorrect download object in acceptance test

### DIFF
--- a/google-cloud-storage/acceptance/storage/file_encryption_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_encryption_test.rb
@@ -117,7 +117,7 @@ describe Google::Cloud::Storage::File, :storage do
       rewritten2.size.must_equal uploaded.size
 
       Tempfile.open ["abc", ".txt"] do |tmpfile|
-        downloaded = uploaded.download tmpfile.path, encryption_key: encryption_key_2
+        downloaded = rewritten2.download tmpfile.path, encryption_key: encryption_key_2
         downloaded.size.must_equal uploaded.size
       end
 
@@ -128,7 +128,7 @@ describe Google::Cloud::Storage::File, :storage do
       rewritten4.size.must_equal uploaded.size
 
       Tempfile.open ["abc", ".txt"] do |tmpfile|
-        downloaded = uploaded.download tmpfile.path
+        downloaded = rewritten4.download tmpfile.path
         downloaded.size.must_equal uploaded.size
       end
 


### PR DESCRIPTION
This change fixes an acceptance test that appears to have been broken since #3734. It changes the test to use the correct `File` instance to download the object data.