### PR TITLE
fix(spanner): Low-level admin clients now honor service_address and service_port

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
@@ -144,6 +144,10 @@ module Google
               #   The default timeout, in seconds, for calls made through this client.
               # @param metadata [Hash]
               #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+              # @param service_address [String]
+              #   Override for the service hostname, or `nil` to leave as the default.
+              # @param service_port [Integer]
+              #   Override for the service port, or `nil` to leave as the default.
               # @param exception_transformer [Proc]
               #   An optional proc that intercepts any exceptions raised during an API call to inject
               #   custom error handling.
@@ -153,6 +157,8 @@ module Google
                   client_config: {},
                   timeout: DEFAULT_TIMEOUT,
                   metadata: nil,
+                  service_address: nil,
+                  service_port: nil,
                   exception_transformer: nil,
                   lib_name: nil,
                   lib_version: ""
@@ -217,8 +223,8 @@ module Google
                 end
 
                 # Allow overriding the service path/port in subclasses.
-                service_path = self.class::SERVICE_ADDRESS
-                port = self.class::DEFAULT_SERVICE_PORT
+                service_path = service_address || self.class::SERVICE_ADDRESS
+                port = service_port || self.class::DEFAULT_SERVICE_PORT
                 interceptors = self.class::GRPC_INTERCEPTORS
                 @database_admin_stub = Google::Gax::Grpc.create_stub(
                   service_path,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
@@ -177,6 +177,10 @@ module Google
               #   The default timeout, in seconds, for calls made through this client.
               # @param metadata [Hash]
               #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+              # @param service_address [String]
+              #   Override for the service hostname, or `nil` to leave as the default.
+              # @param service_port [Integer]
+              #   Override for the service port, or `nil` to leave as the default.
               # @param exception_transformer [Proc]
               #   An optional proc that intercepts any exceptions raised during an API call to inject
               #   custom error handling.
@@ -186,6 +190,8 @@ module Google
                   client_config: {},
                   timeout: DEFAULT_TIMEOUT,
                   metadata: nil,
+                  service_address: nil,
+                  service_port: nil,
                   exception_transformer: nil,
                   lib_name: nil,
                   lib_version: ""
@@ -250,8 +256,8 @@ module Google
                 end
 
                 # Allow overriding the service path/port in subclasses.
-                service_path = self.class::SERVICE_ADDRESS
-                port = self.class::DEFAULT_SERVICE_PORT
+                service_path = service_address || self.class::SERVICE_ADDRESS
+                port = service_port || self.class::DEFAULT_SERVICE_PORT
                 interceptors = self.class::GRPC_INTERCEPTORS
                 @instance_admin_stub = Google::Gax::Grpc.create_stub(
                   service_path,

--- a/google-cloud-spanner/synth.metadata
+++ b/google-cloud-spanner/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-08-08T10:47:31.704157Z",
+  "updateTime": "2019-08-14T00:53:38.813812Z",
   "sources": [
     {
       "generator": {
@@ -12,8 +12,8 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7e56e8d4fec63bb04ab4f79a98f65b29f235a0a0",
-        "internalRef": "262242585"
+        "sha": "3406d1e899f1f41123b3fa9210ad4bef25c9a720",
+        "internalRef": "263234709"
       }
     }
   ],

--- a/google-cloud-spanner/synth.py
+++ b/google-cloud-spanner/synth.py
@@ -103,7 +103,10 @@ s.replace(
 
 # Support for service_address
 s.replace(
-    'lib/google/cloud/spanner/v*/*_client.rb',
+    [
+        'lib/google/cloud/spanner/v*/*_client.rb',
+        'lib/google/cloud/spanner/admin/*/v*/*_client.rb'
+    ],
     '\n(\\s+)#(\\s+)@param exception_transformer',
     '\n\\1#\\2@param service_address [String]\n' +
         '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +
@@ -112,17 +115,26 @@ s.replace(
         '\\1#\\2@param exception_transformer'
 )
 s.replace(
-    'lib/google/cloud/spanner/v*/*_client.rb',
+    [
+        'lib/google/cloud/spanner/v*/*_client.rb',
+        'lib/google/cloud/spanner/admin/*/v*/*_client.rb'
+    ],
     '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',
     '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'
 )
 s.replace(
-    'lib/google/cloud/spanner/v*/*_client.rb',
+    [
+        'lib/google/cloud/spanner/v*/*_client.rb',
+        'lib/google/cloud/spanner/admin/*/v*/*_client.rb'
+    ],
     'service_path = self\\.class::SERVICE_ADDRESS',
     'service_path = service_address || self.class::SERVICE_ADDRESS'
 )
 s.replace(
-    'lib/google/cloud/spanner/v*/*_client.rb',
+    [
+        'lib/google/cloud/spanner/v*/*_client.rb',
+        'lib/google/cloud/spanner/admin/*/v*/*_client.rb'
+    ],
     'port = self\\.class::DEFAULT_SERVICE_PORT',
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )


### PR DESCRIPTION
Updates synth script, and reruns synth to get the changes to the clients.