### PR TITLE
Release google-cloud 0.62.0

### DIFF
--- a/google-cloud/CHANGELOG.md
+++ b/google-cloud/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.62.0 / 2019-09-30
+
+#### Features
+
+* Update google-cloud-pubsub dependency to 1.0
+
 ### 0.61.0 / 2019-08-23
 
 #### Features

--- a/google-cloud/lib/google/cloud/version.rb
+++ b/google-cloud/lib/google/cloud/version.rb
@@ -15,6 +15,6 @@
 
 module Google
   module Cloud
-    VERSION = "0.61.0".freeze
+    VERSION = "0.62.0".freeze
   end
 end


### PR DESCRIPTION
#### Features

* Update google-cloud-pubsub dependency to 1.0

<details><summary>Commits since previous release</summary><pre><code>[33mcommit e9c98ede97ca32657b76014af7c2397342da3d6b[m
Author: Mike Moore <mike@blowmage.com>
Date:   Mon Sep 30 13:53:56 2019 -0600

    Release google-cloud-pubsub 1.0.0 (#4098)
    
    * Allow wait to block for specified time
       * Add timeout argument to Subscriber#wait! method.
       * Document timeout argument on AsyncPublisher#wait! method.
     * Add stop! convenience method, calling both stop and wait
       * Add Subscriber#stop! method.
       * Add AsyncPublisher#stop! method.
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
[1mdiff --git a/google-cloud/google-cloud.gemspec b/google-cloud/google-cloud.gemspec[m
[1mindex 040a4ec3f..72858e7a6 100644[m
[1m--- a/google-cloud/google-cloud.gemspec[m
[1m+++ b/google-cloud/google-cloud.gemspec[m
[36m@@ -37,7 +37,7 @@[m [mGem::Specification.new do |gem|[m
   gem.add_dependency "google-cloud-monitoring", "~> 0.28"[m
   gem.add_dependency "google-cloud-os_login", "~> 0.1"[m
   gem.add_dependency "google-cloud-phishing_protection", "~> 0.1"[m
[31m-  gem.add_dependency "google-cloud-pubsub", "~> 0.30"[m
[32m+[m[32m  gem.add_dependency "google-cloud-pubsub", "~> 1.0"[m
   gem.add_dependency "google-cloud-recaptcha_enterprise", "~> 0.1"[m
   gem.add_dependency "google-cloud-redis", "~> 0.2"[m
   gem.add_dependency "google-cloud-resource_manager", "~> 0.29"[m

```

</details>

This pull request was generated using releasetool.