### PR TITLE
test(spanner): acceptance tests for multi-use #3705

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
@@ -301,6 +301,7 @@ describe "Spanner Client", :snapshot, :spanner do
       results.must_be_kind_of Google::Cloud::Spanner::Results
 
       rows = results.rows.to_a
+      rows.count.must_equal default_account_rows.count
       rows.zip(default_account_rows).each do |expected, actual|
         expected[:account_id].must_equal actual[:account_id]
         expected[:username].must_equal actual[:username]
@@ -313,6 +314,7 @@ describe "Spanner Client", :snapshot, :spanner do
       results2 = snp.read "accounts", [:account_id, :username], keys: keys
       results2.must_be_kind_of Google::Cloud::Spanner::Results
       rows2 = results.rows.to_a
+      rows2.count.must_equal default_account_rows.count
       rows2.zip(default_account_rows).each do |expected, actual|
         expected[:account_id].must_equal actual[:account_id]
         expected[:username].must_equal actual[:username]
@@ -335,6 +337,7 @@ describe "Spanner Client", :snapshot, :spanner do
       results.must_be_kind_of Google::Cloud::Spanner::Results
 
       rows = results.rows.to_a
+      rows.count.must_equal default_account_rows.count
       rows.zip(default_account_rows).each do |expected, actual|
         expected[:account_id].must_equal actual[:account_id]
         expected[:username].must_equal actual[:username]
@@ -347,6 +350,7 @@ describe "Spanner Client", :snapshot, :spanner do
       results2 = snp.read "accounts", [:account_id, :username], keys: keys
       results2.must_be_kind_of Google::Cloud::Spanner::Results
       rows2 = results.rows.to_a
+      rows2.count.must_equal default_account_rows.count
       rows2.zip(default_account_rows).each do |expected, actual|
         expected[:account_id].must_equal actual[:account_id]
         expected[:username].must_equal actual[:username]
@@ -372,6 +376,7 @@ describe "Spanner Client", :snapshot, :spanner do
       results.must_be_kind_of Google::Cloud::Spanner::Results
 
       rows = results.rows.to_a
+      rows.count.must_equal default_account_rows.count
       rows.zip(default_account_rows).each do |expected, actual|
         expected[:account_id].must_equal actual[:account_id]
         expected[:username].must_equal actual[:username]
@@ -384,6 +389,7 @@ describe "Spanner Client", :snapshot, :spanner do
       results2 = snp.read "accounts", [:account_id, :username], keys: keys
       results2.must_be_kind_of Google::Cloud::Spanner::Results
       rows2 = results.rows.to_a
+      rows2.count.must_equal default_account_rows.count
       rows2.zip(default_account_rows).each do |expected, actual|
         expected[:account_id].must_equal actual[:account_id]
         expected[:username].must_equal actual[:username]

--- a/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
@@ -313,7 +313,8 @@ describe "Spanner Client", :snapshot, :spanner do
       # read rows and from snaphot and verify rows got from the snapshot
       results2 = snp.read "accounts", [:account_id, :username], keys: keys
       results2.must_be_kind_of Google::Cloud::Spanner::Results
-      rows2 = results.rows.to_a
+      rows2 = results2.rows.to_a
+
       rows2.count.must_equal default_account_rows.count
       rows2.zip(default_account_rows).each do |expected, actual|
         expected[:account_id].must_equal actual[:account_id]
@@ -349,7 +350,7 @@ describe "Spanner Client", :snapshot, :spanner do
       # read rows and from snaphot and verify rows got from the snapshot
       results2 = snp.read "accounts", [:account_id, :username], keys: keys
       results2.must_be_kind_of Google::Cloud::Spanner::Results
-      rows2 = results.rows.to_a
+      rows2 = results2.rows.to_a
       rows2.count.must_equal default_account_rows.count
       rows2.zip(default_account_rows).each do |expected, actual|
         expected[:account_id].must_equal actual[:account_id]
@@ -388,7 +389,7 @@ describe "Spanner Client", :snapshot, :spanner do
       # read rows and from snaphot and verify rows got from the snapshot
       results2 = snp.read "accounts", [:account_id, :username], keys: keys
       results2.must_be_kind_of Google::Cloud::Spanner::Results
-      rows2 = results.rows.to_a
+      rows2 = results2.rows.to_a
       rows2.count.must_equal default_account_rows.count
       rows2.zip(default_account_rows).each do |expected, actual|
         expected[:account_id].must_equal actual[:account_id]


### PR DESCRIPTION
issue #3705 

- acceptance test for multi-use.  
- Ruby client storing transaction id of snapshot and using it for subsequent operations so by default snapshots created by a ruby client are multi-use.
- snapshot read and update acceptance test are available which are multi-use