### PR TITLE
fix(storage): Fix Bucket Policy Only service bug temporarily

### DIFF
--- a/google-cloud-storage/acceptance/storage/bucket_policy_only_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_policy_only_test.rb
@@ -38,7 +38,6 @@ describe Google::Cloud::Storage::Bucket, :policy_only, :storage do
   end
 
   it "sets policy_only true and is unable to modify file ACL rules" do
-    skip "Removed due to consistent failure in GCS. @frankyn will notify when fixed."
     refute bucket.policy_only?
     bucket.policy_only_locked_at.must_be :nil?
     file = bucket.create_file local_file, "ReaderTest.png"
@@ -54,7 +53,6 @@ describe Google::Cloud::Storage::Bucket, :policy_only, :storage do
   end
 
   it "sets policy_only true and is unable to get the file" do
-    skip "Removed due to consistent failure in GCS. @frankyn will notify when fixed."
     refute bucket.policy_only?
     file = bucket.create_file local_file, "ReaderTest.png"
 
@@ -70,18 +68,16 @@ describe Google::Cloud::Storage::Bucket, :policy_only, :storage do
   end
 
   it "sets policy_only true and is unable to modify bucket ACL rules" do
-    skip "Removed due to consistent failure in GCS. @frankyn will notify when fixed."
     refute bucket.policy_only?
     bucket.policy_only = true
     assert bucket.policy_only?
     err = expect do
       bucket.acl.public!
     end.must_raise Google::Cloud::InvalidArgumentError
-    err.message.must_match /Cannot use ACL API to update bucket policy when Bucket Policy Only is enabled. Use IAM instead./
+    err.message.must_match /Cannot use ACL API to update bucket policy when Bucket Policy Only is enabled./
   end
 
   it "sets policy_only true and is unable to modify default ACL rules" do
-    skip "Removed due to consistent failure in GCS. @frankyn will notify when fixed."
     refute bucket.policy_only?
     bucket.policy_only = true
     assert bucket.policy_only?
@@ -89,7 +85,7 @@ describe Google::Cloud::Storage::Bucket, :policy_only, :storage do
     err = expect do
       bucket.default_acl.public!
     end.must_raise Google::Cloud::InvalidArgumentError
-    err.message.must_match /Cannot use ACL API to update bucket policy when Bucket Policy Only is enabled. Use IAM instead./
+    err.message.must_match /Cannot use ACL API to update bucket policy when Bucket Policy Only is enabled./
   end
 
   it "creates new bucket with policy_only true and is able to insert and get a file" do
@@ -106,7 +102,6 @@ describe Google::Cloud::Storage::Bucket, :policy_only, :storage do
   end
 
   it "sets policy_only true and default object acl and object acls are preserved" do
-    skip "Removed due to consistent failure in GCS. @frankyn will notify when fixed."
     bucket.default_acl.public!
     bucket.default_acl.readers.must_equal ["allUsers"]
     file_default_acl = bucket.create_file StringIO.new("default_acl"), "default_acl.txt"

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -843,10 +843,14 @@ module Google
         #   puts bucket.policy_only_locked_at
         #
         def policy_only= new_policy_only
-          @gapi.iam_configuration ||= API::Bucket::IamConfiguration.new \
-            bucket_policy_only: \
-              API::Bucket::IamConfiguration::BucketPolicyOnly.new
+          @gapi.iam_configuration ||= API::Bucket::IamConfiguration.new
+          @gapi.iam_configuration.bucket_policy_only ||= \
+            API::Bucket::IamConfiguration::BucketPolicyOnly.new
+          @gapi.iam_configuration.uniform_bucket_level_access ||= \
+            API::Bucket::IamConfiguration::UniformBucketLevelAccess.new
           @gapi.iam_configuration.bucket_policy_only.enabled = new_policy_only
+          @gapi.iam_configuration.uniform_bucket_level_access.enabled = \
+            new_policy_only
           patch_gapi! :iam_configuration
         end
 

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -185,6 +185,13 @@ class MockStorage < Minitest::Spec
       enabled: policy_only
     )
     bpo.locked_time = (Date.today + 1).to_datetime if locked_time
-    Google::Apis::StorageV1::Bucket::IamConfiguration.new bucket_policy_only: bpo
+    ubla = Google::Apis::StorageV1::Bucket::IamConfiguration::UniformBucketLevelAccess.new(
+      enabled: policy_only
+    )
+    ubla.locked_time = (Date.today + 1).to_datetime if locked_time
+    Google::Apis::StorageV1::Bucket::IamConfiguration.new(
+      bucket_policy_only: bpo,
+      uniform_bucket_level_access: ubla
+    )
   end
 end


### PR DESCRIPTION
* Set `UniformBucketLevelAccess` to same value as `BucketPolicyOnly`.
* Restore acceptance tests that were skipped in #3772.

[closes #3781]