### PR TITLE
fix(error_reporting): Middleware reuses existing default reporter

### DIFF
--- a/google-cloud-error_reporting/acceptance/error_reporting/error_reporting_test.rb
+++ b/google-cloud-error_reporting/acceptance/error_reporting/error_reporting_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::ErrorReporting, :error_reporting do
     end
 
     # Query for error group
-    project_id = Google::Cloud::ErrorReporting.send(:default_client).error_reporting.project
+    project_id = Google::Cloud::ErrorReporting.default_reporter.error_reporting.project
     formatted_project = Google::Cloud::ErrorReporting::V1beta1::ErrorStatsServiceClient.project_path project_id
     v1beta1 = Google::Devtools::Clouderrorreporting::V1beta1
     time_range = v1beta1::QueryTimeRange.new period: v1beta1::QueryTimeRange::Period::PERIOD_1_HOUR

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -54,14 +54,12 @@ module Google
 
           @error_reporting =
             error_reporting ||
-            ErrorReporting::AsyncErrorReporter.new(
-              ErrorReporting.new(project: configuration.project_id,
-                                 credentials: configuration.credentials)
-            )
-
-          # Set module default client to reuse the same client. Update module
-          # configuration parameters.
-          ErrorReporting.class_variable_set :@@default_client, @error_reporting
+            ErrorReporting.default_reporter do
+              ErrorReporting::AsyncErrorReporter.new(
+                ErrorReporting.new(project: configuration.project_id,
+                                   credentials: configuration.credentials)
+              )
+            end
         end
 
         ##

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
@@ -83,9 +83,12 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
       end
     end
 
-    it "sets Google::Cloud::ErrorReporting\#@@default_client" do
-      middleware
-      Google::Cloud::ErrorReporting.class_variable_get(:@@default_client).object_id.must_equal error_reporting.object_id
+    it "sets Google::Cloud::ErrorReporting.default_reporter" do
+      Google::Cloud::ErrorReporting.instance_variable_set :@default_reporter, nil
+      Google::Cloud::ErrorReporting.stub :new, nil do
+        mw = Google::Cloud::ErrorReporting::Middleware.new nil, project_id: project_id
+        Google::Cloud::ErrorReporting.instance_variable_get(:@default_reporter).object_id.must_equal mw.error_reporting.object_id
+      end
     end
 
     it "sets Google::Cloud::ErrorReporting.configure" do

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
@@ -73,6 +73,7 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
     end
 
     it "creates a default async_error_reporter if not given one" do
+      Google::Cloud::ErrorReporting.instance_variable_set :@default_reporter, nil
       Google::Cloud::ErrorReporting::AsyncErrorReporter.stub :new, "A default reporter" do
         Google::Cloud::ErrorReporting.stub :new, nil do
           middleware = Google::Cloud::ErrorReporting::Middleware.new nil,

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting_test.rb
@@ -130,15 +130,15 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
     let(:exception) { RuntimeError.new "test-exception" }
 
     before {
-      Google::Cloud::ErrorReporting.class_variable_set :@@default_client, nil
-      Google::Cloud::ErrorReporting.class_variable_get(:@@default_client).must_be_nil
+      Google::Cloud::ErrorReporting.instance_variable_set :@default_reporter, nil
+      Google::Cloud::ErrorReporting.instance_variable_get(:@default_reporter).must_be_nil
     }
 
     after {
       Google::Cloud.configure.reset!
       Google::Cloud::ErrorReporting.configure.reset!
-      Google::Cloud::ErrorReporting.class_variable_set :@@default_client, nil
-      Google::Cloud::ErrorReporting.class_variable_get(:@@default_client).must_be_nil
+      Google::Cloud::ErrorReporting.instance_variable_set :@default_reporter, nil
+      Google::Cloud::ErrorReporting.instance_variable_get(:@default_reporter).must_be_nil
     }
 
     it "doesn't call Project#report_exception if Google::Cloud.configure.use_error_reporting is false" do
@@ -146,7 +146,7 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
         config.use_error_reporting = false
       end
       stubbed_report = ->(_) { fail "Shouldn't be called" }
-      Google::Cloud::ErrorReporting.class_variable_set :@@default_client, error_reporting
+      Google::Cloud::ErrorReporting.instance_variable_set :@default_reporter, error_reporting
 
       error_reporting.stub :report, stubbed_report do
         Google::Cloud::ErrorReporting.report exception
@@ -160,7 +160,7 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
         event.service_version.must_equal "test-service-version"
       end
 
-      Google::Cloud::ErrorReporting.stub :default_client, mocked_client do
+      Google::Cloud::ErrorReporting.stub :default_reporter, mocked_client do
         Google::Cloud::ErrorReporting.report exception, service_name: "test-service-name",
                                                         service_version: "test-service-version"
       end
@@ -179,7 +179,7 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
         event.service_version.must_equal "test-service-version"
       end
 
-      Google::Cloud::ErrorReporting.stub :default_client, mocked_client do
+      Google::Cloud::ErrorReporting.stub :default_reporter, mocked_client do
         Google::Cloud::ErrorReporting.report exception
       end
     end
@@ -198,7 +198,7 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
         event.function_name.must_equal "report"
       end
 
-      Google::Cloud::ErrorReporting.stub :default_client, mocked_client do
+      Google::Cloud::ErrorReporting.stub :default_reporter, mocked_client do
         Google::Cloud::ErrorReporting.stub :caller, ["error_reporting.rb:123:in `report'"] do
           Google::Cloud::ErrorReporting.report exception
         end
@@ -206,7 +206,7 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
     end
   end
 
-  describe ".default_client" do
+  describe ".default_reporter" do
     after {
       Google::Cloud.configure.reset!
       Google::Cloud::ErrorReporting.configure.reset!
@@ -224,7 +224,7 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
       }
 
       Google::Cloud::ErrorReporting.stub :new, stubbed_new do
-        Google::Cloud::ErrorReporting.send :default_client
+        Google::Cloud::ErrorReporting.default_reporter
       end
     end
 
@@ -240,7 +240,7 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
       }
 
       Google::Cloud::ErrorReporting.stub :new, stubbed_new do
-        Google::Cloud::ErrorReporting.send :default_client
+        Google::Cloud::ErrorReporting.default_reporter
       end
     end
 
@@ -256,7 +256,7 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
       }
 
       Google::Cloud::ErrorReporting.stub :new, stubbed_new do
-        Google::Cloud::ErrorReporting.send :default_client
+        Google::Cloud::ErrorReporting.default_reporter
       end
     end
 
@@ -272,7 +272,7 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
       }
 
       Google::Cloud::ErrorReporting.stub :new, stubbed_new do
-        Google::Cloud::ErrorReporting.send :default_client
+        Google::Cloud::ErrorReporting.default_reporter
       end
     end
 
@@ -286,8 +286,8 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
 
       Google::Cloud::ErrorReporting::AsyncErrorReporter.stub :new, stubbed_async_reporter do
         Google::Cloud::ErrorReporting.stub :new, nil do
-          first_client = Google::Cloud::ErrorReporting.send :default_client
-          Google::Cloud::ErrorReporting.send(:default_client).must_equal first_client
+          first_client = Google::Cloud::ErrorReporting.default_reporter
+          Google::Cloud::ErrorReporting.default_reporter.must_equal first_client
         end
       end
     end


### PR DESCRIPTION
Possible fix for #4149.

* Renamed `ErrorReporting.default_client` to `ErrorReporting.default_reporter` because it isn't actually a full client. (Normally it is an AsyncReporter.) The method was private so this isn't a breaking change.
* Made the method public so the middleware can call it directly.
* Change the method so it atomically sets the value if one is not yet available.
* Change the middleware so it gets its reporter from the default reporter (and sets the default reporter in the process if one is not yet present). This will prevent multiple middleware instances from each having a separate reporter.