### PR TITLE
GKE Metadata Server requires header "Metadata-Flavor": "Google" at METADATA_ROOT_PATH

### DIFF
--- a/google-cloud-env/lib/google/cloud/env.rb
+++ b/google-cloud-env/lib/google/cloud/env.rb
@@ -356,7 +356,9 @@ module Google
         path = METADATA_ROOT_PATH
         if @disable_metadata_cache || !metadata_cache.include?(path)
           metadata_cache[path] = retry_or_fail_with false do
-            resp = connection.get path
+            resp = connection.get path do |req|
+              req.headers = { "Metadata-Flavor" => "Google" }
+            end
             resp.status == 200 && resp.headers["Metadata-Flavor"] == "Google"
           end
         end


### PR DESCRIPTION
In GKE 1.13.7-gke.8, Metadata Server METADATA_ROOT_PATH(http://169.254.169.254) requires the header "Metadata-Flavor": "Google".

```
# curl http://169.254.169.254 -vvv
* Rebuilt URL to: http://169.254.169.254/
*   Trying 169.254.169.254...
* Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
> GET / HTTP/1.1
> Host: 169.254.169.254
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 403 Forbidden
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Wed, 07 Aug 2019 14:33:12 GMT
< Content-Length: 94
< 
GKE Metadata Server encountered an error: Missing required header "Metadata-Flavor": "Google"
* Connection #0 to host 169.254.169.254 left intact

# curl -H 'Metadata-Flavor:Google' http://169.254.169.254 -vvv
* Rebuilt URL to: http://169.254.169.254/
*   Trying 169.254.169.254...
* Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
> GET / HTTP/1.1
> Host: 169.254.169.254
> User-Agent: curl/7.47.0
> Accept: */*
> Metadata-Flavor:Google
> 
< HTTP/1.1 200 OK
< Content-Type: application/text
< Metadata-Flavor: Google
< Server: GKE Metadata Server
< Date: Wed, 07 Aug 2019 14:33:15 GMT
< Content-Length: 17
< 
computeMetadata/
* Connection #0 to host 169.254.169.254 left intact
```

