### PR TITLE
Fix Subscriber#wait! behavior.

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -109,7 +109,7 @@ module Google
 
           def wait!
             # Wait for all queued callbacks to be processed.
-            @callback_thread_pool.wait_for_termination 60
+            @callback_thread_pool.wait_for_termination
 
             self
           end


### PR DESCRIPTION
* Fix an issue introduced in 0.39.2 where the Subscriber would
  only wait for 60 seconds, and not indefinitely.

This was introduced in #4022.

[fixes #4081]