### PR TITLE
Update Pool#init to use BatchCreateSessions

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -1287,6 +1287,20 @@ module Google
           Session.from_grpc grpc, @project.service
         end
 
+        ##
+        # @private
+        # Creates a batch of new session objects of size `session_count`.
+        def batch_create_new_sessions session_count
+          ensure_service!
+          resp = @project.service.batch_create_sessions \
+            Admin::Database::V1::DatabaseAdminClient.database_path(
+              project_id, instance_id, database_id
+            ),
+            session_count,
+            labels: @session_labels
+          resp.session.map { |grpc| Session.from_grpc grpc, @project.service }
+        end
+
         # @private
         def to_s
           "(project_id: #{project_id}, instance_id: #{instance_id}, " \

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -1289,8 +1289,23 @@ module Google
 
         ##
         # @private
-        # Creates a batch of new session objects of size `session_count`.
-        def batch_create_new_sessions session_count
+        # Creates a batch of new session objects of size `total`.
+        # Makes multiple RPCs if necessary. Returns empty array if total is 0.
+        def batch_create_new_sessions total
+          sessions = []
+          remaining = total
+          while remaining > 0
+            sessions += batch_create_sessions remaining
+            remaining = total - sessions.count
+          end
+          sessions
+        end
+
+        ##
+        # @private
+        # The response may have fewer sessions than requested in the RPC.
+        #
+        def batch_create_sessions session_count
           ensure_service!
           resp = @project.service.batch_create_sessions \
             Admin::Database::V1::DatabaseAdminClient.database_path(

--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -210,8 +210,7 @@ module Google
           # init the keepalive task
           create_keepalive_task!
           # init session queue
-          @all_sessions = []
-          @all_sessions = @client.batch_create_new_sessions @min if @min > 0
+          @all_sessions = @client.batch_create_new_sessions @min
           sessions = @all_sessions.dup
           num_transactions = (@min * @write_ratio).round
           pending_transactions = sessions.shift num_transactions

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -265,8 +265,8 @@ module Google
           execute do
             # The response may have fewer sessions than requested in the RPC.
             service.batch_create_sessions database_name,
+                                          session_count,
                                           session_template: session,
-                                          session_count: session_count,
                                           options: opts
           end
         end

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -259,6 +259,17 @@ module Google
           end
         end
 
+        def batch_create_sessions database_name, session_count, labels: nil
+          opts = default_options_from_session database_name
+          session = Google::Spanner::V1::Session.new labels: labels if labels
+          execute do
+            service.batch_create_sessions database_name,
+                                          session_template: session,
+                                          session_count: session_count,
+                                          options: opts
+          end
+        end
+
         def delete_session session_name
           opts = default_options_from_session session_name
           execute do

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -263,6 +263,7 @@ module Google
           opts = default_options_from_session database_name
           session = Google::Spanner::V1::Session.new labels: labels if labels
           execute do
+            # The response may have fewer sessions than requested in the RPC.
             service.batch_create_sessions database_name,
                                           session_template: session,
                                           session_count: session_count,

--- a/google-cloud-spanner/support/doctest_helper.rb
+++ b/google-cloud-spanner/support/doctest_helper.rb
@@ -238,9 +238,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::BatchSnapshot#execute" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -251,9 +249,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::BatchSnapshot#execute_sql" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -288,9 +284,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::BatchUpdate" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -333,9 +327,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Project@Obtaining a client for use with a database." do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -357,9 +349,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Project#client" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -436,9 +426,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -449,27 +437,21 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#execute" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", String, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Spanner::Client#execute_sql" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", String, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Spanner::Client#execute_partition_update" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       6.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -479,9 +461,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#execute_pdml" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -491,9 +471,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#transaction" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -505,9 +483,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#snapshot" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -518,9 +494,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#fields" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -532,9 +506,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#range" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -544,9 +516,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#read" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -558,9 +528,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Commit" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -572,9 +540,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Data" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users", Hash]
     end
   end
@@ -651,9 +617,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Fields" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users", Hash]
     end
   end
@@ -662,9 +626,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::ColumnValue" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, OpenStruct.new(name: "session-name"), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -676,9 +638,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Range" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -690,9 +650,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Results" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users", Hash]
     end
   end
@@ -701,9 +659,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Rollback" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -716,9 +672,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Snapshot" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -729,9 +683,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Snapshot#execute_sql@Query using query parameters:" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -742,9 +694,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Snapshot#range" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -754,9 +704,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Snapshot#read" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -778,9 +726,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -792,9 +738,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#batch_update" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -805,9 +749,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#execute" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -818,9 +760,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#execute_sql" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -831,9 +771,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#execute_update" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -844,9 +782,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#execute_sql@Query using query parameters:" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -857,9 +793,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#range" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -870,9 +804,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#read" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end

--- a/google-cloud-spanner/support/doctest_helper.rb
+++ b/google-cloud-spanner/support/doctest_helper.rb
@@ -284,7 +284,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::BatchUpdate" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -327,7 +327,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Project@Obtaining a client for use with a database." do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -349,7 +349,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Project#client" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -426,7 +426,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -437,21 +437,21 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#execute" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", String, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Spanner::Client#execute_sql" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", String, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Spanner::Client#execute_partition_update" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       6.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -461,7 +461,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#execute_pdml" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -471,7 +471,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#transaction" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -483,7 +483,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#snapshot" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -494,7 +494,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#fields" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -506,7 +506,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#range" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -516,7 +516,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#read" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -528,7 +528,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Commit" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -540,7 +540,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Data" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users", Hash]
     end
   end
@@ -617,7 +617,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Fields" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users", Hash]
     end
   end
@@ -626,7 +626,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::ColumnValue" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -638,7 +638,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Range" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -650,7 +650,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Results" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users", Hash]
     end
   end
@@ -659,7 +659,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Rollback" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -672,7 +672,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Snapshot" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -683,7 +683,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Snapshot#execute_sql@Query using query parameters:" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -694,7 +694,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Snapshot#range" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -704,7 +704,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Snapshot#read" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -726,7 +726,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -738,7 +738,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#batch_update" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -749,7 +749,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#execute" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -760,7 +760,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#execute_sql" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -771,7 +771,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#execute_update" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -782,7 +782,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#execute_sql@Query using query parameters:" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -793,7 +793,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#range" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -804,7 +804,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#read" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(20) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -40,7 +40,7 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
         Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002"))
       ]
     )
-    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), session_template: nil, session_count: 2, options: default_options]
+    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), 2, session_template: nil, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [String, tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -67,8 +67,8 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
         Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")),
       ]
     )
-    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), session_template: nil, session_count: 2, options: default_options]
-    mock.expect :batch_create_sessions, sessions_2, [database_path(instance_id, database_id), session_template: nil, session_count: 1, options: default_options]
+    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), 2, session_template: nil, options: default_options]
+    mock.expect :batch_create_sessions, sessions_2, [database_path(instance_id, database_id), 1, session_template: nil, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [String, tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -94,7 +94,7 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
         Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005"))
       ]
     )
-    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), session_template: nil, session_count: 5, options: default_options]
+    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), 5, session_template: nil, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-003-01"), [String, tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-004-01"), [String, tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-005-01"), [String, tx_opts, options: default_options]
@@ -125,7 +125,7 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
         Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-008"))
       ]
     )
-    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), session_template: nil, session_count: 8, options: default_options]
+    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), 8, session_template: nil, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-007-01"), [String, tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-008-01"), [String, tx_opts, options: default_options]
     spanner.service.mocked_service = mock

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -34,8 +34,13 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
   it "creates two sessions and one transaction" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    sessions = Google::Spanner::V1::BatchCreateSessionsResponse.new(
+      session: [
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002"))
+      ]
+    )
+    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), session_template: nil, session_count: 2, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [String, tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -52,11 +57,16 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
   it "creates five sessions and three transactions" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    sessions = Google::Spanner::V1::BatchCreateSessionsResponse.new(
+      session: [
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005"))
+      ]
+    )
+    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), session_template: nil, session_count: 5, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-003-01"), [String, tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-004-01"), [String, tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-005-01"), [String, tx_opts, options: default_options]
@@ -75,14 +85,19 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
   it "creates eight sessions and three transactions" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-006")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-007")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-008")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    sessions = Google::Spanner::V1::BatchCreateSessionsResponse.new(
+      session: [
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-006")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-007")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-008"))
+      ]
+    )
+    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), session_template: nil, session_count: 8, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-007-01"), [String, tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-008-01"), [String, tx_opts, options: default_options]
     spanner.service.mocked_service = mock


### PR DESCRIPTION
Replace the loop in `Pool#init` that repeatedly calls `CreateSession` RPC with a single call to the new `BatchCreateSessions` RPC.

This change passes `rake acceptance` for me locally.