### PR TITLE
chore: Pin all minitest versions to 5.11.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source "https://rubygems.org"
 
 gem "rake", "~> 12.3"
-gem "minitest", "~> 5.10"
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"
 gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.1"
 gem "minitest-rg", "~> 5.2"

--- a/gcloud/Gemfile
+++ b/gcloud/Gemfile
@@ -44,3 +44,7 @@ gem "google-cloud-vision", path: "../google-cloud-vision"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-asset/Gemfile
+++ b/google-cloud-asset/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.0"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-automl/Gemfile
+++ b/google-cloud-automl/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.0"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-bigquery-data_transfer/Gemfile
+++ b/google-cloud-bigquery-data_transfer/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -8,3 +8,7 @@ gem "google-cloud-storage", path: "../google-cloud-storage"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-bigtable/Gemfile
+++ b/google-cloud-bigtable/Gemfile
@@ -7,3 +7,7 @@ gem "google-cloud-env", path: "../google-cloud-env"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-container/Gemfile
+++ b/google-cloud-container/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-container_analysis/Gemfile
+++ b/google-cloud-container_analysis/Gemfile
@@ -4,3 +4,7 @@ gemspec
 
 gem "grafeas-client", path: "../grafeas-client"
 gem "rake", "~> 12.0"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-dataproc/Gemfile
+++ b/google-cloud-dataproc/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -6,3 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-dialogflow/Gemfile
+++ b/google-cloud-dialogflow/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-dlp/Gemfile
+++ b/google-cloud-dlp/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-dns/Gemfile
+++ b/google-cloud-dns/Gemfile
@@ -6,3 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-env/Gemfile
+++ b/google-cloud-env/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-error_reporting/Gemfile
+++ b/google-cloud-error_reporting/Gemfile
@@ -7,3 +7,7 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-firestore/Gemfile
+++ b/google-cloud-firestore/Gemfile
@@ -8,3 +8,7 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "rake", "~> 12.3"
 
 gem "stackprof" unless Gem.win_platform?
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-irm/Gemfile
+++ b/google-cloud-irm/Gemfile
@@ -7,3 +7,7 @@ gemspec
 gem "google-cloud-monitoring", "~> 0.29"
 gem "public_suffix", "~> 2.0"
 gem "rake", "~> 12.0"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-kms/Gemfile
+++ b/google-cloud-kms/Gemfile
@@ -10,3 +10,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   gem "jwt", "~> 1.5"
   gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-language/Gemfile
+++ b/google-cloud-language/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-monitoring/Gemfile
+++ b/google-cloud-monitoring/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-os_login/Gemfile
+++ b/google-cloud-os_login/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-phishing_protection/Gemfile
+++ b/google-cloud-phishing_protection/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.0"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -7,3 +7,7 @@ gem "google-cloud-env", path: "../google-cloud-env"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-recaptcha_enterprise/Gemfile
+++ b/google-cloud-recaptcha_enterprise/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.0"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-redis/Gemfile
+++ b/google-cloud-redis/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-resource_manager/Gemfile
+++ b/google-cloud-resource_manager/Gemfile
@@ -6,3 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-scheduler/Gemfile
+++ b/google-cloud-scheduler/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.0"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-security_center/Gemfile
+++ b/google-cloud-security_center/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -6,3 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-speech/Gemfile
+++ b/google-cloud-speech/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -8,3 +8,7 @@ gem "google-cloud-pubsub", path: "../google-cloud-pubsub"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-talent/Gemfile
+++ b/google-cloud-talent/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.0"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-tasks/Gemfile
+++ b/google-cloud-tasks/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-text_to_speech/Gemfile
+++ b/google-cloud-text_to_speech/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-trace/Gemfile
+++ b/google-cloud-trace/Gemfile
@@ -7,3 +7,7 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-translate/Gemfile
+++ b/google-cloud-translate/Gemfile
@@ -6,3 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-video_intelligence/Gemfile
+++ b/google-cloud-video_intelligence/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-vision/Gemfile
+++ b/google-cloud-vision/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud-webrisk/Gemfile
+++ b/google-cloud-webrisk/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.0"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/google-cloud/Gemfile
+++ b/google-cloud/Gemfile
@@ -43,3 +43,7 @@ gem "google-cloud-vision", path: "../google-cloud-vision"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/grafeas-client/Gemfile
+++ b/grafeas-client/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.0"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/stackdriver-core/Gemfile
+++ b/stackdriver-core/Gemfile
@@ -6,3 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"

--- a/stackdriver/Gemfile
+++ b/stackdriver/Gemfile
@@ -11,3 +11,7 @@ gem "google-cloud-trace", path: "../google-cloud-trace"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"


### PR DESCRIPTION
Pin minitest to `5.11.x` in all Gemfiles not covered by #4115 