### PR TITLE
Release google-cloud-pubsub 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Availability (GA)](#versioning) quality level:
 * [Cloud Firestore](#cloud-firestore-ga) (GA)
 * [Cloud Key Management Service](#cloud-key-management-service-ga) (GA)
 * [Stackdriver Logging](#stackdriver-logging-ga) (GA)
+* [Cloud Pub/Sub](#cloud-pubsub-ga) (GA)
 * [Cloud Spanner API](#cloud-spanner-api-ga) (GA)
 * [Cloud Storage](#cloud-storage-ga) (GA)
 * [Cloud Translation API](#cloud-translation-api-ga) (GA)
@@ -31,7 +32,6 @@ This client supports the following Google Cloud Platform services at a
 * [Cloud Bigtable](#cloud-bigtable-beta) (Beta)
 * [Stackdriver Debugger](#stackdriver-debugger-beta) (Beta)
 * [Stackdriver Error Reporting](#stackdriver-error-reporting-beta) (Beta)
-* [Cloud Pub/Sub](#cloud-pubsub-beta) (Beta)
 * [Stackdriver Monitoring API](#stackdriver-monitoring-api-beta) (Beta)
 * [Stackdriver Trace](#stackdriver-trace-beta) (Beta)
 
@@ -642,7 +642,7 @@ $ gem install google-cloud-os_login
 $ gem install google-cloud-phishing_protection
 ```
 
-### Cloud Pub/Sub (Beta)
+### Cloud Pub/Sub (GA)
 
 - [google-cloud-pubsub README](google-cloud-pubsub/README.md)
 - [google-cloud-pubsub API documentation](https://googleapis.dev/ruby/google-cloud-pubsub/latest)

--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### 1.0.0 / 2019-09-30
 
- #### Features
+#### Features
 
- * Allow wait to block for specified time
-   * Add timeout argument to Subscriber#wait! method.
-   * Document timeout argument on AsyncPublisher#wait! method.
+* Allow wait to block for specified time
+  * Add timeout argument to Subscriber#wait! method.
+  * Document timeout argument on AsyncPublisher#wait! method.
 * Add stop! convenience method, calling both stop and wait
   * Add Subscriber#stop! method.
   * Add AsyncPublisher#stop! method.

--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Release History
 
+### 1.0.0 / 2019-09-30
+
+### 1.0.0 / 2019-09-30
+
+ #### Features
+
+ * Allow wait to block for specified time
+   * Add timeout argument to Subscriber#wait! method.
+   * Document timeout argument on AsyncPublisher#wait! method.
+* Add stop! convenience method, calling both stop and wait
+  * Add Subscriber#stop! method.
+  * Add AsyncPublisher#stop! method.
+
 ### 0.39.3 / 2019-09-27
 
 #### Bug Fixes

--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### 1.0.0 / 2019-09-30
 
-### 1.0.0 / 2019-09-30
-
  #### Features
 
  * Allow wait to block for specified time

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module PubSub
-      VERSION = "0.39.3".freeze
+      VERSION = "1.0.0".freeze
     end
 
     Pubsub = PubSub unless const_defined? :Pubsub

--- a/google-cloud/google-cloud.gemspec
+++ b/google-cloud/google-cloud.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-monitoring", "~> 0.28"
   gem.add_dependency "google-cloud-os_login", "~> 0.1"
   gem.add_dependency "google-cloud-phishing_protection", "~> 0.1"
-  gem.add_dependency "google-cloud-pubsub", "~> 0.30"
+  gem.add_dependency "google-cloud-pubsub", "~> 1.0"
   gem.add_dependency "google-cloud-recaptcha_enterprise", "~> 0.1"
   gem.add_dependency "google-cloud-redis", "~> 0.2"
   gem.add_dependency "google-cloud-resource_manager", "~> 0.29"


### PR DESCRIPTION
### 1.0.0 / 2019-09-30

 #### Features

 * Allow wait to block for specified time
   * Add timeout argument to Subscriber#wait! method.
   * Document timeout argument on AsyncPublisher#wait! method.
* Add stop! convenience method, calling both stop and wait
  * Add Subscriber#stop! method.
  * Add AsyncPublisher#stop! method.

<details><summary>Commits since previous release</summary><pre><code>[33mcommit 86c51bc5f5fad67b3703dbeb6d72fe8659567887[m
Author: Mike Moore <mike@blowmage.com>
Date:   Mon Sep 30 12:26:01 2019 -0600

    feat(pubsub): Add stop! convenience method
    
    * Convenience method calls both stop and wait.
    * Add Subscriber#stop! method.
    * Add AsyncPublisher#stop! method.
    
    pr: #4092

[33mcommit a5f572155ecec28b553fac26144e11bb56162935[m
Author: Mike Moore <mike@blowmage.com>
Date:   Fri Sep 27 16:54:58 2019 -0600

    feat(pubsub): Allow wait to block for specified time
    
    * Add timeout argument to Subscriber#wait! method.
    * Document timeout argument on AsyncPublisher#wait! method.
    
    pr: #4087
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
[1mdiff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb[m
[1mindex cd71d2329..de6a2d1f3 100644[m
[1m--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb[m
[1m+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb[m
[36m@@ -136,10 +136,15 @@[m [mmodule Google[m
         end[m
 [m
         ##[m
[31m-        # Blocks until the publisher is fully stopped, all pending messages[m
[31m-        # have been published, and all callbacks have completed. Does not stop[m
[31m-        # the publisher. To stop the publisher, first call {#stop} and then[m
[31m-        # call {#wait!} to block until the publisher is stopped.[m
[32m+[m[32m        # Blocks until the publisher is fully stopped, all pending messages have[m
[32m+[m[32m        # been published, and all callbacks have completed, or until `timeout`[m
[32m+[m[32m        # seconds have passed.[m
[32m+[m[32m        #[m
[32m+[m[32m        # Does not stop the publisher. To stop the publisher, first call {#stop}[m
[32m+[m[32m        # and then call {#wait!} to block until the publisher is stopped[m
[32m+[m[32m        #[m
[32m+[m[32m        # @param [Number, nil] timeout The number of seconds to block until the[m
[32m+[m[32m        #   publisher is fully stopped. Default will block indefinitely.[m
         #[m
         # @return [AsyncPublisher] returns self so calls can be chained.[m
         def wait! timeout = nil[m
[36m@@ -157,6 +162,22 @@[m [mmodule Google[m
           self[m
         end[m
 [m
[32m+[m[32m        ##[m
[32m+[m[32m        # Stop this publisher and block until the publisher is fully stopped,[m
[32m+[m[32m        # all pending messages have been published, and all callbacks have[m
[32m+[m[32m        # completed, or until `timeout` seconds have passed.[m
[32m+[m[32m        #[m
[32m+[m[32m        # The same as calling {#stop} and {#wait!}.[m
[32m+[m[32m        #[m
[32m+[m[32m        # @param [Number, nil] timeout The number of seconds to block until the[m
[32m+[m[32m        #   publisher is fully stopped. Default will block indefinitely.[m
[32m+[m[32m        #[m
[32m+[m[32m        # @return [AsyncPublisher] returns self so calls can be chained.[m
[32m+[m[32m        def stop! timeout = nil[m
[32m+[m[32m          stop[m
[32m+[m[32m          wait! timeout[m
[32m+[m[32m        end[m
[32m+[m
         ##[m
         # Forces all messages in the current batch to be published[m
         # immediately.[m
[1mdiff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb[m
[1mindex 92fc81209..7f651a668 100644[m
[1m--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb[m
[1m+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb[m
[36m@@ -149,17 +149,21 @@[m [mmodule Google[m
 [m
         ##[m
         # Blocks until the subscriber is fully stopped and all received messages[m
[31m-        # have been processed or released.[m
[32m+[m[32m        # have been processed or released, or until `timeout` seconds have[m
[32m+[m[32m        # passed.[m
         #[m
         # Does not stop the subscriber. To stop the subscriber, first call[m
         # {#stop} and then call {#wait!} to block until the subscriber is[m
         # stopped.[m
         #[m
[32m+[m[32m        # @param [Number, nil] timeout The number of seconds to block until the[m
[32m+[m[32m        #   subscriber is fully stopped. Default will block indefinitely.[m
[32m+[m[32m        #[m
         # @return [Subscriber] returns self so calls can be chained.[m
[31m-        def wait![m
[32m+[m[32m        def wait! timeout = nil[m
           wait_pool = synchronize do[m
             @stream_pool.map do |stream|[m
[31m-              Thread.new { stream.wait! }[m
[32m+[m[32m              Thread.new { stream.wait! timeout }[m
             end[m
           end[m
           wait_pool.map(&:join)[m
[36m@@ -167,6 +171,23 @@[m [mmodule Google[m
           self[m
         end[m
 [m
[32m+[m[32m        ##[m
[32m+[m[32m        # Stop this subscriber and block until the subscriber is fully stopped[m
[32m+[m[32m        # and all received messages have been processed or released, or until[m
[32m+[m[32m        # `timeout` seconds have passed.[m
[32m+[m[32m        #[m
[32m+[m[32m        # The same as calling {#stop} and {#wait!}.[m
[32m+[m[32m        #[m
[32m+[m[32m        # @param [Number, nil] timeout The number of seconds to block until the[m
[32m+[m[32m        #   subscriber is fully stopped. Default will block indefinitely.[m
[32m+[m[32m        #[m
[32m+[m[32m        # @return [Subscriber] returns self so calls can be chained.[m
[32m+[m[32m        #[m
[32m+[m[32m        def stop! timeout = nil[m
[32m+[m[32m          stop[m
[32m+[m[32m          wait! timeout[m
[32m+[m[32m        end[m
[32m+[m
         ##[m
         # Whether the subscriber has been started.[m
         #[m
[1mdiff --git a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb[m
[1mindex 6a7afd719..cb33f822f 100644[m
[1m--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb[m
[1m+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb[m
[36m@@ -107,9 +107,9 @@[m [mmodule Google[m
             synchronize { @paused }[m
           end[m
 [m
[31m-          def wait![m
[32m+[m[32m          def wait! timeout = nil[m
             # Wait for all queued callbacks to be processed.[m
[31m-            @callback_thread_pool.wait_for_termination[m
[32m+[m[32m            @callback_thread_pool.wait_for_termination timeout[m
 [m
             self[m
           end[m
[1mdiff --git a/google-cloud-pubsub/support/doctest_helper.rb b/google-cloud-pubsub/support/doctest_helper.rb[m
[1mindex eb751552d..419040861 100644[m
[1m--- a/google-cloud-pubsub/support/doctest_helper.rb[m
[1m+++ b/google-cloud-pubsub/support/doctest_helper.rb[m
[36m@@ -46,7 +46,10 @@[m [mmodule Google[m
         def stop[m
           self[m
         end[m
[31m-        def wait![m
[32m+[m[32m        def wait! *_args[m
[32m+[m[32m          self[m
[32m+[m[32m        end[m
[32m+[m[32m        def stop! *_args[m
           self[m
         end[m
       end[m

```

</details>

This pull request was generated using releasetool.