### PR TITLE
Release google-cloud-spanner 1.11.0

### DIFF
--- a/google-cloud-spanner/CHANGELOG.md
+++ b/google-cloud-spanner/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Release History
 
+### 1.11.0 / 2019-10-07
+
+#### BREAKING CHANGES (LOWER-LEVEL API ONLY)
+
+* Make the session_count argument required in the lower-level API batch_create_sessions call
+
+#### Performance Improvements
+
+* Update Pool#init to use BatchCreateSessions
+  * Update pool checkout to pop sessions for LIFO
+
+#### Documentation
+
+* Update Policy example code
+* Update IAM Policy class description and sample code
+
 ### 1.10.1 / 2019-09-04
 
 #### Documentation

--- a/google-cloud-spanner/lib/google/cloud/spanner/version.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Spanner
-      VERSION = "1.10.1".freeze
+      VERSION = "1.11.0".freeze
     end
   end
 end


### PR DESCRIPTION
#### BREAKING CHANGES (LOWER-LEVEL API ONLY)

* Make the session_count argument required in the lower-level API batch_create_sessions call

#### Performance Improvements

* Update Pool#init to use BatchCreateSessions
  * Update pool checkout to pop sessions for LIFO

#### Documentation

* Update Policy example code
* Update IAM Policy class description and sample code

<details><summary>Commits since previous release</summary><pre><code>commit 7e986c8e0468e5f07790bf20db755454298751a6
Author: Jiren Patel <jirenpatel@gmail.com>
Date:   Mon Oct 7 20:20:16 2019 +0530

    test(spanner): add acceptance tests for multi-use
    
    [closes #3705, pr #4071]

commit 05f7155cb1bbf9da71c10c2908639a916685e64f
Author: Daniel Azuma <dazuma@google.com>
Date:   Thu Oct 3 16:28:06 2019 -0700

    chore: Pin all minitest versions to 5.11.x

commit f55d7e11d66843aabddeeccad1991df96a6f59af
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Thu Oct 3 14:20:25 2019 -0700

    docs(spanner): Update Policy example code

commit eb6f296baf58fc3216056705bcb6086f80104f61
Author: Chris Smith <quartzmo@gmail.com>
Date:   Wed Oct 2 09:42:17 2019 -0600

    perf(spanner): Update Pool#init to use BatchCreateSessions
    
    * Update pool checkout to pop sessions for LIFO
    
    [refs #4063, pr #4040]

commit 060384feb2e3ce47a54336c171b019c480adf044
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Tue Oct 1 10:57:42 2019 -0700

    fix(spanner)!: Make the session_count argument required in the low-level batch_create_sessions call

commit 9fe09b41932f79948f45de3728920e0f98011de6
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Sep 23 12:46:27 2019 -0700

    docs(tasks): Update IAM Policy class description and sample code
    
    pr: #4044
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-spanner/Gemfile b/google-cloud-spanner/Gemfile
index 192e20081..6072450e2 100644
--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -6,3 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
 gem "rake", "~> 12.3"
+
+# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
+# See https://github.com/googleapis/google-cloud-ruby/issues/4110
+gem "minitest", "~> 5.11.3"
diff --git a/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb b/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
index 4ba859a11..e6441925e 100644
--- a/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
@@ -290,6 +290,118 @@ describe "Spanner Client", :snapshot, :spanner do
     end
   end
 
+  it "multiuse snapshot reads are consistent even when delete happen" do
+    keys = default_account_rows.map{|row| row[:account_id] }
+
+    db.snapshot do |snp|
+      snp.transaction_id.wont_be :nil?
+      snp.timestamp.wont_be :nil?
+
+      results = snp.read "accounts", [:account_id, :username], keys: keys
+      results.must_be_kind_of Google::Cloud::Spanner::Results
+
+      rows = results.rows.to_a
+      rows.count.must_equal default_account_rows.count
+      rows.zip(default_account_rows).each do |expected, actual|
+        expected[:account_id].must_equal actual[:account_id]
+        expected[:username].must_equal actual[:username]
+      end
+
+      # outside of the snapshot, delete rows
+      db.delete "accounts", keys
+
+      # read rows and from snaphot and verify rows got from the snapshot
+      results2 = snp.read "accounts", [:account_id, :username], keys: keys
+      results2.must_be_kind_of Google::Cloud::Spanner::Results
+      rows2 = results2.rows.to_a
+
+      rows2.count.must_equal default_account_rows.count
+      rows2.zip(default_account_rows).each do |expected, actual|
+        expected[:account_id].must_equal actual[:account_id]
+        expected[:username].must_equal actual[:username]
+      end
+    end
+
+    # outside of snapshot check all rows are deleted
+    rows3 = db.execute_sql("SELECT * FROM accounts").rows.to_a
+    rows3.count.must_equal 0
+  end
+
+  it "multiuse snapshot reads with read timestamp are consistent even when delete happen" do
+    keys = default_account_rows.map{|row| row[:account_id] }
+
+    db.snapshot read_timestamp: @setup_timestamp do |snp|
+      snp.transaction_id.wont_be :nil?
+      snp.timestamp.wont_be :nil?
+
+      results = snp.read "accounts", [:account_id, :username], keys: keys
+      results.must_be_kind_of Google::Cloud::Spanner::Results
+
+      rows = results.rows.to_a
+      rows.count.must_equal default_account_rows.count
+      rows.zip(default_account_rows).each do |expected, actual|
+        expected[:account_id].must_equal actual[:account_id]
+        expected[:username].must_equal actual[:username]
+      end
+
+      # outside of the snapshot, delete rows
+      db.delete "accounts", keys
+
+      # read rows and from snaphot and verify rows got from the snapshot
+      results2 = snp.read "accounts", [:account_id, :username], keys: keys
+      results2.must_be_kind_of Google::Cloud::Spanner::Results
+      rows2 = results2.rows.to_a
+      rows2.count.must_equal default_account_rows.count
+      rows2.zip(default_account_rows).each do |expected, actual|
+        expected[:account_id].must_equal actual[:account_id]
+        expected[:username].must_equal actual[:username]
+      end
+    end
+
+    # outside of snapshot check all rows are deleted
+    rows3 = db.execute_sql("SELECT * FROM accounts").rows.to_a
+    rows3.count.must_equal 0
+  end
+
+  it "multiuse snapshot reads with exact staleness are consistent even when delete happen" do
+    keys = default_account_rows.map{|row| row[:account_id] }
+
+    sleep 1
+    delta = 0.001
+
+    db.snapshot exact_staleness: delta do |snp|
+      snp.transaction_id.wont_be :nil?
+      snp.timestamp.wont_be :nil?
+
+      results = snp.read "accounts", [:account_id, :username], keys: keys
+      results.must_be_kind_of Google::Cloud::Spanner::Results
+
+      rows = results.rows.to_a
+      rows.count.must_equal default_account_rows.count
+      rows.zip(default_account_rows).each do |expected, actual|
+        expected[:account_id].must_equal actual[:account_id]
+        expected[:username].must_equal actual[:username]
+      end
+
+      # outside of the snapshot, delete rows
+      db.delete "accounts", keys
+
+      # read rows and from snaphot and verify rows got from the snapshot
+      results2 = snp.read "accounts", [:account_id, :username], keys: keys
+      results2.must_be_kind_of Google::Cloud::Spanner::Results
+      rows2 = results2.rows.to_a
+      rows2.count.must_equal default_account_rows.count
+      rows2.zip(default_account_rows).each do |expected, actual|
+        expected[:account_id].must_equal actual[:account_id]
+        expected[:username].must_equal actual[:username]
+      end
+    end
+
+    # outside of snapshot check all rows are deleted
+    rows3 = db.execute_sql("SELECT * FROM accounts").rows.to_a
+    rows3.count.must_equal 0
+  end
+
   def assert_accounts_equal expected, actual
     if actual[:account_id].nil?
       expected[:account_id].must_be :nil?
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
index 373abe457..d7cdf07b8 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
@@ -20,27 +20,36 @@ module Google
       # specify access control policies for Cloud Platform resources.
       #
       #
-      # A `Policy` consists of a list of `bindings`. A `binding` binds a list of
-      # `members` to a `role`, where the members can be user accounts, Google groups,
-      # Google domains, and service accounts. A `role` is a named list of permissions
-      # defined by IAM.
+      # A `Policy` is a collection of `bindings`. A `binding` binds one or more
+      # `members` to a single `role`. Members can be user accounts, service accounts,
+      # Google groups, and domains (such as G Suite). A `role` is a named list of
+      # permissions (defined by IAM or configured by users). A `binding` can
+      # optionally specify a `condition`, which is a logic expression that further
+      # constrains the role binding based on attributes about the request and/or
+      # target resource.
       #
       # **JSON Example**
       #
       #     {
       #       "bindings": [
       #         {
-      #           "role": "roles/owner",
+      #           "role": "roles/resourcemanager.organizationAdmin",
       #           "members": [
       #             "user:mike@example.com",
       #             "group:admins@example.com",
       #             "domain:google.com",
-      #             "serviceAccount:my-other-app@appspot.gserviceaccount.com"
+      #             "serviceAccount:my-project-id@appspot.gserviceaccount.com"
       #           ]
       #         },
       #         {
-      #           "role": "roles/viewer",
-      #           "members": ["user:sean@example.com"]
+      #           "role": "roles/resourcemanager.organizationViewer",
+      #           "members": ["user:eve@example.com"],
+      #           "condition": {
+      #             "title": "expirable access",
+      #             "description": "Does not grant access after Sep 2020",
+      #             "expression": "request.time <
+      #             timestamp('2020-10-01T00:00:00.000Z')",
+      #           }
       #         }
       #       ]
       #     }
@@ -52,15 +61,18 @@ module Google
       #   * user:mike@example.com
       #     * group:admins@example.com
       #       * domain:google.com
-      #       * serviceAccount:my-other-app@appspot.gserviceaccount.com
-      #         role: roles/owner
+      #       * serviceAccount:my-project-id@appspot.gserviceaccount.com
+      #         role: roles/resourcemanager.organizationAdmin
       #       * members:
-      #       * user:sean@example.com
-      #         role: roles/viewer
-      #
-      #
-      #     For a description of IAM and its features, see the
-      #     [IAM developer's guide](https://cloud.google.com/iam/docs).
+      #       * user:eve@example.com
+      #         role: roles/resourcemanager.organizationViewer
+      #         condition:
+      #         title: expirable access
+      #         description: Does not grant access after Sep 2020
+      #         expression: request.time < timestamp('2020-10-01T00:00:00.000Z')
+      #
+      #       For a description of IAM and its features, see the
+      #       [IAM developer's guide](https://cloud.google.com/iam/docs).
       # @!attribute [rw] version
       #   @return [Integer]
       #     Specifies the format of the policy.
@@ -68,12 +80,18 @@ module Google
       #     Valid values are 0, 1, and 3. Requests specifying an invalid value will be
       #     rejected.
       #
-      #     Policies with any conditional bindings must specify version 3. Policies
-      #     without any conditional bindings may specify any valid value or leave the
-      #     field unset.
+      #     Operations affecting conditional bindings must specify version 3. This can
+      #     be either setting a conditional policy, modifying a conditional binding,
+      #     or removing a conditional binding from the stored conditional policy.
+      #     Operations on non-conditional policies may specify any valid value or
+      #     leave the field unset.
+      #
+      #     If no etag is provided in the call to `setIamPolicy`, any version
+      #     compliance checks on the incoming and/or stored policy is skipped.
       # @!attribute [rw] bindings
       #   @return [Array<Google::Iam::V1::Binding>]
-      #     Associates a list of `members` to a `role`.
+      #     Associates a list of `members` to a `role`. Optionally may specify a
+      #     `condition` that determines when binding is in effect.
       #     `bindings` with no members will result in an error.
       # @!attribute [rw] etag
       #   @return [String]
@@ -86,7 +104,9 @@ module Google
       #     ensure that their change will be applied to the same version of the policy.
       #
       #     If no `etag` is provided in the call to `setIamPolicy`, then the existing
-      #     policy is overwritten.
+      #     policy is overwritten. Due to blind-set semantics of an etag-less policy,
+      #     'setIamPolicy' will not fail even if either of incoming or stored policy
+      #     does not meet the version requirements.
       class Policy; end
 
       # Associates `members` with a `role`.
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
index 373abe457..d7cdf07b8 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
@@ -20,27 +20,36 @@ module Google
       # specify access control policies for Cloud Platform resources.
       #
       #
-      # A `Policy` consists of a list of `bindings`. A `binding` binds a list of
-      # `members` to a `role`, where the members can be user accounts, Google groups,
-      # Google domains, and service accounts. A `role` is a named list of permissions
-      # defined by IAM.
+      # A `Policy` is a collection of `bindings`. A `binding` binds one or more
+      # `members` to a single `role`. Members can be user accounts, service accounts,
+      # Google groups, and domains (such as G Suite). A `role` is a named list of
+      # permissions (defined by IAM or configured by users). A `binding` can
+      # optionally specify a `condition`, which is a logic expression that further
+      # constrains the role binding based on attributes about the request and/or
+      # target resource.
       #
       # **JSON Example**
       #
       #     {
       #       "bindings": [
       #         {
-      #           "role": "roles/owner",
+      #           "role": "roles/resourcemanager.organizationAdmin",
       #           "members": [
       #             "user:mike@example.com",
       #             "group:admins@example.com",
       #             "domain:google.com",
-      #             "serviceAccount:my-other-app@appspot.gserviceaccount.com"
+      #             "serviceAccount:my-project-id@appspot.gserviceaccount.com"
       #           ]
       #         },
       #         {
-      #           "role": "roles/viewer",
-      #           "members": ["user:sean@example.com"]
+      #           "role": "roles/resourcemanager.organizationViewer",
+      #           "members": ["user:eve@example.com"],
+      #           "condition": {
+      #             "title": "expirable access",
+      #             "description": "Does not grant access after Sep 2020",
+      #             "expression": "request.time <
+      #             timestamp('2020-10-01T00:00:00.000Z')",
+      #           }
       #         }
       #       ]
       #     }
@@ -52,15 +61,18 @@ module Google
       #   * user:mike@example.com
       #     * group:admins@example.com
       #       * domain:google.com
-      #       * serviceAccount:my-other-app@appspot.gserviceaccount.com
-      #         role: roles/owner
+      #       * serviceAccount:my-project-id@appspot.gserviceaccount.com
+      #         role: roles/resourcemanager.organizationAdmin
       #       * members:
-      #       * user:sean@example.com
-      #         role: roles/viewer
-      #
-      #
-      #     For a description of IAM and its features, see the
-      #     [IAM developer's guide](https://cloud.google.com/iam/docs).
+      #       * user:eve@example.com
+      #         role: roles/resourcemanager.organizationViewer
+      #         condition:
+      #         title: expirable access
+      #         description: Does not grant access after Sep 2020
+      #         expression: request.time < timestamp('2020-10-01T00:00:00.000Z')
+      #
+      #       For a description of IAM and its features, see the
+      #       [IAM developer's guide](https://cloud.google.com/iam/docs).
       # @!attribute [rw] version
       #   @return [Integer]
       #     Specifies the format of the policy.
@@ -68,12 +80,18 @@ module Google
       #     Valid values are 0, 1, and 3. Requests specifying an invalid value will be
       #     rejected.
       #
-      #     Policies with any conditional bindings must specify version 3. Policies
-      #     without any conditional bindings may specify any valid value or leave the
-      #     field unset.
+      #     Operations affecting conditional bindings must specify version 3. This can
+      #     be either setting a conditional policy, modifying a conditional binding,
+      #     or removing a conditional binding from the stored conditional policy.
+      #     Operations on non-conditional policies may specify any valid value or
+      #     leave the field unset.
+      #
+      #     If no etag is provided in the call to `setIamPolicy`, any version
+      #     compliance checks on the incoming and/or stored policy is skipped.
       # @!attribute [rw] bindings
       #   @return [Array<Google::Iam::V1::Binding>]
-      #     Associates a list of `members` to a `role`.
+      #     Associates a list of `members` to a `role`. Optionally may specify a
+      #     `condition` that determines when binding is in effect.
       #     `bindings` with no members will result in an error.
       # @!attribute [rw] etag
       #   @return [String]
@@ -86,7 +104,9 @@ module Google
       #     ensure that their change will be applied to the same version of the policy.
       #
       #     If no `etag` is provided in the call to `setIamPolicy`, then the existing
-      #     policy is overwritten.
+      #     policy is overwritten. Due to blind-set semantics of an etag-less policy,
+      #     'setIamPolicy' will not fail even if either of incoming or stored policy
+      #     does not meet the version requirements.
       class Policy; end
 
       # Associates `members` with a `role`.
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/client.rb b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
index af4e63650..d5fcc1ed9 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -1287,6 +1287,35 @@ module Google
           Session.from_grpc grpc, @project.service
         end
 
+        ##
+        # @private
+        # Creates a batch of new session objects of size `total`.
+        # Makes multiple RPCs if necessary. Returns empty array if total is 0.
+        def batch_create_new_sessions total
+          sessions = []
+          remaining = total
+          while remaining > 0
+            sessions += batch_create_sessions remaining
+            remaining = total - sessions.count
+          end
+          sessions
+        end
+
+        ##
+        # @private
+        # The response may have fewer sessions than requested in the RPC.
+        #
+        def batch_create_sessions session_count
+          ensure_service!
+          resp = @project.service.batch_create_sessions \
+            Admin::Database::V1::DatabaseAdminClient.database_path(
+              project_id, instance_id, database_id
+            ),
+            session_count,
+            labels: @session_labels
+          resp.session.map { |grpc| Session.from_grpc grpc, @project.service }
+        end
+
         # @private
         def to_s
           "(project_id: #{project_id}, instance_id: #{instance_id}, " \
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
index a8ec05bfc..6e780d6f8 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -65,9 +65,11 @@ module Google
             loop do
               raise ClientClosedError if @closed
 
-              read_session = session_queue.shift
+              # Use LIFO to ensure sessions are used from backend caches, which
+              # will reduce the read / write latencies on user requests.
+              read_session = session_queue.pop # LIFO
               return read_session if read_session
-              write_transaction = transaction_queue.shift
+              write_transaction = transaction_queue.pop # LIFO
               return write_transaction.session if write_transaction
 
               if can_allocate_more_sessions?
@@ -117,9 +119,9 @@ module Google
             loop do
               raise ClientClosedError if @closed
 
-              write_transaction = transaction_queue.shift
+              write_transaction = transaction_queue.pop # LIFO
               return write_transaction if write_transaction
-              read_session = session_queue.shift
+              read_session = session_queue.pop
               if read_session
                 action = read_session
                 break
@@ -204,21 +206,19 @@ module Google
             max_threads: @threads
           # init the queues
           @new_sessions_in_process = 0
-          @all_sessions = []
-          @session_queue = []
           @transaction_queue = []
           # init the keepalive task
           create_keepalive_task!
           # init session queue
+          @all_sessions = @client.batch_create_new_sessions @min
+          sessions = @all_sessions.dup
           num_transactions = (@min * @write_ratio).round
-          num_sessions = @min.to_i - num_transactions
-          num_sessions.times.each do
-            future { checkin_session new_session! }
-          end
+          pending_transactions = sessions.shift num_transactions
           # init transaction queue
-          num_transactions.times.each do
-            future { checkin_transaction new_transaction! }
+          pending_transactions.each do |transaction|
+            future { checkin_transaction transaction.create_transaction }
           end
+          @session_queue = sessions
         end
 
         def shutdown
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/service.rb b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
index 874f05907..75f874b7b 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -259,6 +259,18 @@ module Google
           end
         end
 
+        def batch_create_sessions database_name, session_count, labels: nil
+          opts = default_options_from_session database_name
+          session = Google::Spanner::V1::Session.new labels: labels if labels
+          execute do
+            # The response may have fewer sessions than requested in the RPC.
+            service.batch_create_sessions database_name,
+                                          session_count,
+                                          session_template: session,
+                                          options: opts
+          end
+        end
+
         def delete_session session_name
           opts = default_options_from_session session_name
           execute do
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
index 69121394f..f5575001f 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
@@ -406,10 +406,6 @@ module Google
           #
           # @param database [String]
           #   Required. The database in which the new sessions are created.
-          # @param session_template [Google::Spanner::V1::Session | Hash]
-          #   Parameters to be applied to each created session.
-          #   A hash of the same form as `Google::Spanner::V1::Session`
-          #   can also be provided.
           # @param session_count [Integer]
           #   Required. The number of sessions to be created in this batch call.
           #   The API may return fewer than the requested number of sessions. If a
@@ -417,6 +413,10 @@ module Google
           #   calls to BatchCreateSessions (adjusting
           #   {Google::Spanner::V1::BatchCreateSessionsRequest#session_count session_count}
           #   as necessary).
+          # @param session_template [Google::Spanner::V1::Session | Hash]
+          #   Parameters to be applied to each created session.
+          #   A hash of the same form as `Google::Spanner::V1::Session`
+          #   can also be provided.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -430,18 +430,21 @@ module Google
           #
           #   spanner_client = Google::Cloud::Spanner::V1::SpannerClient.new
           #   formatted_database = Google::Cloud::Spanner::V1::SpannerClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
-          #   response = spanner_client.batch_create_sessions(formatted_database)
+          #
+          #   # TODO: Initialize `session_count`:
+          #   session_count = 0
+          #   response = spanner_client.batch_create_sessions(formatted_database, session_count)
 
           def batch_create_sessions \
               database,
+              session_count,
               session_template: nil,
-              session_count: nil,
               options: nil,
               &block
             req = {
               database: database,
-              session_template: session_template,
-              session_count: session_count
+              session_count: session_count,
+              session_template: session_template
             }.delete_if { |_, v| v.nil? }
             req = Google::Gax::to_proto(req, Google::Spanner::V1::BatchCreateSessionsRequest)
             @batch_create_sessions.call(req, options, &block)
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json
index d4041d6eb..cbe4698b1 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json
@@ -15,19 +15,19 @@
           "initial_retry_delay_millis": 250,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 32000,
-          "initial_rpc_timeout_millis": 60000,
+          "initial_rpc_timeout_millis": 360000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 60000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 360000,
+          "total_timeout_millis": 3600000
         },
         "streaming": {
           "initial_retry_delay_millis": 250,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 32000,
-          "initial_rpc_timeout_millis": 120000,
+          "initial_rpc_timeout_millis": 360000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 120000,
-          "total_timeout_millis": 1200000
+          "max_rpc_timeout_millis": 360000,
+          "total_timeout_millis": 3600000
         },
         "long_running": {
           "initial_retry_delay_millis": 250,
diff --git a/google-cloud-spanner/support/doctest_helper.rb b/google-cloud-spanner/support/doctest_helper.rb
index e8f1549e0..5e02001bb 100644
--- a/google-cloud-spanner/support/doctest_helper.rb
+++ b/google-cloud-spanner/support/doctest_helper.rb
@@ -238,9 +238,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::BatchSnapshot#execute" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -251,9 +249,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::BatchSnapshot#execute_sql" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -288,9 +284,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::BatchUpdate" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -333,9 +327,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Project@Obtaining a client for use with a database." do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -357,9 +349,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Project#client" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -436,9 +426,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -449,27 +437,21 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#execute" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", String, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Spanner::Client#execute_sql" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", String, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Spanner::Client#execute_partition_update" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       6.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -479,9 +461,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#execute_pdml" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -491,9 +471,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#transaction" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -505,9 +483,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#snapshot" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -518,9 +494,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#fields" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -532,9 +506,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#range" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -544,9 +516,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Client#read" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -558,9 +528,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Commit" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -572,9 +540,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Data" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users", Hash]
     end
   end
@@ -651,9 +617,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Fields" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users", Hash]
     end
   end
@@ -662,9 +626,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::ColumnValue" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, OpenStruct.new(name: "session-name"), ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -676,9 +638,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Range" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -690,9 +650,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Results" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users", Hash]
     end
   end
@@ -701,9 +659,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Rollback" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -716,9 +672,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Snapshot" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -729,9 +683,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Snapshot#execute_sql@Query using query parameters:" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -742,9 +694,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Snapshot#range" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -754,9 +704,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Snapshot#read" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -778,9 +726,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -792,9 +738,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#batch_update" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -805,9 +749,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#execute" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -818,9 +760,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#execute_sql" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -831,9 +771,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#execute_update" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -844,9 +782,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#execute_sql@Query using query parameters:" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -857,9 +793,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#range" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
@@ -870,9 +804,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Spanner::Transaction#read" do
     mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
+      mock.expect :batch_create_sessions, OpenStruct.new(session: Array.new(10) { session_grpc }), ["projects/my-project/instances/my-instance/databases/my-database", 10, Hash]
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
diff --git a/google-cloud-spanner/synth.metadata b/google-cloud-spanner/synth.metadata
index 11e2c81d3..4b9c017c7 100644
--- a/google-cloud-spanner/synth.metadata
+++ b/google-cloud-spanner/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-08-27T10:44:34.339077Z",
+  "updateTime": "2019-10-02T10:42:57.475021Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.35.1",
-        "dockerImage": "googleapis/artman@sha256:b11c7ea0d0831c54016fb50f4b796d24d1971439b30fbc32a369ba1ac887c384"
+        "version": "0.37.1",
+        "dockerImage": "googleapis/artman@sha256:6068f67900a3f0bdece596b97bda8fc70406ca0e137a941f4c81d3217c994a80"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "650caad718bb063f189405c23972dc9818886358",
-        "internalRef": "265565344"
+        "sha": "2123bcae97debe57e0870fca157cdf21e32bf3fb",
+        "internalRef": "272289410"
       }
     }
   ],
diff --git a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
index e9d79f447..ffcc9d7fc 100644
--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -34,8 +34,41 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
   it "creates two sessions and one transaction" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    sessions = Google::Spanner::V1::BatchCreateSessionsResponse.new(
+      session: [
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002"))
+      ]
+    )
+    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), 2, session_template: nil, options: default_options]
+    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [String, tx_opts, options: default_options]
+    spanner.service.mocked_service = mock
+
+    pool = Google::Cloud::Spanner::Pool.new client, min: 2, write_ratio: 0.5
+
+    shutdown_pool! pool
+
+    pool.all_sessions.size.must_equal 2
+    pool.session_queue.size.must_equal 1
+    pool.transaction_queue.size.must_equal 1
+
+    mock.verify
+  end
+
+  it "calls batch_create_sessions until min number of sessions are returned" do
+    mock = Minitest::Mock.new
+    sessions = Google::Spanner::V1::BatchCreateSessionsResponse.new(
+      session: [
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")),
+      ]
+    )
+    sessions_2 = Google::Spanner::V1::BatchCreateSessionsResponse.new(
+      session: [
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")),
+      ]
+    )
+    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), 2, session_template: nil, options: default_options]
+    mock.expect :batch_create_sessions, sessions_2, [database_path(instance_id, database_id), 1, session_template: nil, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [String, tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -52,11 +85,16 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
   it "creates five sessions and three transactions" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    sessions = Google::Spanner::V1::BatchCreateSessionsResponse.new(
+      session: [
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005"))
+      ]
+    )
+    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), 5, session_template: nil, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-003-01"), [String, tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-004-01"), [String, tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-005-01"), [String, tx_opts, options: default_options]
@@ -75,14 +113,19 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
   it "creates eight sessions and three transactions" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-006")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-007")), [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-008")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    sessions = Google::Spanner::V1::BatchCreateSessionsResponse.new(
+      session: [
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-006")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-007")),
+        Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-008"))
+      ]
+    )
+    mock.expect :batch_create_sessions, sessions, [database_path(instance_id, database_id), 8, session_template: nil, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-007-01"), [String, tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-008-01"), [String, tx_opts, options: default_options]
     spanner.service.mocked_service = mock
diff --git a/google-cloud-spanner/test/google/cloud/spanner/v1/spanner_client_test.rb b/google-cloud-spanner/test/google/cloud/spanner/v1/spanner_client_test.rb
index 3cc09993b..f36481ff0 100644
--- a/google-cloud-spanner/test/google/cloud/spanner/v1/spanner_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/v1/spanner_client_test.rb
@@ -147,6 +147,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
     it 'invokes batch_create_sessions without error' do
       # Create request parameters
       formatted_database = Google::Cloud::Spanner::V1::SpannerClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
+      session_count = 0
 
       # Create expected grpc response
       expected_response = {}
@@ -156,6 +157,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Spanner::V1::BatchCreateSessionsRequest, request)
         assert_equal(formatted_database, request.database)
+        assert_equal(session_count, request.session_count)
         OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub_v1.new(:batch_create_sessions, mock_method)
@@ -168,13 +170,13 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          response = client.batch_create_sessions(formatted_database)
+          response = client.batch_create_sessions(formatted_database, session_count)
 
           # Verify the response
           assert_equal(expected_response, response)
 
           # Call method with block
-          client.batch_create_sessions(formatted_database) do |response, operation|
+          client.batch_create_sessions(formatted_database, session_count) do |response, operation|
             # Verify the response
             assert_equal(expected_response, response)
             refute_nil(operation)
@@ -186,11 +188,13 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
     it 'invokes batch_create_sessions with error' do
       # Create request parameters
       formatted_database = Google::Cloud::Spanner::V1::SpannerClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
+      session_count = 0
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Spanner::V1::BatchCreateSessionsRequest, request)
         assert_equal(formatted_database, request.database)
+        assert_equal(session_count, request.session_count)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v1.new(:batch_create_sessions, mock_method)
@@ -204,7 +208,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
 
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
-            client.batch_create_sessions(formatted_database)
+            client.batch_create_sessions(formatted_database, session_count)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

```

</details>

This pull request was generated using releasetool.