### PR TITLE
Add note about streaming insert issues

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1953,8 +1953,17 @@ module Google
         # the need to complete a load operation before the data can appear in
         # query results.
         #
+        # Because BigQuery's streaming API is designed for high insertion rates,
+        # modifications to the underlying table metadata exhibit are eventually
+        # consistent when interacting with the streaming system. In most cases
+        # metadata changes are propagated within minutes, but during this period
+        # API responses may reflect the inconsistent state of the table.
+        #
         # @see https://cloud.google.com/bigquery/streaming-data-into-bigquery
         #   Streaming Data Into BigQuery
+        #
+        # @see https://cloud.google.com/bigquery/troubleshooting-errors#metadata-errors-for-streaming-inserts
+        #   BigQuery Troubleshooting: Metadata errors for streaming inserts
         #
         # @param [String] table_id The ID of the destination table.
         # @param [Hash, Array<Hash>] rows A hash object or array of hash objects

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1972,8 +1972,17 @@ module Google
         # need to complete a load operation before the data can appear in query
         # results.
         #
+        # Because BigQuery's streaming API is designed for high insertion rates,
+        # modifications to the underlying table metadata exhibit are eventually
+        # consistent when interacting with the streaming system. In most cases
+        # metadata changes are propagated within minutes, but during this period
+        # API responses may reflect the inconsistent state of the table.
+        #
         # @see https://cloud.google.com/bigquery/streaming-data-into-bigquery
         #   Streaming Data Into BigQuery
+        #
+        # @see https://cloud.google.com/bigquery/troubleshooting-errors#metadata-errors-for-streaming-inserts
+        #   BigQuery Troubleshooting: Metadata errors for streaming inserts
         #
         # @param [Hash, Array<Hash>] rows A hash object or array of hash objects
         #   containing the data. Required.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -100,6 +100,19 @@ module Google
           # collected in batches and inserted together.
           # See {Google::Cloud::Bigquery::Table#insert_async}.
           #
+          # Because BigQuery's streaming API is designed for high insertion
+          # rates, modifications to the underlying table metadata exhibit are
+          # eventually consistent when interacting with the streaming system. In
+          # most cases metadata changes are propagated within minutes, but
+          # during this period API responses may reflect the inconsistent state
+          # of the table.
+          #
+          # @see https://cloud.google.com/bigquery/streaming-data-into-bigquery
+          #   Streaming Data Into BigQuery
+          #
+          # @see https://cloud.google.com/bigquery/troubleshooting-errors#metadata-errors-for-streaming-inserts
+          #   BigQuery Troubleshooting: Metadata errors for streaming inserts
+          #
           # @param [Hash, Array<Hash>] rows A hash object or array of hash
           #   objects containing the data.
           # @param [Array<String>] insert_ids A unique ID for each row. BigQuery


### PR DESCRIPTION
There are tradeoffs about inserting rows of data when table metadata has been changed. Indicate this and add a link to [BigQuery Troubleshooting: Metadata errors for streaming inserts](https://cloud.google.com/bigquery/troubleshooting-errors#metadata-errors-for-streaming-inserts) in the docs for the following methods:

* `Table#insert`
* `Table::AsyncInserter#insert`
* `Dataset#insert`

[closes #3809]