### PR TITLE
remove auth-doc-gen-specific repo-metadata fields

### DIFF
--- a/google-cloud-asset/.repo-metadata.json
+++ b/google-cloud-asset/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "cloudasset",
     "language": "ruby",
-    "distribution_name": "google-cloud-asset",
-    "module_name": "Asset",
-    "module_name_credentials": "Asset::V1",
-    "env_var_prefix": "ASSET"
+    "distribution_name": "google-cloud-asset"
 }

--- a/google-cloud-automl/.repo-metadata.json
+++ b/google-cloud-automl/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
   "name": "automl",
   "language": "ruby",
-  "distribution_name": "google-cloud-automl",
-  "module_name": "AutoML",
-  "module_name_credentials": "AutoML::V1beta1",
-  "env_var_prefix": "AUTOML"
+  "distribution_name": "google-cloud-automl"
 }

--- a/google-cloud-bigquery-data_transfer/.repo-metadata.json
+++ b/google-cloud-bigquery-data_transfer/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "bigquerydatatransfer",
     "language": "ruby",
-    "distribution_name": "google-cloud-bigquery-data_transfer",
-    "module_name": "Bigquery::DataTransfer",
-    "module_name_credentials": "Bigquery::DataTransfer::V1",
-    "env_var_prefix": "DATA_TRANSFER"
+    "distribution_name": "google-cloud-bigquery-data_transfer"
 }

--- a/google-cloud-container/.repo-metadata.json
+++ b/google-cloud-container/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "container",
     "language": "ruby",
-    "distribution_name": "google-cloud-container",
-    "module_name": "Container",
-    "module_name_credentials": "Container::V1",
-    "env_var_prefix": "CONTAINER"
+    "distribution_name": "google-cloud-container"
 }

--- a/google-cloud-container_analysis/.repo-metadata.json
+++ b/google-cloud-container_analysis/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
   "name": "containeranalysis",
   "language": "ruby",
-  "distribution_name": "google-cloud-container_analysis",
-  "module_name": "ContainerAnalysis",
-  "module_name_credentials": "ContainerAnalysis::V1",
-  "env_var_prefix": "CONTAINER_ANALYSIS"
+  "distribution_name": "google-cloud-container_analysis"
 }

--- a/google-cloud-dataproc/.repo-metadata.json
+++ b/google-cloud-dataproc/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "dataproc",
     "language": "ruby",
-    "distribution_name": "google-cloud-dataproc",
-    "module_name": "Dataproc",
-    "module_name_credentials": "Dataproc::V1",
-    "env_var_prefix": "DATAPROC"
+    "distribution_name": "google-cloud-dataproc"
 }

--- a/google-cloud-dialogflow/.repo-metadata.json
+++ b/google-cloud-dialogflow/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "dialogflow",
     "language": "ruby",
-    "distribution_name": "google-cloud-dialogflow",
-    "module_name": "Dialogflow",
-    "module_name_credentials": "Dialogflow::V2",
-    "env_var_prefix": "DIALOGFLOW"
+    "distribution_name": "google-cloud-dialogflow"
 }

--- a/google-cloud-dlp/.repo-metadata.json
+++ b/google-cloud-dlp/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "dlp",
     "language": "ruby",
-    "distribution_name": "google-cloud-dlp",
-    "module_name": "Dlp",
-    "module_name_credentials": "Dlp::V2",
-    "env_var_prefix": "DLP"
+    "distribution_name": "google-cloud-dlp"
 }

--- a/google-cloud-irm/.repo-metadata.json
+++ b/google-cloud-irm/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "irm",
     "language": "ruby",
-    "distribution_name": "google-cloud-irm",
-    "module_name": "Irm",
-    "module_name_credentials": "Irm::V1alpha2",
-    "env_var_prefix": "IRM"
+    "distribution_name": "google-cloud-irm"
 }

--- a/google-cloud-kms/.repo-metadata.json
+++ b/google-cloud-kms/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "cloudkms",
     "language": "ruby",
-    "distribution_name": "google-cloud-kms",
-    "module_name": "Kms",
-    "module_name_credentials": "Kms::V1",
-    "env_var_prefix": "KMS"
+    "distribution_name": "google-cloud-kms"
 }

--- a/google-cloud-language/.repo-metadata.json
+++ b/google-cloud-language/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "language",
     "language": "ruby",
-    "distribution_name": "google-cloud-language",
-    "module_name": "Language",
-    "module_name_credentials": "Language::V1",
-    "env_var_prefix": "LANGUAGE"
+    "distribution_name": "google-cloud-language"
 }

--- a/google-cloud-monitoring/.repo-metadata.json
+++ b/google-cloud-monitoring/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "monitoring",
     "language": "ruby",
-    "distribution_name": "google-cloud-monitoring",
-    "module_name": "Monitoring",
-    "module_name_credentials": "Monitoring::V3",
-    "env_var_prefix": "MONITORING"
+    "distribution_name": "google-cloud-monitoring"
 }

--- a/google-cloud-os_login/.repo-metadata.json
+++ b/google-cloud-os_login/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "oslogin",
     "language": "ruby",
-    "distribution_name": "google-cloud-os_login",
-    "module_name": "OsLogin",
-    "module_name_credentials": "OsLogin::V1",
-    "env_var_prefix": "OS_LOGIN"
+    "distribution_name": "google-cloud-os_login"
 }

--- a/google-cloud-phishing_protection/.repo-metadata.json
+++ b/google-cloud-phishing_protection/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "phishingprotection",
     "language": "ruby",
-    "distribution_name": "google-cloud-phishing_protection",
-    "module_name": "PhishingProtection",
-    "module_name_credentials": "PhishingProtection::V1beta1",
-    "env_var_prefix": "PHISHING_PROTECTION"
+    "distribution_name": "google-cloud-phishing_protection"
 }

--- a/google-cloud-recaptcha_enterprise/.repo-metadata.json
+++ b/google-cloud-recaptcha_enterprise/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "recaptchaenterprise",
     "language": "ruby",
-    "distribution_name": "google-cloud-recaptcha_enterprise",
-    "module_name": "RecaptchaEnterprise",
-    "module_name_credentials": "RecaptchaEnterprise::V1beta1",
-    "env_var_prefix": "RECAPTCHA_ENTERPRISE"
+    "distribution_name": "google-cloud-recaptcha_enterprise"
 }

--- a/google-cloud-redis/.repo-metadata.json
+++ b/google-cloud-redis/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "redis",
     "language": "ruby",
-    "distribution_name": "google-cloud-redis",
-    "module_name": "Redis",
-    "module_name_credentials": "Redis::V1",
-    "env_var_prefix": "REDIS"
+    "distribution_name": "google-cloud-redis"
 }

--- a/google-cloud-scheduler/.repo-metadata.json
+++ b/google-cloud-scheduler/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "cloudscheduler",
     "language": "ruby",
-    "distribution_name": "google-cloud-scheduler",
-    "module_name": "Scheduler",
-    "module_name_credentials": "Scheduler::V1",
-    "env_var_prefix": "SCHEDULER"
+    "distribution_name": "google-cloud-scheduler"
 }

--- a/google-cloud-security_center/.repo-metadata.json
+++ b/google-cloud-security_center/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "securitycenter",
     "language": "ruby",
-    "distribution_name": "google-cloud-security_center",
-    "module_name": "SecurityCenter",
-    "module_name_credentials": "SecurityCenter::V1",
-    "env_var_prefix": "SECURITY_CENTER"
+    "distribution_name": "google-cloud-security_center"
 }

--- a/google-cloud-speech/.repo-metadata.json
+++ b/google-cloud-speech/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "speech",
     "language": "ruby",
-    "distribution_name": "google-cloud-speech",
-    "module_name": "Speech",
-    "module_name_credentials": "Speech::V1",
-    "env_var_prefix": "SPEECH"
+    "distribution_name": "google-cloud-speech"
 }

--- a/google-cloud-talent/.repo-metadata.json
+++ b/google-cloud-talent/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "talent",
     "language": "ruby",
-    "distribution_name": "google-cloud-talent",
-    "module_name": "Talent",
-    "module_name_credentials": "Talent::V4beta1",
-    "env_var_prefix": "TALENT"
+    "distribution_name": "google-cloud-talent"
 }

--- a/google-cloud-tasks/.repo-metadata.json
+++ b/google-cloud-tasks/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "cloudtasks",
     "language": "ruby",
-    "distribution_name": "google-cloud-tasks",
-    "module_name": "Tasks",
-    "module_name_credentials": "Tasks::V2",
-    "env_var_prefix": "TASKS"
+    "distribution_name": "google-cloud-tasks"
 }

--- a/google-cloud-text_to_speech/.repo-metadata.json
+++ b/google-cloud-text_to_speech/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "texttospeech",
     "language": "ruby",
-    "distribution_name": "google-cloud-text_to_speech",
-    "module_name": "TextToSpeech",
-    "module_name_credentials": "TextToSpeech::V1",
-    "env_var_prefix": "TEXTTOSPEECH"
+    "distribution_name": "google-cloud-text_to_speech"
 }

--- a/google-cloud-video_intelligence/.repo-metadata.json
+++ b/google-cloud-video_intelligence/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "videointelligence",
     "language": "ruby",
-    "distribution_name": "google-cloud-video_intelligence",
-    "module_name": "VideoIntelligence",
-    "module_name_credentials": "VideoIntelligence::V1",
-    "env_var_prefix": "VIDEO_INTELLIGENCE"
+    "distribution_name": "google-cloud-video_intelligence"
 }

--- a/google-cloud-vision/.repo-metadata.json
+++ b/google-cloud-vision/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "vision",
     "language": "ruby",
-    "distribution_name": "google-cloud-vision",
-    "module_name": "Vision",
-    "module_name_credentials": "Vision::V1",
-    "env_var_prefix": "VISION"
+    "distribution_name": "google-cloud-vision"
 }

--- a/google-cloud-webrisk/.repo-metadata.json
+++ b/google-cloud-webrisk/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
     "name": "webrisk",
     "language": "ruby",
-    "distribution_name": "google-cloud-webrisk",
-    "module_name": "Webrisk",
-    "module_name_credentials": "Webrisk::V1beta1",
-    "env_var_prefix": "WEBRISK"
+    "distribution_name": "google-cloud-webrisk"
 }

--- a/grafeas-client/.repo-metadata.json
+++ b/grafeas-client/.repo-metadata.json
@@ -1,8 +1,5 @@
 {
   "name": "grafeas",
   "language": "ruby",
-  "distribution_name": "grafeas-client",
-  "module_name": "Grafeas",
-  "module_name_credentials": "Grafeas::V1",
-  "env_var_prefix": "GRAFEAS"
+  "distribution_name": "grafeas-client"
 }


### PR DESCRIPTION
to be merged after https://github.com/googleapis/google-cloud-ruby/pull/4190 and we are no longer relying on https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/ruby_library/AUTHENTICATION.md