### PR TITLE
Release google-cloud-pubsub 0.39.1

### DIFF
--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+### 0.39.1 / 2019-09-04
+
+#### Features
+
+* Update Dead Letter Policy
+  * Add ReceivedMessage#delivery_attempt
+  * Experimental
+
 ### 0.39.0 / 2019-08-23
 
 #### Features

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module PubSub
-      VERSION = "0.39.0".freeze
+      VERSION = "0.39.1".freeze
     end
 
     Pubsub = PubSub unless const_defined? :Pubsub


### PR DESCRIPTION
#### Features

* Update Dead Letter Policy
  * Add ReceivedMessage#delivery_attempt
  * Experimental

<details><summary>Commits since previous release</summary><pre><code>[33mcommit 86f81d9b18c8de66d6955e93fa4e3af4bd5ae4b7[m
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Aug 28 06:56:21 2019 -0700

    refactor(pubsub): Update documentation
    
    * Update Timestamp doc formatting
      * No content changes, only whitespace formatting.
    
    pr #3968

[33mcommit ad9c0d101ca7bc9339bc0e30f9c356efd623cd19[m
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Sat Aug 24 17:59:44 2019 -0700

    feat(pubsub): Add ReceivedMessage#delivery_attempt
    
    * Experimental, part of Dead Letter Policy
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
[1mdiff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/timestamp.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/timestamp.rb[m
[1mindex 521fa94fa..a9e2c027b 100644[m
[1m--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/timestamp.rb[m
[1m+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/timestamp.rb[m
[36m@@ -88,11 +88,13 @@[m [mmodule Google[m
     # 01:30 UTC on January 15, 2017.[m
     #[m
     # In JavaScript, one can convert a Date object to this format using the[m
[31m-    # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)[m
[32m+[m[32m    # standard[m
[32m+[m[32m    # [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)[m
     # method. In Python, a standard `datetime.datetime` object can be converted[m
[31m-    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)[m
[31m-    # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one[m
[31m-    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`]([m
[32m+[m[32m    # to this format using[m
[32m+[m[32m    # [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with[m
[32m+[m[32m    # the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use[m
[32m+[m[32m    # the Joda Time's [`ISODateTimeFormat.dateTime()`]([m
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D[m
     # ) to obtain a formatter capable of generating timestamps in this format.[m
     # @!attribute [rw] seconds[m
[1mdiff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb[m
[1mindex abc684f41..3ebb92f14 100644[m
[1m--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb[m
[1m+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb[m
[36m@@ -412,6 +412,24 @@[m [mmodule Google[m
       # @!attribute [rw] message[m
       #   @return [Google::Cloud::PubSub::V1::PubsubMessage][m
       #     The message.[m
[32m+[m[32m      # @!attribute [rw] delivery_attempt[m
[32m+[m[32m      #   @return [Integer][m
[32m+[m[32m      #     Delivery attempt counter is 1 + (the sum of number of NACKs and number of[m
[32m+[m[32m      #     ack_deadline exceeds) for this message.[m
[32m+[m[32m      #[m
[32m+[m[32m      #     A NACK is any call to ModifyAckDeadline with a 0 deadline. An ack_deadline[m
[32m+[m[32m      #     exceeds event is whenever a message is not acknowledged within[m
[32m+[m[32m      #     ack_deadline. Note that ack_deadline is initially[m
[32m+[m[32m      #     Subscription.ackDeadlineSeconds, but may get extended automatically by[m
[32m+[m[32m      #     the client library.[m
[32m+[m[32m      #[m
[32m+[m[32m      #     The first delivery of a given message will have this value as 1. The value[m
[32m+[m[32m      #     is calculated at best effort and is approximate.[m
[32m+[m[32m      #[m
[32m+[m[32m      #     If a DeadLetterPolicy is not set on the subscription, this will be 0.[m
[32m+[m[32m      #     <b>EXPERIMENTAL:</b> This feature is part of a closed alpha release. This[m
[32m+[m[32m      #     API might be changed in backward-incompatible ways and is not recommended[m
[32m+[m[32m      #     for production use. It is not subject to any SLA or deprecation policy.[m
       class ReceivedMessage; end[m
 [m
       # Request for the GetSubscription method.[m
[1mdiff --git a/google-cloud-pubsub/lib/google/pubsub/v1/pubsub_pb.rb b/google-cloud-pubsub/lib/google/pubsub/v1/pubsub_pb.rb[m
[1mindex b4f1bc0fc..fc434ebb2 100644[m
[1m--- a/google-cloud-pubsub/lib/google/pubsub/v1/pubsub_pb.rb[m
[1m+++ b/google-cloud-pubsub/lib/google/pubsub/v1/pubsub_pb.rb[m
[36m@@ -104,6 +104,7 @@[m [mGoogle::Protobuf::DescriptorPool.generated_pool.build do[m
   add_message "google.pubsub.v1.ReceivedMessage" do[m
     optional :ack_id, :string, 1[m
     optional :message, :message, 2, "google.pubsub.v1.PubsubMessage"[m
[32m+[m[32m    optional :delivery_attempt, :int32, 3[m
   end[m
   add_message "google.pubsub.v1.GetSubscriptionRequest" do[m
     optional :subscription, :string, 1[m
[1mdiff --git a/google-cloud-pubsub/synth.metadata b/google-cloud-pubsub/synth.metadata[m
[1mindex 0d551ef48..694c81bd1 100644[m
[1m--- a/google-cloud-pubsub/synth.metadata[m
[1m+++ b/google-cloud-pubsub/synth.metadata[m
[36m@@ -1,19 +1,19 @@[m
 {[m
[31m-  "updateTime": "2019-08-22T10:41:38.054487Z",[m
[32m+[m[32m  "updateTime": "2019-08-27T10:42:55.558010Z",[m
   "sources": [[m
     {[m
       "generator": {[m
         "name": "artman",[m
[31m-        "version": "0.34.0",[m
[31m-        "dockerImage": "googleapis/artman@sha256:38a27ba6245f96c3e86df7acb2ebcc33b4f186d9e475efe2d64303aec3d4e0ea"[m
[32m+[m[32m        "version": "0.35.1",[m
[32m+[m[32m        "dockerImage": "googleapis/artman@sha256:b11c7ea0d0831c54016fb50f4b796d24d1971439b30fbc32a369ba1ac887c384"[m
       }[m
     },[m
     {[m
       "git": {[m
         "name": "googleapis",[m
         "remote": "https://github.com/googleapis/googleapis.git",[m
[31m-        "sha": "92bebf78345af8b2d3585220527115bda8bdedf8",[m
[31m-        "internalRef": "264715111"[m
[32m+[m[32m        "sha": "650caad718bb063f189405c23972dc9818886358",[m
[32m+[m[32m        "internalRef": "265565344"[m
       }[m
     }[m
   ],[m

```

</details>

This pull request was generated using releasetool.