### PR TITLE
Update Bucket#post_object

### DIFF
--- a/google-cloud-storage/acceptance/storage/bucket_post_object_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_post_object_test.rb
@@ -1,0 +1,90 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "storage_helper"
+require 'net/http'
+require 'uri'
+
+describe Google::Cloud::Storage::Bucket, :post_object, :storage do
+  let(:bucket_name) { $bucket_names.first }
+  let :bucket do
+    storage.bucket(bucket_name) ||
+    safe_gcs_execute { storage.create_bucket(bucket_name) }
+  end
+  let(:uri) { URI.parse Google::Cloud::Storage::GOOGLEAPIS_URL }
+  let(:data_file) { "logo.jpg" }
+  let(:data) { File.expand_path("../data/#{data_file}", __dir__) }
+  let :policy do
+    {
+      expiration: (Time.now + 600).iso8601,
+      conditions: [
+        ["starts-with", "$key", ""]
+      ]
+    }
+  end
+
+  it "generates a signed post object" do
+    file_name = "logo-#{SecureRandom.hex(4).downcase}.jpg"
+
+    bucket.file(file_name).must_be :nil?
+
+    signed_post = bucket.post_object file_name, policy: policy
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    request = Net::HTTP::Post.new(uri.request_uri)
+
+    form_data = [
+      ['file', File.open(data)],
+      ['key', signed_post.fields[:key]],
+      ['GoogleAccessId', signed_post.fields[:GoogleAccessId]],
+      ['policy', signed_post.fields[:policy]],
+      ['signature', signed_post.fields[:signature]]
+    ]
+    request.set_form form_data, 'multipart/form-data'
+
+    response = http.request(request)
+
+    response.code.must_equal "204"
+    bucket.file(file_name).wont_be :nil?
+  end
+
+  it "generates a signed post object with special variable key ${filename}" do
+    # "You can also use the ${filename} variable if a user is providing a file name."
+    #  https://cloud.google.com/storage/docs/xml-api/post-object
+    special_key = "${filename}"
+
+    bucket.file(data_file).must_be :nil?
+
+    signed_post = bucket.post_object special_key, policy: policy
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    request = Net::HTTP::Post.new(uri.request_uri)
+
+    form_data = [
+      ['file', File.open(data)],
+      ['key', signed_post.fields[:key]],
+      ['GoogleAccessId', signed_post.fields[:GoogleAccessId]],
+      ['policy', signed_post.fields[:policy]],
+      ['signature', signed_post.fields[:signature]]
+    ]
+    request.set_form form_data, 'multipart/form-data'
+
+    response = http.request(request)
+
+    response.code.must_equal "204"
+    bucket.file(data_file).wont_be :nil?
+  end
+end

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v2.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v2.rb
@@ -41,9 +41,20 @@ module Google
           end
 
           ##
-          # The external path to the file.
+          # The external path to the file, URI-encoded.
+          # Will not URI encode the special `${filename}` variable.
+          # "You can also use the ${filename} variable..."
+          # https://cloud.google.com/storage/docs/xml-api/post-object
+          #
           def ext_path
-            Addressable::URI.escape "/#{@bucket}/#{@path}"
+            path = "/#{@bucket}/#{@path}"
+            escaped = Addressable::URI.escape path
+            special_var = "${filename}"
+            # Restore the unencoded `${filename}` variable, if present.
+            if path.include? special_var
+              return escaped.gsub "$%7Bfilename%7D", special_var
+            end
+            escaped
           end
 
           ##

--- a/google-cloud-storage/test/google/cloud/storage/bucket_post_object_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_post_object_test.rb
@@ -19,7 +19,9 @@ describe Google::Cloud::Storage::Bucket, :post_object, :mock_storage do
   let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash(bucket_name).to_json }
   let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
 
-  let(:file_path) { "file.ext" }
+  let(:file_path) { "a/b/c/{my_file}.ext" }
+  let(:file_path_encoded) { "a/b/c/%7Bmy_file%7D.ext" }
+  let(:file_path_special_variable) { "a/b/c/${filename}" }
 
   it "uses the credentials' issuer and signing_key to generate signed post objects" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
@@ -46,6 +48,7 @@ describe Google::Cloud::Storage::Bucket, :post_object, :mock_storage do
       signed_post.url.must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
       signed_post.fields[:GoogleAccessId].must_equal "native_client_email"
       signed_post.fields[:signature].must_equal Base64.strict_encode64("native-signature").delete("\n")
+      signed_post.fields[:key].must_equal [bucket_name, file_path_encoded].join("/")
 
       signing_key_mock.verify
     end
@@ -65,6 +68,28 @@ describe Google::Cloud::Storage::Bucket, :post_object, :mock_storage do
     signed_post.url.must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
     signed_post.fields[:GoogleAccessId].must_equal "native_client_email"
     signed_post.fields[:signature].must_equal Base64.strict_encode64("native-signature").delete("\n")
+    signed_post.fields[:key].must_equal [bucket_name, file_path_encoded].join("/")
+
+    signing_key_mock.verify
+  end
+
+  it "gives a signature without URI encoding the special variable path ${filename}" do
+    # "You can also use the ${filename} variable if a user is providing a file name."
+    # https://cloud.google.com/storage/docs/xml-api/post-object
+    signing_key_mock = Minitest::Mock.new
+
+    json_policy = Base64.strict_encode64("{}").delete("\n")
+    signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, json_policy]
+    credentials.issuer = "native_client_email"
+    credentials.signing_key = signing_key_mock
+
+
+    signed_post = bucket.post_object file_path_special_variable
+
+    signed_post.url.must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
+    signed_post.fields[:GoogleAccessId].must_equal "native_client_email"
+    signed_post.fields[:signature].must_equal Base64.strict_encode64("native-signature").delete("\n")
+    signed_post.fields[:key].must_equal [bucket_name, file_path_special_variable].join("/")
 
     signing_key_mock.verify
   end


### PR DESCRIPTION
* Avoid encoding special variable name `${filename}`

> You can also use the ${filename} variable if a user is providing a file name.

See [Post Object - Form fields - key](https://cloud.google.com/storage/docs/xml-api/post-object).

[fixes #4047]