### PR TITLE
feat(bigtable): Add Bigtable::RoutingPolicy

### DIFF
--- a/google-cloud-bigtable/acceptance/bigtable/app_profile_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/app_profile_test.rb
@@ -36,6 +36,7 @@ describe "Instance AppProfiles", :bigtable do
   it "create multi cluster routing app profile and delete" do
     app_profile_id = "multi-cluster-#{Time.now.to_i}"
     routing_policy = Google::Cloud::Bigtable::AppProfile.multi_cluster_routing
+    routing_policy.must_be_instance_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
 
     app_profile = instance.create_app_profile(
       app_profile_id,
@@ -45,7 +46,8 @@ describe "Instance AppProfiles", :bigtable do
     )
 
     app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
-    app_profile.multi_cluster_routing.wont_be :nil?
+    app_profile.single_cluster_routing.must_be :nil?
+    app_profile.multi_cluster_routing.must_be_instance_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
 
     app_profile = instance.app_profile(app_profile_id)
     app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
@@ -60,6 +62,9 @@ describe "Instance AppProfiles", :bigtable do
       bigtable_cluster_id,
       allow_transactional_writes: true
     )
+    routing_policy.must_be_instance_of Google::Cloud::Bigtable::SingleClusterRouting
+    routing_policy.cluster_id.must_equal bigtable_cluster_id
+    routing_policy.allow_transactional_writes.must_equal true
 
     app_profile = instance.create_app_profile(
       app_profile_id,
@@ -68,7 +73,10 @@ describe "Instance AppProfiles", :bigtable do
       ignore_warnings: true
     )
     app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
-    app_profile.single_cluster_routing.wont_be :nil?
+    app_profile.multi_cluster_routing.must_be :nil?
+    app_profile.single_cluster_routing.must_be_instance_of Google::Cloud::Bigtable::SingleClusterRouting
+    app_profile.single_cluster_routing.cluster_id.must_equal bigtable_cluster_id
+    app_profile.single_cluster_routing.allow_transactional_writes.must_equal true
 
     app_profile = instance.app_profile(app_profile_id)
     app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
@@ -91,7 +99,8 @@ describe "Instance AppProfiles", :bigtable do
       ignore_warnings: true
     )
     app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
-    app_profile.single_cluster_routing.wont_be :nil?
+    app_profile.multi_cluster_routing.must_be :nil?
+    app_profile.single_cluster_routing.must_be_instance_of Google::Cloud::Bigtable::SingleClusterRouting
 
     app_profile.routing_policy = Google::Cloud::Bigtable::AppProfile.multi_cluster_routing
     job = app_profile.save(ignore_warnings: true)
@@ -100,7 +109,7 @@ describe "Instance AppProfiles", :bigtable do
 
     app_profile.reload!
     app_profile.single_cluster_routing.must_be :nil?
-    app_profile.multi_cluster_routing.wont_be :nil?
+    app_profile.multi_cluster_routing.must_be_instance_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
 
     app_profile.delete(ignore_warnings: true)
     instance.app_profile(app_profile_id).must_be :nil?

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/routing_policy.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/routing_policy.rb
@@ -1,0 +1,171 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Bigtable
+      ##
+      # # RoutingPolicy
+      #
+      # An abstract routing policy.
+      #
+      # See subclasses for concrete implementations:
+      # * {Google::Cloud::Bigtable::MultiClusterRoutingUseAny} - Read/write
+      #   requests may be routed to any cluster in the instance and will
+      #   fail over to another cluster in the event of transient errors or
+      #   delays. Choosing this option sacrifices read-your-writes
+      #   consistency to improve availability.
+      # * {Google::Cloud::Bigtable::SingleClusterRouting} - Unconditionally
+      #   routes all read/write requests to a specific cluster. This option
+      #   preserves read-your-writes consistency but does not improve
+      #   availability. Value contains `cluster_id` and optional field
+      #   `allow_transactional_writes`.
+      #
+      # @example Create an app profile with a single cluster routing policy
+      #   require "google/cloud/bigtable"
+      #
+      #   bigtable = Google::Cloud::Bigtable.new
+      #
+      #   instance = bigtable.instance("my-instance")
+      #
+      #   routing_policy = Google::Cloud::Bigtable::AppProfile.single_cluster_routing(
+      #     "my-instance-cluster-1",
+      #     allow_transactional_writes: true
+      #   )
+      #
+      #   app_profile = instance.create_app_profile(
+      #     "my-app-profile",
+      #     routing_policy,
+      #     description: "App profile for user data instance"
+      #   )
+      #   puts app_profile.routing_policy
+      #
+      # @example Create an app profile with multi-cluster routing policy
+      #   require "google/cloud/bigtable"
+      #
+      #   bigtable = Google::Cloud::Bigtable.new
+      #
+      #   instance = bigtable.instance("my-instance")
+      #
+      #   routing_policy = Google::Cloud::Bigtable::AppProfile.multi_cluster_routing
+      #
+      #   app_profile = instance.create_app_profile(
+      #     "my-app-profile",
+      #     routing_policy,
+      #     description: "App profile for user data instance"
+      #   )
+      #   puts app_profile.routing_policy
+      #
+      class RoutingPolicy
+      end
+
+      ##
+      # A multi-cluster routing policy for all read/write requests that use the
+      # associated app profile.
+      #
+      # Read/write requests may be routed to any cluster in the instance, and will
+      # fail over to another cluster in the event of transient errors or delays.
+      # Choosing this option sacrifices read-your-writes consistency to improve
+      # availability.
+      #
+      # @example
+      #   require "google/cloud/bigtable"
+      #
+      #   bigtable = Google::Cloud::Bigtable.new
+      #
+      #   instance = bigtable.instance("my-instance")
+      #
+      #   routing_policy = Google::Cloud::Bigtable::AppProfile.multi_cluster_routing
+      #
+      #   app_profile = instance.create_app_profile(
+      #     "my-app-profile",
+      #     routing_policy,
+      #     description: "App profile for user data instance"
+      #   )
+      #   puts app_profile.routing_policy
+      #
+      class MultiClusterRoutingUseAny < RoutingPolicy
+        # @private
+        def to_grpc
+          Google::Bigtable::Admin::V2::AppProfile::MultiClusterRoutingUseAny.new
+        end
+      end
+
+      ##
+      # A single-cluster routing policy for all read/write requests that use the
+      # associated app profile.
+      #
+      # Unconditionally routes all read/write requests to a specific cluster.
+      # This option preserves read-your-writes consistency, but does not improve
+      # availability.
+      #
+      # @example
+      #   require "google/cloud/bigtable"
+      #
+      #   bigtable = Google::Cloud::Bigtable.new
+      #
+      #   instance = bigtable.instance("my-instance")
+      #
+      #   routing_policy = Google::Cloud::Bigtable::AppProfile.single_cluster_routing(
+      #     "my-instance-cluster-1",
+      #     allow_transactional_writes: true
+      #   )
+      #
+      #   app_profile = instance.create_app_profile(
+      #     "my-app-profile",
+      #     routing_policy,
+      #     description: "App profile for user data instance"
+      #   )
+      #   puts app_profile.routing_policy
+      #
+      # @!attribute [rw] cluster_id
+      #   @return [String]
+      #     The cluster to which read/write requests should be routed.
+      # @!attribute [rw] allow_transactional_writes
+      #   @return [true, false]
+      #     If true, `CheckAndMutateRow` and `ReadModifyWriteRow` requests are
+      #     allowed by this app profile. It is unsafe to send these requests to
+      #     the same table/row/column in multiple clusters.
+      #     Default value is false.
+      class SingleClusterRouting < RoutingPolicy
+        attr_reader :cluster_id, :allow_transactional_writes
+
+        ##
+        # Creates a new single-cluster routing policy.
+        #
+        # @param cluster_id [String] The cluster to which read/write requests
+        #   should be routed.
+        # @param allow_transactional_writes [Boolean]
+        #   If true, `CheckAndMutateRow` and `ReadModifyWriteRow` requests are
+        #   allowed by this app profile. It is unsafe to send these requests to
+        #   the same table/row/column in multiple clusters.
+        #   Default value is false.
+        #
+        def initialize cluster_id, allow_transactional_writes
+          @cluster_id = cluster_id
+          @allow_transactional_writes = allow_transactional_writes
+        end
+
+        # @private
+        def to_grpc
+          Google::Bigtable::Admin::V2::AppProfile::SingleClusterRouting.new(
+            cluster_id: cluster_id,
+            allow_transactional_writes: allow_transactional_writes
+          )
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-bigtable/support/doctest_helper.rb
+++ b/google-cloud-bigtable/support/doctest_helper.rb
@@ -97,7 +97,6 @@ YARD::Doctest.configure do |doctest|
       mocked_instances.expect :update_app_profile, mocked_job, [Google::Bigtable::Admin::V2::AppProfile, Google::Protobuf::FieldMask, Hash]
       mocked_job.expect :wait_until_done!, nil, []
       mocked_instances.expect :delete_app_profile, nil, ["projects/my-project/instances/my-instance/appProfiles/my-app-profile", false]
-
     end
   end
 
@@ -107,6 +106,34 @@ YARD::Doctest.configure do |doctest|
       mocked_instances.expect :get_app_profile, app_profile_resp, ["projects/my-project/instances/my-instance/appProfiles/my-app-profile"]
       mocked_instances.expect :delete_app_profile, nil, ["projects/my-project/instances/my-instance/appProfiles/my-app-profile", true]
       mocked_instances.expect :delete_app_profile, nil, ["projects/my-project/instances/my-instance/appProfiles/my-app-profile", false]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigtable::AppProfile.multi_cluster_routing" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_instances.expect :get_instance, instance_resp, ["projects/my-project/instances/my-instance"]
+      mocked_instances.expect :create_app_profile, app_profile_resp, ["projects/my-project/instances/my-instance", "my-app-profile", app_profile_create, Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigtable::AppProfile#routing_policy" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_instances.expect :get_instance, instance_resp, ["projects/my-project/instances/my-instance"]
+      mocked_instances.expect :create_app_profile, app_profile_resp, ["projects/my-project/instances/my-instance", "my-app-profile", app_profile_create, Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigtable::AppProfile#routing_policy=" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_instances.expect :get_instance, instance_resp, ["projects/my-project/instances/my-instance"]
+      mocked_instances.expect :get_app_profile, app_profile_resp, ["projects/my-project/instances/my-instance/appProfiles/my-app-profile"]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigtable::AppProfile.single_cluster_routing" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_instances.expect :get_instance, instance_resp, ["projects/my-project/instances/my-instance"]
+      mocked_instances.expect :create_app_profile, app_profile_resp, ["projects/my-project/instances/my-instance", "my-app-profile", Google::Bigtable::Admin::V2::AppProfile, Hash]
     end
   end
 
@@ -369,6 +396,13 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigtable::MultiClusterRoutingUseAny" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_instances.expect :get_instance, instance_resp, ["projects/my-project/instances/my-instance"]
+      mocked_instances.expect :create_app_profile, app_profile_resp, ["projects/my-project/instances/my-instance", "my-app-profile", app_profile_create, Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigtable::MutationOperations" do
     mock_bigtable do |mock, mocked_instances, mocked_tables|
       mock.expect :mutate_row, nil, ["projects/my-project/instances/my-instance/tables/my-table", "user-1", Array, Hash]
@@ -498,6 +532,13 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigtable::RoutingPolicy" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_instances.expect :get_instance, instance_resp, ["projects/my-project/instances/my-instance"]
+      mocked_instances.expect :create_app_profile, app_profile_resp, ["projects/my-project/instances/my-instance", "my-app-profile", Google::Bigtable::Admin::V2::AppProfile, Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigtable::SampleRowKey" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
       mocked_tables.expect :get_table, table_resp, ["projects/my-project/instances/my-instance/tables/my-table", Hash]
@@ -508,6 +549,13 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigtable::Status" do
     mock_bigtable do |mock, mocked_instances, mocked_tables|
       mock.expect :mutate_rows, [], ["projects/my-project/instances/my-instance/tables/my-table", Array, Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigtable::SingleClusterRouting" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_instances.expect :get_instance, instance_resp, ["projects/my-project/instances/my-instance"]
+      mocked_instances.expect :create_app_profile, app_profile_resp, ["projects/my-project/instances/my-instance", "my-app-profile", Google::Bigtable::Admin::V2::AppProfile, Hash]
     end
   end
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/app_profile/delete_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/app_profile/delete_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Bigtable::AppProfile, :delete, :mock_bigtable do
     Google::Bigtable::Admin::V2::AppProfile.new(
       name: app_profile_path(instance_id, app_profile_id),
       description: "Test instance app profile",
-      multi_cluster_routing_use_any: Google::Cloud::Bigtable::AppProfile.multi_cluster_routing
+      multi_cluster_routing_use_any: multi_cluster_routing_grpc
     )
   }
   let(:app_profile) {

--- a/google-cloud-bigtable/test/google/cloud/bigtable/app_profile/save_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/app_profile/save_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Bigtable::AppProfile, :save, :mock_bigtable do
     Google::Bigtable::Admin::V2::AppProfile.new(
       name: app_profile_path(instance_id, app_profile_id),
       description: "Test instance app profile",
-      multi_cluster_routing_use_any: Google::Cloud::Bigtable::AppProfile.multi_cluster_routing
+      multi_cluster_routing_use_any: multi_cluster_routing_grpc
     )
   }
   let(:app_profile) {

--- a/google-cloud-bigtable/test/google/cloud/bigtable/app_profile_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/app_profile_test.rb
@@ -21,11 +21,11 @@ describe Google::Cloud::Bigtable::AppProfile, :mock_bigtable do
 
   it "knows the identifiers" do
     description = "Test instance app profile"
-    routing_policy = Google::Cloud::Bigtable::AppProfile.multi_cluster_routing
+    routing_policy_grpc = multi_cluster_routing_grpc
     app_profile_grpc = Google::Bigtable::Admin::V2::AppProfile.new(
       name: app_profile_path(instance_id, app_profile_id),
       description: description,
-      multi_cluster_routing_use_any: routing_policy
+      multi_cluster_routing_use_any: routing_policy_grpc
     )
 
     app_profile = Google::Cloud::Bigtable::AppProfile.from_grpc(app_profile_grpc, bigtable.service)
@@ -36,8 +36,8 @@ describe Google::Cloud::Bigtable::AppProfile, :mock_bigtable do
     app_profile.name.must_equal app_profile_id
     app_profile.path.must_equal app_profile_path(instance_id, app_profile_id)
     app_profile.description.must_equal description
-    app_profile.multi_cluster_routing.must_equal routing_policy
-    app_profile.routing_policy.must_equal routing_policy
+    app_profile.multi_cluster_routing.to_grpc.must_equal routing_policy_grpc
+    app_profile.routing_policy.to_grpc.must_equal routing_policy_grpc
     app_profile.single_cluster_routing.must_be :nil?
   end
 
@@ -52,8 +52,8 @@ describe Google::Cloud::Bigtable::AppProfile, :mock_bigtable do
     routing_policy = Google::Cloud::Bigtable::AppProfile.multi_cluster_routing
     app_profile.routing_policy = routing_policy
 
-    app_profile.routing_policy.must_be_kind_of Google::Bigtable::Admin::V2::AppProfile::MultiClusterRoutingUseAny
-    app_profile.routing_policy.must_equal routing_policy
+    app_profile.routing_policy.must_be_kind_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
+    app_profile.routing_policy.to_grpc.must_equal routing_policy.to_grpc
   end
 
   it "set single_cluster_routing policy" do
@@ -70,7 +70,7 @@ describe Google::Cloud::Bigtable::AppProfile, :mock_bigtable do
     )
     app_profile.routing_policy = routing_policy
 
-    app_profile.routing_policy.must_be_kind_of Google::Bigtable::Admin::V2::AppProfile::SingleClusterRouting
-    app_profile.routing_policy.must_equal routing_policy
+    app_profile.routing_policy.must_be_kind_of Google::Cloud::Bigtable::SingleClusterRouting
+    app_profile.routing_policy.to_grpc.must_equal routing_policy.to_grpc
   end
 end

--- a/google-cloud-bigtable/test/helper.rb
+++ b/google-cloud-bigtable/test/helper.rb
@@ -140,6 +140,10 @@ class MockBigtable < Minitest::Spec
     end
   end
 
+  def multi_cluster_routing_grpc
+    Google::Bigtable::Admin::V2::AppProfile::MultiClusterRoutingUseAny.new
+  end
+
   def table_hash name: nil, cluster_states: nil, column_families: nil, granularity: nil
     {
       name: name,


### PR DESCRIPTION
BREAKING CHANGES: All return types and parameters associated with
AppProfile routing policy have been changed to wrapper types. The
new types have exactly the same API as the old types, so this
change should only affect type introspection.

[refs #4146]