### PR TITLE
Update storage class examples in docs and tests

### DIFF
--- a/google-cloud-storage/acceptance/storage/bucket_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_test.rb
@@ -145,7 +145,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
                                    age: 10,
                                    created_before: Date.parse("2013-01-15"), # string in RFC 3339 date format also ok
                                    is_live: true,
-                                   matches_storage_class: ["MULTI_REGIONAL"],
+                                   matches_storage_class: ["STANDARD"],
                                    num_newer_versions: 3
 
     end
@@ -157,7 +157,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
     bucket.lifecycle.last.age.must_equal 10
     bucket.lifecycle.last.created_before.must_equal Date.parse("2013-01-15")
     bucket.lifecycle.last.is_live.must_equal true
-    bucket.lifecycle.last.matches_storage_class.must_equal ["MULTI_REGIONAL"]
+    bucket.lifecycle.last.matches_storage_class.must_equal ["STANDARD"]
     bucket.lifecycle.last.num_newer_versions.must_equal 3
 
     bucket.reload!

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -234,7 +234,7 @@ module Google
         #   rule.action #=> "SetStorageClass"
         #   rule.storage_class #=> "COLDLINE"
         #   rule.age #=> 10
-        #   rule.matches_storage_class #=> ["MULTI_REGIONAL", "REGIONAL"]
+        #   rule.matches_storage_class #=> ["STANDARD", "NEARLINE"]
         #
         # @example Updating the bucket's lifecycle management rules in a block.
         #   require "google/cloud/storage"

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/lifecycle.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/lifecycle.rb
@@ -52,7 +52,7 @@ module Google
         #   rule.action #=> "SetStorageClass"
         #   rule.storage_class #=> "COLDLINE"
         #   rule.age #=> 10
-        #   rule.matches_storage_class #=> ["MULTI_REGIONAL", "REGIONAL"]
+        #   rule.matches_storage_class #=> ["STANDARD", "NEARLINE"]
         #
         # @example Updating the bucket's lifecycle management rules in a block.
         #   require "google/cloud/storage"
@@ -256,7 +256,7 @@ module Google
           #   rule.action #=> "SetStorageClass"
           #   rule.storage_class #=> "COLDLINE"
           #   rule.age #=> 10
-          #   rule.matches_storage_class #=> ["MULTI_REGIONAL", "REGIONAL"]
+          #   rule.matches_storage_class #=> ["STANDARD", "NEARLINE"]
           #
           # @example Updating the bucket's lifecycle rules in a block.
           #   require "google/cloud/storage"

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/lifecycle.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/lifecycle.rb
@@ -110,10 +110,11 @@ module Google
           #   is `false`, it matches archived files.
           # @param [String,Symbol,Array<String,Symbol>] matches_storage_class
           #   Files having any of the storage classes specified by this
-          #   condition will be matched. Values include `MULTI_REGIONAL`,
-          #   `REGIONAL`, `NEARLINE`, `COLDLINE`, `STANDARD`, and
-          #   `DURABLE_REDUCED_AVAILABILITY`. Arguments will be converted from
-          #   symbols and lower-case to upper-case strings.
+          #   condition will be matched. Values include `STANDARD`, `NEARLINE`,
+          #   and `COLDLINE`. `REGIONAL`,`MULTI_REGIONAL`, and
+          #   `DURABLE_REDUCED_AVAILABILITY` are supported as legacy storage
+          #   classes. Arguments will be converted from symbols and lower-case
+          #   to upper-case strings.
           # @param [Integer] num_newer_versions Relevant only for versioned
           #   files. If the value is N, this condition is satisfied when there
           #   are at least N versions (including the live version) newer than
@@ -160,10 +161,11 @@ module Google
           #   is `false`, it matches archived files.
           # @param [String,Symbol,Array<String,Symbol>] matches_storage_class
           #   Files having any of the storage classes specified by this
-          #   condition will be matched. Values include `MULTI_REGIONAL`,
-          #   `REGIONAL`, `NEARLINE`, `COLDLINE`, `STANDARD`, and
-          #   `DURABLE_REDUCED_AVAILABILITY`. Arguments will be converted from
-          #   symbols and lower-case to upper-case strings.
+          #   condition will be matched. Values include `STANDARD`, `NEARLINE`,
+          #   and `COLDLINE`. `REGIONAL`,`MULTI_REGIONAL`, and
+          #   `DURABLE_REDUCED_AVAILABILITY` are supported as legacy storage
+          #   classes. Arguments will be converted from symbols and lower-case
+          #   to upper-case strings.
           # @param [Integer] num_newer_versions Relevant only for versioned
           #   files. If the value is N, this condition is satisfied when there
           #   are at least N versions (including the live version) newer than
@@ -238,8 +240,9 @@ module Google
           #   is `false`, it matches archived files.
           # @attr [Array<String>] matches_storage_class Files having any of the
           #   storage classes specified by this condition will be matched.
-          #   Values include `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`,
-          #   `COLDLINE`, `STANDARD`, and `DURABLE_REDUCED_AVAILABILITY`.
+          #   Values include `STANDARD`, `NEARLINE`, and `COLDLINE`. `REGIONAL`,
+          #   `MULTI_REGIONAL`, and `DURABLE_REDUCED_AVAILABILITY` are supported
+          #   as legacy storage classes.
           # @attr [Integer] num_newer_versions Relevant only for versioned
           #   files. If the value is N, this condition is satisfied when there
           #   are at least N versions (including the live version) newer than

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -300,9 +300,7 @@ module Google
         #   as well as the equivalent strings returned by
         #   {Bucket#storage_class}. For more information, see [Storage
         #   Classes](https://cloud.google.com/storage/docs/storage-classes). The
-        #   default value is the Standard storage class, which is equivalent to
-        #   `:multi_regional` or `:regional` depending on the bucket's location
-        #   settings.
+        #   default value is the `:standard` storage class.
         # @param [Boolean] versioning Whether [Object
         #   Versioning](https://cloud.google.com/storage/docs/object-versioning)
         #   is to be enabled for the bucket. The default value is `false`.

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -1221,7 +1221,7 @@ def lifecycle_hash
         },
         "condition" => {
           "age" => 10,
-          "matchesStorageClass" => ["MULTI_REGIONAL", "REGIONAL"]
+          "matchesStorageClass" => ["STANDARD", "NEARLINE"]
         }
       },
       {

--- a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
@@ -38,7 +38,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
                                        age: 32,
                                        created_before: bucket_lifecycle_created_before,
                                        is_live: true,
-                                       matches_storage_class: ["MULTI_REGIONAL"],
+                                       matches_storage_class: ["STANDARD"],
                                        num_newer_versions: 3)
   end
   let(:bucket_lifecycle_hash) { JSON.parse bucket_lifecycle_gapi.to_json }
@@ -497,7 +497,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
                                      age: 32,
                                      created_before: bucket_lifecycle_created_before,
                                      is_live: true,
-                                     matches_storage_class: ["MULTI_REGIONAL"],
+                                     matches_storage_class: ["STANDARD"],
                                      num_newer_versions: 3
       end
 
@@ -510,7 +510,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       rule.age.must_equal 32
       rule.created_before.must_equal bucket_lifecycle_created_before
       rule.is_live.must_equal true
-      rule.matches_storage_class.must_equal ["MULTI_REGIONAL"]
+      rule.matches_storage_class.must_equal ["STANDARD"]
       rule.num_newer_versions.must_equal 3
     end
 
@@ -530,7 +530,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
                               age: 32,
                               created_before: bucket_lifecycle_created_before,
                               is_live: true,
-                              matches_storage_class: ["MULTI_REGIONAL"],
+                              matches_storage_class: ["STANDARD"],
                               num_newer_versions: 3),
           lifecycle_rule_gapi("Delete", age: 40, is_live: false)
         )
@@ -588,11 +588,11 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
                                 age: 32,
                                 created_before: bucket_lifecycle_created_before,
                                 is_live: true,
-                                matches_storage_class: ["MULTI_REGIONAL"],
+                                matches_storage_class: ["STANDARD"],
                                 num_newer_versions: 3),
               lifecycle_rule_gapi("Delete", age: 40, is_live: false),
               lifecycle_rule_gapi("Delete", is_live: false, num_newer_versions: 8),
-              lifecycle_rule_gapi("SetStorageClass", storage_class: "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["MULTI_REGIONAL", "REGIONAL"])
+              lifecycle_rule_gapi("SetStorageClass", storage_class: "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["STANDARD", "NEARLINE"])
           )
       )
       returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
@@ -606,7 +606,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       bucket_with_cors.update do |b|
         b.lifecycle.add_delete_rule age: 40, is_live: false
         b.lifecycle.add_delete_rule is_live: false, num_newer_versions: 8
-        b.lifecycle.add_set_storage_class_rule "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["MULTI_REGIONAL", "REGIONAL"]
+        b.lifecycle.add_set_storage_class_rule "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["STANDARD", "NEARLINE"]
       end
 
       mock.verify
@@ -621,7 +621,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
                                 age: 32,
                                 created_before: bucket_lifecycle_created_before,
                                 is_live: true,
-                                matches_storage_class: ["MULTI_REGIONAL"],
+                                matches_storage_class: ["STANDARD"],
                                 num_newer_versions: 3),
               lifecycle_rule_gapi("Delete", age: 40, is_live: false)
           )
@@ -635,14 +635,14 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       bucket_with_cors.lifecycle.must_be :frozen?
       bucket_with_cors.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
       bucket_with_cors.lifecycle do |l|
-        l.add_set_storage_class_rule :coldline, created_before: "2013-01-15", matches_storage_class: [:MULTI_REGIONAL, :regional]  # alias: set_storage_class
+        l.add_set_storage_class_rule :coldline, created_before: "2013-01-15", matches_storage_class: [:STANDARD, :nearline]  # alias: set_storage_class
         l.add_delete_rule age: 40, is_live: false
         l.add_delete_rule is_live: false, num_newer_versions: 8
 
         # Remove the last Lifecycle rule from the array
         l.pop
         # Remove all existing rules that match predicate
-        l.delete_if { |r| r.matches_storage_class.include? "REGIONAL" }
+        l.delete_if { |r| r.matches_storage_class.include? "NEARLINE" }
       end
 
       mock.verify

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_update_test.rb
@@ -521,7 +521,7 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
           lifecycle: lifecycle_gapi(
               lifecycle_rule_gapi("Delete", age: 40, is_live: false),
               lifecycle_rule_gapi("Delete", is_live: false, num_newer_versions: 8),
-              lifecycle_rule_gapi("SetStorageClass", storage_class: "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["MULTI_REGIONAL", "REGIONAL"])
+              lifecycle_rule_gapi("SetStorageClass", storage_class: "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["STANDARD", "NEARLINE"])
           )
       )
       returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
@@ -535,7 +535,7 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
       bucket.update do |b|
         b.lifecycle.add_delete_rule age: 40, is_live: false
         b.lifecycle.add_delete_rule is_live: false, num_newer_versions: 8
-        b.lifecycle.add_set_storage_class_rule "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["MULTI_REGIONAL", "REGIONAL"]
+        b.lifecycle.add_set_storage_class_rule "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["STANDARD", "NEARLINE"]
       end
 
       mock.verify
@@ -557,14 +557,14 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
       bucket.lifecycle.must_be :frozen?
       bucket.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
       bucket.lifecycle do |l|
-        l.add_set_storage_class_rule "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["MULTI_REGIONAL", "REGIONAL"]
+        l.add_set_storage_class_rule "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["STANDARD", "NEARLINE"]
         l.add_delete_rule age: 40, is_live: false
         l.add_delete_rule is_live: false, num_newer_versions: 8
 
         # Remove the last Lifecycle rule from the array
         l.pop
         # Remove all existing rules that match predicate
-        l.delete_if { |r| r.matches_storage_class.include? "MULTI_REGIONAL" }
+        l.delete_if { |r| r.matches_storage_class.include? "STANDARD" }
       end
 
       mock.verify


### PR DESCRIPTION
Replace `MULTI_REGIONAL` and `REGIONAL` with `STANDARD` and `NEARLINE` in code examples and tests.

[closes #4006]