### PR TITLE
Fix Ruby 2.7 compatibility in Cloud::Config#mehtod_missing

### DIFF
--- a/google-cloud-core/lib/google/cloud/config.rb
+++ b/google-cloud-core/lib/google/cloud/config.rb
@@ -458,8 +458,8 @@ module Google
       def method_missing name, *args
         name_str = name.to_s
         super unless name_str =~ /^[a-zA-Z]\w*=?$/
-        if name_str.chomp! "="
-          self[name_str] = args.first
+        if name_str.end_with? "="
+          self[name_str[0...-1]] = args.first
         else
           self[name]
         end


### PR DESCRIPTION
Recently an experimental feature has been merged in Ruby's master https://bugs.ruby-lang.org/issues/16150

In short `Symbol#to_s` will return a frozen string, whereas before it would always return a new mutable string.

Because of this `Google::Cloud::Config#method_missing` breaks on `ruby-head`.

The fix is quite straightforward, I simply reworked the code a little bit to avoid mutating the string.