### PR TITLE
feat!(bigtable): Update Table#column_families to return frozen ColumnFamilyMap

### DIFF
--- a/google-cloud-bigtable/acceptance/bigtable/column_family_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/column_family_test.rb
@@ -39,7 +39,7 @@ describe "Table ColumnFamily", :bigtable do
     cf.gc_rule.max_versions.must_equal 1
 
     table.reload!
-    cf = table.column_families.find{|cf| cf.name == "cfcreate"}
+    cf = table.column_families["cfcreate"]
     cf.wont_be :nil?
 
     cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
@@ -56,7 +56,7 @@ describe "Table ColumnFamily", :bigtable do
     cf.gc_rule.must_be :nil?
 
     table.reload!
-    cf = table.column_families.find{|cf| cf.name == "cfcreate"}
+    cf = table.column_families["cfcreate"]
     cf.wont_be :nil?
 
     cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
@@ -65,19 +65,19 @@ describe "Table ColumnFamily", :bigtable do
   end
 
   it "update column family" do
-    cf = table.column_families.find{|cf| cf.name == "cf1"}
+    cf = table.column_families["cf1"]
     cf.gc_rule.max_age = 300
     updated_cf = cf.save
     updated_cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
     updated_cf.gc_rule.max_age.must_equal 300
 
     table.reload!
-    cf = table.column_families.find{|cf| cf.name == "cf1"}
+    cf = table.column_families["cf1"]
     cf.gc_rule.max_age.must_equal 300
   end
 
   it "update column family without gc_rule" do
-    cf = table.column_families.find{|cf| cf.name == "cf1"}
+    cf = table.column_families["cf1"]
     cf.gc_rule.wont_be :nil?
     cf.gc_rule = nil
     updated_cf = cf.save
@@ -85,16 +85,16 @@ describe "Table ColumnFamily", :bigtable do
     updated_cf.gc_rule.must_be :nil?
 
     table.reload!
-    cf = table.column_families.find{|cf| cf.name == "cf1"}
+    cf = table.column_families["cf1"]
     cf.gc_rule.must_be :nil?
   end
 
   it "delete column family" do
-    cf = table.column_families.find{|cf| cf.name == "cf2"}
+    cf = table.column_families["cf2"]
     cf.delete.must_equal true
 
     table.reload!
-    table.column_families.find{|cf| cf.name == "cf2"}.must_be :nil?
+    cf = table.column_families["cf2"].must_be :nil?
   end
 
   it "create column family with union gc rules" do

--- a/google-cloud-bigtable/acceptance/bigtable/table_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table_test.rb
@@ -96,14 +96,18 @@ describe "Instance Tables", :bigtable do
     updated_table.must_be_kind_of Google::Cloud::Bigtable::Table
 
     column_families = updated_table.column_families
-    cf3 = column_families.find{|c| c.name == "cf3"}
+    column_families.class.must_equal Google::Cloud::Bigtable::Table::ColumnFamilyMap
+    column_families.must_be_kind_of Hash
+    column_families.must_be :frozen?
+
+    cf3 = column_families["cf3"]
     cf3.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
     cf3.gc_rule.max_age.must_equal 600
 
-    cf2 = column_families.find{|c| c.name == "cf2"}
+    cf2 = column_families["cf2"]
     cf2.gc_rule.max_versions.must_equal 5
 
-    column_families.find{|c| c.name == "cf1"}.must_be :nil?
+    column_families["cf1"]
 
     table.delete
   end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/column_family.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/column_family.rb
@@ -33,17 +33,13 @@ module Google
       #   instance = bigtable.instance("my-instance")
       #   table = instance.table("my-table")
       #
-      #   # Create
-      #   gc_rule = Google::Cloud::Bigtable::GcRule.max_versions(5)
-      #   column_family = table.column_families.add("cf1", gc_rule)
-      #
       #   # Update
-      #   column_family = table.column_families.find_by_name("cf2")
+      #   column_family = table.column_families["cf2"]
       #   column_family.gc_rule = Google::Cloud::Bigtable::GcRule.max_age(600)
       #   column_family.update
       #
       #   # Delete
-      #   column_family = table.column_families.find_by_name("cf3")
+      #   column_family = table.column_families["cf3"]
       #   column_family.delete
       #
       class ColumnFamily
@@ -126,7 +122,7 @@ module Google
         #   instance = bigtable.instance("my-instance")
         #   table = instance.table("my-table")
         #
-        #   column_family = table.column_families.find {|cf| cf.name == "cf" }
+        #   column_family = table.column_families["cf1"]
         #   column_family.gc_rule = Google::Cloud::Bigtable::GcRule.max_age(600)
         #   column_family.save
         #
@@ -148,7 +144,7 @@ module Google
         #   instance = bigtable.instance("my-instance")
         #   table = instance.table("my-table")
         #
-        #   column_family = table.column_families.find {|cf| cf.name == "cf" }
+        #   column_family = table.column_families["cf1"]
         #   column_family.delete
         #
         def delete
@@ -278,7 +274,7 @@ module Google
             table_id,
             modification
           )
-          table.column_families.find { |cf| cf.name == name }
+          table.column_families[name]
         end
 
         # @private

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
@@ -485,7 +485,7 @@ module Google
         #   # Default view is full view
         #   table = instance.table("my-table", perform_lookup: true)
         #   puts table.name
-        #   puts table.column_families.inspect
+        #   puts table.column_families
         #
         #   # Name-only view
         #   table = instance.table("my-table", view: :NAME_ONLY, perform_lookup: true)

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
@@ -485,7 +485,7 @@ module Google
         #   # Default view is full view
         #   table = instance.table("my-table", perform_lookup: true)
         #   puts table.name
-        #   puts table.column_families
+        #   puts table.column_families.inspect
         #
         #   # Name-only view
         #   table = instance.table("my-table", view: :NAME_ONLY, perform_lookup: true)

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
@@ -294,7 +294,7 @@ module Google
         #
         #   bigtable.tables("my-instance").all do |table|
         #     puts table.name
-        #     puts table.column_families
+        #     puts table.column_families.inspect
         #   end
         #
         def tables instance_id
@@ -332,8 +332,8 @@ module Google
         #
         #   table = bigtable.table("my-instance", "my-table", perform_lookup: true, view: :SCHEMA_VIEW)
         #   if table
-        #     p table.name
-        #     p table.column_families
+        #     puts table.name
+        #     puts table.column_families.inspect
         #   end
         #
         # @example Get table object without calling get table admin api.
@@ -351,8 +351,8 @@ module Google
         #   table = bigtable.table("my-instance", "my-table", view: :FULL, perform_lookup: true)
         #   if table
         #     puts table.name
-        #     p table.column_families
-        #     p table.cluster_states
+        #     puts table.column_families.inspect
+        #     puts table.cluster_states.inspect
         #   end
         #
         # @example Mutate rows
@@ -563,7 +563,7 @@ module Google
         #
         #   table = bigtable.modify_column_families("my-instance", "my-table", modifications)
         #
-        #   p table.column_families
+        #   puts table.column_families.inspect
         #
         def modify_column_families instance_id, table_id, modifications
           ensure_service!

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
@@ -294,7 +294,7 @@ module Google
         #
         #   bigtable.tables("my-instance").all do |table|
         #     puts table.name
-        #     puts table.column_families.inspect
+        #     puts table.column_families
         #   end
         #
         def tables instance_id
@@ -333,7 +333,7 @@ module Google
         #   table = bigtable.table("my-instance", "my-table", perform_lookup: true, view: :SCHEMA_VIEW)
         #   if table
         #     puts table.name
-        #     puts table.column_families.inspect
+        #     puts table.column_families
         #   end
         #
         # @example Get table object without calling get table admin api.
@@ -351,8 +351,8 @@ module Google
         #   table = bigtable.table("my-instance", "my-table", view: :FULL, perform_lookup: true)
         #   if table
         #     puts table.name
-        #     puts table.column_families.inspect
-        #     puts table.cluster_states.inspect
+        #     puts table.column_families
+        #     puts table.cluster_states
         #   end
         #
         # @example Mutate rows
@@ -563,7 +563,7 @@ module Google
         #
         #   table = bigtable.modify_column_families("my-instance", "my-table", modifications)
         #
-        #   puts table.column_families.inspect
+        #   puts table.column_families
         #
         def modify_column_families instance_id, table_id, modifications
           ensure_service!

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
@@ -362,7 +362,7 @@ module Google
         #
         #   table = table.modify_column_families(modifications)
         #
-        #   puts table.column_families.inspect
+        #   puts table.column_families
         #
         def modify_column_families modifications
           ensure_service!

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/table/column_family_map.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/table/column_family_map.rb
@@ -20,8 +20,9 @@ module Google
     module Bigtable
       class Table
         ##
-        # Table::ColumnFamilyMap is a hash accepting string `ColumnFamily` names as keys and `GcRule` objects as values.
-        # It is used to create an instance.
+        # Table::ColumnFamilyMap is a hash accepting string column family names
+        # as keys and `ColumnFamily` objects as values.
+        # It is used to manage the column families belonging to a table.
         #
         class ColumnFamilyMap < DelegateClass(::Hash)
           # @private
@@ -52,6 +53,23 @@ module Google
           #
           def remove name
             delete(name)
+          end
+
+          def self.from_grpc grpc, instance_id, table_id, service
+            new(
+              grpc.map do |name, cf_grpc|
+                [
+                  name,
+                  ColumnFamily.from_grpc(
+                    cf_grpc,
+                    service,
+                    name: name,
+                    instance_id: instance_id,
+                    table_id: table_id
+                  )
+                ]
+              end.to_h
+            )
           end
         end
       end

--- a/google-cloud-bigtable/samples/tableadmin.rb
+++ b/google-cloud-bigtable/samples/tableadmin.rb
@@ -133,7 +133,7 @@ def run_table_operations instance_id, table_id
   puts ""
   puts "==> Updating column family cf1 GC rule"
   # [START bigtable_update_gc_rule]
-  family = table.column_families.find { |cf| cf.name == "cf1" }
+  family = table.column_families["cf1"]
   family.gc_rule = Google::Cloud::Bigtable::GcRule.max_versions(1)
   updated_family = family.save
   p updated_family
@@ -143,14 +143,14 @@ def run_table_operations instance_id, table_id
 
   puts "==> Print updated column family cf1 GC rule"
   # [START bigtable_family_get_gc_rule]
-  family = table.column_families.find { |cf| cf.name == "cf1" }
+  family = table.column_families["cf1"]
   # [END bigtable_family_get_gc_rule]
   p family
 
   puts ""
   puts "==> Delete a column family cf2"
   # [START bigtable_delete_family]
-  family = table.column_families.find { |cf| cf.name == "cf2" }
+  family = table.column_families["cf2"]
   family.delete
   # [END bigtable_delete_family]
   puts "==> #{family.name} deleted successfully"

--- a/google-cloud-bigtable/support/doctest_helper.rb
+++ b/google-cloud-bigtable/support/doctest_helper.rb
@@ -204,14 +204,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.skip "Google::Cloud::Bigtable::ColumnFamily" # TODO: (#4134) Add update block to Table#column_families
-  # doctest.before "Google::Cloud::Bigtable::ColumnFamily" do
-  #   mock_bigtable do |mock, mocked_instances, mocked_tables|
-  #     mocked_instances.expect :get_instance, instance_resp, ["projects/my-project/instances/my-instance"]
-  #     mocked_tables.expect :get_table, table_resp, ["projects/my-project/instances/my-instance/tables/my-table", { view: :SCHEMA_VIEW }]
-  #     mocked_tables.expect :modify_column_families, table_resp, ["projects/my-project/instances/my-instance/tables/my-table", Array]
-  #   end
-  # end
+  doctest.before "Google::Cloud::Bigtable::ColumnFamily" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables|
+      mocked_instances.expect :get_instance, instance_resp, ["projects/my-project/instances/my-instance"]
+      mocked_tables.expect :get_table, table_resp, ["projects/my-project/instances/my-instance/tables/my-table", { view: :SCHEMA_VIEW }]
+      mocked_tables.expect :modify_column_families, table_resp, ["projects/my-project/instances/my-instance/tables/my-table", Array]
+      mocked_tables.expect :modify_column_families, table_resp, ["projects/my-project/instances/my-instance/tables/my-table", Array]
+    end
+  end
 
   doctest.before "Google::Cloud::Bigtable::Instance" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
@@ -513,7 +513,12 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.skip "Google::Cloud::Bigtable::Table#column_families" # TODO: (#4134) Add update block to Table#column_families, and (#4133) change return type to frozen hash.
+  doctest.before "Google::Cloud::Bigtable::Table#column_families" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_instances.expect :get_instance, instance_resp, ["projects/my-project/instances/my-instance"]
+      mocked_tables.expect :get_table, table_resp, ["projects/my-project/instances/my-instance/tables/my-table", Hash]
+    end
+  end
 
   doctest.before "Google::Cloud::Bigtable::Table#column_family" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
@@ -757,14 +762,14 @@ def column_family_hash(max_versions: nil, max_age: nil, intersection: nil, union
   { gc_rule: gc_rule }
 end
 
-def column_families_hash num: 3, start_id: 1
+def column_families_hash num: 3
   num.times.each_with_object({}) do |i, r|
-    r["cf"] = column_family_hash(max_versions: 3)
+    r["cf#{i+1}"] = column_family_hash(max_versions: 3)
   end
 end
 
-def column_families_grpc num: 3, start_id: 1
-  column_families_hash(num: num, start_id: start_id)
+def column_families_grpc num: 3
+  column_families_hash(num: num)
     .each_with_object({}) do |(k,v), r|
     r[k] = Google::Bigtable::Admin::V2::ColumnFamily.new(v)
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/create_table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/create_table_test.rb
@@ -93,8 +93,8 @@ describe Google::Cloud::Bigtable::Instance, :create_table, :mock_bigtable do
     table.name.must_equal table_id
     table.path.must_equal table_path(instance_id, table_id)
     table.granularity.must_equal :MILLIS
-    table.column_families.map(&:name).sort.must_equal column_families.keys
-    table.column_families.each do |cf|
+    table.column_families.keys.sort.must_equal column_families.keys
+    table.column_families.each do |name, cf|
       cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
     end
     table.cluster_states.map(&:cluster_name).sort.must_equal cluster_states.keys
@@ -143,8 +143,8 @@ describe Google::Cloud::Bigtable::Instance, :create_table, :mock_bigtable do
     table.name.must_equal table_id
     table.path.must_equal table_path(instance_id, table_id)
     table.granularity.must_equal :MILLIS
-    table.column_families.map(&:name).sort.must_equal column_families.keys
-    table.column_families.each do |cf|
+    table.column_families.keys.sort.must_equal column_families.keys
+    table.column_families.each do |name, cf|
       cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
     end
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/table_test.rb
@@ -56,8 +56,8 @@ describe Google::Cloud::Bigtable::Instance, :table, :mock_bigtable do
       cs.replication_state.must_equal :READY
     end
 
-    table.column_families.map(&:name).sort.must_equal column_families.keys
-    table.column_families.each do |cf|
+    table.column_families.keys.sort.must_equal column_families.keys
+    table.column_families.each do |name, cf|
       cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
     end
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/create_table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/create_table_test.rb
@@ -66,8 +66,8 @@ describe Google::Cloud::Bigtable::Project, :create_table, :mock_bigtable do
     table.name.must_equal table_id
     table.path.must_equal table_path(instance_id, table_id)
     table.granularity.must_equal :MILLIS
-    table.column_families.map(&:name).sort.must_equal column_families.keys
-    table.column_families.each do |cf|
+    table.column_families.keys.sort.must_equal column_families.keys
+    table.column_families.each do |name, cf|
       cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
     end
     table.cluster_states.map(&:cluster_name).sort.must_equal cluster_states.keys
@@ -125,8 +125,8 @@ describe Google::Cloud::Bigtable::Project, :create_table, :mock_bigtable do
     table.name.must_equal table_id
     table.path.must_equal table_path(instance_id, table_id)
     table.granularity.must_equal :MILLIS
-    table.column_families.map(&:name).sort.must_equal column_families.keys
-    table.column_families.each do |cf|
+    table.column_families.keys.sort.must_equal column_families.keys
+    table.column_families.each do |name, cf|
       cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
     end
     table.cluster_states.map(&:cluster_name).sort.must_equal cluster_states.keys

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/modify_column_families_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/modify_column_families_test.rb
@@ -58,10 +58,14 @@ describe Google::Cloud::Bigtable::Project, :modify_column_families, :mock_bigtab
     table.name.must_equal table_id
     table.path.must_equal table_path(instance_id, table_id)
     table.granularity.must_equal :MILLIS
-  
-    table.column_families.map(&:name).sort.must_equal column_families.keys
-    table.column_families[0].gc_rule.to_grpc.must_equal Google::Cloud::Bigtable::GcRule.max_age(300).to_grpc
-    table.column_families[1].gc_rule.must_be :nil?
+
+    cfm = table.column_families
+    cfm.class.must_equal Google::Cloud::Bigtable::Table::ColumnFamilyMap
+    cfm.must_be_kind_of Hash
+    cfm.must_be :frozen?
+    cfm.keys.sort.must_equal column_families.keys
+    cfm["cf1"].gc_rule.to_grpc.must_equal Google::Cloud::Bigtable::GcRule.max_age(300).to_grpc
+    cfm["cf2"].gc_rule.must_be :nil?
   end
 
   it "modify single column family in table" do
@@ -89,8 +93,8 @@ describe Google::Cloud::Bigtable::Project, :modify_column_families, :mock_bigtab
 
     mock.verify
 
-    table.column_families.map(&:name).sort.must_equal column_families.keys
-    table.column_families.each do |cf|
+    table.column_families.keys.sort.must_equal column_families.keys
+    table.column_families.each do |name, cf|
       cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
     end
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/table_test.rb
@@ -50,8 +50,8 @@ describe Google::Cloud::Bigtable::Project, :table, :mock_bigtable do
       cs.replication_state.must_equal :READY
     end
 
-    table.column_families.map(&:name).sort.must_equal column_families.keys
-    table.column_families.each do |cf|
+    table.column_families.keys.sort.must_equal column_families.keys
+    table.column_families.each do |name, cf|
       cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
     end
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/modify_column_families_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/modify_column_families_test.rb
@@ -73,8 +73,8 @@ describe Google::Cloud::Bigtable::Table, :modify_column_families, :mock_bigtable
     updated_table.name.must_equal table_id
     updated_table.path.must_equal table_path(instance_id, table_id)
     updated_table.granularity.must_equal :MILLIS
-    updated_table.column_families.map(&:name).sort.must_equal column_families.keys
-    updated_table.column_families[0].gc_rule.to_grpc.must_equal Google::Cloud::Bigtable::GcRule.max_age(300).to_grpc
-    updated_table.column_families[1].gc_rule.must_be :nil?
+    updated_table.column_families.keys.sort.must_equal column_families.keys
+    updated_table.column_families["cf1"].gc_rule.to_grpc.must_equal Google::Cloud::Bigtable::GcRule.max_age(300).to_grpc
+    updated_table.column_families["cf2"].gc_rule.must_be :nil?
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table_test.rb
@@ -48,8 +48,8 @@ describe Google::Cloud::Bigtable::Table, :mock_bigtable do
       cs.replication_state.must_equal :READY
     end
 
-    table.column_families.map(&:name).sort.must_equal column_families.keys
-    table.column_families.each do |cf|
+    table.column_families.keys.sort.must_equal column_families.keys
+    table.column_families.each do |name, cf|
       cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
     end
   end


### PR DESCRIPTION
BREAKING CHANGE: `Table#column_families` return type changed from mutable Array to
frozen `ColumnFamilyMap`.

[closes #4133]

Note: This PR only partially changes `ColumnFamilyMap`. Until the PR for #4134 is completed, `ColumnFamilyMap#add` will continue to store `Google::Bigtable::Admin::V2::ColumnFamily` objects as well.