### PR TITLE
Set lower max_bytes default

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
@@ -27,7 +27,7 @@ module Google
 
           attr_reader :max_bytes, :interval
 
-          def initialize subscriber, max_bytes: 10000000, interval: 1.0
+          def initialize subscriber, max_bytes: 500000, interval: 1.0
             super() # to init MonitorMixin
 
             @subscriber = subscriber


### PR DESCRIPTION
The acknowledge and modify_ack_deadline RPCs have a lower payload limit.
Requests larger than 524288 bytes will raise an invalid argument error.