### PR TITLE
Register is a Hash, not Concurrent::Map

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/timed_unary_buffer.rb
@@ -135,7 +135,7 @@ module Google
               synchronize do
                 return {} if @register.empty?
                 reg = @register
-                @register = Concurrent::Map.new
+                @register = {}
                 reg
               end
 


### PR DESCRIPTION
This is a simple refactor to bring this instance in line with the other times that the variable is set to an empty hash.