### PR TITLE
feat: Update Ruby dependency to minimum of 2.4

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,7 +19,7 @@ In order to use the google-cloud-ruby console and run the project's tests, there
 small amount of setup:
 
 1. Install Ruby.
-    google-cloud-ruby requires Ruby 2.3+. You may choose to manage your Ruby and gem installations with [RVM](https://rvm.io/), [rbenv](https://github.com/rbenv/rbenv), or [chruby](https://github.com/postmodern/chruby).
+    google-cloud-ruby requires Ruby 2.4+. You may choose to manage your Ruby and gem installations with [RVM](https://rvm.io/), [rbenv](https://github.com/rbenv/rbenv), or [chruby](https://github.com/postmodern/chruby).
 
 2. Install [Bundler](http://bundler.io/).
 

--- a/README.md
+++ b/README.md
@@ -1185,11 +1185,11 @@ $ gem install google-cloud-video_intelligence
 
 ## Supported Ruby Versions
 
-These libraries are currently supported on Ruby 2.3+.
+These libraries are currently supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/gcloud/.rubocop.yml
+++ b/gcloud/.rubocop.yml
@@ -1,9 +1,11 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "gcloud.gemspec"
     - "Rakefile"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
@@ -13,7 +15,3 @@ Layout/EmptyLines: # for the extra line between copyright and code
 Metrics/LineLength:
   Exclude: 
     - "Gemfile"
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/gcloud/CONTRIBUTING.md
+++ b/gcloud/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -39,11 +39,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/gcloud/gcloud.gemspec
+++ b/gcloud/gcloud.gemspec
@@ -16,17 +16,17 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud", "~> 0.23"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-asset/.rubocop.yml
+++ b/google-cloud-asset/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-asset.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-asset/README.md
+++ b/google-cloud-asset/README.md
@@ -58,11 +58,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-asset/google-cloud-asset.gemspec
+++ b/google-cloud-asset/google-cloud-asset.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-asset/synth.metadata
+++ b/google-cloud-asset/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-10-12T10:40:43.989266Z",
+  "updateTime": "2019-10-17T22:33:16.651186Z",
   "sources": [
     {
       "generator": {
@@ -12,8 +12,8 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "af8dd2c1750558b538eaa6bdaa3bc899079533ee",
-        "internalRef": "274260771"
+        "sha": "a05f640453ac7b4e1361dfceeae15ee6e02317f1",
+        "internalRef": "275258873"
       }
     },
     {

--- a/google-cloud-asset/synth.metadata
+++ b/google-cloud-asset/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-17T22:33:16.651186Z",
+  "updateTime": "2019-10-18T20:52:57.030484Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a05f640453ac7b4e1361dfceeae15ee6e02317f1",
-        "internalRef": "275258873"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -54,6 +54,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-asset.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Support for service_address
 s.replace(
     [

--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -51,6 +51,9 @@ s.copy(v1beta1_library / 'test/google/cloud/asset/v1beta1')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-asset.gemspec')
+
 # Support for service_address
 s.replace(
     [
@@ -96,7 +99,7 @@ s.replace(
 s.replace(
     'google-cloud-asset.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2232
 s.replace(
@@ -154,13 +157,6 @@ s.replace(
     'README.md',
     '# Ruby Client for Cloud Asset API \(\[Alpha\]\(https:\/\/github\.com\/googleapis\/google-cloud-ruby#versioning\)\)',
     '# Ruby Client for Cloud Asset API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-asset.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 for version in ['v1', 'v1beta1']:

--- a/google-cloud-automl/.rubocop.yml
+++ b/google-cloud-automl/.rubocop.yml
@@ -1,5 +1,7 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
-  TargetRubyVersion: 2.2
   Exclude:
     - "google-cloud-automl.gemspec"
     - "lib/google/**/*"
@@ -10,10 +12,6 @@ AllCops:
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-automl.rb"

--- a/google-cloud-automl/README.md
+++ b/google-cloud-automl/README.md
@@ -59,11 +59,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-automl/google-cloud-automl.gemspec
+++ b/google-cloud-automl/google-cloud-automl.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-automl/synth.metadata
+++ b/google-cloud-automl/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-17T21:54:37.850630Z",
+  "updateTime": "2019-10-18T20:53:21.254639Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a05f640453ac7b4e1361dfceeae15ee6e02317f1",
-        "internalRef": "275258873"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-automl/synth.metadata
+++ b/google-cloud-automl/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-09-24T10:37:10.713896Z",
+  "updateTime": "2019-10-17T21:54:37.850630Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.37.0",
-        "dockerImage": "googleapis/artman@sha256:0f66008f69061ea6d41499e2a34da3fc64fc7c9798077e3a37158653a135d801"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "cc332bd19c2dd9640b025e5693e83a1b428d5dff",
-        "internalRef": "270834186"
+        "sha": "a05f640453ac7b4e1361dfceeae15ee6e02317f1",
+        "internalRef": "275258873"
       }
     },
     {

--- a/google-cloud-automl/synth.py
+++ b/google-cloud-automl/synth.py
@@ -53,6 +53,9 @@ s.copy(v1beta1_library / 'google-cloud-automl.gemspec', merge=ruby.merge_gemspec
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-automl.gemspec')
+
 # Update file paths in generated files
 s.replace(
     [
@@ -143,7 +146,7 @@ s.replace(
 s.replace(
     'google-cloud-automl.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
@@ -186,13 +189,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-automl.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 s.replace(

--- a/google-cloud-automl/synth.py
+++ b/google-cloud-automl/synth.py
@@ -56,6 +56,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-automl.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Update file paths in generated files
 s.replace(
     [

--- a/google-cloud-bigquery-data_transfer/.rubocop.yml
+++ b/google-cloud-bigquery-data_transfer/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-bigquery-data_transfer.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-bigquery-data_transfer/README.md
+++ b/google-cloud-bigquery-data_transfer/README.md
@@ -81,11 +81,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec
+++ b/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-bigquery-data_transfer/synth.metadata
+++ b/google-cloud-bigquery-data_transfer/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-17T22:41:32.095328Z",
+  "updateTime": "2019-10-18T20:53:55.505780Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a05f640453ac7b4e1361dfceeae15ee6e02317f1",
-        "internalRef": "275258873"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-bigquery-data_transfer/synth.metadata
+++ b/google-cloud-bigquery-data_transfer/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-09-27T10:41:08.525106Z",
+  "updateTime": "2019-10-17T22:41:32.095328Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.37.1",
-        "dockerImage": "googleapis/artman@sha256:6068f67900a3f0bdece596b97bda8fc70406ca0e137a941f4c81d3217c994a80"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "cd112d8d255e0099df053643d4bd12c228ef7b1b",
-        "internalRef": "271468707"
+        "sha": "a05f640453ac7b4e1361dfceeae15ee6e02317f1",
+        "internalRef": "275258873"
       }
     },
     {

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -45,6 +45,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-bigquery-data_transfer.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Support for service_address
 s.replace(
     [

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -42,6 +42,9 @@ s.copy(v1_library / 'google-cloud-bigquery-data_transfer.gemspec', merge=ruby.me
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-bigquery-data_transfer.gemspec')
+
 # Support for service_address
 s.replace(
     [
@@ -85,7 +88,7 @@ s.replace(
 s.replace(
     'google-cloud-bigquery-data_transfer.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
 
 # PERMANENT: Use custom credentials env variable names
 s.replace(
@@ -147,13 +150,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-bigquery-data_transfer.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 s.replace(

--- a/google-cloud-bigquery/.rubocop.yml
+++ b/google-cloud-bigquery/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "acceptance/**/*"
@@ -6,45 +9,29 @@ AllCops:
     - "google-cloud-bigquery.gemspec"
     - "Rakefile"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodCallWithArgsParentheses:
-  Enabled: true
-  EnforcedStyle: omit_parentheses
-  AllowParenthesesInMultilineCall: true
-  AllowParenthesesInCamelCaseMethod: true
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Style/NumericLiterals:
-  Enabled: false
-Style/TrivialAccessors:
-  Enabled: false
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
 Metrics/ClassLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 30
-Metrics/ParameterLists:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
-  Enabled: false
-Layout/AlignHash:
-  EnforcedHashRocketStyle: table
-  EnforcedColonStyle: table
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-bigquery.rb"
 Naming/UncommunicativeMethodParamName:
+  Exclude:
+    - "lib/google/cloud/bigquery/external.rb"
+Style/IfUnlessModifier:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/SafeNavigation:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: false
+Style/WordArray:
   Enabled: false

--- a/google-cloud-bigquery/CONTRIBUTING.md
+++ b/google-cloud-bigquery/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-bigquery console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-bigquery requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud-bigquery requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-bigquery/README.md
+++ b/google-cloud-bigquery/README.md
@@ -67,11 +67,11 @@ Google::Apis.logger = my_logger
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -16,21 +16,21 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-api-client", "~> 0.31"
-  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
+  gem.add_dependency "google-api-client", "~> 0.33"
+  gem.add_dependency "googleauth", "~> 0.9"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_dependency "mini_mime", "~> 1.0"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-bigtable/.rubocop.yml
+++ b/google-cloud-bigtable/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-bigtable.gemspec"
@@ -13,38 +16,33 @@ AllCops:
     - "conformance/**/*"
     - "samples/**/*"
     - "support/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: true
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Style/NumericLiterals:
+Layout/AlignHash:
   Enabled: false
-Style/TrivialAccessors:
+Metrics/ClassLength:
   Enabled: false
 Metrics/LineLength:
   Max: 80
   IgnoredPatterns: ['(\A|\s)#']
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
-Metrics/ClassLength:
-  Enabled: false
 Metrics/MethodLength:
   Max: 30
-Metrics/ParameterLists:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
-  Enabled: false
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-bigtable.rb"
+Style/MethodCallWithArgsParentheses:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/RedundantFreeze:
+  Enabled: false
+Style/SafeNavigation:
+  Enabled: false
+Style/UnpackFirst:
+  Enabled: false
+Style/WordArray:
+  Enabled: false

--- a/google-cloud-bigtable/CONTRIBUTING.md
+++ b/google-cloud-bigtable/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-bigtable console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-bigtable requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud-bigtable requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-bigtable/README.md
+++ b/google-cloud-bigtable/README.md
@@ -52,11 +52,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-bigtable/google-cloud-bigtable.gemspec
+++ b/google-cloud-bigtable/google-cloud-bigtable.gemspec
@@ -19,17 +19,17 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "EMULATOR.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   gem.add_dependency "google-cloud-core", "~> 1.1"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-container/.rubocop.yml
+++ b/google-cloud-container/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-container.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-container/README.md
+++ b/google-cloud-container/README.md
@@ -70,11 +70,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-container/google-cloud-container.gemspec
+++ b/google-cloud-container/google-cloud-container.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-container/synth.metadata
+++ b/google-cloud-container/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-07-17T10:38:16.629069Z",
+  "updateTime": "2019-10-17T22:44:45.145943Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.30.0",
-        "dockerImage": "googleapis/artman@sha256:a44d9fb6fe826ca0ea7d6f7be23c596346bed82ee513a0043f3c068279717439"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "96d5a05171e99b6a2378eb0a3423f765351878b7",
-        "internalRef": "258424288"
+        "sha": "a05f640453ac7b4e1361dfceeae15ee6e02317f1",
+        "internalRef": "275258873"
       }
     },
     {

--- a/google-cloud-container/synth.metadata
+++ b/google-cloud-container/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-17T22:44:45.145943Z",
+  "updateTime": "2019-10-18T20:54:38.950450Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a05f640453ac7b4e1361dfceeae15ee6e02317f1",
-        "internalRef": "275258873"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -55,6 +55,13 @@ s.copy(v1_library / 'google-cloud-container.gemspec', merge=ruby.merge_gemspec)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-container.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Support for service_address
 s.replace(
     [

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -52,6 +52,9 @@ s.copy(v1_library / '.gitignore')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-container.gemspec', merge=ruby.merge_gemspec)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-container.gemspec')
+
 # Support for service_address
 s.replace(
     [
@@ -95,7 +98,7 @@ s.replace(
 s.replace(
     'google-cloud-container.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
 
 # Fix for tests that assume protos implement to_hash
 s.replace(
@@ -142,13 +145,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-container.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 s.replace(

--- a/google-cloud-container_analysis/.rubocop.yml
+++ b/google-cloud-container_analysis/.rubocop.yml
@@ -1,5 +1,7 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
-  TargetRubyVersion: 2.2
   Exclude:
     - "google-cloud-container_analysis.gemspec"
     - "lib/google/**/*"
@@ -10,10 +12,6 @@ AllCops:
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-container_analysis.rb"

--- a/google-cloud-container_analysis/README.md
+++ b/google-cloud-container_analysis/README.md
@@ -71,11 +71,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-container_analysis/google-cloud-container_analysis.gemspec
+++ b/google-cloud-container_analysis/google-cloud-container_analysis.gemspec
@@ -19,15 +19,15 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "grafeas-client", "~> 0.3"
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-container_analysis/synth.metadata
+++ b/google-cloud-container_analysis/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-09-26T10:39:24.238470Z",
+  "updateTime": "2019-10-17T22:52:50.381108Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.37.1",
-        "dockerImage": "googleapis/artman@sha256:6068f67900a3f0bdece596b97bda8fc70406ca0e137a941f4c81d3217c994a80"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4c2ca81a0c976d4d37a8999984b7894d9af22124",
-        "internalRef": "271130964"
+        "sha": "a05f640453ac7b4e1361dfceeae15ee6e02317f1",
+        "internalRef": "275258873"
       }
     },
     {

--- a/google-cloud-container_analysis/synth.py
+++ b/google-cloud-container_analysis/synth.py
@@ -41,6 +41,9 @@ s.copy(v1_library / 'google-cloud-container_analysis.gemspec', merge=ruby.merge_
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-container_analysis.gemspec')
+
 # Hack grpc service class name and location
 s.replace(
     'lib/google/devtools/containeranalysis/v1/containeranalysis_services_pb.rb',
@@ -101,7 +104,7 @@ s.replace(
 s.replace(
     'google-cloud-container_analysis.gemspec',
     '\n\n  gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
-    '\n\n  gem.add_dependency "grafeas-client", "~> 0.3"\n  gem.add_dependency "google-gax", "~> 1.7"',
+    '\n\n  gem.add_dependency "grafeas-client", "~> 0.3"\n  gem.add_dependency "google-gax", "~> 1.8"',
 )
 s.replace(
     'lib/google/cloud/container_analysis.rb',
@@ -179,13 +182,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-container_analysis.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 s.replace(

--- a/google-cloud-core/.rubocop.yml
+++ b/google-cloud-core/.rubocop.yml
@@ -1,48 +1,36 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-core.gemspec"
     - "Rakefile"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodCallWithArgsParentheses:
-  Enabled: true
-  EnforcedStyle: omit_parentheses
-  AllowParenthesesInMultilineCall: true
-  AllowParenthesesInCamelCaseMethod: true
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Style/RescueModifier:
+Layout/AlignHash:
   Exclude:
     - "lib/google/cloud/credentials.rb"
-Style/MutableConstant:
-  Exclude:
-    - "lib/google/cloud/credentials.rb"
-Style/CaseEquality:
-  Exclude:
-    - "lib/google/cloud/config.rb"
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
 Metrics/ClassLength:
-  Enabled: false
-Metrics/MethodLength:
-  Max: 20
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-core.rb"
-Style/RescueStandardError:
+Style/CaseEquality:
+  Exclude:
+    - "lib/google/cloud/config.rb"
+Style/IfUnlessModifier:
+  Enabled: false
+Style/MutableConstant:
+  Exclude:
+    - "lib/google/cloud/credentials.rb"
+Style/SafeNavigation:
+  Enabled: false
+Style/SymbolArray:
+  Exclude:
+    - "lib/google/cloud/config.rb"
+Style/WordArray:
   Exclude:
     - "lib/google/cloud/credentials.rb"

--- a/google-cloud-core/CONTRIBUTING.md
+++ b/google-cloud-core/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-core/README.md
+++ b/google-cloud-core/README.md
@@ -9,11 +9,11 @@ information about the individual google-cloud gems.
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-core/google-cloud-core.gemspec
+++ b/google-cloud-core/google-cloud-core.gemspec
@@ -17,17 +17,17 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-env", "~> 1.0"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-dataproc/.rubocop.yml
+++ b/google-cloud-dataproc/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-dataproc.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-dataproc/README.md
+++ b/google-cloud-dataproc/README.md
@@ -81,11 +81,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-dataproc/google-cloud-dataproc.gemspec
+++ b/google-cloud-dataproc/google-cloud-dataproc.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-dataproc/synth.metadata
+++ b/google-cloud-dataproc/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-10-16T10:38:43.584156Z",
+  "updateTime": "2019-10-18T00:36:18.130428Z",
   "sources": [
     {
       "generator": {
@@ -12,8 +12,8 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "c6e62c7e5e61e6dae7fdc3bc3de81f60e6a9445c",
-        "internalRef": "274798600"
+        "sha": "a05f640453ac7b4e1361dfceeae15ee6e02317f1",
+        "internalRef": "275258873"
       }
     },
     {

--- a/google-cloud-dataproc/synth.metadata
+++ b/google-cloud-dataproc/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-18T00:36:18.130428Z",
+  "updateTime": "2019-10-18T21:14:29.495560Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a05f640453ac7b4e1361dfceeae15ee6e02317f1",
-        "internalRef": "275258873"
+        "sha": "0e9a6d15fcb944ed40921ba0aad2082ee1bc7edd",
+        "internalRef": "275543900"
       }
     },
     {

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -59,6 +59,9 @@ s.replace(
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-dataproc.gemspec')
+
 # Update Authentication Guide for multi-service clients
 s.replace(
     'AUTHENTICATION.md',
@@ -109,7 +112,7 @@ s.replace(
 s.replace(
     'google-cloud-dataproc.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
@@ -152,13 +155,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-dataproc.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 # https://github.com/googleapis/gapic-generator/issues/2492

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -62,6 +62,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-dataproc.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Update Authentication Guide for multi-service clients
 s.replace(
     'AUTHENTICATION.md',

--- a/google-cloud-datastore/.rubocop.yml
+++ b/google-cloud-datastore/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "acceptance/**/*"
@@ -7,38 +10,26 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodCallWithArgsParentheses:
-  Enabled: true
-  EnforcedStyle: omit_parentheses
-  AllowParenthesesInMultilineCall: true
-  AllowParenthesesInCamelCaseMethod: true
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
+Layout/AlignHash:
+  Enabled: false
 Metrics/ClassLength:
-  Enabled: false
-Metrics/MethodLength:
-  Max: 25
-Metrics/ParameterLists:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-datastore.rb"
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
 Naming/UncommunicativeMethodParamName:
+  Enabled: false
+Style/ConditionalAssignment:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/SafeNavigation:
   Enabled: false

--- a/google-cloud-datastore/CONTRIBUTING.md
+++ b/google-cloud-datastore/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-datastore console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-datastore requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud-datastore requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-datastore/README.md
+++ b/google-cloud-datastore/README.md
@@ -71,11 +71,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-datastore/google-cloud-datastore.gemspec
+++ b/google-cloud-datastore/google-cloud-datastore.gemspec
@@ -16,19 +16,19 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "EMULATOR.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "google-protobuf", "~> 3.3"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-debugger/.rubocop.yml
+++ b/google-cloud-debugger/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "acceptance/**/*"
@@ -11,49 +14,41 @@ AllCops:
     - "support/**/*"
     - "test/**/*"
     - "tmp/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodCallWithArgsParentheses:
-  Enabled: true
-  EnforcedStyle: omit_parentheses
-  AllowParenthesesInMultilineCall: true
-  AllowParenthesesInCamelCaseMethod: true
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Style/NumericLiterals:
+Layout/AlignHash:
   Enabled: false
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
-Metrics/BlockLength:
-  Exclude:
-    - "lib/google-cloud-debugger.rb"
-Metrics/ClassLength:
+Layout/SpaceInsideStringInterpolation:
   Enabled: false
-Metrics/MethodLength:
-  Max: 25
-Metrics/ParameterLists:
-  Enabled: false
-Metrics/ModuleLength:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
-  Enabled: false
-Naming/FileName:
-  Exclude:
-    - "lib/google-cloud-debugger.rb"
 Lint/UnifiedInteger:
   Exclude:
     - "lib/google/cloud/debugger/breakpoint/evaluator.rb"
 Lint/InheritException:
   Exclude:
     - "lib/google/cloud/debugger/breakpoint/evaluator.rb"
+Metrics/BlockLength:
+  Exclude:
+    - "lib/google-cloud-debugger.rb"
+Metrics/ClassLength:
+  Enabled: false
+Naming/FileName:
+  Exclude:
+    - "lib/google-cloud-debugger.rb"
+Style/ConditionalAssignment:
+  Enabled: false
+Style/EmptyMethod:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/SafeNavigation:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: false
+Style/WordArray:
+  Enabled: false

--- a/google-cloud-debugger/CONTRIBUTING.md
+++ b/google-cloud-debugger/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-debugger console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-debugger requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud-debugger requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-debugger/README.md
+++ b/google-cloud-debugger/README.md
@@ -246,11 +246,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -16,24 +16,24 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "INSTRUMENTATION.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.2.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.extensions << "ext/google/cloud/debugger/debugger_c/extconf.rb"
 
   gem.add_dependency "binding_of_caller", "~> 0.7"
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "google-cloud-logging", "~> 1.0"
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.8"

--- a/google-cloud-dialogflow/.rubocop.yml
+++ b/google-cloud-dialogflow/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-dialogflow.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-dialogflow/README.md
+++ b/google-cloud-dialogflow/README.md
@@ -59,11 +59,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
+++ b/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-dialogflow/synth.metadata
+++ b/google-cloud-dialogflow/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-18T00:38:17.324514Z",
+  "updateTime": "2019-10-18T20:56:41.530938Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a05f640453ac7b4e1361dfceeae15ee6e02317f1",
-        "internalRef": "275258873"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-dialogflow/synth.metadata
+++ b/google-cloud-dialogflow/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-04T10:39:01.671903Z",
+  "updateTime": "2019-10-18T00:38:17.324514Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.38.0",
-        "dockerImage": "googleapis/artman@sha256:0d2f8d429110aeb8d82df6550ef4ede59d40df9062d260a1580fce688b0512bf"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "d9576d95b44f64fb0e3da4760adfc4a24fa1faab",
-        "internalRef": "272741510"
+        "sha": "a05f640453ac7b4e1361dfceeae15ee6e02317f1",
+        "internalRef": "275258873"
       }
     },
     {

--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -41,6 +41,9 @@ s.copy(v2_library / 'google-cloud-dialogflow.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-dialogflow.gemspec')
+
 # Update Authentication Guide for multi-service clients
 s.replace(
     'AUTHENTICATION.md',
@@ -129,18 +132,11 @@ s.replace(
     'https://googleapis.github.io/google-cloud-ruby'
 )
 
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-dialogflow.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
-)
-
 s.replace(
     'google-cloud-dialogflow.gemspec',
     'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.7"',
+        'gem.add_dependency "google-gax", "~> 1.8"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )

--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -44,6 +44,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-dialogflow.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Update Authentication Guide for multi-service clients
 s.replace(
     'AUTHENTICATION.md',

--- a/google-cloud-dlp/.rubocop.yml
+++ b/google-cloud-dlp/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-dlp.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-dlp/README.md
+++ b/google-cloud-dlp/README.md
@@ -60,11 +60,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-dlp/synth.metadata
+++ b/google-cloud-dlp/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T00:40:19.075749Z",
+  "updateTime": "2019-10-18T20:57:03.089537Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-dlp/synth.metadata
+++ b/google-cloud-dlp/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-08-27T10:40:15.617151Z",
+  "updateTime": "2019-10-18T00:40:19.075749Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.35.1",
-        "dockerImage": "googleapis/artman@sha256:b11c7ea0d0831c54016fb50f4b796d24d1971439b30fbc32a369ba1ac887c384"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "650caad718bb063f189405c23972dc9818886358",
-        "internalRef": "265565344"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -43,6 +43,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-dlp.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Support for service_address
 s.replace(
     [

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -40,6 +40,9 @@ s.copy(v2_library / 'google-cloud-dlp.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-dlp.gemspec')
+
 # Support for service_address
 s.replace(
     [
@@ -124,18 +127,11 @@ s.replace(
     'https://googleapis.github.io/google-cloud-ruby'
 )
 
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-dlp.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
-)
-
 s.replace(
     'google-cloud-dlp.gemspec',
     'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.7"',
+        'gem.add_dependency "google-gax", "~> 1.8"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )

--- a/google-cloud-dns/.rubocop.yml
+++ b/google-cloud-dns/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "acceptance/**/*"
@@ -5,31 +8,24 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
+Layout/AlignHash:
+  Enabled: false
 Metrics/ClassLength:
-  Enabled: false
-Metrics/MethodLength:
-  Max: 20
-Metrics/ParameterLists:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-dns.rb"
+Style/IfUnlessModifier:
+  Enabled: false
+Style/MethodCallWithArgsParentheses:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/SafeNavigation:
+  Enabled: false
+Style/WordArray:
+  Enabled: false

--- a/google-cloud-dns/CONTRIBUTING.md
+++ b/google-cloud-dns/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-dns console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-dns requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud-dns requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-dns/README.md
+++ b/google-cloud-dns/README.md
@@ -60,11 +60,11 @@ Google::Apis.logger = my_logger
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-dns/google-cloud-dns.gemspec
+++ b/google-cloud-dns/google-cloud-dns.gemspec
@@ -16,20 +16,20 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-api-client", ">= 0.30.4", "< 1.0"
-  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
+  gem.add_dependency "google-api-client", "~> 0.33"
+  gem.add_dependency "googleauth", "~> 0.9"
   gem.add_dependency "zonefile", "~> 1.04"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-env/.rubocop.yml
+++ b/google-cloud-env/.rubocop.yml
@@ -1,36 +1,19 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-env.gemspec"
     - "Rakefile"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodCallWithArgsParentheses:
-  Enabled: true
-  EnforcedStyle: omit_parentheses
-  AllowParenthesesInMultilineCall: true
-  AllowParenthesesInCamelCaseMethod: true
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
 Metrics/ClassLength:
-  Enabled: false
-Metrics/MethodLength:
-  Max: 20
-Metrics/ParameterLists:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-env.rb"
+Style/IfUnlessModifier:
+  Enabled: false

--- a/google-cloud-env/CONTRIBUTING.md
+++ b/google-cloud-env/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-env console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-env requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud-env requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-env/README.md
+++ b/google-cloud-env/README.md
@@ -7,11 +7,11 @@ apps running on Google Cloud Platform.
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-env/google-cloud-env.gemspec
+++ b/google-cloud-env/google-cloud-env.gemspec
@@ -16,17 +16,17 @@ Gem::Specification.new do |gem|
                       ["README.md", "CONTRIBUTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "faraday", "~> 0.11"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-error_reporting/.rubocop.yml
+++ b/google-cloud-error_reporting/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "acceptance/**/*"
@@ -9,49 +12,31 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodCallWithArgsParentheses:
-  Enabled: true
-  EnforcedStyle: omit_parentheses
-  AllowParenthesesInMultilineCall: true
-  AllowParenthesesInCamelCaseMethod: true
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Style/ClassVars:
+Layout/AlignHash:
   Enabled: false
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
-Metrics/BlockLength:
-  Exclude:
-    - "lib/google-cloud-error_reporting.rb"
-Metrics/ClassLength:
-  Enabled: false
-Metrics/MethodLength:
-  Max: 20
-  Exclude:
-    - "lib/google/cloud/error_reporting.rb"
-Metrics/ParameterLists:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
-  Enabled: false
-Naming/FileName:
-  Exclude:
-    - "lib/google-cloud-error_reporting.rb"
 Lint/RescueException:
   Exclude:
     - "lib/google/cloud/error_reporting/middleware.rb"
 Lint/AmbiguousOperator:
   Exclude:
     - "lib/google/cloud/error_reporting/project.rb"
+Metrics/BlockLength:
+  Exclude:
+    - "lib/google-cloud-error_reporting.rb"
+Metrics/ClassLength:
+  Enabled: false
+Naming/FileName:
+  Exclude:
+    - "lib/google-cloud-error_reporting.rb"
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/SafeNavigation:
+  Enabled: false

--- a/google-cloud-error_reporting/CONTRIBUTING.md
+++ b/google-cloud-error_reporting/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-error_reporting console and run the project's
 tests, there is a small amount of setup:
 
-1. Install Ruby. google-cloud-error_reporting requires Ruby 2.3+. You may choose
+1. Install Ruby. google-cloud-error_reporting requires Ruby 2.4+. You may choose
    to manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-error_reporting/README.md
+++ b/google-cloud-error_reporting/README.md
@@ -214,11 +214,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
+++ b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
@@ -18,19 +18,19 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "INSTRUMENTATION.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "railties", "~> 4.0"
   gem.add_development_dependency "rack", ">= 0.1"
   gem.add_development_dependency "simplecov", "~> 0.9"

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
@@ -271,8 +271,6 @@ module Google
           )
         end
 
-        # rubocop:disable Metrics/AbcSize
-
         ##
         # @private Formats the http request context as a
         # Google::Devtools::Clouderrorreporting::V1beta1::HttpRequestContext
@@ -289,8 +287,6 @@ module Google
             remote_ip: http_remote_ip.to_s
           )
         end
-
-        # rubocop:enable Metrics/AbcSize
 
         ##
         # @private Formats the source location as a

--- a/google-cloud-firestore/.rubocop.yml
+++ b/google-cloud-firestore/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "benchmark/**/*"
@@ -14,48 +17,28 @@ AllCops:
     - "acceptance/**/*"
     - "conformance/**/*"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodCallWithArgsParentheses:
-  Enabled: true
-  EnforcedStyle: omit_parentheses
-  AllowParenthesesInMultilineCall: true
-  AllowParenthesesInCamelCaseMethod: true
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Style/RescueModifier:
-  Enabled: false
-Style/TrivialAccessors:
+Metrics/ClassLength:
   Enabled: false
 Metrics/CyclomaticComplexity:
   Max: 15
 Metrics/PerceivedComplexity:
   Max: 15
-Metrics/AbcSize:
-  Max: 30
-Metrics/ClassLength:
-  Enabled: false
-Metrics/MethodLength:
-  Max: 25
-Metrics/ParameterLists:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
-  Enabled: false
-Layout/AlignHash:
-  EnforcedHashRocketStyle: table
-  EnforcedColonStyle: table
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-firestore.rb"
-Style/RescueStandardError:
-  Exclude:
-  - "lib/google/cloud/firestore/client.rb"
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
 Naming/UncommunicativeMethodParamName:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/SafeNavigation:
+  Enabled: false
+Style/SymbolArray:
   Enabled: false

--- a/google-cloud-firestore/CONTRIBUTING.md
+++ b/google-cloud-firestore/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-firestore console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-firestore requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud-firestore requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-firestore/README.md
+++ b/google-cloud-firestore/README.md
@@ -50,11 +50,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-firestore/google-cloud-firestore.gemspec
+++ b/google-cloud-firestore/google-cloud-firestore.gemspec
@@ -17,20 +17,20 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "EMULATOR.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_dependency "rbtree", "~> 0.4.2"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-irm/.rubocop.yml
+++ b/google-cloud-irm/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-irm.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-irm/README.md
+++ b/google-cloud-irm/README.md
@@ -58,11 +58,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-irm/google-cloud-irm.gemspec
+++ b/google-cloud-irm/google-cloud-irm.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-irm/synth.metadata
+++ b/google-cloud-irm/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-08-27T10:41:12.104396Z",
+  "updateTime": "2019-10-18T00:42:25.484671Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.35.1",
-        "dockerImage": "googleapis/artman@sha256:b11c7ea0d0831c54016fb50f4b796d24d1971439b30fbc32a369ba1ac887c384"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "650caad718bb063f189405c23972dc9818886358",
-        "internalRef": "265565344"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-irm/synth.metadata
+++ b/google-cloud-irm/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T00:42:25.484671Z",
+  "updateTime": "2019-10-18T20:57:40.781414Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-irm/synth.py
+++ b/google-cloud-irm/synth.py
@@ -44,6 +44,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-irm.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Support for service_address
 s.replace(
     [

--- a/google-cloud-irm/synth.py
+++ b/google-cloud-irm/synth.py
@@ -41,6 +41,9 @@ s.copy(v1alpha2 / 'google-cloud-irm.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-irm.gemspec')
+
 # Support for service_address
 s.replace(
     [
@@ -84,7 +87,7 @@ s.replace(
 s.replace(
     'google-cloud-irm.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
@@ -114,13 +117,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-irm.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 # Require the helpers file

--- a/google-cloud-kms/.rubocop.yml
+++ b/google-cloud-kms/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-kms.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-kms/README.md
+++ b/google-cloud-kms/README.md
@@ -80,11 +80,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-kms/google-cloud-kms.gemspec
+++ b/google-cloud-kms/google-cloud-kms.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-kms/synth.metadata
+++ b/google-cloud-kms/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T00:44:00.688042Z",
+  "updateTime": "2019-10-18T20:58:13.507924Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-kms/synth.metadata
+++ b/google-cloud-kms/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-08-27T10:41:29.346426Z",
+  "updateTime": "2019-10-18T00:44:00.688042Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.35.1",
-        "dockerImage": "googleapis/artman@sha256:b11c7ea0d0831c54016fb50f4b796d24d1971439b30fbc32a369ba1ac887c384"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "650caad718bb063f189405c23972dc9818886358",
-        "internalRef": "265565344"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -46,6 +46,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-kms.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # PERMANENT: API name for cloudkms
 s.replace(
     [

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -43,6 +43,9 @@ s.copy(v1_library / 'google-cloud-kms.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-kms.gemspec')
+
 # PERMANENT: API name for cloudkms
 s.replace(
     [
@@ -123,7 +126,7 @@ s.replace(
 s.replace(
     'google-cloud-kms.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
@@ -166,13 +169,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-kms.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 # Require the helpers file

--- a/google-cloud-language/.rubocop.yml
+++ b/google-cloud-language/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-language.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-language/README.md
+++ b/google-cloud-language/README.md
@@ -60,11 +60,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-language/google-cloud-language.gemspec
+++ b/google-cloud-language/google-cloud-language.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-language/synth.metadata
+++ b/google-cloud-language/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-01T10:39:40.223178Z",
+  "updateTime": "2019-10-18T05:48:54.486280Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.37.1",
-        "dockerImage": "googleapis/artman@sha256:6068f67900a3f0bdece596b97bda8fc70406ca0e137a941f4c81d3217c994a80"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "ce3c574d1266026cebea3a893247790bd68191c2",
-        "internalRef": "272147209"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-language/synth.metadata
+++ b/google-cloud-language/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-10-18T05:48:54.486280Z",
+  "updateTime": "2019-10-18T20:58:39.798138Z",
   "sources": [
     {
       "generator": {

--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -54,6 +54,9 @@ s.copy(v1beta2_library / 'test/google/cloud/language/v1beta2')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-language.gemspec')
+
 # Support for service_address
 s.replace(
     [
@@ -136,13 +139,6 @@ s.replace(
     'https://googleapis.github.io/google-cloud-ruby'
 )
 
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-language.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
-)
-
 s.replace(
     'lib/google/cloud/language/**/credentials.rb',
     '\n'.join([
@@ -156,7 +152,7 @@ s.replace(
     'google-cloud-language.gemspec',
     'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.7"',
+        'gem.add_dependency "google-gax", "~> 1.8"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )

--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -57,6 +57,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-language.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Support for service_address
 s.replace(
     [

--- a/google-cloud-logging/.rubocop.yml
+++ b/google-cloud-logging/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "acceptance/**/*"
@@ -9,50 +12,40 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodCallWithArgsParentheses:
-  Enabled: true
-  EnforcedStyle: omit_parentheses
-  AllowParenthesesInMultilineCall: true
-  AllowParenthesesInCamelCaseMethod: true
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Style/NumericLiterals:
-  Enabled: false
-Style/CaseEquality:
+Lint/RescueException:
   Exclude:
-    - "lib/google/cloud/logging/middleware.rb"
-Metrics/CyclomaticComplexity:
-  Max: 12
-Metrics/PerceivedComplexity:
-  Max: 12
-Metrics/AbcSize:
-  Max: 28
+    - "lib/google/cloud/logging/rails.rb"
 Metrics/BlockLength:
   Exclude:
     - "lib/google-cloud-logging.rb"
 Metrics/ClassLength:
   Enabled: false
-Metrics/MethodLength:
-  Max: 25
-Metrics/ParameterLists:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
-  Enabled: false
-Layout/AlignHash:
-  EnforcedHashRocketStyle: table
-  EnforcedColonStyle: table
+Metrics/CyclomaticComplexity:
+  Max: 15
+Metrics/PerceivedComplexity:
+  Max: 15
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-logging.rb"
-Lint/RescueException:
-  Exclude:
-    - "lib/google/cloud/logging/rails.rb"
+Style/CaseEquality:
+  Enabled: false
+Style/ConditionalAssignment:
+  Enabled: false
+Style/EmptyMethod:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/MultilineWhenThen:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/SafeNavigation:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: false

--- a/google-cloud-logging/CONTRIBUTING.md
+++ b/google-cloud-logging/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-logging console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-logging requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud-logging requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -180,11 +180,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -16,21 +16,21 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "INSTRUMENTATION.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -615,9 +615,6 @@ module Google
         end
         alias find_sinks sinks
 
-        # rubocop:disable Metrics/LineLength
-        # overload is too long...
-
         ##
         # Creates a new project sink. When you create a sink, only new log
         # entries that match the sink's filter are exported. Stackdriver Logging
@@ -700,8 +697,6 @@ module Google
           Sink.from_grpc grpc, service
         end
         alias new_sink create_sink
-
-        # rubocop:enable Metrics/LineLength
 
         ##
         # Retrieves a sink by name.

--- a/google-cloud-monitoring/.rubocop.yml
+++ b/google-cloud-monitoring/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-monitoring.gemspec"
@@ -5,15 +8,9 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
 
 Naming/FileName:
   Exclude:

--- a/google-cloud-monitoring/README.md
+++ b/google-cloud-monitoring/README.md
@@ -82,11 +82,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-monitoring/google-cloud-monitoring.gemspec
+++ b/google-cloud-monitoring/google-cloud-monitoring.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-monitoring/synth.metadata
+++ b/google-cloud-monitoring/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-10-12T10:44:08.567973Z",
+  "updateTime": "2019-10-18T00:46:44.018135Z",
   "sources": [
     {
       "generator": {
@@ -12,8 +12,8 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "af8dd2c1750558b538eaa6bdaa3bc899079533ee",
-        "internalRef": "274260771"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-monitoring/synth.metadata
+++ b/google-cloud-monitoring/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T00:46:44.018135Z",
+  "updateTime": "2019-10-18T20:59:15.480372Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -46,6 +46,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-monitoring.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Update Authentication Guide for multi-service clients
 s.replace(
     'AUTHENTICATION.md',

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -43,6 +43,9 @@ s.copy(v3_library / 'google-cloud-monitoring.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-monitoring.gemspec')
+
 # Update Authentication Guide for multi-service clients
 s.replace(
     'AUTHENTICATION.md',
@@ -95,7 +98,7 @@ s.replace(
 s.replace(
     'google-cloud-monitoring.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"')
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
@@ -138,13 +141,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-monitoring.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 s.replace(

--- a/google-cloud-os_login/.rubocop.yml
+++ b/google-cloud-os_login/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-os_login.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-os_login/README.md
+++ b/google-cloud-os_login/README.md
@@ -59,11 +59,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-os_login/google-cloud-os_login.gemspec
+++ b/google-cloud-os_login/google-cloud-os_login.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-os_login/synth.metadata
+++ b/google-cloud-os_login/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-09T10:43:05.529744Z",
+  "updateTime": "2019-10-18T00:48:27.698007Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.38.0",
-        "dockerImage": "googleapis/artman@sha256:0d2f8d429110aeb8d82df6550ef4ede59d40df9062d260a1580fce688b0512bf"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "2dec8f98383214ad4fafa7680eb0cc46d6531976",
-        "internalRef": "273619851"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-os_login/synth.metadata
+++ b/google-cloud-os_login/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T00:48:27.698007Z",
+  "updateTime": "2019-10-18T20:59:55.712866Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -59,6 +59,13 @@ s.copy(v1beta_library / 'test/google/cloud/os_login/v1beta')
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-os_login.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # PERMANENT: API name for oslogin
 s.replace(
     [

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -56,6 +56,9 @@ s.copy(v1beta_library / 'lib/google/cloud/os_login/v1beta.rb')
 s.copy(v1beta_library / 'lib/google/cloud/oslogin/v1beta')
 s.copy(v1beta_library / 'test/google/cloud/os_login/v1beta')
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-os_login.gemspec')
+
 # PERMANENT: API name for oslogin
 s.replace(
     [
@@ -109,7 +112,7 @@ s.replace(
 s.replace(
     'google-cloud-os_login.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
@@ -163,13 +166,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-os_login.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 s.replace(

--- a/google-cloud-phishing_protection/.rubocop.yml
+++ b/google-cloud-phishing_protection/.rubocop.yml
@@ -1,5 +1,7 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
-  TargetRubyVersion: 2.2
   Exclude:
     - "google-cloud-phishing_protection.gemspec"
     - "lib/google/**/*"
@@ -9,8 +11,3 @@ AllCops:
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-phishing_protection/README.md
+++ b/google-cloud-phishing_protection/README.md
@@ -58,11 +58,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-phishing_protection/google-cloud-phishing_protection.gemspec
+++ b/google-cloud-phishing_protection/google-cloud-phishing_protection.gemspec
@@ -19,15 +19,15 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-phishing_protection/synth.metadata
+++ b/google-cloud-phishing_protection/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-09-26T10:42:04.247542Z",
+  "updateTime": "2019-10-18T00:50:04.835005Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.37.1",
-        "dockerImage": "googleapis/artman@sha256:6068f67900a3f0bdece596b97bda8fc70406ca0e137a941f4c81d3217c994a80"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4c2ca81a0c976d4d37a8999984b7894d9af22124",
-        "internalRef": "271130964"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-phishing_protection/synth.metadata
+++ b/google-cloud-phishing_protection/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T00:50:04.835005Z",
+  "updateTime": "2019-10-18T21:00:32.496659Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-phishing_protection/synth.py
+++ b/google-cloud-phishing_protection/synth.py
@@ -47,6 +47,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-phishing_protection.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Support for service_address
 s.replace(
     [

--- a/google-cloud-phishing_protection/synth.py
+++ b/google-cloud-phishing_protection/synth.py
@@ -44,6 +44,9 @@ s.copy(v1beta1_library / 'google-cloud-phishing_protection.gemspec', merge=ruby.
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-phishing_protection.gemspec')
+
 # Support for service_address
 s.replace(
     [
@@ -128,19 +131,12 @@ s.replace(
     'https://googleapis.github.io/google-cloud-ruby'
 )
 
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-phishing_protection.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
-)
-
 # https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-phishing_protection.gemspec',
     'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.7"',
+        'gem.add_dependency "google-gax", "~> 1.8"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
         '  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"'
     ])

--- a/google-cloud-pubsub/.rubocop.yml
+++ b/google-cloud-pubsub/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "acceptance/**/*"
@@ -9,45 +12,25 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodCallWithArgsParentheses:
-  Enabled: true
-  EnforcedStyle: omit_parentheses
-  AllowParenthesesInMultilineCall: true
-  AllowParenthesesInCamelCaseMethod: true
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Style/NumericLiterals:
-  Enabled: false
-Style/TrivialAccessors:
-  Enabled: false
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
 Metrics/ClassLength:
   Enabled: false
 Metrics/MethodLength:
-  Max: 25
   Exclude:
     - "lib/google/cloud/pubsub.rb"
-Metrics/ParameterLists:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
-  Enabled: false
-Layout/AlignHash:
-  EnforcedHashRocketStyle: table
-  EnforcedColonStyle: table
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-pubsub.rb"
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/SafeNavigation:
+  Enabled: false

--- a/google-cloud-pubsub/CONTRIBUTING.md
+++ b/google-cloud-pubsub/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-pubsub console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-pubsub requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud-pubsub requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-pubsub/README.md
+++ b/google-cloud-pubsub/README.md
@@ -74,11 +74,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -16,21 +16,21 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "EMULATOR.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-recaptcha_enterprise/.rubocop.yml
+++ b/google-cloud-recaptcha_enterprise/.rubocop.yml
@@ -1,5 +1,7 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
-  TargetRubyVersion: 2.2
   Exclude:
     - "google-cloud-recaptcha_enterprise.gemspec"
     - "lib/google/**/*"
@@ -9,8 +11,3 @@ AllCops:
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-recaptcha_enterprise/README.md
+++ b/google-cloud-recaptcha_enterprise/README.md
@@ -58,11 +58,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-recaptcha_enterprise/google-cloud-recaptcha_enterprise.gemspec
+++ b/google-cloud-recaptcha_enterprise/google-cloud-recaptcha_enterprise.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-recaptcha_enterprise/synth.metadata
+++ b/google-cloud-recaptcha_enterprise/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-09-25T10:41:14.650537Z",
+  "updateTime": "2019-10-18T00:51:39.072958Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.37.1",
-        "dockerImage": "googleapis/artman@sha256:6068f67900a3f0bdece596b97bda8fc70406ca0e137a941f4c81d3217c994a80"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "662bfb2666b4310027475928234f1355dcf8a935",
-        "internalRef": "270960038"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-recaptcha_enterprise/synth.metadata
+++ b/google-cloud-recaptcha_enterprise/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T00:51:39.072958Z",
+  "updateTime": "2019-10-18T21:00:57.092055Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-recaptcha_enterprise/synth.py
+++ b/google-cloud-recaptcha_enterprise/synth.py
@@ -43,6 +43,9 @@ s.copy(v1beta1_library / 'google-cloud-recaptcha_enterprise.gemspec', merge=ruby
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-recaptcha_enterprise.gemspec')
+
 # Support for service_address
 s.replace(
     [
@@ -88,7 +91,7 @@ s.replace(
 s.replace(
     'google-cloud-recaptcha_enterprise.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
@@ -131,13 +134,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-recaptcha_enterprise.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 os.rename(

--- a/google-cloud-recaptcha_enterprise/synth.py
+++ b/google-cloud-recaptcha_enterprise/synth.py
@@ -46,6 +46,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-recaptcha_enterprise.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Support for service_address
 s.replace(
     [

--- a/google-cloud-redis/.rubocop.yml
+++ b/google-cloud-redis/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-redis.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-redis/README.md
+++ b/google-cloud-redis/README.md
@@ -58,11 +58,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-redis/google-cloud-redis.gemspec
+++ b/google-cloud-redis/google-cloud-redis.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-redis/synth.metadata
+++ b/google-cloud-redis/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T00:53:02.069005Z",
+  "updateTime": "2019-10-18T21:01:29.331829Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-redis/synth.metadata
+++ b/google-cloud-redis/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-08T10:41:12.422857Z",
+  "updateTime": "2019-10-18T00:53:02.069005Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.38.0",
-        "dockerImage": "googleapis/artman@sha256:0d2f8d429110aeb8d82df6550ef4ede59d40df9062d260a1580fce688b0512bf"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "122bdbf877ad87439f8dd9d1474a8e5dde188087",
-        "internalRef": "273381131"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -54,6 +54,13 @@ s.copy(v1beta1_library / 'test/google/cloud/redis/v1beta1')
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-redis.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Support for service_address
 s.replace(
     [

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -51,6 +51,9 @@ s.copy(v1beta1_library / 'lib/google/cloud/redis/v1beta1')
 s.copy(v1beta1_library / 'lib/google/cloud/redis/v1beta1.rb')
 s.copy(v1beta1_library / 'test/google/cloud/redis/v1beta1')
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-redis.gemspec')
+
 # Support for service_address
 s.replace(
     [
@@ -155,18 +158,11 @@ s.replace(
     'https://googleapis.github.io/google-cloud-ruby'
 )
 
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-redis.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
-)
-
 s.replace(
     'google-cloud-redis.gemspec',
     'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.7"',
+        'gem.add_dependency "google-gax", "~> 1.8"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )

--- a/google-cloud-resource_manager/.rubocop.yml
+++ b/google-cloud-resource_manager/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "acceptance/**/*"
@@ -7,36 +10,20 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodCallWithArgsParentheses:
-  Enabled: true
-  EnforcedStyle: omit_parentheses
-  AllowParenthesesInMultilineCall: true
-  AllowParenthesesInCamelCaseMethod: true
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
+Layout/AlignHash:
+  Enabled: false
 Metrics/ClassLength:
-  Enabled: false
-Metrics/MethodLength:
-  Max: 20
-Metrics/ParameterLists:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-resource_manager.rb"
+Style/IfUnlessModifier:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/WordArray:
+  Enabled: false

--- a/google-cloud-resource_manager/CONTRIBUTING.md
+++ b/google-cloud-resource_manager/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-resource_manager console and run the project's
 tests, there is a small amount of setup:
 
-1. Install Ruby. google-cloud-resource_manager requires Ruby 2.3+. You may
+1. Install Ruby. google-cloud-resource_manager requires Ruby 2.4+. You may
    choose to manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-resource_manager/README.md
+++ b/google-cloud-resource_manager/README.md
@@ -80,11 +80,11 @@ Google::Apis.logger = my_logger
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
+++ b/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
@@ -16,19 +16,19 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-api-client", "~> 0.23"
-  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
+  gem.add_dependency "google-api-client", "~> 0.33"
+  gem.add_dependency "googleauth", "~> 0.9"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-scheduler/.rubocop.yml
+++ b/google-cloud-scheduler/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-scheduler.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-scheduler/README.md
+++ b/google-cloud-scheduler/README.md
@@ -58,11 +58,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-scheduler/google-cloud-scheduler.gemspec
+++ b/google-cloud-scheduler/google-cloud-scheduler.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.50.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-scheduler/synth.metadata
+++ b/google-cloud-scheduler/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-10-12T10:45:32.906080Z",
+  "updateTime": "2019-10-18T00:54:44.364963Z",
   "sources": [
     {
       "generator": {
@@ -12,8 +12,8 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "af8dd2c1750558b538eaa6bdaa3bc899079533ee",
-        "internalRef": "274260771"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-scheduler/synth.metadata
+++ b/google-cloud-scheduler/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T00:54:44.364963Z",
+  "updateTime": "2019-10-18T21:01:57.539949Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-scheduler/synth.py
+++ b/google-cloud-scheduler/synth.py
@@ -59,6 +59,9 @@ s.copy(v1_library / '.gitignore')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-scheduler.gemspec', merge=ruby.merge_gemspec)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-scheduler.gemspec')
+
 # Support for service_address
 s.replace(
     [
@@ -140,7 +143,7 @@ s.replace(
     'google-cloud-scheduler.gemspec',
     'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.7"',
+        'gem.add_dependency "google-gax", "~> 1.8"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )

--- a/google-cloud-scheduler/synth.py
+++ b/google-cloud-scheduler/synth.py
@@ -62,6 +62,13 @@ s.copy(v1_library / 'google-cloud-scheduler.gemspec', merge=ruby.merge_gemspec)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-scheduler.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Support for service_address
 s.replace(
     [

--- a/google-cloud-security_center/.rubocop.yml
+++ b/google-cloud-security_center/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-security_center.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-security_center/README.md
+++ b/google-cloud-security_center/README.md
@@ -59,11 +59,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-security_center/google-cloud-security_center.gemspec
+++ b/google-cloud-security_center/google-cloud-security_center.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-security_center/synth.metadata
+++ b/google-cloud-security_center/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-09-26T10:42:54.838990Z",
+  "updateTime": "2019-10-18T00:56:04.162412Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.37.1",
-        "dockerImage": "googleapis/artman@sha256:6068f67900a3f0bdece596b97bda8fc70406ca0e137a941f4c81d3217c994a80"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4c2ca81a0c976d4d37a8999984b7894d9af22124",
-        "internalRef": "271130964"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-security_center/synth.metadata
+++ b/google-cloud-security_center/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T00:56:04.162412Z",
+  "updateTime": "2019-10-18T21:02:51.166528Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-security_center/synth.py
+++ b/google-cloud-security_center/synth.py
@@ -53,6 +53,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-security_center.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Permanent: rename securitycenter file paths to security_center
 s.replace(
     [

--- a/google-cloud-security_center/synth.py
+++ b/google-cloud-security_center/synth.py
@@ -50,6 +50,9 @@ s.copy(v1_library / 'google-cloud-security_center.gemspec', merge=ruby.merge_gem
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-security_center.gemspec')
+
 # Permanent: rename securitycenter file paths to security_center
 s.replace(
     [
@@ -111,7 +114,7 @@ s.replace(
 s.replace(
     'google-cloud-security_center.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
@@ -151,13 +154,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-security_center.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 s.replace(

--- a/google-cloud-spanner/.rubocop.yml
+++ b/google-cloud-spanner/.rubocop.yml
@@ -1,3 +1,5 @@
+inherit_gem:
+  google-style: google-style.yml
 
 AllCops:
   Exclude:
@@ -10,44 +12,30 @@ AllCops:
     - "lib/google/spanner/**/*"
     - "lib/google/cloud/spanner/v1/**/*"
     - "lib/google/cloud/spanner/admin/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodCallWithArgsParentheses:
-  Enabled: true
-  EnforcedStyle: omit_parentheses
-  AllowParenthesesInMultilineCall: true
-  AllowParenthesesInCamelCaseMethod: true
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Style/NumericLiterals:
+Layout/AlignHash:
   Enabled: false
-Style/TrivialAccessors:
-  Enabled: false
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 30
 Metrics/ClassLength:
-  Enabled: false
-Metrics/MethodLength:
-  Max: 25
-Metrics/ParameterLists:
-  Enabled: false
-Lint/HandleExceptions:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-spanner.rb"
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
 Naming/UncommunicativeMethodParamName:
+  Enabled: false
+Style/EmptyMethod:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: false
+Style/WordArray:
   Enabled: false

--- a/google-cloud-spanner/CONTRIBUTING.md
+++ b/google-cloud-spanner/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-spanner console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-spanner requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud-spanner requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-spanner/README.md
+++ b/google-cloud-spanner/README.md
@@ -60,11 +60,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -16,20 +16,20 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-spanner/lib/google/cloud/spanner/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database.rb
@@ -83,8 +83,6 @@ module Google
           @grpc.name.split("/")[5]
         end
 
-        # rubocop:disable LineLength
-
         ##
         # The full path for the database resource. Values are of the form
         # `projects/<project_id>/instances/<instance_id>/databases/<database_id>`.
@@ -92,8 +90,6 @@ module Google
         def path
           @grpc.name
         end
-
-        # rubocop:enable LineLength
 
         ##
         # The current database state. Possible values are `:CREATING` and

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -79,8 +79,6 @@ module Google
           @grpc.name.split("/")[7]
         end
 
-        # rubocop:disable LineLength
-
         ##
         # The full path for the session resource. Values are of the form
         # `projects/<project_id>/instances/<instance_id>/databases/<database_id>/sessions/<session_id>`.
@@ -88,8 +86,6 @@ module Google
         def path
           @grpc.name
         end
-
-        # rubocop:enable LineLength
 
         ##
         # Executes a SQL query.

--- a/google-cloud-speech/.rubocop.yml
+++ b/google-cloud-speech/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-speech.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-speech/README.md
+++ b/google-cloud-speech/README.md
@@ -84,11 +84,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -25,13 +25,13 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-speech/synth.metadata
+++ b/google-cloud-speech/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T00:58:21.774315Z",
+  "updateTime": "2019-10-18T21:03:17.009507Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-speech/synth.metadata
+++ b/google-cloud-speech/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-09-26T10:43:13.922162Z",
+  "updateTime": "2019-10-18T00:58:21.774315Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.37.1",
-        "dockerImage": "googleapis/artman@sha256:6068f67900a3f0bdece596b97bda8fc70406ca0e137a941f4c81d3217c994a80"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4c2ca81a0c976d4d37a8999984b7894d9af22124",
-        "internalRef": "271130964"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -56,6 +56,13 @@ s.copy(v1p1beta1_library / 'test/google/cloud/speech/v1p1beta1')
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-speech.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # PERMANENT: Install partial gapics
 s.replace(
     'lib/google/cloud/speech/v1.rb',

--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -53,6 +53,9 @@ s.copy(v1p1beta1_library / 'lib/google/cloud/speech/v1p1beta1.rb')
 s.copy(v1p1beta1_library / 'lib/google/cloud/speech/v1p1beta1')
 s.copy(v1p1beta1_library / 'test/google/cloud/speech/v1p1beta1')
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-speech.gemspec')
+
 # PERMANENT: Install partial gapics
 s.replace(
     'lib/google/cloud/speech/v1.rb',
@@ -164,7 +167,7 @@ s.replace(
 s.replace(
     'google-cloud-speech.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2122
 s.replace(
@@ -224,13 +227,6 @@ s.replace(
     '.yardopts',
     'README.md\n',
     'README.md\nAUTHENTICATION.md\nLICENSE\n'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-speech.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 # https://github.com/googleapis/google-cloud-ruby/issues/3058

--- a/google-cloud-storage/.rubocop.yml
+++ b/google-cloud-storage/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "acceptance/**/*"
@@ -6,45 +9,28 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "support/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodCallWithArgsParentheses:
-  Enabled: true
-  EnforcedStyle: omit_parentheses
-  AllowParenthesesInMultilineCall: true
-  AllowParenthesesInCamelCaseMethod: true
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Style/RescueModifier:
+Layout/AlignHash:
   Enabled: false
-Style/TrivialAccessors:
+Layout/SpaceAroundOperators:
   Enabled: false
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 30
 Metrics/ClassLength:
-  Enabled: false
-Metrics/MethodLength:
-  Max: 25
-Metrics/ParameterLists:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
-  Enabled: false
-Naming/VariableNumber:
   Enabled: false
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-storage.rb"
-Style/RescueStandardError:
-  Exclude:
-  - "lib/google/cloud/storage/policy.rb"
+Style/IfUnlessModifier:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/SafeNavigation:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: false
+Style/UnpackFirst:
+  Enabled: false
+Style/WordArray:
+  Enabled: false

--- a/google-cloud-storage/CONTRIBUTING.md
+++ b/google-cloud-storage/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-storage console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-storage requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud-storage requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-storage/README.md
+++ b/google-cloud-storage/README.md
@@ -60,11 +60,11 @@ Google::Apis.logger = my_logger
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -16,22 +16,22 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-api-client", "~> 0.26"
-  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
+  gem.add_dependency "google-api-client", "~> 0.33"
+  gem.add_dependency "googleauth", "~> 0.9"
   gem.add_dependency "digest-crc", "~> 0.4"
   gem.add_dependency "addressable", "~> 2.5"
   gem.add_dependency "mini_mime", "~> 1.0"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/google-cloud-talent/.rubocop.yml
+++ b/google-cloud-talent/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-talent.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-talent/README.md
+++ b/google-cloud-talent/README.md
@@ -59,11 +59,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-talent/google-cloud-talent.gemspec
+++ b/google-cloud-talent/google-cloud-talent.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-talent/synth.metadata
+++ b/google-cloud-talent/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T01:00:07.087716Z",
+  "updateTime": "2019-10-18T21:03:40.355010Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-talent/synth.metadata
+++ b/google-cloud-talent/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-09T10:45:07.741570Z",
+  "updateTime": "2019-10-18T01:00:07.087716Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.38.0",
-        "dockerImage": "googleapis/artman@sha256:0d2f8d429110aeb8d82df6550ef4ede59d40df9062d260a1580fce688b0512bf"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "2dec8f98383214ad4fafa7680eb0cc46d6531976",
-        "internalRef": "273619851"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-talent/synth.py
+++ b/google-cloud-talent/synth.py
@@ -46,6 +46,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-talent.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Update Authentication Guide for multi-service clients
 s.replace(
     'AUTHENTICATION.md',

--- a/google-cloud-talent/synth.py
+++ b/google-cloud-talent/synth.py
@@ -43,6 +43,9 @@ s.copy(v4beta1 / 'google-cloud-talent.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-talent.gemspec')
+
 # Update Authentication Guide for multi-service clients
 s.replace(
     'AUTHENTICATION.md',
@@ -95,7 +98,7 @@ s.replace(
 s.replace(
     'google-cloud-talent.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"\n\n'
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"\n\n'
 )
 
 # https://github.com/googleapis/gapic-generator/issues/2243
@@ -126,13 +129,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-talent.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 services = ['Application', 'Company', 'Job', 'Profile', 'Tenant']

--- a/google-cloud-tasks/.rubocop.yml
+++ b/google-cloud-tasks/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-tasks.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-tasks/README.md
+++ b/google-cloud-tasks/README.md
@@ -58,11 +58,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-tasks/google-cloud-tasks.gemspec
+++ b/google-cloud-tasks/google-cloud-tasks.gemspec
@@ -19,15 +19,15 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-tasks/synth.metadata
+++ b/google-cloud-tasks/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T01:03:47.137895Z",
+  "updateTime": "2019-10-18T21:04:13.411559Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-tasks/synth.metadata
+++ b/google-cloud-tasks/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-09-26T10:43:40.690832Z",
+  "updateTime": "2019-10-18T01:03:47.137895Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.37.1",
-        "dockerImage": "googleapis/artman@sha256:6068f67900a3f0bdece596b97bda8fc70406ca0e137a941f4c81d3217c994a80"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4c2ca81a0c976d4d37a8999984b7894d9af22124",
-        "internalRef": "271130964"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -63,6 +63,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-tasks.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Support for service_address
 s.replace(
     [

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -60,6 +60,9 @@ s.copy(v2_library / 'google-cloud-tasks.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-tasks.gemspec')
+
 # Support for service_address
 s.replace(
     [
@@ -144,13 +147,6 @@ s.replace(
     'https://googleapis.github.io/google-cloud-ruby'
 )
 
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-tasks.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
-)
-
 s.replace(
     'lib/google/cloud/tasks/v2/*.rb',
     "require 'google/api/resource_pb'\n",
@@ -173,7 +169,7 @@ s.replace(
     'google-cloud-tasks.gemspec',
     'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
-        'gem.add_dependency "google-gax", "~> 1.7"',
+        'gem.add_dependency "google-gax", "~> 1.8"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
     ])
 )

--- a/google-cloud-text_to_speech/.rubocop.yml
+++ b/google-cloud-text_to_speech/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-text_to_speech.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-text_to_speech/README.md
+++ b/google-cloud-text_to_speech/README.md
@@ -59,11 +59,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
+++ b/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-text_to_speech/synth.metadata
+++ b/google-cloud-text_to_speech/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T01:05:32.936627Z",
+  "updateTime": "2019-10-18T21:05:05.020375Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-text_to_speech/synth.metadata
+++ b/google-cloud-text_to_speech/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-09-28T10:41:16.488393Z",
+  "updateTime": "2019-10-18T01:05:32.936627Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.37.1",
-        "dockerImage": "googleapis/artman@sha256:6068f67900a3f0bdece596b97bda8fc70406ca0e137a941f4c81d3217c994a80"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "fcdec366bb4076be75649031706548128a01fc02",
-        "internalRef": "271635926"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -49,6 +49,9 @@ s.copy(v1beta1_library / 'test/google/cloud/text_to_speech/v1beta1')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-text_to_speech.gemspec')
+
 # Support for service_address
 s.replace(
     [
@@ -92,7 +95,7 @@ s.replace(
 s.replace(
     'google-cloud-text_to_speech.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
@@ -122,13 +125,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-text_to_speech.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 s.replace(

--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -52,6 +52,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-text_to_speech.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Support for service_address
 s.replace(
     [

--- a/google-cloud-trace/.rubocop.yml
+++ b/google-cloud-trace/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "acceptance/**/*"
@@ -11,52 +14,79 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Style/HashSyntax:
-  Exclude:
-    - "lib/google/cloud/trace/v1/**/*"
-Style/NumericLiterals:
-  Enabled: false
-Style/ClassVars:
-  Enabled: false
-Style/TrivialAccessors:
-  Enabled: false
-Style/CaseEquality:
-  Enabled: false
-Style/GuardClause:
-  Enabled: false
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
-Metrics/ClassLength:
-  Enabled: false
-Metrics/MethodLength:
-  Max: 20
-  Exclude:
-    - "lib/google/cloud/trace/v1/**/*"
-Metrics/LineLength:
-  Exclude:
-    - "lib/google/cloud/trace/v1/**/*"
-Metrics/ParameterLists:
+Layout/AlignHash:
   Enabled: false
 Lint/RescueException:
   Exclude:
     - "lib/google/cloud/trace/rails.rb"
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
+Metrics/ClassLength:
   Enabled: false
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-trace.rb"
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+Style/CaseEquality:
+  Enabled: false
+Style/ClassVars:
+  Enabled: false
+Style/GuardClause:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/MethodCallWithArgsParentheses:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/SafeNavigation:
+  Enabled: false
+Style/WhileUntilModifier:
+  Enabled: false
+
+# Style/StringLiterals:
+#   EnforcedStyle: double_quotes
+# Style/MethodDefParentheses:
+#   EnforcedStyle: require_no_parentheses
+# Style/HashSyntax:
+#   Exclude:
+#     - "lib/google/cloud/trace/v1/**/*"
+# Style/NumericLiterals:
+#   Enabled: false
+# Style/ClassVars:
+#   Enabled: false
+# Style/TrivialAccessors:
+#   Enabled: false
+# Style/CaseEquality:
+#   Enabled: false
+# Style/GuardClause:
+#   Enabled: false
+# Metrics/CyclomaticComplexity:
+#   Max: 10
+# Metrics/PerceivedComplexity:
+#   Max: 10
+# Metrics/AbcSize:
+#   Max: 25
+# Metrics/ClassLength:
+#   Enabled: false
+# Metrics/MethodLength:
+#   Max: 20
+#   Exclude:
+#     - "lib/google/cloud/trace/v1/**/*"
+# Metrics/LineLength:
+#   Exclude:
+#     - "lib/google/cloud/trace/v1/**/*"
+# Metrics/ParameterLists:
+#   Enabled: false
+# Lint/RescueException:
+#   Exclude:
+#     - "lib/google/cloud/trace/rails.rb"
+# Layout/EmptyLineAfterGuardClause:
+#   Enabled: false
+# Layout/EmptyLines: # for the extra line between copyright and code
+#   Enabled: false

--- a/google-cloud-trace/CONTRIBUTING.md
+++ b/google-cloud-trace/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-trace console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-trace requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud-trace requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-trace/README.md
+++ b/google-cloud-trace/README.md
@@ -207,11 +207,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -18,22 +18,22 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "INSTRUMENTATION.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "faraday", "~> 0.8"
-  gem.add_development_dependency "railties", "~> 4.0"
+  gem.add_development_dependency "railties", ">= 4.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest" #, "~> 0.1.6"

--- a/google-cloud-trace/lib/google/cloud/trace/service.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/service.rb
@@ -86,8 +86,6 @@ module Google
           Google::Cloud::Trace::TraceRecord.from_grpc trace_proto
         end
 
-        # rubocop:disable Metrics/MethodLength
-
         ##
         # Searches for traces matching the given criteria.
         #
@@ -124,8 +122,6 @@ module Google
             page_size: page_size,
             page_token: page_token
         end
-
-        # rubocop:enable Metrics/MethodLength
 
         # @private
         def inspect

--- a/google-cloud-trace/lib/google/cloud/trace/span.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/span.rb
@@ -116,8 +116,6 @@ module Google
           @labels = labels
         end
 
-        # rubocop:disable Metrics/AbcSize
-
         ##
         # Standard value equality check for this object.
         #
@@ -137,8 +135,6 @@ module Google
             labels == other.labels
         end
         alias == eql?
-
-        # rubocop:enable Metrics/AbcSize
 
         ##
         # Create a new Span object from a TraceSpan protobuf and insert it

--- a/google-cloud-translate/CONTRIBUTING.md
+++ b/google-cloud-translate/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-translate console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-translate requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud-translate requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-translate/README.md
+++ b/google-cloud-translate/README.md
@@ -64,11 +64,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-translate/google-cloud-translate.gemspec
+++ b/google-cloud-translate/google-cloud-translate.gemspec
@@ -16,11 +16,11 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "faraday", "~> 0.13"
-  gem.add_dependency "googleauth", ">= 0.6.2", "< 0.10.0"
+  gem.add_dependency "googleauth", "~> 0.9"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "google-style", "~> 0.3"

--- a/google-cloud-video_intelligence/.rubocop.yml
+++ b/google-cloud-video_intelligence/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud-video_intelligence.gemspec"
@@ -5,12 +8,6 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "acceptance/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-video_intelligence/README.md
+++ b/google-cloud-video_intelligence/README.md
@@ -98,11 +98,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
+++ b/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-video_intelligence/synth.metadata
+++ b/google-cloud-video_intelligence/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T01:07:54.530165Z",
+  "updateTime": "2019-10-18T21:05:45.998824Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-video_intelligence/synth.metadata
+++ b/google-cloud-video_intelligence/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-10-12T10:47:46.385242Z",
+  "updateTime": "2019-10-18T01:07:54.530165Z",
   "sources": [
     {
       "generator": {
@@ -12,8 +12,8 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "af8dd2c1750558b538eaa6bdaa3bc899079533ee",
-        "internalRef": "274260771"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -77,6 +77,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-video_intelligence.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Support for service_address
 s.replace(
     [

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -74,6 +74,9 @@ s.copy(v1beta2_library / 'test/google/cloud/video_intelligence/v1beta2')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-video_intelligence.gemspec')
+
 # Support for service_address
 s.replace(
     [
@@ -117,7 +120,7 @@ s.replace(
 s.replace(
     'google-cloud-video_intelligence.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
 
 # PERMANENT: API name for videointelligence
 s.replace(
@@ -170,13 +173,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'google-cloud-video_intelligence.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 s.replace(

--- a/google-cloud-vision/.rubocop.yml
+++ b/google-cloud-vision/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "acceptance/**/*"
@@ -10,35 +13,6 @@ AllCops:
     - "lib/google/cloud/vision/v1p3beta1.rb"
     - "lib/google/cloud/vision/v1p3beta1/**/*"
     - "test/**/*"
-  TargetRubyVersion: 2.2
-    
 
 Documentation:
-  Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Style/TrivialAccessors:
-  Enabled: false
-Style/FormatStringToken: # we have many uses of this, we don't want to change
-  Enabled: false
-Metrics/CyclomaticComplexity:
-  Max: 15
-Metrics/PerceivedComplexity:
-  Max: 15
-Metrics/AbcSize:
-  Max: 25
-Metrics/ClassLength:
-  Enabled: false
-Metrics/MethodLength:
-  Max: 26
-Metrics/ParameterLists:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
-  Enabled: false
-Naming/UncommunicativeMethodParamName:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
   Enabled: false

--- a/google-cloud-vision/README.md
+++ b/google-cloud-vision/README.md
@@ -84,11 +84,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-vision/google-cloud-vision.gemspec
+++ b/google-cloud-vision/google-cloud-vision.gemspec
@@ -25,13 +25,13 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-vision/synth.metadata
+++ b/google-cloud-vision/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-10T10:45:14.340019Z",
+  "updateTime": "2019-10-18T01:09:15.562056Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.38.0",
-        "dockerImage": "googleapis/artman@sha256:0d2f8d429110aeb8d82df6550ef4ede59d40df9062d260a1580fce688b0512bf"
+        "version": "0.39.0",
+        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "10f91fa12f70e8e0209a45fc10807ed1f77c7e4e",
-        "internalRef": "273826591"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-vision/synth.metadata
+++ b/google-cloud-vision/synth.metadata
@@ -1,11 +1,11 @@
 {
-  "updateTime": "2019-10-18T01:09:15.562056Z",
+  "updateTime": "2019-10-18T21:06:39.867033Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.39.0",
-        "dockerImage": "googleapis/artman@sha256:72554d0b3bdc0b4ac7d6726a6a606c00c14b454339037ed86be94574fb05d9f3"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {

--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -55,6 +55,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-vision.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Update Authentication Guide for multi-service clients
 s.replace(
     'AUTHENTICATION.md',

--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -52,6 +52,9 @@ s.copy(v1p3beta1 / 'test/google/cloud/vision/v1p3beta1')
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-vision.gemspec')
+
 # Update Authentication Guide for multi-service clients
 s.replace(
     'AUTHENTICATION.md',
@@ -102,7 +105,7 @@ s.replace(
 s.replace(
     'google-cloud-vision.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
 
 # PERMANENT: Add migration guide to docs
 s.replace(
@@ -188,11 +191,6 @@ s.replace(
     ['lib/**/*.rb', 'README.md'],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-s.replace(
-    'google-cloud-vision.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 s.replace(

--- a/google-cloud-webrisk/.rubocop.yml
+++ b/google-cloud-webrisk/.rubocop.yml
@@ -1,5 +1,7 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
-  TargetRubyVersion: 2.2
   Exclude:
     - "google-cloud-webrisk.gemspec"
     - "lib/google/**/*"
@@ -9,8 +11,3 @@ AllCops:
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud-webrisk/README.md
+++ b/google-cloud-webrisk/README.md
@@ -58,11 +58,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-webrisk/google-cloud-webrisk.gemspec
+++ b/google-cloud-webrisk/google-cloud-webrisk.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/google-cloud-webrisk/synth.metadata
+++ b/google-cloud-webrisk/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-10-18T01:15:10.545286Z",
+  "updateTime": "2019-10-18T20:46:43.983890Z",
   "sources": [
     {
       "generator": {

--- a/google-cloud-webrisk/synth.metadata
+++ b/google-cloud-webrisk/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-09T10:46:38.983137Z",
+  "updateTime": "2019-10-18T01:15:10.545286Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.38.0",
-        "dockerImage": "googleapis/artman@sha256:0d2f8d429110aeb8d82df6550ef4ede59d40df9062d260a1580fce688b0512bf"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "2dec8f98383214ad4fafa7680eb0cc46d6531976",
-        "internalRef": "273619851"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/google-cloud-webrisk/synth.py
+++ b/google-cloud-webrisk/synth.py
@@ -40,6 +40,9 @@ s.copy(v1beta1 / 'google-cloud-webrisk.gemspec', merge=ruby.merge_gemspec)
 templates = gcp.CommonTemplates().ruby_library()
 s.copy(templates)
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('google-cloud-webrisk.gemspec')
+
 # Support for service_address
 s.replace(
     [
@@ -83,7 +86,7 @@ s.replace(
 s.replace(
     'google-cloud-webrisk.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
 
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
@@ -108,11 +111,7 @@ s.replace(
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
 )
-s.replace(
-    'google-cloud-webrisk.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
-)
+
 # Fix product documentation links
 s.replace(
     ['README.md', 'lib/**/*.rb'],

--- a/google-cloud-webrisk/synth.py
+++ b/google-cloud-webrisk/synth.py
@@ -43,6 +43,13 @@ s.copy(templates)
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('google-cloud-webrisk.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Support for service_address
 s.replace(
     [

--- a/google-cloud/.rubocop.yml
+++ b/google-cloud/.rubocop.yml
@@ -1,9 +1,11 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "google-cloud.gemspec"
     - "Rakefile"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
@@ -16,7 +18,3 @@ Metrics/LineLength:
 Naming/FileName:
   Exclude:
     - "lib/google-cloud.rb"
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/google-cloud/CONTRIBUTING.md
+++ b/google-cloud/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud requires Ruby 2.3+. You may choose to
+1. Install Ruby. google-cloud requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud/README.md
+++ b/google-cloud/README.md
@@ -82,11 +82,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud/google-cloud.gemspec
+++ b/google-cloud/google-cloud.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
 
   gem.add_dependency "google-cloud-asset", "~> 0.1"
@@ -55,12 +55,12 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-vision", "~> 0.28"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"

--- a/grafeas-client/.rubocop.yml
+++ b/grafeas-client/.rubocop.yml
@@ -1,5 +1,7 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
-  TargetRubyVersion: 2.2
   Exclude:
     - "grafeas-client.gemspec"
     - "lib/**/*"
@@ -9,8 +11,3 @@ AllCops:
 
 Documentation:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses

--- a/grafeas-client/README.md
+++ b/grafeas-client/README.md
@@ -59,11 +59,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/grafeas-client/grafeas-client.gemspec
+++ b/grafeas-client/grafeas-client.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |gem|
                       ["README.md", "AUTHENTICATION.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/grafeas-client/synth.metadata
+++ b/grafeas-client/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-10-18T01:18:25.968956Z",
+  "updateTime": "2019-10-18T20:45:55.386633Z",
   "sources": [
     {
       "generator": {

--- a/grafeas-client/synth.metadata
+++ b/grafeas-client/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-08-27T10:47:25.176961Z",
+  "updateTime": "2019-10-18T01:18:25.968956Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.35.1",
-        "dockerImage": "googleapis/artman@sha256:b11c7ea0d0831c54016fb50f4b796d24d1971439b30fbc32a369ba1ac887c384"
+        "version": "0.40.0",
+        "dockerImage": "googleapis/artman@sha256:fd2b49cce3d652929cc80157ec2d91bebe993f7cd4e89afaad80f9c785f8bf36"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "650caad718bb063f189405c23972dc9818886358",
-        "internalRef": "265565344"
+        "sha": "906335b5a958557e1070fc6f275171dc8a42b1ec",
+        "internalRef": "275374583"
       }
     },
     {

--- a/grafeas-client/synth.py
+++ b/grafeas-client/synth.py
@@ -72,6 +72,13 @@ s.replace(
 # Update gemspec to reflect Ruby 2.4
 ruby.update_gemspec('grafeas-client.gemspec')
 
+# Update README to reflect Ruby 2.4
+s.replace(
+    'README.md',
+    'Ruby 2.3',
+    'Ruby 2.4'
+)
+
 # Hack AUTHENTICATION.md to fix nonstandard name.
 s.replace(
     'AUTHENTICATION.md',

--- a/grafeas-client/synth.py
+++ b/grafeas-client/synth.py
@@ -69,6 +69,9 @@ s.replace(
     'gem install grafeas-client\n'
 )
 
+# Update gemspec to reflect Ruby 2.4
+ruby.update_gemspec('grafeas-client.gemspec')
+
 # Hack AUTHENTICATION.md to fix nonstandard name.
 s.replace(
     'AUTHENTICATION.md',
@@ -139,7 +142,7 @@ s.replace(
 s.replace(
     'grafeas-client.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.7"\n')
+    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
 
 # Fix for tests that assume protos implement to_hash
 s.replace(
@@ -199,13 +202,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-
-# https://github.com/googleapis/gapic-generator/issues/2393
-s.replace(
-    'grafeas-client.gemspec',
-    'gem.add_development_dependency "rubocop".*$',
-    'gem.add_development_dependency "rubocop", "~> 0.64.0"'
 )
 
 s.replace(

--- a/stackdriver-core/.rubocop.yml
+++ b/stackdriver-core/.rubocop.yml
@@ -31,32 +31,3 @@ Style/NumericPredicate:
   Enabled: false
 Style/SafeNavigation:
   Enabled: false
-
-# Style/StringLiterals:
-#   EnforcedStyle: double_quotes
-# Style/MethodDefParentheses:
-#   EnforcedStyle: require_no_parentheses
-# Style/ClassVars:
-#   Exclude:
-#     - "lib/google/cloud/configuration.rb"
-# Metrics/CyclomaticComplexity:
-#   Max: 10
-# Metrics/PerceivedComplexity:
-#   Max: 10
-# Metrics/AbcSize:
-#   Max: 25
-# Metrics/ClassLength:
-#   Enabled: false
-# Metrics/MethodLength:
-#   Max: 20
-# Metrics/ModuleLength:
-#   Enabled: false
-# Metrics/ParameterLists:
-#   Enabled: false
-# Layout/EmptyLineAfterGuardClause:
-#   Enabled: false
-# Layout/EmptyLines: # for the extra line between copyright and code
-#   Enabled: false
-# Naming/AccessorMethodName:
-#   Exclude:
-#     - "lib/stackdriver/core/async_actor.rb"

--- a/stackdriver-core/.rubocop.yml
+++ b/stackdriver-core/.rubocop.yml
@@ -1,41 +1,62 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "stackdriver-core.gemspec"
     - "Rakefile"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Style/ClassVars:
-  Exclude:
-    - "lib/google/cloud/configuration.rb"
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
-Metrics/ClassLength:
+Layout/AlignHash:
   Enabled: false
-Metrics/MethodLength:
-  Max: 20
 Metrics/ModuleLength:
   Enabled: false
-Metrics/ParameterLists:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLines: # for the extra line between copyright and code
+Metrics/ClassLength:
   Enabled: false
 Naming/AccessorMethodName:
-  Exclude:
-    - "lib/stackdriver/core/async_actor.rb"
+  Enabled: false
 Naming/FileName:
   Exclude:
     - "lib/stackdriver-core.rb"
+Style/EmptyMethod:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/MethodCallWithArgsParentheses:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/SafeNavigation:
+  Enabled: false
+
+# Style/StringLiterals:
+#   EnforcedStyle: double_quotes
+# Style/MethodDefParentheses:
+#   EnforcedStyle: require_no_parentheses
+# Style/ClassVars:
+#   Exclude:
+#     - "lib/google/cloud/configuration.rb"
+# Metrics/CyclomaticComplexity:
+#   Max: 10
+# Metrics/PerceivedComplexity:
+#   Max: 10
+# Metrics/AbcSize:
+#   Max: 25
+# Metrics/ClassLength:
+#   Enabled: false
+# Metrics/MethodLength:
+#   Max: 20
+# Metrics/ModuleLength:
+#   Enabled: false
+# Metrics/ParameterLists:
+#   Enabled: false
+# Layout/EmptyLineAfterGuardClause:
+#   Enabled: false
+# Layout/EmptyLines: # for the extra line between copyright and code
+#   Enabled: false
+# Naming/AccessorMethodName:
+#   Exclude:
+#     - "lib/stackdriver/core/async_actor.rb"

--- a/stackdriver-core/CONTRIBUTING.md
+++ b/stackdriver-core/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the stackdriver console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. stackdriver requires Ruby 2.3+. You may choose to
+1. Install Ruby. stackdriver requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/stackdriver-core/README.md
+++ b/stackdriver-core/README.md
@@ -9,11 +9,11 @@ information about the individual google-cloud gems.
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/stackdriver-core/stackdriver-core.gemspec
+++ b/stackdriver-core/stackdriver-core.gemspec
@@ -16,16 +16,16 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "CONTRIBUTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"

--- a/stackdriver/.rubocop.yml
+++ b/stackdriver/.rubocop.yml
@@ -1,17 +1,12 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "*.gemspec"
     - "Rakefile"
     - "lib/legacy_stackdriver.rb"
     - "test/**/*"
-  TargetRubyVersion: 2.2
 
 Documentation:
-  Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Layout/EmptyLines: # for the extra line between copyright and code
   Enabled: false

--- a/stackdriver/CONTRIBUTING.md
+++ b/stackdriver/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the stackdriver console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. stackdriver requires Ruby 2.3+. You may choose to
+1. Install Ruby. stackdriver requires Ruby 2.4+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -108,11 +108,11 @@ See the gem documentation for each individual gem for more information.
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.3+.
+This library is supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.3 and
+security maintenance, and not end of life. Currently, this means Ruby 2.4 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/stackdriver/stackdriver.gemspec
+++ b/stackdriver/stackdriver.gemspec
@@ -16,20 +16,20 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "INSTRUMENTATION_CONFIGURATION.md", "CONTRIBUTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.2.0"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_runtime_dependency "google-cloud-debugger", "~> 0.32"
   gem.add_runtime_dependency "google-cloud-error_reporting", "~> 0.30"
   gem.add_runtime_dependency "google-cloud-logging", "~> 1.5"
   gem.add_runtime_dependency "google-cloud-trace", "~> 0.33"
 
+  gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.6"


### PR DESCRIPTION
It turns out I needed to move everything to google-style anyway because moving the Ruby dependency to 2.4 causes Rubocop to want to use a later TargetRubyVersion. So all the Rubocop configs now inherit from google-style. There were a bunch of new Rubocop failures, but I didn't go through and correct them in code. Instead, I just disabled the corresponding cops in the Rubocop configs. Later we need to do a cleanup pass and either fix the code itself, or modify google-style to customize or disable those cops.

* Updated all minimum Ruby dependencies to `>= 2.4`.
* Updated all gax dependencies to `~> 1.8`.
* Updated all googleauth dependencies to `~> 0.9`.
* Updated all direct google-api-client dependencies to `~> 0.33`.
* Replaced all direct rubocop dependencies with google-style `~> 1.24.0`.
* Updated synth scripts for libraries that generate their gemspecs. (This includes all fully-generated libraries.)
* Changed all rubocop configs to inherit google-style, and disabled any failing cops.
