### PR TITLE
Release google-cloud-bigquery-data_transfer 0.3.0

### DIFF
--- a/google-cloud-bigquery-data_transfer/CHANGELOG.md
+++ b/google-cloud-bigquery-data_transfer/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Release History
 
+### 0.3.0 / 2019-08-23
+
+#### Features
+
+* Add StartManualTransferRuns
+  * DataTransferServiceClient changes:
+    * Add DataTransferServiceClient#start_manual_transfer_runs
+    * Deprecate DataTransferServiceClient#schedule_transfer_runs
+    * Add version_info argument to DataTransferServiceClient#create_transfer_config
+    * Add version_info argument to DataTransferServiceClient#update_transfer_config
+  * DataSourceParameter changes:
+    * Add DataSourceParameter#deprecated attribute
+    * Deprecate DataSourceParameter#repeated attribute
+    * Deprecate DataSourceParameter#fields attribute
+    * Deprecate DataSourceParameter::Type::RECORD value
+  * TransferConfig changes:
+    * Deprecate TransferConfig#schedule_options
+    * Deprecate TransferConfig#user_id
+  * TransferRun changes:
+    * Deprecate TransferRun#user_id
+* Add location path helpers
+* Add service_address and service_port to client constructor
+
+#### Documentation
+
+* Update documentation
+
 ### 0.2.5 / 2019-06-11
 
 * Add VERSION constant

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/version.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/version.rb
@@ -17,7 +17,7 @@ module Google
   module Cloud
     module Bigquery
       module DataTransfer
-        VERSION = "0.2.5".freeze
+        VERSION = "0.3.0".freeze
       end
     end
   end


### PR DESCRIPTION
#### Features

* Add StartManualTransferRuns
  * DataTransferServiceClient changes:
    * Add DataTransferServiceClient#start_manual_transfer_runs
    * Deprecate DataTransferServiceClient#schedule_transfer_runs
    * Add version_info argument to DataTransferServiceClient#create_transfer_config
    * Add version_info argument to DataTransferServiceClient#update_transfer_config
  * DataSourceParameter changes:
    * Add DataSourceParameter#deprecated attribute
    * Deprecate DataSourceParameter#repeated attribute
    * Deprecate DataSourceParameter#fields attribute
    * Deprecate DataSourceParameter::Type::RECORD value
  * TransferConfig changes:
    * Deprecate TransferConfig#schedule_options
    * Deprecate TransferConfig#user_id
  * TransferRun changes:
    * Deprecate TransferRun#user_id
* Add location path helpers
* Add service_address and service_port to client constructor

#### Documentation

* Update documentation

<details><summary>Commits since previous release</summary><pre><code>[33mcommit 9503c5518812de44f7016c104de431d78215ac5b[m
Author: Graham Paye <paye@google.com>
Date:   Fri Aug 23 11:08:09 2019 -0700

    Release google-cloud-bigquery-data_transfer 0.3.0 (#3904)
    
    #### Features
    
    * Add StartManualTransferRuns
      * DataTransferServiceClient changes:
        * Add DataTransferServiceClient#start_manual_transfer_runs
        * Deprecate DataTransferServiceClient#schedule_transfer_runs
        * Add version_info argument to DataTransferServiceClient#create_transfer_config
        * Add version_info argument to DataTransferServiceClient#update_transfer_config
      * DataSourceParameter changes:
        * Add DataSourceParameter#deprecated attribute
        * Deprecate DataSourceParameter#repeated attribute
        * Deprecate DataSourceParameter#fields attribute
        * Deprecate DataSourceParameter::Type::RECORD value
      * TransferConfig changes:
        * Deprecate TransferConfig#schedule_options
        * Deprecate TransferConfig#user_id
      * TransferRun changes:
        * Deprecate TransferRun#user_id
    * Add location path helpers
    * Add service_address and service_port to client constructor
    
    #### Documentation
    
    * Update documentation

[33mcommit 7905dcf525b9b4e729e5e8f18ea0b7709a3d8648[m
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Thu Jul 25 14:00:11 2019 -0700

    docs(bigquery-data_transfer): Update links to googleapis.dev

[33mcommit ac8ce21c294ea111e33142a7ba6da82786cc8935[m
Author: Graham Paye <paye@google.com>
Date:   Wed Jul 24 12:35:57 2019 -0700

    docs: update links to point to new docsite (#3684)

[33mcommit f897dc7ca351230dca8012271fba698ab0e1fd21[m
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Jul 10 15:09:17 2019 -0700

    feat(bigquery-data_transfer): Add location path helpers

[33mcommit d939037bf99bfa5493eaad32f42ec28eb9bad192[m
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Jul 1 11:58:32 2019 -0700

    feat(bigquery-data_transfer): Add service_address and service_port to client constructor

[33mcommit 37d27c979f94c80a5c740d7bfe93f743cae1e9c4[m
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 30 16:44:04 2019 -0700

    chore: Support overriding service host and port for generated clients

[33mcommit b383994751c8c9e630a78dbfe7852f3f56b4be04[m
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Fri Jun 14 08:33:40 2019 -0700

    feat(bigquery-data_transfer): Add StartManualTransferRuns
    
    * DataTransferServiceClient changes:
      * Add DataTransferServiceClient#start_manual_transfer_runs
      * Deprecate DataTransferServiceClient#schedule_transfer_runs
      * Add version_info argument to DataTransferServiceClient#create_transfer_config
      * Add version_info argument to DataTransferServiceClient#update_transfer_config
    * DataSourceParameter changes:
      * Add DataSourceParameter#deprecated attribute
      * Deprecate DataSourceParameter#repeated attribute
      * Deprecate DataSourceParameter#fields attribute
      * Deprecate DataSourceParameter::Type::RECORD value
    * TransferConfig changes:
      * Deprecate TransferConfig#schedule_options
      * Deprecate TransferConfig#user_id
    * TransferRun changes:
      * Deprecate TransferRun#user_id
    
    [pr #3484]
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
[1mdiff --git a/google-cloud-bigquery-data_transfer/CHANGELOG.md b/google-cloud-bigquery-data_transfer/CHANGELOG.md[m
[1mindex c29b30cae..8942a5e5e 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/CHANGELOG.md[m
[1m+++ b/google-cloud-bigquery-data_transfer/CHANGELOG.md[m
[36m@@ -1,5 +1,32 @@[m
 # Release History[m
 [m
[32m+[m[32m### 0.3.0 / 2019-08-23[m
[32m+[m
[32m+[m[32m#### Features[m
[32m+[m
[32m+[m[32m* Add StartManualTransferRuns[m
[32m+[m[32m  * DataTransferServiceClient changes:[m
[32m+[m[32m    * Add DataTransferServiceClient#start_manual_transfer_runs[m
[32m+[m[32m    * Deprecate DataTransferServiceClient#schedule_transfer_runs[m
[32m+[m[32m    * Add version_info argument to DataTransferServiceClient#create_transfer_config[m
[32m+[m[32m    * Add version_info argument to DataTransferServiceClient#update_transfer_config[m
[32m+[m[32m  * DataSourceParameter changes:[m
[32m+[m[32m    * Add DataSourceParameter#deprecated attribute[m
[32m+[m[32m    * Deprecate DataSourceParameter#repeated attribute[m
[32m+[m[32m    * Deprecate DataSourceParameter#fields attribute[m
[32m+[m[32m    * Deprecate DataSourceParameter::Type::RECORD value[m
[32m+[m[32m  * TransferConfig changes:[m
[32m+[m[32m    * Deprecate TransferConfig#schedule_options[m
[32m+[m[32m    * Deprecate TransferConfig#user_id[m
[32m+[m[32m  * TransferRun changes:[m
[32m+[m[32m    * Deprecate TransferRun#user_id[m
[32m+[m[32m* Add location path helpers[m
[32m+[m[32m* Add service_address and service_port to client constructor[m
[32m+[m
[32m+[m[32m#### Documentation[m
[32m+[m
[32m+[m[32m* Update documentation[m
[32m+[m
 ### 0.2.5 / 2019-06-11[m
 [m
 * Add VERSION constant[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/README.md b/google-cloud-bigquery-data_transfer/README.md[m
[1mindex b0576dbf4..dd28fec07 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/README.md[m
[1m+++ b/google-cloud-bigquery-data_transfer/README.md[m
[36m@@ -13,7 +13,7 @@[m [msteps:[m
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)[m
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)[m
 3. [Enable the BigQuery Data Transfer API.](https://console.cloud.google.com/apis/library/bigquerydatatransfer.googleapis.com)[m
[31m-4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)[m
[32m+[m[32m4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/latest/file.AUTHENTICATION.html)[m
 [m
 ### Installation[m
 ```[m
[36m@@ -26,7 +26,7 @@[m [m$ gem install google-cloud-bigquery-data_transfer[m
 require "google/cloud/bigquery/data_transfer"[m
 [m
 data_transfer_client = Google::Cloud::Bigquery::DataTransfer.new[m
[31m-formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.project_path(project_id)[m
[32m+[m[32mformatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.location_path(project_id, "us-central1")[m
 [m
 # Iterate over all results.[m
 data_transfer_client.list_data_sources(formatted_parent).each do |element|[m
[36m@@ -50,14 +50,14 @@[m [mend[m
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)[m
   to see the full list of Cloud APIs that we cover.[m
 [m
[31m-[Client Library Documentation]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-bigquery-data_transfer/latest/google/cloud/bigquery/datatransfer/v1[m
[32m+[m[32m[Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/latest[m
 [Product Documentation]: https://cloud.google.com/bigquery/transfer/[m
 [m
 ## Enabling Logging[m
 [m
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.[m
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,[m
[31m-or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)[m
[32m+[m[32mor a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
 that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
 [m
[1mdiff --git a/google-cloud-bigquery-data_transfer/acceptance/google/cloud/bigquery/data_transfer/v1/data_transfer_service_smoke_test.rb b/google-cloud-bigquery-data_transfer/acceptance/google/cloud/bigquery/data_transfer/v1/data_transfer_service_smoke_test.rb[m
[1mindex f90c7faa0..cd799181a 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/acceptance/google/cloud/bigquery/data_transfer/v1/data_transfer_service_smoke_test.rb[m
[1m+++ b/google-cloud-bigquery-data_transfer/acceptance/google/cloud/bigquery/data_transfer/v1/data_transfer_service_smoke_test.rb[m
[36m@@ -27,7 +27,7 @@[m [mdescribe "DataTransferServiceSmokeTest v1" do[m
     project_id = ENV["DATA_TRANSFER_TEST_PROJECT"].freeze[m
 [m
     data_transfer_client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)[m
[31m-    formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.project_path(project_id)[m
[32m+[m[32m    formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.location_path(project_id, "us-central1")[m
 [m
     # Iterate over all results.[m
     data_transfer_client.list_data_sources(formatted_parent).each do |element|[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec b/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec[m
[1mindex f6ccc4b16..4592a2f48 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec[m
[1m+++ b/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec[m
[36m@@ -21,7 +21,7 @@[m [mGem::Specification.new do |gem|[m
 [m
   gem.required_ruby_version = ">= 2.0.0"[m
 [m
[31m-  gem.add_dependency "google-gax", "~> 1.3"[m
[32m+[m[32m  gem.add_dependency "google-gax", "~> 1.7"[m
 [m
   gem.add_development_dependency "minitest", "~> 5.10"[m
   gem.add_development_dependency "redcarpet", "~> 3.0"[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer.rb[m
[1mindex c1de63c00..acddeaa8d 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer.rb[m
[1m+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer.rb[m
[36m@@ -36,7 +36,7 @@[m [mmodule Google[m
       # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)[m
       # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)[m
       # 3. [Enable the BigQuery Data Transfer API.](https://console.cloud.google.com/apis/library/bigquerydatatransfer.googleapis.com)[m
[31m-      # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)[m
[32m+[m[32m      # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/latest/file.AUTHENTICATION.html)[m
       #[m
       # ### Installation[m
       # ```[m
[36m@@ -49,7 +49,7 @@[m [mmodule Google[m
       # require "google/cloud/bigquery/data_transfer"[m
       #[m
       # data_transfer_client = Google::Cloud::Bigquery::DataTransfer.new[m
[31m-      # formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.project_path(project_id)[m
[32m+[m[32m      # formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.location_path(project_id, "us-central1")[m
       #[m
       # # Iterate over all results.[m
       # data_transfer_client.list_data_sources(formatted_parent).each do |element|[m
[36m@@ -77,7 +77,7 @@[m [mmodule Google[m
       #[m
       # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.[m
       # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,[m
[31m-      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)[m
[32m+[m[32m      # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
       # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
       # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
       #[m
[36m@@ -146,6 +146,10 @@[m [mmodule Google[m
         #     The default timeout, in seconds, for calls made through this client.[m
         #   @param metadata [Hash][m
         #     Default metadata to be sent with each request. This can be overridden on a per call basis.[m
[32m+[m[32m        #   @param service_address [String][m
[32m+[m[32m        #     Override for the service hostname, or `nil` to leave as the default.[m
[32m+[m[32m        #   @param service_port [Integer][m
[32m+[m[32m        #     Override for the service port, or `nil` to leave as the default.[m
         #   @param exception_transformer [Proc][m
         #     An optional proc that intercepts any exceptions raised during an API call to inject[m
         #     custom error handling.[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1.rb[m
[1mindex d61b0bf0c..a0453ba9e 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1.rb[m
[1m+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1.rb[m
[36m@@ -36,7 +36,7 @@[m [mmodule Google[m
         # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)[m
         # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)[m
         # 3. [Enable the BigQuery Data Transfer API.](https://console.cloud.google.com/apis/library/bigquerydatatransfer.googleapis.com)[m
[31m-        # 4. [Setup Authentication.](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)[m
[32m+[m[32m        # 4. [Setup Authentication.](https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/latest/file.AUTHENTICATION.html)[m
         #[m
         # ### Installation[m
         # ```[m
[36m@@ -49,7 +49,7 @@[m [mmodule Google[m
         # require "google/cloud/bigquery/data_transfer"[m
         #[m
         # data_transfer_client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)[m
[31m-        # formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.project_path(project_id)[m
[32m+[m[32m        # formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.location_path(project_id, "us-central1")[m
         #[m
         # # Iterate over all results.[m
         # data_transfer_client.list_data_sources(formatted_parent).each do |element|[m
[36m@@ -77,7 +77,7 @@[m [mmodule Google[m
         #[m
         # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.[m
         # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,[m
[31m-        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)[m
[32m+[m[32m        # or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)[m
         # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)[m
         # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.[m
         #[m
[36m@@ -134,6 +134,10 @@[m [mmodule Google[m
           #   The default timeout, in seconds, for calls made through this client.[m
           # @param metadata [Hash][m
           #   Default metadata to be sent with each request. This can be overridden on a per call basis.[m
[32m+[m[32m          # @param service_address [String][m
[32m+[m[32m          #   Override for the service hostname, or `nil` to leave as the default.[m
[32m+[m[32m          # @param service_port [Integer][m
[32m+[m[32m          #   Override for the service port, or `nil` to leave as the default.[m
           # @param exception_transformer [Proc][m
           #   An optional proc that intercepts any exceptions raised during an API call to inject[m
           #   custom error handling.[m
[36m@@ -143,6 +147,8 @@[m [mmodule Google[m
               client_config: nil,[m
               timeout: nil,[m
               metadata: nil,[m
[32m+[m[32m              service_address: nil,[m
[32m+[m[32m              service_port: nil,[m
               exception_transformer: nil,[m
               lib_name: nil,[m
               lib_version: nil[m
[36m@@ -154,6 +160,8 @@[m [mmodule Google[m
               metadata: metadata,[m
               exception_transformer: exception_transformer,[m
               lib_name: lib_name,[m
[32m+[m[32m              service_address: service_address,[m
[32m+[m[32m              service_port: service_port,[m
               lib_version: lib_version[m
             }.select { |_, v| v != nil }[m
             Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.new(**kwargs)[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb[m
[1mindex cda8c8717..9681da688 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb[m
[1m+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb[m
[36m@@ -84,6 +84,30 @@[m [mmodule Google[m
             ].freeze[m
 [m
 [m
[32m+[m[32m            LOCATION_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m              "projects/{project}/locations/{location}"[m
[32m+[m[32m            )[m
[32m+[m
[32m+[m[32m            private_constant :LOCATION_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m            LOCATION_DATA_SOURCE_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m              "projects/{project}/locations/{location}/dataSources/{data_source}"[m
[32m+[m[32m            )[m
[32m+[m
[32m+[m[32m            private_constant :LOCATION_DATA_SOURCE_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m            LOCATION_RUN_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m              "projects/{project}/locations/{location}/transferConfigs/{transfer_config}/runs/{run}"[m
[32m+[m[32m            )[m
[32m+[m
[32m+[m[32m            private_constant :LOCATION_RUN_PATH_TEMPLATE[m
[32m+[m
[32m+[m[32m            LOCATION_TRANSFER_CONFIG_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
[32m+[m[32m              "projects/{project}/locations/{location}/transferConfigs/{transfer_config}"[m
[32m+[m[32m            )[m
[32m+[m
[32m+[m[32m            private_constant :LOCATION_TRANSFER_CONFIG_PATH_TEMPLATE[m
[32m+[m
             PROJECT_PATH_TEMPLATE = Google::Gax::PathTemplate.new([m
               "projects/{project}"[m
             )[m
[36m@@ -108,6 +132,58 @@[m [mmodule Google[m
 [m
             private_constant :PROJECT_TRANSFER_CONFIG_PATH_TEMPLATE[m
 [m
[32m+[m[32m            # Returns a fully-qualified location resource name string.[m
[32m+[m[32m            # @param project [String][m
[32m+[m[32m            # @param location [String][m
[32m+[m[32m            # @return [String][m
[32m+[m[32m            def self.location_path project, location[m
[32m+[m[32m              LOCATION_PATH_TEMPLATE.render([m
[32m+[m[32m                :"project" => project,[m
[32m+[m[32m                :"location" => location[m
[32m+[m[32m              )[m
[32m+[m[32m            end[m
[32m+[m
[32m+[m[32m            # Returns a fully-qualified location_data_source resource name string.[m
[32m+[m[32m            # @param project [String][m
[32m+[m[32m            # @param location [String][m
[32m+[m[32m            # @param data_source [String][m
[32m+[m[32m            # @return [String][m
[32m+[m[32m            def self.location_data_source_path project, location, data_source[m
[32m+[m[32m              LOCATION_DATA_SOURCE_PATH_TEMPLATE.render([m
[32m+[m[32m                :"project" => project,[m
[32m+[m[32m                :"location" => location,[m
[32m+[m[32m                :"data_source" => data_source[m
[32m+[m[32m              )[m
[32m+[m[32m            end[m
[32m+[m
[32m+[m[32m            # Returns a fully-qualified location_run resource name string.[m
[32m+[m[32m            # @param project [String][m
[32m+[m[32m            # @param location [String][m
[32m+[m[32m            # @param transfer_config [String][m
[32m+[m[32m            # @param run [String][m
[32m+[m[32m            # @return [String][m
[32m+[m[32m            def self.location_run_path project, location, transfer_config, run[m
[32m+[m[32m              LOCATION_RUN_PATH_TEMPLATE.render([m
[32m+[m[32m                :"project" => project,[m
[32m+[m[32m                :"location" => location,[m
[32m+[m[32m                :"transfer_config" => transfer_config,[m
[32m+[m[32m                :"run" => run[m
[32m+[m[32m              )[m
[32m+[m[32m            end[m
[32m+[m
[32m+[m[32m            # Returns a fully-qualified location_transfer_config resource name string.[m
[32m+[m[32m            # @param project [String][m
[32m+[m[32m            # @param location [String][m
[32m+[m[32m            # @param transfer_config [String][m
[32m+[m[32m            # @return [String][m
[32m+[m[32m            def self.location_transfer_config_path project, location, transfer_config[m
[32m+[m[32m              LOCATION_TRANSFER_CONFIG_PATH_TEMPLATE.render([m
[32m+[m[32m                :"project" => project,[m
[32m+[m[32m                :"location" => location,[m
[32m+[m[32m                :"transfer_config" => transfer_config[m
[32m+[m[32m              )[m
[32m+[m[32m            end[m
[32m+[m
             # Returns a fully-qualified project resource name string.[m
             # @param project [String][m
             # @return [String][m
[36m@@ -178,6 +254,10 @@[m [mmodule Google[m
             #   The default timeout, in seconds, for calls made through this client.[m
             # @param metadata [Hash][m
             #   Default metadata to be sent with each request. This can be overridden on a per call basis.[m
[32m+[m[32m            # @param service_address [String][m
[32m+[m[32m            #   Override for the service hostname, or `nil` to leave as the default.[m
[32m+[m[32m            # @param service_port [Integer][m
[32m+[m[32m            #   Override for the service port, or `nil` to leave as the default.[m
             # @param exception_transformer [Proc][m
             #   An optional proc that intercepts any exceptions raised during an API call to inject[m
             #   custom error handling.[m
[36m@@ -187,6 +267,8 @@[m [mmodule Google[m
                 client_config: {},[m
                 timeout: DEFAULT_TIMEOUT,[m
                 metadata: nil,[m
[32m+[m[32m                service_address: nil,[m
[32m+[m[32m                service_port: nil,[m
                 exception_transformer: nil,[m
                 lib_name: nil,[m
                 lib_version: ""[m
[36m@@ -241,8 +323,8 @@[m [mmodule Google[m
               end[m
 [m
               # Allow overriding the service path/port in subclasses.[m
[31m-              service_path = self.class::SERVICE_ADDRESS[m
[31m-              port = self.class::DEFAULT_SERVICE_PORT[m
[32m+[m[32m              service_path = service_address || self.class::SERVICE_ADDRESS[m
[32m+[m[32m              port = service_port || self.class::DEFAULT_SERVICE_PORT[m
               interceptors = self.class::GRPC_INTERCEPTORS[m
               @data_transfer_service_stub = Google::Gax::Grpc.create_stub([m
                 service_path,[m
[36m@@ -359,6 +441,14 @@[m [mmodule Google[m
                   {'name' => request.name}[m
                 end[m
               )[m
[32m+[m[32m              @start_manual_transfer_runs = Google::Gax.create_api_call([m
[32m+[m[32m                @data_transfer_service_stub.method(:start_manual_transfer_runs),[m
[32m+[m[32m                defaults["start_manual_transfer_runs"],[m
[32m+[m[32m                exception_transformer: exception_transformer,[m
[32m+[m[32m                params_extractor: proc do |request|[m
[32m+[m[32m                  {'parent' => request.parent}[m
[32m+[m[32m                end[m
[32m+[m[32m              )[m
             end[m
 [m
             # Service calls[m
[36m@@ -455,7 +545,7 @@[m [mmodule Google[m
             #[m
             # @param parent [String][m
             #   The BigQuery project id where the transfer configuration should be created.[m
[31m-            #   Must be in the format /projects/\\{project_id}/locations/\\{location_id}[m
[32m+[m[32m            #   Must be in the format projects/\\{project_id}/locations/\\{location_id}[m
             #   If specified location and location of the destination bigquery dataset[m
             #   do not match - the request will fail.[m
             # @param transfer_config [Google::Cloud::Bigquery::Datatransfer::V1::TransferConfig | Hash][m
[36m@@ -479,6 +569,13 @@[m [mmodule Google[m
             #     urn:ietf:wg:oauth:2.0:oob means that authorization code should be[m
             #     returned in the title bar of the browser, with the page text prompting[m
             #     the user to copy the code and paste it in the application.[m
[32m+[m[32m            # @param version_info [String][m
[32m+[m[32m            #   Optional version info. If users want to find a very recent access token,[m
[32m+[m[32m            #   that is, immediately after approving access, users have to set the[m
[32m+[m[32m            #   version_info claim in the token request. To obtain the version_info, users[m
[32m+[m[32m            #   must use the "none+gsession" response type. which be return a[m
[32m+[m[32m            #   version_info back in the authorization response which be be put in a JWT[m
[32m+[m[32m            #   claim in the token request.[m
             # @param options [Google::Gax::CallOptions][m
             #   Overrides the default settings for this call, e.g, timeout,[m
             #   retries, etc.[m
[36m@@ -501,12 +598,14 @@[m [mmodule Google[m
                 parent,[m
                 transfer_config,[m
                 authorization_code: nil,[m
[32m+[m[32m                version_info: nil,[m
                 options: nil,[m
                 &block[m
               req = {[m
                 parent: parent,[m
                 transfer_config: transfer_config,[m
[31m-                authorization_code: authorization_code[m
[32m+[m[32m                authorization_code: authorization_code,[m
[32m+[m[32m                version_info: version_info[m
               }.delete_if { |_, v| v.nil? }[m
               req = Google::Gax::to_proto(req, Google::Cloud::Bigquery::Datatransfer::V1::CreateTransferConfigRequest)[m
               @create_transfer_config.call(req, options, &block)[m
[36m@@ -540,6 +639,13 @@[m [mmodule Google[m
             #     urn:ietf:wg:oauth:2.0:oob means that authorization code should be[m
             #     returned in the title bar of the browser, with the page text prompting[m
             #     the user to copy the code and paste it in the application.[m
[32m+[m[32m            # @param version_info [String][m
[32m+[m[32m            #   Optional version info. If users want to find a very recent access token,[m
[32m+[m[32m            #   that is, immediately after approving access, users have to set the[m
[32m+[m[32m            #   version_info claim in the token request. To obtain the version_info, users[m
[32m+[m[32m            #   must use the "none+gsession" response type. which be return a[m
[32m+[m[32m            #   version_info back in the authorization response which be be put in a JWT[m
[32m+[m[32m            #   claim in the token request.[m
             # @param options [Google::Gax::CallOptions][m
             #   Overrides the default settings for this call, e.g, timeout,[m
             #   retries, etc.[m
[36m@@ -564,12 +670,14 @@[m [mmodule Google[m
                 transfer_config,[m
                 update_mask,[m
                 authorization_code: nil,[m
[32m+[m[32m                version_info: nil,[m
                 options: nil,[m
                 &block[m
               req = {[m
                 transfer_config: transfer_config,[m
                 update_mask: update_mask,[m
[31m-                authorization_code: authorization_code[m
[32m+[m[32m                authorization_code: authorization_code,[m
[32m+[m[32m                version_info: version_info[m
               }.delete_if { |_, v| v.nil? }[m
               req = Google::Gax::to_proto(req, Google::Cloud::Bigquery::Datatransfer::V1::UpdateTransferConfigRequest)[m
               @update_transfer_config.call(req, options, &block)[m
[36m@@ -701,6 +809,7 @@[m [mmodule Google[m
             # For each date - or whatever granularity the data source supports - in the[m
             # range, one transfer run is created.[m
             # Note that runs are created per UTC time in the time range.[m
[32m+[m[32m            # DEPRECATED: use StartManualTransferRuns instead.[m
             #[m
             # @param parent [String][m
             #   Transfer configuration name in the form:[m
[36m@@ -972,6 +1081,52 @@[m [mmodule Google[m
               req = Google::Gax::to_proto(req, Google::Cloud::Bigquery::Datatransfer::V1::CheckValidCredsRequest)[m
               @check_valid_creds.call(req, options, &block)[m
             end[m
[32m+[m
[32m+[m[32m            # Start manual transfer runs to be executed now with schedule_time equal to[m
[32m+[m[32m            # current time. The transfer runs can be created for a time range where the[m
[32m+[m[32m            # run_time is between start_time (inclusive) and end_time (exclusive), or for[m
[32m+[m[32m            # a specific run_time.[m
[32m+[m[32m            #[m
[32m+[m[32m            # @param parent [String][m
[32m+[m[32m            #   Transfer configuration name in the form:[m
[32m+[m[32m            #   `projects/{project_id}/transferConfigs/{config_id}`.[m
[32m+[m[32m            # @param requested_time_range [Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsRequest::TimeRange | Hash][m
[32m+[m[32m            #   Time range for the transfer runs that should be started.[m
[32m+[m[32m            #   A hash of the same form as `Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsRequest::TimeRange`[m
[32m+[m[32m            #   can also be provided.[m
[32m+[m[32m            # @param requested_run_time [Google::Protobuf::Timestamp | Hash][m
[32m+[m[32m            #   Specific run_time for a transfer run to be started. The[m
[32m+[m[32m            #   requested_run_time must not be in the future.[m
[32m+[m[32m            #   A hash of the same form as `Google::Protobuf::Timestamp`[m
[32m+[m[32m            #   can also be provided.[m
[32m+[m[32m            # @param options [Google::Gax::CallOptions][m
[32m+[m[32m            #   Overrides the default settings for this call, e.g, timeout,[m
[32m+[m[32m            #   retries, etc.[m
[32m+[m[32m            # @yield [result, operation] Access the result along with the RPC operation[m
[32m+[m[32m            # @yieldparam result [Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsResponse][m
[32m+[m[32m            # @yieldparam operation [GRPC::ActiveCall::Operation][m
[32m+[m[32m            # @return [Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsResponse][m
[32m+[m[32m            # @raise [Google::Gax::GaxError] if the RPC is aborted.[m
[32m+[m[32m            # @example[m
[32m+[m[32m            #   require "google/cloud/bigquery/data_transfer"[m
[32m+[m[32m            #[m
[32m+[m[32m            #   data_transfer_client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)[m
[32m+[m[32m            #   response = data_transfer_client.start_manual_transfer_runs[m
[32m+[m
[32m+[m[32m            def start_manual_transfer_runs \[m
[32m+[m[32m                parent: nil,[m
[32m+[m[32m                requested_time_range: nil,[m
[32m+[m[32m                requested_run_time: nil,[m
[32m+[m[32m                options: nil,[m
[32m+[m[32m                &block[m
[32m+[m[32m              req = {[m
[32m+[m[32m                parent: parent,[m
[32m+[m[32m                requested_time_range: requested_time_range,[m
[32m+[m[32m                requested_run_time: requested_run_time[m
[32m+[m[32m              }.delete_if { |_, v| v.nil? }[m
[32m+[m[32m              req = Google::Gax::to_proto(req, Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsRequest)[m
[32m+[m[32m              @start_manual_transfer_runs.call(req, options, &block)[m
[32m+[m[32m            end[m
           end[m
         end[m
       end[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_config.json b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_config.json[m
[1mindex 5949db4c5..07463d03d 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_config.json[m
[1m+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_config.json[m
[36m@@ -84,6 +84,11 @@[m
           "timeout_millis": 30000,[m
           "retry_codes_name": "idempotent",[m
           "retry_params_name": "default"[m
[32m+[m[32m        },[m
[32m+[m[32m        "StartManualTransferRuns": {[m
[32m+[m[32m          "timeout_millis": 60000,[m
[32m+[m[32m          "retry_codes_name": "non_idempotent",[m
[32m+[m[32m          "retry_params_name": "default"[m
         }[m
       }[m
     }[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/data_transfer/v1/data_transfer.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/data_transfer/v1/data_transfer.rb[m
[1mindex c4b3e8e40..aabdc9afb 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/data_transfer/v1/data_transfer.rb[m
[1m+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/data_transfer/v1/data_transfer.rb[m
[36m@@ -25,8 +25,7 @@[m [mmodule Google[m
         # | [DataTransferServiceClient][] | The Google BigQuery Data Transfer Service API enables BigQuery users to configure the transfer of their data from other Google Products into BigQuery. |[m
         # | [Data Types][] | Data types for Google::Cloud::Bigquery::DataTransfer::V1 |[m
         #[m
[31m-        # [DataTransferServiceClient]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-bigquery-data_transfer/latest/google/cloud/bigquery/datatransfer/v1/datatransferserviceclient[m
[31m-        # [Data Types]: https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-bigquery-data_transfer/latest/google/cloud/bigquery/datatransfer/v1/datatypes[m
[32m+[m[32m        # [DataTransferServiceClient]: https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/latest/Google/Cloud/Bigquery/DataTransfer/V1/DataTransferServiceClient.html[m
         #[m
         module V1[m
           # Represents a data source parameter with validation rules, so that[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datasource.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datasource.rb[m
[1mnew file mode 100644[m
[1mindex 000000000..628547397[m
[1m--- /dev/null[m
[1m+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datasource.rb[m
[36m@@ -0,0 +1,25 @@[m
[32m+[m[32m# Copyright 2019 Google LLC[m
[32m+[m[32m#[m
[32m+[m[32m# Licensed under the Apache License, Version 2.0 (the "License");[m
[32m+[m[32m# you may not use this file except in compliance with the License.[m
[32m+[m[32m# You may obtain a copy of the License at[m
[32m+[m[32m#[m
[32m+[m[32m#     https://www.apache.org/licenses/LICENSE-2.0[m
[32m+[m[32m#[m
[32m+[m[32m# Unless required by applicable law or agreed to in writing, software[m
[32m+[m[32m# distributed under the License is distributed on an "AS IS" BASIS,[m
[32m+[m[32m# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.[m
[32m+[m[32m# See the License for the specific language governing permissions and[m
[32m+[m[32m# limitations under the License.[m
[32m+[m
[32m+[m
[32m+[m[32mmodule Google[m
[32m+[m[32m  module Cloud[m
[32m+[m[32m    module Bigquery[m
[32m+[m[32m      module Datatransfer[m
[32m+[m[32m        module V1[m
[32m+[m[32m        end[m
[32m+[m[32m      end[m
[32m+[m[32m    end[m
[32m+[m[32m  end[m
[32m+[m[32mend[m
\ No newline at end of file[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb[m
[1mindex 4387b5d63..362c36cef 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb[m
[1m+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb[m
[36m@@ -41,7 +41,7 @@[m [mmodule Google[m
           #     Is parameter required.[m
           # @!attribute [rw] repeated[m
           #   @return [true, false][m
[31m-          #     Can parameter have multiple values.[m
[32m+[m[32m          #     Deprecated. This field has no effect.[m
           # @!attribute [rw] validation_regex[m
           #   @return [String][m
           #     Regular expression which can be used for parameter validation.[m
[36m@@ -56,7 +56,7 @@[m [mmodule Google[m
           #     For integer and double values specifies maxminum allowed value.[m
           # @!attribute [rw] fields[m
           #   @return [Array<Google::Cloud::Bigquery::Datatransfer::V1::DataSourceParameter>][m
[31m-          #     When parameter is a record, describes child fields.[m
[32m+[m[32m          #     Deprecated. This field has no effect.[m
           # @!attribute [rw] validation_description[m
           #   @return [String][m
           #     Description of the requirements for this field, in case the user input does[m
[36m@@ -69,8 +69,11 @@[m [mmodule Google[m
           #     Cannot be changed after initial creation.[m
           # @!attribute [rw] recurse[m
           #   @return [true, false][m
[31m-          #     If set to true, schema should be taken from the parent with the same[m
[31m-          #     parameter_id. Only applicable when parameter type is RECORD.[m
[32m+[m[32m          #     Deprecated. This field has no effect.[m
[32m+[m[32m          # @!attribute [rw] deprecated[m
[32m+[m[32m          #   @return [true, false][m
[32m+[m[32m          #     If true, it should not be used in new transfers, and it should not be[m
[32m+[m[32m          #     visible to users.[m
           class DataSourceParameter[m
             # Parameter type.[m
             module Type[m
[36m@@ -90,7 +93,7 @@[m [mmodule Google[m
               # Boolean parameter.[m
               BOOLEAN = 4[m
 [m
[31m-              # Record parameter.[m
[32m+[m[32m              # Deprecated. This field has no effect.[m
               RECORD = 5[m
 [m
               # Page ID for a Google+ Page.[m
[36m@@ -115,24 +118,21 @@[m [mmodule Google[m
           # @!attribute [rw] client_id[m
           #   @return [String][m
           #     Data source client id which should be used to receive refresh token.[m
[31m-          #     When not supplied, no offline credentials are populated for data transfer.[m
           # @!attribute [rw] scopes[m
           #   @return [Array<String>][m
[31m-          #     Api auth scopes for which refresh token needs to be obtained. Only valid[m
[31m-          #     when `client_id` is specified. Ignored otherwise. These are scopes needed[m
[31m-          #     by a data source to prepare data and ingest them into BigQuery,[m
[31m-          #     e.g., https://www.googleapis.com/auth/bigquery[m
[32m+[m[32m          #     Api auth scopes for which refresh token needs to be obtained. These are[m
[32m+[m[32m          #     scopes needed by a data source to prepare data and ingest them into[m
[32m+[m[32m          #     BigQuery, e.g., https://www.googleapis.com/auth/bigquery[m
           # @!attribute [rw] transfer_type[m
           #   @return [Google::Cloud::Bigquery::Datatransfer::V1::TransferType][m
           #     Deprecated. This field has no effect.[m
           # @!attribute [rw] supports_multiple_transfers[m
           #   @return [true, false][m
[31m-          #     Indicates whether the data source supports multiple transfers[m
[31m-          #     to different BigQuery targets.[m
[32m+[m[32m          #     Deprecated. This field has no effect.[m
           # @!attribute [rw] update_deadline_seconds[m
           #   @return [Integer][m
           #     The number of seconds to wait for an update from the data source[m
[31m-          #     before BigQuery marks the transfer as failed.[m
[32m+[m[32m          #     before the Data Transfer Service marks the transfer as FAILED.[m
           # @!attribute [rw] default_schedule[m
           #   @return [String][m
           #     Default data transfer schedule.[m
[36m@@ -248,7 +248,7 @@[m [mmodule Google[m
           # @!attribute [rw] parent[m
           #   @return [String][m
           #     The BigQuery project id where the transfer configuration should be created.[m
[31m-          #     Must be in the format /projects/\\{project_id}/locations/\\{location_id}[m
[32m+[m[32m          #     Must be in the format projects/\\{project_id}/locations/\\{location_id}[m
           #     If specified location and location of the destination bigquery dataset[m
           #     do not match - the request will fail.[m
           # @!attribute [rw] transfer_config[m
[36m@@ -272,6 +272,14 @@[m [mmodule Google[m
           #       urn:ietf:wg:oauth:2.0:oob means that authorization code should be[m
           #       returned in the title bar of the browser, with the page text prompting[m
           #       the user to copy the code and paste it in the application.[m
[32m+[m[32m          # @!attribute [rw] version_info[m
[32m+[m[32m          #   @return [String][m
[32m+[m[32m          #     Optional version info. If users want to find a very recent access token,[m
[32m+[m[32m          #     that is, immediately after approving access, users have to set the[m
[32m+[m[32m          #     version_info claim in the token request. To obtain the version_info, users[m
[32m+[m[32m          #     must use the "none+gsession" response type. which be return a[m
[32m+[m[32m          #     version_info back in the authorization response which be be put in a JWT[m
[32m+[m[32m          #     claim in the token request.[m
           class CreateTransferConfigRequest; end[m
 [m
           # A request to update a transfer configuration. To update the user id of the[m
[36m@@ -300,6 +308,14 @@[m [mmodule Google[m
           # @!attribute [rw] update_mask[m
           #   @return [Google::Protobuf::FieldMask][m
           #     Required list of fields to be updated in this request.[m
[32m+[m[32m          # @!attribute [rw] version_info[m
[32m+[m[32m          #   @return [String][m
[32m+[m[32m          #     Optional version info. If users want to find a very recent access token,[m
[32m+[m[32m          #     that is, immediately after approving access, users have to set the[m
[32m+[m[32m          #     version_info claim in the token request. To obtain the version_info, users[m
[32m+[m[32m          #     must use the "none+gsession" response type. which be return a[m
[32m+[m[32m          #     version_info back in the authorization response which be be put in a JWT[m
[32m+[m[32m          #     claim in the token request.[m
           class UpdateTransferConfigRequest; end[m
 [m
           # A request to get data transfer information.[m
[36m@@ -481,6 +497,42 @@[m [mmodule Google[m
           #   @return [Array<Google::Cloud::Bigquery::Datatransfer::V1::TransferRun>][m
           #     The transfer runs that were scheduled.[m
           class ScheduleTransferRunsResponse; end[m
[32m+[m
[32m+[m[32m          # A request to start manual transfer runs.[m
[32m+[m[32m          # @!attribute [rw] parent[m
[32m+[m[32m          #   @return [String][m
[32m+[m[32m          #     Transfer configuration name in the form:[m
[32m+[m[32m          #     `projects/{project_id}/transferConfigs/{config_id}`.[m
[32m+[m[32m          # @!attribute [rw] requested_time_range[m
[32m+[m[32m          #   @return [Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsRequest::TimeRange][m
[32m+[m[32m          #     Time range for the transfer runs that should be started.[m
[32m+[m[32m          # @!attribute [rw] requested_run_time[m
[32m+[m[32m          #   @return [Google::Protobuf::Timestamp][m
[32m+[m[32m          #     Specific run_time for a transfer run to be started. The[m
[32m+[m[32m          #     requested_run_time must not be in the future.[m
[32m+[m[32m          class StartManualTransferRunsRequest[m
[32m+[m[32m            # A specification for a time range, this will request transfer runs with[m
[32m+[m[32m            # run_time between start_time (inclusive) and end_time (exclusive).[m
[32m+[m[32m            # @!attribute [rw] start_time[m
[32m+[m[32m            #   @return [Google::Protobuf::Timestamp][m
[32m+[m[32m            #     Start time of the range of transfer runs. For example,[m
[32m+[m[32m            #     `"2017-05-25T00:00:00+00:00"`. The start_time must be strictly less than[m
[32m+[m[32m            #     the end_time. Creates transfer runs where run_time is in the range betwen[m
[32m+[m[32m            #     start_time (inclusive) and end_time (exlusive).[m
[32m+[m[32m            # @!attribute [rw] end_time[m
[32m+[m[32m            #   @return [Google::Protobuf::Timestamp][m
[32m+[m[32m            #     End time of the range of transfer runs. For example,[m
[32m+[m[32m            #     `"2017-05-30T00:00:00+00:00"`. The end_time must not be in the future.[m
[32m+[m[32m            #     Creates transfer runs where run_time is in the range betwen start_time[m
[32m+[m[32m            #     (inclusive) and end_time (exlusive).[m
[32m+[m[32m            class TimeRange; end[m
[32m+[m[32m          end[m
[32m+[m
[32m+[m[32m          # A response to start manual transfer runs.[m
[32m+[m[32m          # @!attribute [rw] runs[m
[32m+[m[32m          #   @return [Array<Google::Cloud::Bigquery::Datatransfer::V1::TransferRun>][m
[32m+[m[32m          #     The transfer runs that were created.[m
[32m+[m[32m          class StartManualTransferRunsResponse; end[m
         end[m
       end[m
     end[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb[m
[1mindex 5e1e4934d..8440232f9 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb[m
[1m+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb[m
[36m@@ -18,6 +18,28 @@[m [mmodule Google[m
     module Bigquery[m
       module Datatransfer[m
         module V1[m
[32m+[m[32m          # Options customizing the data transfer schedule.[m
[32m+[m[32m          # @!attribute [rw] disable_auto_scheduling[m
[32m+[m[32m          #   @return [true, false][m
[32m+[m[32m          #     If true, automatic scheduling of data transfer runs for this configuration[m
[32m+[m[32m          #     will be disabled. The runs can be started on ad-hoc basis using[m
[32m+[m[32m          #     StartManualTransferRuns API. When automatic scheduling is disabled, the[m
[32m+[m[32m          #     TransferConfig.schedule field will be ignored.[m
[32m+[m[32m          # @!attribute [rw] start_time[m
[32m+[m[32m          #   @return [Google::Protobuf::Timestamp][m
[32m+[m[32m          #     Specifies time to start scheduling transfer runs. The first run will be[m
[32m+[m[32m          #     scheduled at or after the start time according to a recurrence pattern[m
[32m+[m[32m          #     defined in the schedule string. The start time can be changed at any[m
[32m+[m[32m          #     moment. The time when a data transfer can be trigerred manually is not[m
[32m+[m[32m          #     limited by this option.[m
[32m+[m[32m          # @!attribute [rw] end_time[m
[32m+[m[32m          #   @return [Google::Protobuf::Timestamp][m
[32m+[m[32m          #     Defines time to stop scheduling transfer runs. A transfer run cannot be[m
[32m+[m[32m          #     scheduled at or after the end time. The end time can be changed at any[m
[32m+[m[32m          #     moment. The time when a data transfer can be trigerred manually is not[m
[32m+[m[32m          #     limited by this option.[m
[32m+[m[32m          class ScheduleOptions; end[m
[32m+[m
           # Represents a data transfer configuration. A transfer configuration[m
           # contains all metadata needed to perform a data transfer. For example,[m
           # `destination_dataset_id` specifies where data should be stored.[m
[36m@@ -27,11 +49,12 @@[m [mmodule Google[m
           # @!attribute [rw] name[m
           #   @return [String][m
           #     The resource name of the transfer config.[m
[31m-          #     Transfer config names have the form[m
[31m-          #     `projects/{project_id}/transferConfigs/{config_id}`.[m
[31m-          #     Where `config_id` is usually a uuid, even though it is not[m
[31m-          #     guaranteed or required. The name is ignored when creating a transfer[m
[31m-          #     config.[m
[32m+[m[32m          #     Transfer config names have the form of[m
[32m+[m[32m          #     `projects/{project_id}/locations/{region}/transferConfigs/{config_id}`.[m
[32m+[m[32m          #     The name is automatically generated based on the config_id specified in[m
[32m+[m[32m          #     CreateTransferConfigRequest along with project_id and region. If config_id[m
[32m+[m[32m          #     is not provided, usually a uuid, even though it is not guaranteed or[m
[32m+[m[32m          #     required, will be generated for config_id.[m
           # @!attribute [rw] destination_dataset_id[m
           #   @return [String][m
           #     The BigQuery target dataset id.[m
[36m@@ -58,6 +81,9 @@[m [mmodule Google[m
           #     See more explanation about the format here:[m
           #     https://cloud.google.com/appengine/docs/flexible/python/scheduling-jobs-with-cron-yaml#the_schedule_format[m
           #     NOTE: the granularity should be at least 8 hours, or less frequent.[m
[32m+[m[32m          # @!attribute [rw] schedule_options[m
[32m+[m[32m          #   @return [Google::Cloud::Bigquery::Datatransfer::V1::ScheduleOptions][m
[32m+[m[32m          #     Options customizing the data transfer schedule.[m
           # @!attribute [rw] data_refresh_window_days[m
           #   @return [Integer][m
           #     The number of days to look back to automatically refresh the data.[m
[36m@@ -81,11 +107,7 @@[m [mmodule Google[m
           #     Output only. State of the most recently updated transfer run.[m
           # @!attribute [rw] user_id[m
           #   @return [Integer][m
[31m-          #     Output only. Unique ID of the user on whose behalf transfer is done.[m
[31m-          #     Applicable only to data sources that do not support service accounts.[m
[31m-          #     When set to 0, the data source service account credentials are used.[m
[31m-          #     May be negative. Note, that this identifier is not stable.[m
[31m-          #     It may change over time even for the same user.[m
[32m+[m[32m          #     Deprecated. Unique ID of the user on whose behalf transfer is done.[m
           # @!attribute [rw] dataset_region[m
           #   @return [String][m
           #     Output only. Region in which BigQuery dataset is located.[m
[36m@@ -103,8 +125,8 @@[m [mmodule Google[m
           #     Minimum time after which a transfer run can be started.[m
           # @!attribute [rw] run_time[m
           #   @return [Google::Protobuf::Timestamp][m
[31m-          #     For batch transfer runs, specifies the date and time that[m
[31m-          #     data should be ingested.[m
[32m+[m[32m          #     For batch transfer runs, specifies the date and time of the data should be[m
[32m+[m[32m          #     ingested.[m
           # @!attribute [rw] error_status[m
           #   @return [Google::Rpc::Status][m
           #     Status of the transfer run.[m
[36m@@ -133,18 +155,14 @@[m [mmodule Google[m
           #     Data transfer run state. Ignored for input requests.[m
           # @!attribute [rw] user_id[m
           #   @return [Integer][m
[31m-          #     Output only. Unique ID of the user on whose behalf transfer is done.[m
[31m-          #     Applicable only to data sources that do not support service accounts.[m
[31m-          #     When set to 0, the data source service account credentials are used.[m
[31m-          #     May be negative. Note, that this identifier is not stable.[m
[31m-          #     It may change over time even for the same user.[m
[32m+[m[32m          #     Deprecated. Unique ID of the user on whose behalf transfer is done.[m
           # @!attribute [rw] schedule[m
           #   @return [String][m
           #     Output only. Describes the schedule of this transfer run if it was[m
           #     created as part of a regular schedule. For batch transfer runs that are[m
           #     scheduled manually, this is empty.[m
           #     NOTE: the system might choose to delay the schedule depending on the[m
[31m-          #     current load, so `schedule_time` doesn't always matches this.[m
[32m+[m[32m          #     current load, so `schedule_time` doesn't always match this.[m
           class TransferRun; end[m
 [m
           # Represents a user facing message for a particular data transfer run.[m
[36m@@ -186,7 +204,7 @@[m [mmodule Google[m
             # Data transfer is in progress.[m
             RUNNING = 3[m
 [m
[31m-            # Data transfer completed successsfully.[m
[32m+[m[32m            # Data transfer completed successfully.[m
             SUCCEEDED = 4[m
 [m
             # Data transfer failed.[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/wrappers.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/wrappers.rb[m
[1mindex 26ae03ea5..f4f885a97 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/wrappers.rb[m
[1m+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/wrappers.rb[m
[36m@@ -1,4 +1,4 @@[m
[31m-# Copyright 2018 Google LLC[m
[32m+[m[32m# Copyright 2019 Google LLC[m
 #[m
 # Licensed under the Apache License, Version 2.0 (the "License");[m
 # you may not use this file except in compliance with the License.[m
[36m@@ -15,76 +15,12 @@[m
 [m
 module Google[m
   module Protobuf[m
[31m-    # Wrapper message for +double+.[m
[32m+[m[32m    # Wrapper message for `double`.[m
     #[m
[31m-    # The JSON representation for +DoubleValue+ is JSON number.[m
[32m+[m[32m    # The JSON representation for `DoubleValue` is JSON number.[m
     # @!attribute [rw] value[m
     #   @return [Float][m
     #     The double value.[m
     class DoubleValue; end[m
[31m-[m
[31m-    # Wrapper message for +float+.[m
[31m-    #[m
[31m-    # The JSON representation for +FloatValue+ is JSON number.[m
[31m-    # @!attribute [rw] value[m
[31m-    #   @return [Float][m
[31m-    #     The float value.[m
[31m-    class FloatValue; end[m
[31m-[m
[31m-    # Wrapper message for +int64+.[m
[31m-    #[m
[31m-    # The JSON representation for +Int64Value+ is JSON string.[m
[31m-    # @!attribute [rw] value[m
[31m-    #   @return [Integer][m
[31m-    #     The int64 value.[m
[31m-    class Int64Value; end[m
[31m-[m
[31m-    # Wrapper message for +uint64+.[m
[31m-    #[m
[31m-    # The JSON representation for +UInt64Value+ is JSON string.[m
[31m-    # @!attribute [rw] value[m
[31m-    #   @return [Integer][m
[31m-    #     The uint64 value.[m
[31m-    class UInt64Value; end[m
[31m-[m
[31m-    # Wrapper message for +int32+.[m
[31m-    #[m
[31m-    # The JSON representation for +Int32Value+ is JSON number.[m
[31m-    # @!attribute [rw] value[m
[31m-    #   @return [Integer][m
[31m-    #     The int32 value.[m
[31m-    class Int32Value; end[m
[31m-[m
[31m-    # Wrapper message for +uint32+.[m
[31m-    #[m
[31m-    # The JSON representation for +UInt32Value+ is JSON number.[m
[31m-    # @!attribute [rw] value[m
[31m-    #   @return [Integer][m
[31m-    #     The uint32 value.[m
[31m-    class UInt32Value; end[m
[31m-[m
[31m-    # Wrapper message for +bool+.[m
[31m-    #[m
[31m-    # The JSON representation for +BoolValue+ is JSON +true+ and +false+.[m
[31m-    # @!attribute [rw] value[m
[31m-    #   @return [true, false][m
[31m-    #     The bool value.[m
[31m-    class BoolValue; end[m
[31m-[m
[31m-    # Wrapper message for +string+.[m
[31m-    #[m
[31m-    # The JSON representation for +StringValue+ is JSON string.[m
[31m-    # @!attribute [rw] value[m
[31m-    #   @return [String][m
[31m-    #     The string value.[m
[31m-    class StringValue; end[m
[31m-[m
[31m-    # Wrapper message for +bytes+.[m
[31m-    #[m
[31m-    # The JSON representation for +BytesValue+ is JSON string.[m
[31m-    # @!attribute [rw] value[m
[31m-    #   @return [String][m
[31m-    #     The bytes value.[m
[31m-    class BytesValue; end[m
   end[m
 end[m
\ No newline at end of file[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datasource_pb.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datasource_pb.rb[m
[1mnew file mode 100644[m
[1mindex 000000000..5643ba32d[m
[1m--- /dev/null[m
[1m+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datasource_pb.rb[m
[36m@@ -0,0 +1,170 @@[m
[32m+[m[32m# Generated by the protocol buffer compiler.  DO NOT EDIT![m
[32m+[m[32m# source: google/cloud/bigquery/datatransfer/v1/datasource.proto[m
[32m+[m
[32m+[m
[32m+[m[32mrequire 'google/protobuf'[m
[32m+[m
[32m+[m[32mrequire 'google/api/annotations_pb'[m
[32m+[m[32mrequire 'google/cloud/bigquery/datatransfer/v1/datatransfer_pb'[m
[32m+[m[32mrequire 'google/cloud/bigquery/datatransfer/v1/transfer_pb'[m
[32m+[m[32mrequire 'google/protobuf/duration_pb'[m
[32m+[m[32mrequire 'google/protobuf/empty_pb'[m
[32m+[m[32mrequire 'google/protobuf/field_mask_pb'[m
[32m+[m[32mrequire 'google/protobuf/timestamp_pb'[m
[32m+[m[32mrequire 'google/protobuf/wrappers_pb'[m
[32m+[m[32mrequire 'google/api/client_pb'[m
[32m+[m[32mGoogle::Protobuf::DescriptorPool.generated_pool.build do[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo" do[m
[32m+[m[32m    optional :sql, :string, 1[m
[32m+[m[32m    optional :destination_table_id, :string, 2[m
[32m+[m[32m    optional :destination_table_description, :string, 10[m
[32m+[m[32m    repeated :table_defs, :message, 3, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.TableDefinition"[m
[32m+[m[32m    repeated :user_defined_functions, :string, 4[m
[32m+[m[32m    optional :write_disposition, :enum, 6, "google.cloud.bigquery.datatransfer.v1.WriteDisposition"[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.FieldSchema" do[m
[32m+[m[32m    optional :field_name, :string, 1[m
[32m+[m[32m    optional :type, :enum, 2, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.FieldSchema.Type"[m
[32m+[m[32m    optional :is_repeated, :bool, 3[m
[32m+[m[32m    optional :description, :string, 4[m
[32m+[m[32m    optional :schema, :message, 5, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.RecordSchema"[m
[32m+[m[32m  end[m
[32m+[m[32m  add_enum "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.FieldSchema.Type" do[m
[32m+[m[32m    value :TYPE_UNSPECIFIED, 0[m
[32m+[m[32m    value :STRING, 1[m
[32m+[m[32m    value :INTEGER, 2[m
[32m+[m[32m    value :FLOAT, 3[m
[32m+[m[32m    value :RECORD, 4[m
[32m+[m[32m    value :BYTES, 5[m
[32m+[m[32m    value :BOOLEAN, 6[m
[32m+[m[32m    value :TIMESTAMP, 7[m
[32m+[m[32m    value :DATE, 8[m
[32m+[m[32m    value :TIME, 9[m
[32m+[m[32m    value :DATETIME, 10[m
[32m+[m[32m    value :NUMERIC, 11[m
[32m+[m[32m    value :GEOGRAPHY, 12[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.RecordSchema" do[m
[32m+[m[32m    repeated :fields, :message, 1, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.FieldSchema"[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.TableDefinition" do[m
[32m+[m[32m    optional :table_id, :string, 1[m
[32m+[m[32m    repeated :source_uris, :string, 2[m
[32m+[m[32m    optional :format, :enum, 3, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.Format"[m
[32m+[m[32m    optional :max_bad_records, :int32, 4[m
[32m+[m[32m    optional :encoding, :enum, 5, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.Encoding"[m
[32m+[m[32m    optional :csv_options, :message, 6, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.TableDefinition.CsvOptions"[m
[32m+[m[32m    optional :schema, :message, 7, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.RecordSchema"[m
[32m+[m[32m    optional :ignore_unknown_values, :message, 10, "google.protobuf.BoolValue"[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.TableDefinition.CsvOptions" do[m
[32m+[m[32m    optional :field_delimiter, :message, 1, "google.protobuf.StringValue"[m
[32m+[m[32m    optional :allow_quoted_newlines, :message, 2, "google.protobuf.BoolValue"[m
[32m+[m[32m    optional :quote_char, :message, 3, "google.protobuf.StringValue"[m
[32m+[m[32m    optional :skip_leading_rows, :message, 4, "google.protobuf.Int64Value"[m
[32m+[m[32m    optional :allow_jagged_rows, :message, 5, "google.protobuf.BoolValue"[m
[32m+[m[32m  end[m
[32m+[m[32m  add_enum "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.Format" do[m
[32m+[m[32m    value :FORMAT_UNSPECIFIED, 0[m
[32m+[m[32m    value :CSV, 1[m
[32m+[m[32m    value :JSON, 2[m
[32m+[m[32m    value :AVRO, 3[m
[32m+[m[32m    value :RECORDIO, 4[m
[32m+[m[32m    value :COLUMNIO, 5[m
[32m+[m[32m    value :CAPACITOR, 6[m
[32m+[m[32m    value :PARQUET, 7[m
[32m+[m[32m    value :ORC, 8[m
[32m+[m[32m  end[m
[32m+[m[32m  add_enum "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.Encoding" do[m
[32m+[m[32m    value :ENCODING_UNSPECIFIED, 0[m
[32m+[m[32m    value :ISO_8859_1, 1[m
[32m+[m[32m    value :UTF8, 2[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.UpdateTransferRunRequest" do[m
[32m+[m[32m    optional :transfer_run, :message, 1, "google.cloud.bigquery.datatransfer.v1.TransferRun"[m
[32m+[m[32m    optional :update_mask, :message, 2, "google.protobuf.FieldMask"[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.LogTransferRunMessagesRequest" do[m
[32m+[m[32m    optional :name, :string, 1[m
[32m+[m[32m    repeated :transfer_messages, :message, 2, "google.cloud.bigquery.datatransfer.v1.TransferMessage"[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.StartBigQueryJobsRequest" do[m
[32m+[m[32m    optional :name, :string, 1[m
[32m+[m[32m    repeated :imported_data, :message, 2, "google.cloud.bigquery.datatransfer.v1.ImportedDataInfo"[m
[32m+[m[32m    optional :user_credentials, :bytes, 3[m
[32m+[m[32m    optional :max_parallelism, :int32, 8[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.FinishRunRequest" do[m
[32m+[m[32m    optional :name, :string, 1[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.CreateDataSourceDefinitionRequest" do[m
[32m+[m[32m    optional :parent, :string, 1[m
[32m+[m[32m    optional :data_source_definition, :message, 2, "google.cloud.bigquery.datatransfer.v1.DataSourceDefinition"[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.UpdateDataSourceDefinitionRequest" do[m
[32m+[m[32m    optional :data_source_definition, :message, 1, "google.cloud.bigquery.datatransfer.v1.DataSourceDefinition"[m
[32m+[m[32m    optional :update_mask, :message, 2, "google.protobuf.FieldMask"[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.DeleteDataSourceDefinitionRequest" do[m
[32m+[m[32m    optional :name, :string, 1[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.GetDataSourceDefinitionRequest" do[m
[32m+[m[32m    optional :name, :string, 1[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.ListDataSourceDefinitionsRequest" do[m
[32m+[m[32m    optional :parent, :string, 1[m
[32m+[m[32m    optional :page_token, :string, 2[m
[32m+[m[32m    optional :page_size, :int32, 3[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.ListDataSourceDefinitionsResponse" do[m
[32m+[m[32m    repeated :data_source_definitions, :message, 1, "google.cloud.bigquery.datatransfer.v1.DataSourceDefinition"[m
[32m+[m[32m    optional :next_page_token, :string, 2[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.DataSourceDefinition" do[m
[32m+[m[32m    optional :name, :string, 21[m
[32m+[m[32m    optional :data_source, :message, 1, "google.cloud.bigquery.datatransfer.v1.DataSource"[m
[32m+[m[32m    optional :transfer_run_pubsub_topic, :string, 13[m
[32m+[m[32m    optional :run_time_offset, :message, 16, "google.protobuf.Duration"[m
[32m+[m[32m    optional :support_email, :string, 22[m
[32m+[m[32m    optional :service_account, :string, 2[m
[32m+[m[32m    optional :disabled, :bool, 5[m
[32m+[m[32m    optional :transfer_config_pubsub_topic, :string, 12[m
[32m+[m[32m    repeated :supported_location_ids, :string, 23[m
[32m+[m[32m  end[m
[32m+[m[32m  add_enum "google.cloud.bigquery.datatransfer.v1.WriteDisposition" do[m
[32m+[m[32m    value :WRITE_DISPOSITION_UNSPECIFIED, 0[m
[32m+[m[32m    value :WRITE_TRUNCATE, 1[m
[32m+[m[32m    value :WRITE_APPEND, 2[m
[32m+[m[32m  end[m
[32m+[m[32mend[m
[32m+[m
[32m+[m[32mmodule Google[m
[32m+[m[32m  module Cloud[m
[32m+[m[32m    module Bigquery[m
[32m+[m[32m      module Datatransfer[m
[32m+[m[32m        module V1[m
[32m+[m[32m          ImportedDataInfo = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo").msgclass[m
[32m+[m[32m          ImportedDataInfo::FieldSchema = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.FieldSchema").msgclass[m
[32m+[m[32m          ImportedDataInfo::FieldSchema::Type = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.FieldSchema.Type").enummodule[m
[32m+[m[32m          ImportedDataInfo::RecordSchema = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.RecordSchema").msgclass[m
[32m+[m[32m          ImportedDataInfo::TableDefinition = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.TableDefinition").msgclass[m
[32m+[m[32m          ImportedDataInfo::TableDefinition::CsvOptions = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.TableDefinition.CsvOptions").msgclass[m
[32m+[m[32m          ImportedDataInfo::Format = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.Format").enummodule[m
[32m+[m[32m          ImportedDataInfo::Encoding = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ImportedDataInfo.Encoding").enummodule[m
[32m+[m[32m          UpdateTransferRunRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.UpdateTransferRunRequest").msgclass[m
[32m+[m[32m          LogTransferRunMessagesRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.LogTransferRunMessagesRequest").msgclass[m
[32m+[m[32m          StartBigQueryJobsRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.StartBigQueryJobsRequest").msgclass[m
[32m+[m[32m          FinishRunRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.FinishRunRequest").msgclass[m
[32m+[m[32m          CreateDataSourceDefinitionRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.CreateDataSourceDefinitionRequest").msgclass[m
[32m+[m[32m          UpdateDataSourceDefinitionRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.UpdateDataSourceDefinitionRequest").msgclass[m
[32m+[m[32m          DeleteDataSourceDefinitionRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.DeleteDataSourceDefinitionRequest").msgclass[m
[32m+[m[32m          GetDataSourceDefinitionRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.GetDataSourceDefinitionRequest").msgclass[m
[32m+[m[32m          ListDataSourceDefinitionsRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ListDataSourceDefinitionsRequest").msgclass[m
[32m+[m[32m          ListDataSourceDefinitionsResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ListDataSourceDefinitionsResponse").msgclass[m
[32m+[m[32m          DataSourceDefinition = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.DataSourceDefinition").msgclass[m
[32m+[m[32m          WriteDisposition = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.WriteDisposition").enummodule[m
[32m+[m[32m        end[m
[32m+[m[32m      end[m
[32m+[m[32m    end[m
[32m+[m[32m  end[m
[32m+[m[32mend[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datasource_services_pb.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datasource_services_pb.rb[m
[1mnew file mode 100644[m
[1mindex 000000000..6b7dd30b2[m
[1m--- /dev/null[m
[1m+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datasource_services_pb.rb[m
[36m@@ -0,0 +1,103 @@[m
[32m+[m[32m# Generated by the protocol buffer compiler.  DO NOT EDIT![m
[32m+[m[32m# Source: google/cloud/bigquery/datatransfer/v1/datasource.proto for package 'google.cloud.bigquery.datatransfer.v1'[m
[32m+[m[32m# Original file comments:[m
[32m+[m[32m# Copyright 2019 Google LLC.[m
[32m+[m[32m#[m
[32m+[m[32m# Licensed under the Apache License, Version 2.0 (the "License");[m
[32m+[m[32m# you may not use this file except in compliance with the License.[m
[32m+[m[32m# You may obtain a copy of the License at[m
[32m+[m[32m#[m
[32m+[m[32m#     http://www.apache.org/licenses/LICENSE-2.0[m
[32m+[m[32m#[m
[32m+[m[32m# Unless required by applicable law or agreed to in writing, software[m
[32m+[m[32m# distributed under the License is distributed on an "AS IS" BASIS,[m
[32m+[m[32m# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.[m
[32m+[m[32m# See the License for the specific language governing permissions and[m
[32m+[m[32m# limitations under the License.[m
[32m+[m[32m#[m
[32m+[m[32m#[m
[32m+[m
[32m+[m
[32m+[m[32mrequire 'grpc'[m
[32m+[m[32mrequire 'google/cloud/bigquery/datatransfer/v1/datasource_pb'[m
[32m+[m
[32m+[m[32mmodule Google[m
[32m+[m[32m  module Cloud[m
[32m+[m[32m    module Bigquery[m
[32m+[m[32m      module Datatransfer[m
[32m+[m[32m        module V1[m
[32m+[m[32m          module DataSourceService[m
[32m+[m[32m            # The Google BigQuery Data Transfer API allows BigQuery users to[m
[32m+[m[32m            # configure transfer of their data from other Google Products into BigQuery.[m
[32m+[m[32m            # This service exposes methods that should be used by data source backend.[m
[32m+[m[32m            class Service[m
[32m+[m
[32m+[m[32m              include GRPC::GenericService[m
[32m+[m
[32m+[m[32m              self.marshal_class_method = :encode[m
[32m+[m[32m              self.unmarshal_class_method = :decode[m
[32m+[m[32m              self.service_name = 'google.cloud.bigquery.datatransfer.v1.DataSourceService'[m
[32m+[m
[32m+[m[32m              # Update a transfer run. If successful, resets[m
[32m+[m[32m              # data_source.update_deadline_seconds timer.[m
[32m+[m[32m              rpc :UpdateTransferRun, UpdateTransferRunRequest, TransferRun[m
[32m+[m[32m              # Log messages for a transfer run. If successful (at least 1 message), resets[m
[32m+[m[32m              # data_source.update_deadline_seconds timer.[m
[32m+[m[32m              rpc :LogTransferRunMessages, LogTransferRunMessagesRequest, Google::Protobuf::Empty[m
[32m+[m[32m              # Notify the Data Transfer Service that data is ready for loading.[m
[32m+[m[32m              # The Data Transfer Service will start and monitor multiple BigQuery Load[m
[32m+[m[32m              # jobs for a transfer run. Monitored jobs will be automatically retried[m
[32m+[m[32m              # and produce log messages when starting and finishing a job.[m
[32m+[m[32m              # Can be called multiple times for the same transfer run.[m
[32m+[m[32m              rpc :StartBigQueryJobs, StartBigQueryJobsRequest, Google::Protobuf::Empty[m
[32m+[m[32m              # Notify the Data Transfer Service that the data source is done processing[m
[32m+[m[32m              # the run. No more status updates or requests to start/monitor jobs will be[m
[32m+[m[32m              # accepted. The run will be finalized by the Data Transfer Service when all[m
[32m+[m[32m              # monitored jobs are completed.[m
[32m+[m[32m              # Does not need to be called if the run is set to FAILED.[m
[32m+[m[32m              rpc :FinishRun, FinishRunRequest, Google::Protobuf::Empty[m
[32m+[m[32m              # Creates a data source definition.  Calling this method will automatically[m
[32m+[m[32m              # use your credentials to create the following Google Cloud resources in[m
[32m+[m[32m              # YOUR Google Cloud project.[m
[32m+[m[32m              # 1. OAuth client[m
[32m+[m[32m              # 2. Pub/Sub Topics and Subscriptions in each supported_location_ids. e.g.,[m
[32m+[m[32m              # projects/\\{project_id}/{topics|subscriptions}/bigquerydatatransfer.\\{data_source_id}.\\{location_id}.run[m
[32m+[m[32m              # The field data_source.client_id should be left empty in the input request,[m
[32m+[m[32m              # as the API will create a new OAuth client on behalf of the caller. On the[m
[32m+[m[32m              # other hand data_source.scopes usually need to be set when there are OAuth[m
[32m+[m[32m              # scopes that need to be granted by end users.[m
[32m+[m[32m              # 3. We need a longer deadline due to the 60 seconds SLO from Pub/Sub admin[m
[32m+[m[32m              # Operations. This also applies to update and delete data source definition.[m
[32m+[m[32m              rpc :CreateDataSourceDefinition, CreateDataSourceDefinitionRequest, DataSourceDefinition[m
[32m+[m[32m              # Updates an existing data source definition. If changing[m
[32m+[m[32m              # supported_location_ids, triggers same effects as mentioned in "Create a[m
[32m+[m[32m              # data source definition."[m
[32m+[m[32m              rpc :UpdateDataSourceDefinition, UpdateDataSourceDefinitionRequest, DataSourceDefinition[m
[32m+[m[32m              # Deletes a data source definition, all of the transfer configs associated[m
[32m+[m[32m              # with this data source definition (if any) must be deleted first by the user[m
[32m+[m[32m              # in ALL regions, in order to delete the data source definition.[m
[32m+[m[32m              # This method is primarily meant for deleting data sources created during[m
[32m+[m[32m              # testing stage.[m
[32m+[m[32m              # If the data source is referenced by transfer configs in the region[m
[32m+[m[32m              # specified in the request URL, the method will fail immediately. If in the[m
[32m+[m[32m              # current region (e.g., US) it's not used by any transfer configs, but in[m
[32m+[m[32m              # another region (e.g., EU) it is, then although the method will succeed in[m
[32m+[m[32m              # region US, but it will fail when the deletion operation is replicated to[m
[32m+[m[32m              # region EU. And eventually, the system will replicate the data source[m
[32m+[m[32m              # definition back from EU to US, in order to bring all regions to[m
[32m+[m[32m              # consistency. The final effect is that the data source appears to be[m
[32m+[m[32m              # 'undeleted' in the US region.[m
[32m+[m[32m              rpc :DeleteDataSourceDefinition, DeleteDataSourceDefinitionRequest, Google::Protobuf::Empty[m
[32m+[m[32m              # Retrieves an existing data source definition.[m
[32m+[m[32m              rpc :GetDataSourceDefinition, GetDataSourceDefinitionRequest, DataSourceDefinition[m
[32m+[m[32m              # Lists supported data source definitions.[m
[32m+[m[32m              rpc :ListDataSourceDefinitions, ListDataSourceDefinitionsRequest, ListDataSourceDefinitionsResponse[m
[32m+[m[32m            end[m
[32m+[m
[32m+[m[32m            Stub = Service.rpc_stub_class[m
[32m+[m[32m          end[m
[32m+[m[32m        end[m
[32m+[m[32m      end[m
[32m+[m[32m    end[m
[32m+[m[32m  end[m
[32m+[m[32mend[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_pb.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_pb.rb[m
[1mindex 0032a1312..8a7635c48 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_pb.rb[m
[1m+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_pb.rb[m
[36m@@ -11,6 +11,7 @@[m [mrequire 'google/protobuf/empty_pb'[m
 require 'google/protobuf/field_mask_pb'[m
 require 'google/protobuf/timestamp_pb'[m
 require 'google/protobuf/wrappers_pb'[m
[32m+[m[32mrequire 'google/api/client_pb'[m
 Google::Protobuf::DescriptorPool.generated_pool.build do[m
   add_message "google.cloud.bigquery.datatransfer.v1.DataSourceParameter" do[m
     optional :param_id, :string, 1[m
[36m@@ -28,6 +29,7 @@[m [mGoogle::Protobuf::DescriptorPool.generated_pool.build do[m
     optional :validation_help_url, :string, 13[m
     optional :immutable, :bool, 14[m
     optional :recurse, :bool, 15[m
[32m+[m[32m    optional :deprecated, :bool, 20[m
   end[m
   add_enum "google.cloud.bigquery.datatransfer.v1.DataSourceParameter.Type" do[m
     value :TYPE_UNSPECIFIED, 0[m
[36m@@ -84,11 +86,13 @@[m [mGoogle::Protobuf::DescriptorPool.generated_pool.build do[m
     optional :parent, :string, 1[m
     optional :transfer_config, :message, 2, "google.cloud.bigquery.datatransfer.v1.TransferConfig"[m
     optional :authorization_code, :string, 3[m
[32m+[m[32m    optional :version_info, :string, 5[m
   end[m
   add_message "google.cloud.bigquery.datatransfer.v1.UpdateTransferConfigRequest" do[m
     optional :transfer_config, :message, 1, "google.cloud.bigquery.datatransfer.v1.TransferConfig"[m
     optional :authorization_code, :string, 3[m
     optional :update_mask, :message, 4, "google.protobuf.FieldMask"[m
[32m+[m[32m    optional :version_info, :string, 5[m
   end[m
   add_message "google.cloud.bigquery.datatransfer.v1.GetTransferConfigRequest" do[m
     optional :name, :string, 1[m
[36m@@ -151,6 +155,20 @@[m [mGoogle::Protobuf::DescriptorPool.generated_pool.build do[m
   add_message "google.cloud.bigquery.datatransfer.v1.ScheduleTransferRunsResponse" do[m
     repeated :runs, :message, 1, "google.cloud.bigquery.datatransfer.v1.TransferRun"[m
   end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsRequest" do[m
[32m+[m[32m    optional :parent, :string, 1[m
[32m+[m[32m    oneof :time do[m
[32m+[m[32m      optional :requested_time_range, :message, 3, "google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsRequest.TimeRange"[m
[32m+[m[32m      optional :requested_run_time, :message, 4, "google.protobuf.Timestamp"[m
[32m+[m[32m    end[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsRequest.TimeRange" do[m
[32m+[m[32m    optional :start_time, :message, 1, "google.protobuf.Timestamp"[m
[32m+[m[32m    optional :end_time, :message, 2, "google.protobuf.Timestamp"[m
[32m+[m[32m  end[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsResponse" do[m
[32m+[m[32m    repeated :runs, :message, 1, "google.cloud.bigquery.datatransfer.v1.TransferRun"[m
[32m+[m[32m  end[m
 end[m
 [m
 module Google[m
[36m@@ -183,6 +201,9 @@[m [mmodule Google[m
           CheckValidCredsResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.CheckValidCredsResponse").msgclass[m
           ScheduleTransferRunsRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ScheduleTransferRunsRequest").msgclass[m
           ScheduleTransferRunsResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ScheduleTransferRunsResponse").msgclass[m
[32m+[m[32m          StartManualTransferRunsRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsRequest").msgclass[m
[32m+[m[32m          StartManualTransferRunsRequest::TimeRange = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsRequest.TimeRange").msgclass[m
[32m+[m[32m          StartManualTransferRunsResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsResponse").msgclass[m
         end[m
       end[m
     end[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_services_pb.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_services_pb.rb[m
[1mindex b32af9f7f..e69e55ee7 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_services_pb.rb[m
[1m+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_services_pb.rb[m
[36m@@ -1,7 +1,7 @@[m
 # Generated by the protocol buffer compiler.  DO NOT EDIT![m
 # Source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto for package 'google.cloud.bigquery.datatransfer.v1'[m
 # Original file comments:[m
[31m-# Copyright 2018 Google Inc.[m
[32m+[m[32m# Copyright 2019 Google LLC.[m
 #[m
 # Licensed under the Apache License, Version 2.0 (the "License");[m
 # you may not use this file except in compliance with the License.[m
[36m@@ -15,6 +15,7 @@[m
 # See the License for the specific language governing permissions and[m
 # limitations under the License.[m
 #[m
[32m+[m[32m#[m
 [m
 [m
 require 'grpc'[m
[36m@@ -60,7 +61,13 @@[m [mmodule Google[m
               # For each date - or whatever granularity the data source supports - in the[m
               # range, one transfer run is created.[m
               # Note that runs are created per UTC time in the time range.[m
[32m+[m[32m              # DEPRECATED: use StartManualTransferRuns instead.[m
               rpc :ScheduleTransferRuns, ScheduleTransferRunsRequest, ScheduleTransferRunsResponse[m
[32m+[m[32m              # Start manual transfer runs to be executed now with schedule_time equal to[m
[32m+[m[32m              # current time. The transfer runs can be created for a time range where the[m
[32m+[m[32m              # run_time is between start_time (inclusive) and end_time (exclusive), or for[m
[32m+[m[32m              # a specific run_time.[m
[32m+[m[32m              rpc :StartManualTransferRuns, StartManualTransferRunsRequest, StartManualTransferRunsResponse[m
               # Returns information about the particular transfer run.[m
               rpc :GetTransferRun, GetTransferRunRequest, TransferRun[m
               # Deletes the specified transfer run.[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/transfer_pb.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/transfer_pb.rb[m
[1mindex 73920f4bf..8f39d5161 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/transfer_pb.rb[m
[1m+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/transfer_pb.rb[m
[36m@@ -9,6 +9,11 @@[m [mrequire 'google/protobuf/struct_pb'[m
 require 'google/protobuf/timestamp_pb'[m
 require 'google/rpc/status_pb'[m
 Google::Protobuf::DescriptorPool.generated_pool.build do[m
[32m+[m[32m  add_message "google.cloud.bigquery.datatransfer.v1.ScheduleOptions" do[m
[32m+[m[32m    optional :disable_auto_scheduling, :bool, 3[m
[32m+[m[32m    optional :start_time, :message, 1, "google.protobuf.Timestamp"[m
[32m+[m[32m    optional :end_time, :message, 2, "google.protobuf.Timestamp"[m
[32m+[m[32m  end[m
   add_message "google.cloud.bigquery.datatransfer.v1.TransferConfig" do[m
     optional :name, :string, 1[m
     optional :destination_dataset_id, :string, 2[m
[36m@@ -16,6 +21,7 @@[m [mGoogle::Protobuf::DescriptorPool.generated_pool.build do[m
     optional :data_source_id, :string, 5[m
     optional :params, :message, 9, "google.protobuf.Struct"[m
     optional :schedule, :string, 7[m
[32m+[m[32m    optional :schedule_options, :message, 24, "google.cloud.bigquery.datatransfer.v1.ScheduleOptions"[m
     optional :data_refresh_window_days, :int32, 12[m
     optional :disabled, :bool, 13[m
     optional :update_time, :message, 4, "google.protobuf.Timestamp"[m
[36m@@ -70,6 +76,7 @@[m [mmodule Google[m
     module Bigquery[m
       module Datatransfer[m
         module V1[m
[32m+[m[32m          ScheduleOptions = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ScheduleOptions").msgclass[m
           TransferConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.TransferConfig").msgclass[m
           TransferRun = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.TransferRun").msgclass[m
           TransferMessage = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.TransferMessage").msgclass[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/synth.metadata b/google-cloud-bigquery-data_transfer/synth.metadata[m
[1mindex e5687c216..8337b5e9d 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/synth.metadata[m
[1m+++ b/google-cloud-bigquery-data_transfer/synth.metadata[m
[36m@@ -1,19 +1,19 @@[m
 {[m
[31m-  "updateTime": "2019-05-30T00:53:14.681155Z",[m
[32m+[m[32m  "updateTime": "2019-07-25T10:38:03.618210Z",[m
   "sources": [[m
     {[m
       "generator": {[m
         "name": "artman",[m
[31m-        "version": "0.21.0",[m
[31m-        "dockerImage": "googleapis/artman@sha256:28d4271586772b275cd3bc95cb46bd227a24d3c9048de45dccdb7f3afb0bfba9"[m
[32m+[m[32m        "version": "0.31.0",[m
[32m+[m[32m        "dockerImage": "googleapis/artman@sha256:9aed6bbde54e26d2fcde7aa86d9f64c0278f741e58808c46573e488cbf6098f0"[m
       }[m
     },[m
     {[m
       "git": {[m
         "name": "googleapis",[m
         "remote": "https://github.com/googleapis/googleapis.git",[m
[31m-        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",[m
[31m-        "internalRef": "250569499"[m
[32m+[m[32m        "sha": "4b12afe72950f36bef6f196a05f4430e4421a873",[m
[32m+[m[32m        "internalRef": "259790363"[m
       }[m
     },[m
     {[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/synth.py b/google-cloud-bigquery-data_transfer/synth.py[m
[1mindex a55d25c65..af2b8a01b 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/synth.py[m
[1m+++ b/google-cloud-bigquery-data_transfer/synth.py[m
[36m@@ -42,6 +42,51 @@[m [ms.copy(v1_library / 'google-cloud-bigquery-data_transfer.gemspec', merge=ruby.me[m
 templates = gcp.CommonTemplates().ruby_library()[m
 s.copy(templates)[m
 [m
[32m+[m[32m# Support for service_address[m
[32m+[m[32ms.replace([m
[32m+[m[32m    [[m
[32m+[m[32m        'lib/google/cloud/bigquery/data_transfer.rb',[m
[32m+[m[32m        'lib/google/cloud/bigquery/data_transfer/v*.rb',[m
[32m+[m[32m        'lib/google/cloud/bigquery/data_transfer/v*/*_client.rb'[m
[32m+[m[32m    ],[m
[32m+[m[32m    '\n(\\s+)#(\\s+)@param exception_transformer',[m
[32m+[m[32m    '\n\\1#\\2@param service_address [String]\n' +[m
[32m+[m[32m        '\\1#\\2  Override for the service hostname, or `nil` to leave as the default.\n' +[m
[32m+[m[32m        '\\1#\\2@param service_port [Integer]\n' +[m
[32m+[m[32m        '\\1#\\2  Override for the service port, or `nil` to leave as the default.\n' +[m
[32m+[m[32m        '\\1#\\2@param exception_transformer'[m
[32m+[m[32m)[m
[32m+[m[32ms.replace([m
[32m+[m[32m    [[m
[32m+[m[32m        'lib/google/cloud/bigquery/data_transfer/v*.rb',[m
[32m+[m[32m        'lib/google/cloud/bigquery/data_transfer/v*/*_client.rb'[m
[32m+[m[32m    ],[m
[32m+[m[32m    '\n(\\s+)metadata: nil,\n\\s+exception_transformer: nil,\n',[m
[32m+[m[32m    '\n\\1metadata: nil,\n\\1service_address: nil,\n\\1service_port: nil,\n\\1exception_transformer: nil,\n'[m
[32m+[m[32m)[m
[32m+[m[32ms.replace([m
[32m+[m[32m    [[m
[32m+[m[32m        'lib/google/cloud/bigquery/data_transfer/v*.rb',[m
[32m+[m[32m        'lib/google/cloud/bigquery/data_transfer/v*/*_client.rb'[m
[32m+[m[32m    ],[m
[32m+[m[32m    ',\n(\\s+)lib_name: lib_name,\n\\s+lib_version: lib_version',[m
[32m+[m[32m    ',\n\\1lib_name: lib_name,\n\\1service_address: service_address,\n\\1service_port: service_port,\n\\1lib_version: lib_version'[m
[32m+[m[32m)[m
[32m+[m[32ms.replace([m
[32m+[m[32m    'lib/google/cloud/bigquery/data_transfer/v*/*_client.rb',[m
[32m+[m[32m    'service_path = self\\.class::SERVICE_ADDRESS',[m
[32m+[m[32m    'service_path = service_address || self.class::SERVICE_ADDRESS'[m
[32m+[m[32m)[m
[32m+[m[32ms.replace([m
[32m+[m[32m    'lib/google/cloud/bigquery/data_transfer/v*/*_client.rb',[m
[32m+[m[32m    'port = self\\.class::DEFAULT_SERVICE_PORT',[m
[32m+[m[32m    'port = service_port || self.class::DEFAULT_SERVICE_PORT'[m
[32m+[m[32m)[m
[32m+[m[32ms.replace([m
[32m+[m[32m    'google-cloud-bigquery-data_transfer.gemspec',[m
[32m+[m[32m    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',[m
[32m+[m[32m    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')[m
[32m+[m
 # PERMANENT: Use custom credentials env variable names[m
 s.replace([m
     'lib/google/cloud/bigquery/data_transfer/v1/credentials.rb',[m
[36m@@ -144,10 +189,25 @@[m [ms.replace([m
     'Google::Cloud::Bigquery::DataTransfer::VERSION'[m
 )[m
 [m
[31m-# Exception tests have to check for both custom errors and retry wrapper errors[m
[31m-for version in ['v1']:[m
[32m+[m[32m# Fix links for devsite migration[m
[32m+[m[32mfor file in ['lib/**/*.rb', '*.md']:[m
     s.replace([m
[31m-        f'test/google/cloud/bigquery/data_transfer/{version}/*_client_test.rb',[m
[31m-        'err = assert_raises Google::Gax::GaxError do',[m
[31m-        f'err = assert_raises Google::Gax::GaxError, CustomTestError_{version} do'[m
[32m+[m[32m        file,[m
[32m+[m[32m        'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',[m
[32m+[m[32m        'https://googleapis.dev/ruby/google-cloud-logging/latest'[m
     )[m
[32m+[m[32ms.replace([m
[32m+[m[32m    '*.md',[m
[32m+[m[32m    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',[m
[32m+[m[32m    'https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/latest/file.AUTHENTICATION.html'[m
[32m+[m[32m)[m
[32m+[m[32ms.replace([m
[32m+[m[32m    'lib/**/*.rb',[m
[32m+[m[32m    'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',[m
[32m+[m[32m    'https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/latest/file.AUTHENTICATION.html'[m
[32m+[m[32m)[m
[32m+[m[32ms.replace([m
[32m+[m[32m    'README.md',[m
[32m+[m[32m    'github.io/google-cloud-ruby/#/docs/google-cloud-bigquery-data_transfer/latest/.*$',[m
[32m+[m[32m    'dev/ruby/google-cloud-bigquery-data_transfer/latest'[m
[32m+[m[32m)[m
[1mdiff --git a/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb b/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb[m
[1mindex 913b6664f..cfbeb01ac 100644[m
[1m--- a/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb[m
[1m+++ b/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb[m
[36m@@ -1125,4 +1125,67 @@[m [mdescribe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do[m
       end[m
     end[m
   end[m
[32m+[m
[32m+[m[32m  describe 'start_manual_transfer_runs' do[m
[32m+[m[32m    custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient#start_manual_transfer_runs."[m
[32m+[m
[32m+[m[32m    it 'invokes start_manual_transfer_runs without error' do[m
[32m+[m[32m      # Create expected grpc response[m
[32m+[m[32m      expected_response = {}[m
[32m+[m[32m      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsResponse)[m
[32m+[m
[32m+[m[32m      # Mock Grpc layer[m
[32m+[m[32m      mock_method = proc do[m
[32m+[m[32m        OpenStruct.new(execute: expected_response)[m
[32m+[m[32m      end[m
[32m+[m[32m      mock_stub = MockGrpcClientStub_v1.new(:start_manual_transfer_runs, mock_method)[m
[32m+[m
[32m+[m[32m      # Mock auth layer[m
[32m+[m[32m      mock_credentials = MockDataTransferServiceCredentials_v1.new("start_manual_transfer_runs")[m
[32m+[m
[32m+[m[32m      Google::Cloud::Bigquery::Datatransfer::V1::DataTransferService::Stub.stub(:new, mock_stub) do[m
[32m+[m[32m        Google::Cloud::Bigquery::DataTransfer::V1::Credentials.stub(:default, mock_credentials) do[m
[32m+[m[32m          client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)[m
[32m+[m
[32m+[m[32m          # Call method[m
[32m+[m[32m          response = client.start_manual_transfer_runs[m
[32m+[m
[32m+[m[32m          # Verify the response[m
[32m+[m[32m          assert_equal(expected_response, response)[m
[32m+[m
[32m+[m[32m          # Call method with block[m
[32m+[m[32m          client.start_manual_transfer_runs do |response, operation|[m
[32m+[m[32m            # Verify the response[m
[32m+[m[32m            assert_equal(expected_response, response)[m
[32m+[m[32m            refute_nil(operation)[m
[32m+[m[32m          end[m
[32m+[m[32m        end[m
[32m+[m[32m      end[m
[32m+[m[32m    end[m
[32m+[m
[32m+[m[32m    it 'invokes start_manual_transfer_runs with error' do[m
[32m+[m[32m      # Mock Grpc layer[m
[32m+[m[32m      mock_method = proc do[m
[32m+[m[32m        raise custom_error[m
[32m+[m[32m      end[m
[32m+[m[32m      mock_stub = MockGrpcClientStub_v1.new(:start_manual_transfer_runs, mock_method)[m
[32m+[m
[32m+[m[32m      # Mock auth layer[m
[32m+[m[32m      mock_credentials = MockDataTransferServiceCredentials_v1.new("start_manual_transfer_runs")[m
[32m+[m
[32m+[m[32m      Google::Cloud::Bigquery::Datatransfer::V1::DataTransferService::Stub.stub(:new, mock_stub) do[m
[32m+[m[32m        Google::Cloud::Bigquery::DataTransfer::V1::Credentials.stub(:default, mock_credentials) do[m
[32m+[m[32m          client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)[m
[32m+[m
[32m+[m[32m          # Call method[m
[32m+[m[32m          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do[m
[32m+[m[32m            client.start_manual_transfer_runs[m
[32m+[m[32m          end[m
[32m+[m
[32m+[m[32m          # Verify the GaxError wrapped the custom error that was raised.[m
[32m+[m[32m          assert_match(custom_error.message, err.message)[m
[32m+[m[32m        end[m
[32m+[m[32m      end[m
[32m+[m[32m    end[m
[32m+[m[32m  end[m
 end[m
\ No newline at end of file[m

```

</details>

This pull request was generated using releasetool.