### PR TITLE
chore(bigtable): Fix style issues in g/c/bigtable.rb

### DIFF
--- a/google-cloud-bigtable/.rubocop.yml
+++ b/google-cloud-bigtable/.rubocop.yml
@@ -3,8 +3,6 @@ AllCops:
     - "google-cloud-bigtable.gemspec"
     - "lib/google-cloud-bigtable.rb"
     - "lib/google/bigtable/**/*"
-    - "lib/google/cloud/bigtable.rb"
-    - "lib/google/cloud/bigtable/credentials.rb"
     - "lib/google/cloud/bigtable/admin.rb"
     - "lib/google/cloud/bigtable/admin/**/*"
     - "lib/google/cloud/bigtable/v2.rb"


### PR DESCRIPTION
google/cloud/bigtable.rb was incorrectly excluded from the rubocop config. As a result, several style issues went unresolved. Among them:
* `self.configure` was actually defined twice(!)
* Several methods had the wrong indentation.
* The complexity of the constructor was higher than allowed. (So I broke out a few helper methods).
