### PR TITLE
feat(trace): Support overriding of service endpoint

### DIFF
--- a/google-cloud-trace/lib/google-cloud-trace.rb
+++ b/google-cloud-trace/lib/google-cloud-trace.rb
@@ -137,6 +137,7 @@ Google::Cloud.configure.add_config! :trace do |config|
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :timeout, nil, match: Integer
   config.add_field! :client_config, nil, match: Hash
+  config.add_field! :endpoint, nil, match: String
   config.add_field! :capture_stack, nil, enum: [true, false]
   config.add_field! :sampler, nil
   config.add_field! :span_id_generator, nil, match: Proc

--- a/google-cloud-trace/lib/google/cloud/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace.rb
@@ -68,6 +68,10 @@ module Google
       #   * `https://www.googleapis.com/auth/cloud-platform`
       #
       # @param [Integer] timeout Default timeout to use in requests. Optional.
+      # @param [Hash] client_config A hash of values to override the default
+      #   behavior of the API client. Optional.
+      # @param [String] endpoint Override of the endpoint host name. Optional.
+      #   If the param is nil, uses the default endpoint.
       # @param [String] project Alias for the `project_id` argument. Deprecated.
       # @param [String] keyfile Alias for the `credentials` argument.
       #   Deprecated.
@@ -85,17 +89,15 @@ module Google
       #   end
       #
       def self.new project_id: nil, credentials: nil, scope: nil, timeout: nil,
-                   client_config: nil, project: nil, keyfile: nil
+                   client_config: nil, endpoint: nil, project: nil, keyfile: nil
         project_id    ||= (project || default_project_id)
         scope         ||= configure.scope
         timeout       ||= configure.timeout
         client_config ||= configure.client_config
+        endpoint      ||= configure.endpoint
         credentials   ||= (keyfile || default_credentials(scope: scope))
 
-        unless credentials.is_a? Google::Auth::Credentials
-          credentials = Trace::Credentials.new credentials, scope: scope
-        end
-
+        credentials = resolve_credentials credentials, scope
         if credentials.respond_to? :project_id
           project_id ||= credentials.project_id
         end
@@ -104,8 +106,8 @@ module Google
 
         Trace::Project.new(
           Trace::Service.new(
-            project_id, credentials, timeout: timeout,
-                                     client_config: client_config
+            project_id, credentials,
+            host: endpoint, timeout: timeout, client_config: client_config
           )
         )
       end
@@ -128,6 +130,8 @@ module Google
       # * `timeout` - (Integer) Default timeout to use in requests.
       # * `client_config` - (Hash) A hash of values to override the default
       #   behavior of the API client.
+      # * `endpoint` - (String) Override of the endpoint host name, or `nil`
+      #   to use the default endpoint.
       # * `capture_stack` - (Boolean) Whether to capture stack traces for each
       #   span. Default: `false`
       # * `sampler` - (Proc) A sampler Proc makes the decision whether to record
@@ -171,6 +175,15 @@ module Google
         Google::Cloud.configure.trace.credentials ||
           Google::Cloud.configure.credentials ||
           Trace::Credentials.default(scope: scope)
+      end
+
+      ##
+      # @private Resolve credentials
+      def self.resolve_credentials credentials, scope
+        unless credentials.is_a? Google::Auth::Credentials
+          credentials = Trace::Credentials.new credentials, scope: scope
+        end
+        credentials
       end
 
       ##

--- a/google-cloud-trace/lib/google/cloud/trace/service.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/service.rb
@@ -17,6 +17,7 @@ require "google/cloud/errors"
 require "google/cloud/trace/version"
 require "google/cloud/trace/v1"
 require "google/gax/errors"
+require "uri"
 
 module Google
   module Cloud
@@ -27,29 +28,17 @@ module Google
       # @private
       #
       class Service
-        ##
-        # @private
-        attr_accessor :project
-
-        ##
-        # @private
-        attr_accessor :credentials
-
-        ##
-        # @private
-        attr_accessor :timeout
-
-        ##
-        # @private
-        attr_accessor :client_config
+        attr_accessor :project, :credentials, :timeout, :client_config, :host
 
         ##
         # Creates a new Service instance.
-        def initialize project, credentials, timeout: nil, client_config: nil
+        def initialize project, credentials, timeout: nil, client_config: nil,
+                       host: nil
           @project = project
           @credentials = credentials
           @timeout = timeout
           @client_config = client_config || {}
+          @host = host || V1::TraceServiceClient::SERVICE_ADDRESS
         end
 
         def lowlevel_client
@@ -65,6 +54,8 @@ module Google
                 credentials: credentials,
                 timeout: timeout,
                 client_config: client_config,
+                service_address: service_address,
+                service_port: service_port,
                 lib_name: "gccl",
                 lib_version: Google::Cloud::Trace::VERSION
               )
@@ -142,6 +133,16 @@ module Google
         end
 
         protected
+
+        def service_address
+          return nil if host.nil?
+          URI.parse("//#{host}").host
+        end
+
+        def service_port
+          return nil if host.nil?
+          URI.parse("//#{host}").port
+        end
 
         def execute
           yield

--- a/google-cloud-trace/test/google/cloud/trace_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace_test.rb
@@ -1,0 +1,485 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud do
+  describe "#trace" do
+    it "calls out to Google::Cloud.trace" do
+      gcloud = Google::Cloud.new
+      stubbed_trace = ->(project, keyfile, scope: nil, timeout: nil, host: nil, client_config: nil) {
+        project.must_be :nil?
+        keyfile.must_be :nil?
+        scope.must_be :nil?
+        timeout.must_be :nil?
+        host.must_be :nil?
+        client_config.must_be :nil?
+        "trace-project-object-empty"
+      }
+      Google::Cloud.stub :trace, stubbed_trace do
+        project = gcloud.trace
+        project.must_equal "trace-project-object-empty"
+      end
+    end
+
+    it "passes project and keyfile to Google::Cloud.trace" do
+      gcloud = Google::Cloud.new "project-id", "keyfile-path"
+      stubbed_trace = ->(project, keyfile, scope: nil, timeout: nil, host: nil, client_config: nil) {
+        project.must_equal "project-id"
+        keyfile.must_equal "keyfile-path"
+        scope.must_be :nil?
+        timeout.must_be :nil?
+        host.must_be :nil?
+        client_config.must_be :nil?
+        "trace-project-object"
+      }
+      Google::Cloud.stub :trace, stubbed_trace do
+        project = gcloud.trace
+        project.must_equal "trace-project-object"
+      end
+    end
+
+    it "passes project and keyfile and options to Google::Cloud.trace" do
+      gcloud = Google::Cloud.new "project-id", "keyfile-path"
+      stubbed_trace = ->(project, keyfile, scope: nil, timeout: nil, host: nil, client_config: nil) {
+        project.must_equal "project-id"
+        keyfile.must_equal "keyfile-path"
+        scope.must_equal "http://example.com/scope"
+        timeout.must_equal 60
+        host.must_be :nil?
+        client_config.must_equal({ "gax" => "options" })
+        "trace-project-object-scoped"
+      }
+      Google::Cloud.stub :trace, stubbed_trace do
+        project = gcloud.trace scope: "http://example.com/scope", timeout: 60, client_config: { "gax" => "options" }
+        project.must_equal "trace-project-object-scoped"
+      end
+    end
+  end
+
+  describe ".trace" do
+    let(:default_credentials) do
+      creds = OpenStruct.new empty: true
+      def creds.is_a? target
+        target == Google::Auth::Credentials
+      end
+      creds
+    end
+    let(:found_credentials) { "{}" }
+
+    it "gets defaults for project_id and keyfile" do
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Get project_id from Google Compute Engine
+        Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
+          Google::Cloud::Trace::Credentials.stub :default, default_credentials do
+            trace = Google::Cloud.trace
+            trace.must_be_kind_of Google::Cloud::Trace::Project
+            trace.project.must_equal "project-id"
+            trace.service.credentials.must_equal default_credentials
+          end
+        end
+      end
+    end
+
+    it "uses provided project_id and keyfile" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        "trace-credentials"
+      }
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "trace-credentials"
+        timeout.must_be :nil?
+        host.must_be :nil?
+        client_config.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Trace::Service.stub :new, stubbed_service do
+                trace = Google::Cloud.trace "project-id", "path/to/keyfile.json"
+                trace.must_be_kind_of Google::Cloud::Trace::Project
+                trace.project.must_equal "project-id"
+                trace.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "Trace.new" do
+    let(:default_credentials) do
+      creds = OpenStruct.new empty: true
+      def creds.is_a? target
+        target == Google::Auth::Credentials
+      end
+      creds
+    end
+    let(:found_credentials) { "{}" }
+
+    it "gets defaults for project_id and keyfile" do
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Get project_id from Google Compute Engine
+        Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
+          Google::Cloud::Trace::Credentials.stub :default, default_credentials do
+            trace = Google::Cloud::Trace.new
+            trace.must_be_kind_of Google::Cloud::Trace::Project
+            trace.project.must_equal "project-id"
+            trace.service.credentials.must_equal default_credentials
+          end
+        end
+      end
+    end
+
+    it "uses provided project_id and credentials" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        "trace-credentials"
+      }
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "trace-credentials"
+        timeout.must_be :nil?
+        host.must_be :nil?
+        client_config.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Trace::Service.stub :new, stubbed_service do
+                trace = Google::Cloud::Trace.new project_id: "project-id", credentials: "path/to/keyfile.json"
+                trace.must_be_kind_of Google::Cloud::Trace::Project
+                trace.project.must_equal "project-id"
+                trace.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
+
+    it "uses provided endpoint" do
+      endpoint = "trace-endpoint2.example.com"
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal default_credentials
+        timeout.must_be :nil?
+        host.must_equal endpoint
+        client_config.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        Google::Cloud::Trace::Service.stub :new, stubbed_service do
+          trace = Google::Cloud::Trace.new project: "project-id", credentials: default_credentials, endpoint: endpoint
+          trace.must_be_kind_of Google::Cloud::Trace::Project
+          trace.project.must_equal "project-id"
+          trace.service.must_be_kind_of OpenStruct
+        end
+      end
+    end
+
+    it "uses provided project and keyfile aliases" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        "trace-credentials"
+      }
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "trace-credentials"
+        timeout.must_be :nil?
+        host.must_be :nil?
+        client_config.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Trace::Service.stub :new, stubbed_service do
+                trace = Google::Cloud::Trace.new project: "project-id", keyfile: "path/to/keyfile.json"
+                trace.must_be_kind_of Google::Cloud::Trace::Project
+                trace.project.must_equal "project-id"
+                trace.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
+
+    it "gets project_id from credentials" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        OpenStruct.new project_id: "project-id"
+      }
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_be_kind_of OpenStruct
+        credentials.project_id.must_equal "project-id"
+        timeout.must_be :nil?
+        host.must_be :nil?
+        client_config.must_be :nil?
+        OpenStruct.new project: project
+      }
+      empty_env = OpenStruct.new
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        Google::Cloud.stub :env, empty_env do
+          File.stub :file?, true, ["path/to/keyfile.json"] do
+            File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+              Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
+                Google::Cloud::Trace::Service.stub :new, stubbed_service do
+                  trace = Google::Cloud::Trace.new credentials: "path/to/keyfile.json"
+                  trace.must_be_kind_of Google::Cloud::Trace::Project
+                  trace.project.must_equal "project-id"
+                  trace.service.must_be_kind_of OpenStruct
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "Trace.configure" do
+    let(:found_credentials) { "{}" }
+    let :trace_client_config do
+      {"interfaces"=>
+         {"google.trace.v1.Trace"=>
+            {"retry_codes"=>{"idempotent"=>["DEADLINE_EXCEEDED", "UNAVAILABLE"]}}}}
+    end
+
+    after do
+      Google::Cloud.configure.reset!
+    end
+
+    it "uses shared config for project and keyfile" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        "trace-credentials"
+      }
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "trace-credentials"
+        timeout.must_be :nil?
+        host.must_be :nil?
+        client_config.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Set new configuration
+        Google::Cloud.configure do |config|
+          config.project = "project-id"
+          config.keyfile = "path/to/keyfile.json"
+        end
+
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Trace::Service.stub :new, stubbed_service do
+                trace = Google::Cloud::Trace.new
+                trace.must_be_kind_of Google::Cloud::Trace::Project
+                trace.project.must_equal "project-id"
+                trace.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
+
+    it "uses shared config for project_id and credentials" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        "trace-credentials"
+      }
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "trace-credentials"
+        timeout.must_be :nil?
+        host.must_be :nil?
+        client_config.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Set new configuration
+        Google::Cloud.configure do |config|
+          config.project_id = "project-id"
+          config.credentials = "path/to/keyfile.json"
+        end
+
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Trace::Service.stub :new, stubbed_service do
+                trace = Google::Cloud::Trace.new
+                trace.must_be_kind_of Google::Cloud::Trace::Project
+                trace.project.must_equal "project-id"
+                trace.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
+
+    it "uses trace config for project and keyfile" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        "trace-credentials"
+      }
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "trace-credentials"
+        timeout.must_equal 42
+        host.must_be :nil?
+        client_config.must_equal trace_client_config
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Set new configuration
+        Google::Cloud::Trace.configure do |config|
+          config.project = "project-id"
+          config.keyfile = "path/to/keyfile.json"
+          config.timeout = 42
+          config.client_config = trace_client_config
+        end
+
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Trace::Service.stub :new, stubbed_service do
+                trace = Google::Cloud::Trace.new
+                trace.must_be_kind_of Google::Cloud::Trace::Project
+                trace.project.must_equal "project-id"
+                trace.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
+
+    it "uses trace config for project_id and credentials" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        "trace-credentials"
+      }
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "trace-credentials"
+        timeout.must_equal 42
+        host.must_be :nil?
+        client_config.must_equal trace_client_config
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Set new configuration
+        Google::Cloud::Trace.configure do |config|
+          config.project_id = "project-id"
+          config.credentials = "path/to/keyfile.json"
+          config.timeout = 42
+          config.client_config = trace_client_config
+        end
+
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Trace::Service.stub :new, stubbed_service do
+                trace = Google::Cloud::Trace.new
+                trace.must_be_kind_of Google::Cloud::Trace::Project
+                trace.project.must_equal "project-id"
+                trace.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
+
+    it "uses trace config for endpoint" do
+      endpoint = "trace-endpoint2.example.com"
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        "trace-credentials"
+      }
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "trace-credentials"
+        timeout.must_be :nil?
+        host.must_equal endpoint
+        client_config.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Set new configuration
+        Google::Cloud::Trace.configure do |config|
+          config.project = "project-id"
+          config.keyfile = "path/to/keyfile.json"
+          config.endpoint = endpoint
+        end
+
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Trace::Service.stub :new, stubbed_service do
+                trace = Google::Cloud::Trace.new
+                trace.must_be_kind_of Google::Cloud::Trace::Project
+                trace.project.must_equal "project-id"
+                trace.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Add missing `client_config` param docs.
* Add missing test file `test/google/cloud/trace_test.rb`.

[closes #3762]