### PR TITLE
Allow wait to block for specified time

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
@@ -136,10 +136,15 @@ module Google
         end
 
         ##
-        # Blocks until the publisher is fully stopped, all pending messages
-        # have been published, and all callbacks have completed. Does not stop
-        # the publisher. To stop the publisher, first call {#stop} and then
-        # call {#wait!} to block until the publisher is stopped.
+        # Blocks until the publisher is fully stopped, all pending messages have
+        # been published, and all callbacks have completed, or until `timeout`
+        # seconds have passed.
+        #
+        # Does not stop the publisher. To stop the publisher, first call {#stop}
+        # and then call {#wait!} to block until the publisher is stopped
+        #
+        # @param [Number, nil] timeout The number of seconds to block until the
+        #   publisher is fully stopped. Default will block indefinitely.
         #
         # @return [AsyncPublisher] returns self so calls can be chained.
         def wait! timeout = nil

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -149,17 +149,21 @@ module Google
 
         ##
         # Blocks until the subscriber is fully stopped and all received messages
-        # have been processed or released.
+        # have been processed or released, or until `timeout` seconds have
+        # passed.
         #
         # Does not stop the subscriber. To stop the subscriber, first call
         # {#stop} and then call {#wait!} to block until the subscriber is
         # stopped.
         #
+        # @param [Number, nil] timeout The number of seconds to block until the
+        #   subscriber is fully stopped. Default will block indefinitely.
+        #
         # @return [Subscriber] returns self so calls can be chained.
-        def wait!
+        def wait! timeout = nil
           wait_pool = synchronize do
             @stream_pool.map do |stream|
-              Thread.new { stream.wait! }
+              Thread.new { stream.wait! timeout }
             end
           end
           wait_pool.map(&:join)

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -107,9 +107,9 @@ module Google
             synchronize { @paused }
           end
 
-          def wait!
+          def wait! timeout = nil
             # Wait for all queued callbacks to be processed.
-            @callback_thread_pool.wait_for_termination
+            @callback_thread_pool.wait_for_termination timeout
 
             self
           end

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -46,7 +46,7 @@ module Google
         def stop
           self
         end
-        def wait!
+        def wait! *_args
           self
         end
       end


### PR DESCRIPTION
* Add timeout argument to Subscriber#wait! method.
* Document timeout argument on AsyncPublisher#wait! method.