### PR TITLE
Update kokoro configs to support current Ruby versions

### DIFF
--- a/.kokoro/docker/autosynth/Dockerfile
+++ b/.kokoro/docker/autosynth/Dockerfile
@@ -45,8 +45,8 @@ RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ru
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
-RUN rbenv install 2.5.5 && rbenv global 2.5.5 \
-    && gem install bundler --version 1.17.3 && gem install rake
+RUN rbenv install 2.6.5 && rbenv global 2.6.5 \
+    && gem install bundler:1.17.3 bundler:2.0.2 rake
 
 # Install pyenv
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
@@ -60,8 +60,8 @@ RUN echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc
 RUN echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
 # Install python
-RUN pyenv install 3.6.1
-RUN pyenv global 3.6.1
+RUN pyenv install 3.6.9
+RUN pyenv global 3.6.9
 
 # Install nodenv
 RUN git clone https://github.com/nodenv/nodenv.git ~/.nodenv
@@ -76,8 +76,8 @@ RUN mkdir -p "$(nodenv root)"/plugins
 RUN git clone https://github.com/nodenv/node-build.git "$(nodenv root)"/plugins/node-build
 
 # Install nodejs
-RUN nodenv install 10.13.0
-RUN nodenv global 10.13.0
+RUN nodenv install 10.16.3
+RUN nodenv global 10.16.3
 
 # Install docker
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -

--- a/.kokoro/docker/multi/Dockerfile
+++ b/.kokoro/docker/multi/Dockerfile
@@ -29,11 +29,11 @@ RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ru
 
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
-ENV RUBY_VERSIONS "2.3.8 2.4.5 2.5.5 2.6.3"
+ENV RUBY_VERSIONS "2.4.9 2.5.7 2.6.5"
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
 RUN for version in ${RUBY_VERSIONS}; do \
         rbenv install "$version" && rbenv global "$version" && \
-        gem install bundler:1.17.3 && gem update --system \
+        gem install bundler:1.17.3 bundler:2.0.2 && gem update --system \
     ; done
 
 RUN apt-get -y autoremove && apt-get -y autoclean

--- a/.kokoro/docker/release/Dockerfile
+++ b/.kokoro/docker/release/Dockerfile
@@ -17,19 +17,19 @@ RUN apt-get -y autoclean
 # Install Ruby
 RUN mkdir $HOME/.ruby
 RUN git clone https://github.com/rbenv/ruby-build.git $HOME/.ruby-build
-RUN $HOME/.ruby-build/bin/ruby-build 2.5.5 $HOME/.ruby
+RUN $HOME/.ruby-build/bin/ruby-build 2.6.5 $HOME/.ruby
 ENV PATH /root/.ruby/bin:$PATH
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
-RUN gem install bundler:1.17.3 && gem update --system
+RUN gem install bundler:1.17.3 bundler:2.0.2 && gem update --system
 
 # Install Python
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 ENV PYENV_ROOT /root/.pyenv
 ENV PATH /root/.pyenv/bin:$PATH
 ENV PATH /root/.pyenv/shims:$PATH
-RUN pyenv install 3.6.8
-RUN pyenv global 3.6.8
+RUN pyenv install 3.6.9
+RUN pyenv global 3.6.9
 RUN ln -s $(which python) /bin/python3
 
 RUN apt-get -y autoremove && apt-get -y autoclean

--- a/.kokoro/osx.sh
+++ b/.kokoro/osx.sh
@@ -22,7 +22,7 @@ function set_failed_status {
 source ~/.rvm/scripts/rvm
 rvm get head --auto-dotfiles
 
-versions=(2.3.8 2.4.5 2.5.5 2.6.3)
+versions=(2.4.9 2.5.7 2.6.5)
 rvm_versions=$(rvm list rubies)
 
 if [[ $JOB_TYPE = "presubmit" ]]; then

--- a/.kokoro/templates/autosynth.Dockerfile.erb
+++ b/.kokoro/templates/autosynth.Dockerfile.erb
@@ -45,8 +45,8 @@ RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ru
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
-RUN rbenv install <%= ruby_versions[-2] %> && rbenv global <%= ruby_versions[-2] %> \
-    && gem install bundler --version 1.17.3 && gem install rake
+RUN rbenv install <%= ruby_versions[-1] %> && rbenv global <%= ruby_versions[-1] %> \
+    && gem install bundler:1.17.3 bundler:2.0.2 rake
 
 # Install pyenv
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
@@ -60,8 +60,8 @@ RUN echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc
 RUN echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
 # Install python
-RUN pyenv install 3.6.1
-RUN pyenv global 3.6.1
+RUN pyenv install 3.6.9
+RUN pyenv global 3.6.9
 
 # Install nodenv
 RUN git clone https://github.com/nodenv/nodenv.git ~/.nodenv
@@ -76,8 +76,8 @@ RUN mkdir -p "$(nodenv root)"/plugins
 RUN git clone https://github.com/nodenv/node-build.git "$(nodenv root)"/plugins/node-build
 
 # Install nodejs
-RUN nodenv install 10.13.0
-RUN nodenv global 10.13.0
+RUN nodenv install 10.16.3
+RUN nodenv global 10.16.3
 
 # Install docker
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -

--- a/.kokoro/templates/multi.Dockerfile.erb
+++ b/.kokoro/templates/multi.Dockerfile.erb
@@ -33,7 +33,7 @@ ENV RUBY_VERSIONS "<%= ruby_versions.join(" ") %>"
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
 RUN for version in ${RUBY_VERSIONS}; do \
         rbenv install "$version" && rbenv global "$version" && \
-        gem install bundler:1.17.3 && gem update --system \
+        gem install bundler:1.17.3 bundler:2.0.2 && gem update --system \
     ; done
 
 RUN apt-get -y autoremove && apt-get -y autoclean

--- a/.kokoro/templates/osx.sh.erb
+++ b/.kokoro/templates/osx.sh.erb
@@ -30,7 +30,7 @@ if [[ $JOB_TYPE = "presubmit" ]]; then
     if [[ $COMMIT_MESSAGE = *"[ci skip]"* || $COMMIT_MESSAGE = *"[skip ci]"* ]]; then
         echo "[ci skip] found. Exiting"
     else
-        version=${versions[<%= ruby_versions.size - 2 %>]}
+        version=${versions[<%= ruby_versions.size - 1 %>]}
         if [[ $rvm_versions != *$version* ]]; then
           rvm install $version
         fi

--- a/.kokoro/templates/release.Dockerfile.erb
+++ b/.kokoro/templates/release.Dockerfile.erb
@@ -17,19 +17,19 @@ RUN apt-get -y autoclean
 # Install Ruby
 RUN mkdir $HOME/.ruby
 RUN git clone https://github.com/rbenv/ruby-build.git $HOME/.ruby-build
-RUN $HOME/.ruby-build/bin/ruby-build <%= ruby_versions[-2] %> $HOME/.ruby
+RUN $HOME/.ruby-build/bin/ruby-build <%= ruby_versions[-1] %> $HOME/.ruby
 ENV PATH /root/.ruby/bin:$PATH
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
-RUN gem install bundler:1.17.3 && gem update --system
+RUN gem install bundler:1.17.3 bundler:2.0.2 && gem update --system
 
 # Install Python
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 ENV PYENV_ROOT /root/.pyenv
 ENV PATH /root/.pyenv/bin:$PATH
 ENV PATH /root/.pyenv/shims:$PATH
-RUN pyenv install 3.6.8
-RUN pyenv global 3.6.8
+RUN pyenv install 3.6.9
+RUN pyenv global 3.6.9
 RUN ln -s $(which python) /bin/python3
 
 RUN apt-get -y autoremove && apt-get -y autoclean

--- a/.kokoro/templates/trampoline.sh.erb
+++ b/.kokoro/templates/trampoline.sh.erb
@@ -27,12 +27,6 @@ cd $REPO_DIR
 
 versions=(<%= ruby_versions.join " " %>)
 
-# Capture failures
-EXIT_STATUS=0 # everything passed
-function set_failed_status {
-    EXIT_STATUS=1
-}
-
 STARTTIME=$(date +%s)
 
 if [[ $JOB_TYPE = "presubmit" ]]; then
@@ -40,24 +34,17 @@ if [[ $JOB_TYPE = "presubmit" ]]; then
     if [[ $COMMIT_MESSAGE = *"[ci skip]"* || $COMMIT_MESSAGE = *"[skip ci]"* ]]; then
         echo "[ci skip] found. Exiting"
     elif [[ $OS = "windows" ]]; then
-            python "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" || set_failed_status
+        python "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}"
     else
-        for version in "${versions[@]}"; do
-            (
-                python3 "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" $version || set_failed_status
-            ) &
-        done
-        wait
+        python3 "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" $version
     fi
 else
     if [[ $OS = "windows" ]]; then
-        python "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" || set_failed_status
+        python "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}"
     else
-        python3 "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" || set_failed_status
+        python3 "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}"
     fi
 fi
 
 ENDTIME=$(date +%s)
 echo "Tests took a total of $(($ENDTIME - $STARTTIME)) seconds"
-
-exit $EXIT_STATUS

--- a/.kokoro/trampoline.sh
+++ b/.kokoro/trampoline.sh
@@ -27,12 +27,6 @@ cd $REPO_DIR
 
 versions=(2.4.9 2.5.7 2.6.5)
 
-# Capture failures
-EXIT_STATUS=0 # everything passed
-function set_failed_status {
-    EXIT_STATUS=1
-}
-
 STARTTIME=$(date +%s)
 
 if [[ $JOB_TYPE = "presubmit" ]]; then
@@ -40,24 +34,17 @@ if [[ $JOB_TYPE = "presubmit" ]]; then
     if [[ $COMMIT_MESSAGE = *"[ci skip]"* || $COMMIT_MESSAGE = *"[skip ci]"* ]]; then
         echo "[ci skip] found. Exiting"
     elif [[ $OS = "windows" ]]; then
-            python "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" || set_failed_status
+        python "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}"
     else
-        for version in "${versions[@]}"; do
-            (
-                python3 "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" $version || set_failed_status
-            ) &
-        done
-        wait
+        python3 "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" $version
     fi
 else
     if [[ $OS = "windows" ]]; then
-        python "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" || set_failed_status
+        python "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}"
     else
-        python3 "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" || set_failed_status
+        python3 "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}"
     fi
 fi
 
 ENDTIME=$(date +%s)
 echo "Tests took a total of $(($ENDTIME - $STARTTIME)) seconds"
-
-exit $EXIT_STATUS

--- a/.kokoro/trampoline.sh
+++ b/.kokoro/trampoline.sh
@@ -25,7 +25,13 @@ function cleanup() {
 
 cd $REPO_DIR
 
-versions=(2.3.8 2.4.5 2.5.5 2.6.3)
+versions=(2.4.9 2.5.7 2.6.5)
+
+# Capture failures
+EXIT_STATUS=0 # everything passed
+function set_failed_status {
+    EXIT_STATUS=1
+}
 
 STARTTIME=$(date +%s)
 
@@ -34,17 +40,24 @@ if [[ $JOB_TYPE = "presubmit" ]]; then
     if [[ $COMMIT_MESSAGE = *"[ci skip]"* || $COMMIT_MESSAGE = *"[skip ci]"* ]]; then
         echo "[ci skip] found. Exiting"
     elif [[ $OS = "windows" ]]; then
-            python "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}"
+            python "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" || set_failed_status
     else
-        python3 "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" $version
+        for version in "${versions[@]}"; do
+            (
+                python3 "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" $version || set_failed_status
+            ) &
+        done
+        wait
     fi
 else
     if [[ $OS = "windows" ]]; then
-        python "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}"
+        python "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" || set_failed_status
     else
-        python3 "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}"
+        python3 "${KOKORO_GFILE_DIR}/${TRAMPOLINE_SCRIPT}" || set_failed_status
     fi
 fi
 
 ENDTIME=$(date +%s)
 echo "Tests took a total of $(($ENDTIME - $STARTTIME)) seconds"
+
+exit $EXIT_STATUS

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require "bundler/setup"
 require "fileutils"
 
-KOKORO_RUBY_VERSIONS = ["2.3.8", "2.4.5", "2.5.5", "2.6.3"].freeze
+KOKORO_RUBY_VERSIONS = ["2.4.9", "2.5.7", "2.6.5"].freeze
 
 task :bundleupdate do
   valid_gems.each do |gem|


### PR DESCRIPTION
Update the set of Ruby versions to test against, and regenerate scripts and images.

Changes:
* Ruby versions changed from `["2.3.8", "2.4.5", "2.5.5", "2.6.3"]` to `["2.4.9", "2.5.7", "2.6.5"]`.
* All pythons updated to 3.6.9.
* All nodejs updated to 10.16.3.
* The autosynth and release jobs now run in the latest Ruby version (now 2.6.5) instead of the second latest.
* Installed both bundler 1.17.3 and 2.0.2 wherever bundler is installed.

Note (@TheRoyalTnetennba) The template for `trampoline.sh` includes reporting of the exit status, but the current `trampoline.sh` does not. It looks like it was not regenerated the last time the template was edited. Since I just did a regen of the files, that exit status handling is now present in the script. I wanted to double-check with you that it should be there.