### PR TITLE
introduce enable_cross_project_tracing option to the faraday middleware

### DIFF
--- a/google-cloud-trace/lib/google/cloud/trace/faraday_middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/faraday_middleware.rb
@@ -112,7 +112,7 @@ module Google
         end
 
         ##
-        # @private Set X-Cloud-Trace-Context for request header
+        # @private Add X-Cloud-Trace-Context for request header
         def add_trace_context_header env
           if (trace_ctx = Stackdriver::Core::TraceContext.get)
             env[:request_headers]["X-Cloud-Trace-Context"] = trace_ctx.to_string

--- a/google-cloud-trace/lib/google/cloud/trace/faraday_middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/faraday_middleware.rb
@@ -21,10 +21,36 @@ module Google
     module Trace
       class FaradayMiddleware < Faraday::Middleware
         ##
+        # # Trace FaradayMiddleware
+        #
+        # A faraday middleware that setup request/response labels for trace.
+        #
+        # ## Installing
+        #
+        # To use this middleware, simply install it in your middleware stack.
+        # Here is an example configuration enable the Trace middleware:
+        #
+        # ```ruby
+        # conn = Faraday.new(:url => 'http://example.com') do |faraday|
+        #   # enable cross project tracing with option to true
+        #   faraday.use Google::Cloud::Trace, enable_cross_project_tracing: true
+        #   faraday.request  :url_encoded             # form-encode POST params
+        #   faraday.response :logger                  # log requests to $stdout
+        #   faraday.adapter  Faraday.default_adapter  # use Net::HTTP adapter
+        # end
+        # ```
+
+        def initialize app, enable_cross_project_tracing: false
+          super(app)
+          @enable_cross_project_tracing = enable_cross_project_tracing || false
+        end
+
+        ##
         # Create a Trace span with the HTTP request/response information.
         def call env
           Google::Cloud::Trace.in_span "faraday_request" do |span|
             add_request_labels span, env if span
+            add_trace_context_header env if @enable_cross_project_tracing
 
             response = @app.call env
 
@@ -83,6 +109,14 @@ module Google
         #
         def set_label labels, key, value
           labels[key] = value if value.is_a? ::String
+        end
+
+        ##
+        # @private Set X-Cloud-Trace-Context for request header
+        def add_trace_context_header env
+          if (trace_ctx = Stackdriver::Core::TraceContext.get)
+            env[:request_headers]["X-Cloud-Trace-Context"] = trace_ctx.to_string
+          end
         end
       end
     end

--- a/google-cloud-trace/test/google/cloud/trace/faraday_middleware_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/faraday_middleware_test.rb
@@ -30,10 +30,10 @@ describe Google::Cloud::Trace::FaradayMiddleware do
   describe "#initialize" do
     it "accepts enable_cross_project_tracing as optional params" do
       middleware = Google::Cloud::Trace::FaradayMiddleware.new app
-      middleware.instance_variable_get(:enable_cross_project_tracing).must_equal(false)
+      middleware.instance_variable_get(:@enable_cross_project_tracing).must_equal(false)
 
       middleware = Google::Cloud::Trace::FaradayMiddleware.new app, enable_cross_project_tracing: true
-      middleware.instance_variable_get(:enable_cross_project_tracing).must_equal(true)
+      middleware.instance_variable_get(:@enable_cross_project_tracing).must_equal(true)
     end
   end
 
@@ -101,12 +101,16 @@ describe Google::Cloud::Trace::FaradayMiddleware do
       Stackdriver::Core::TraceContext.set(trace_context)
     end
 
+    after do
+      Stackdriver::Core::TraceContext.set(nil)
+    end
+
     it "sets trace context header when enable_cross_project_tracing is set to true" do
-      env = OpenStruct.new response: OpenStruct.new(headers: {location: "new-url"}, request_headers: {})
+      env = OpenStruct.new headers: {location: "new-url"}, request_headers: {}
 
       middleware.send :add_trace_context_header, env
 
-      env.[:request_headers]["X-Cloud-Trace-Context"].must_equal trace_context.to_string
+      env[:request_headers]["X-Cloud-Trace-Context"].must_equal trace_context.to_string
     end
   end
 end


### PR DESCRIPTION
Hey @dazuma 

I created this PR to make it easy to add `X-Cloud-Trace-Context` headers for user who use `faraday`, that would safe user to create their own faraday middleware.

However, I am not familiar with the minitest, so didn't manage to add test for the change. But would happy to do that if you can show me how to setup the gem and run test in local.