### PR TITLE
Do not interrupt Subscriber callbacks when stopping

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -109,7 +109,7 @@ module Google
 
           def wait!
             # Wait for all queued callbacks to be processed.
-            @callback_thread_pool.wait_for_termination
+            @callback_thread_pool.wait_for_termination 60
 
             self
           end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -88,8 +88,9 @@ module Google
               @pause_cond.broadcast
 
               # Now that the reception thread is stopped, immediately stop the
-              # callback thread pool and purge all pending callbacks.
-              @callback_thread_pool.kill
+              # callback thread pool. All queued callbacks will see the stream
+              # is stopped and perform a noop.
+              @callback_thread_pool.shutdown
 
               # Once all the callbacks are stopped, we can stop the inventory.
               @inventory.stop
@@ -107,6 +108,9 @@ module Google
           end
 
           def wait!
+            # Wait for all queued callbacks to be processed.
+            @callback_thread_pool.wait_for_termination
+
             self
           end
 
@@ -268,14 +272,14 @@ module Google
             return unless callback_thread_pool.running?
 
             Concurrent::Promises.future_on(
-              callback_thread_pool, @subscriber, @inventory, rec_msg
-            ) do |sub, inv, msg|
+              callback_thread_pool, self, rec_msg
+            ) do |stream, msg|
               begin
-                sub.callback.call msg
+                stream.subscriber.callback.call msg unless stream.stopped?
               rescue StandardError => callback_error
-                sub.error! callback_error
+                stream.subscriber.error! callback_error
               ensure
-                inv.remove msg.ack_id
+                stream.inventory.remove msg.ack_id
               end
             end
           end


### PR DESCRIPTION
This PR fixes an issue described in #4011, where an in-process callback will be interrupted when a Subscriber is stopped. We want to allow for in-process callbacks to complete, but to clear all queued callback threads. Unfortunately, we can't control the queued jobs on the callback thread pool, so this change adds a conditional to the pending callback thread so it will only perform the callback if the subscriber's stream is running (not stopped).

[fixes #4020]