### PR TITLE
fix!(bigtable): Add MutationOperations::Response and Bigtable::Status

### DIFF
--- a/google-cloud-bigtable/acceptance/bigtable/table/mutate_rows_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/mutate_rows_test.rb
@@ -32,10 +32,10 @@ describe "DataClient Mutate Rows", :bigtable do
     entry2 = table.new_mutation_entry("#{row_key}-2")
     entry2.set_cell(family, qualifier, "mutatetest value #{postfix} 2")
 
-    statuses = table.mutate_rows([entry1, entry2])
-    statuses.length.must_equal 2
+    responses = table.mutate_rows([entry1, entry2])
+    responses.length.must_equal 2
 
-    success_count = statuses.count{|s| s.status.code == 0 }
+    success_count = responses.count{ |r| r.status.code == 0 }
 
     keys = ["#{row_key}-1", "#{row_key}-2"]
     rows = table.read_rows(keys: keys).to_a

--- a/google-cloud-bigtable/acceptance/bigtable/table_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table_test.rb
@@ -63,7 +63,10 @@ describe "Instance Tables", :bigtable do
       table.new_mutation_entry(key).set_cell("cf", "field1", "v-#{i+1}")
     end
 
-    table.mutate_rows(entries)
+    responses = table.mutate_rows(entries)
+    responses.count.must_equal entries.count
+    responses.each { |r| r.status.code.must_equal 0 }
+
     sample_keys = table.sample_row_keys.to_a.map(&:key)
 
     initial_splits.each do |key|

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
@@ -57,6 +57,7 @@ module Google
       class MutationEntry
         attr_accessor :row_key
 
+        # @private
         # mutations gRPC list
         # @return [Array<Google::Bigtable::V2::Mutation>]
         attr_accessor :mutations

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
@@ -111,7 +111,7 @@ module Google
         #   responses = table.mutate_rows(entries)
         #
         #   responses.each do |response|
-        #     puts response.status
+        #     puts response.status.description
         #   end
         #
         def mutate_rows entries
@@ -375,7 +375,7 @@ module Google
         #   responses = table.mutate_rows(entries)
         #
         #   responses.each do |response|
-        #     puts response.status
+        #     puts response.status.description
         #   end
         #
         class Response

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
@@ -19,6 +19,7 @@ require "google/cloud/bigtable/mutation_entry"
 require "google/cloud/bigtable/row"
 require "google/cloud/bigtable/rows_mutator"
 require "google/cloud/bigtable/read_modify_write_rule"
+require "google/cloud/bigtable/status"
 
 module Google
   module Cloud
@@ -107,10 +108,15 @@ module Google
         #   entries = []
         #   entries << table.new_mutation_entry("row-1").set_cell("cf1", "field1", "XYZ")
         #   entries << table.new_mutation_entry("row-2").set_cell("cf1", "field1", "ABC")
-        #   table.mutate_rows(entries)
+        #   responses = table.mutate_rows(entries)
+        #
+        #   responses.each do |response|
+        #     puts response.status
+        #   end
         #
         def mutate_rows entries
-          RowsMutator.new(self, entries).apply_mutations
+          statuses = RowsMutator.new(self, entries).apply_mutations
+          statuses.map { |s| Response.from_grpc s }
         end
 
         ##
@@ -227,14 +233,14 @@ module Google
         #   otherwise_mutations = Google::Cloud::Bigtable::MutationEntry.new
         #   otherwise_mutations.delete_from_family("cf3")
         #
-        #   response = table.check_and_mutate_row(
+        #   predicate_matched = table.check_and_mutate_row(
         #     "user01",
         #     predicate_filter,
         #     on_match: on_match_mutations,
         #     otherwise: otherwise_mutations
         #   )
         #
-        #   if response
+        #   if predicate_matched
         #     puts "All predicates matched"
         #   end
         #
@@ -341,6 +347,53 @@ module Google
         #
         def new_read_modify_write_rule family, qualifier
           Google::Cloud::Bigtable::ReadModifyWriteRule.new(family, qualifier)
+        end
+
+        ##
+        # # MutationEntry::Response
+        #
+        # Represents a response message from BigtableService.MutateRows.
+        #
+        # @attr [Integer] index The index into the original request's `entries`
+        #   list of the Entry for which a result is being reported.
+        # @attr [Google::Cloud::Bigtable::Status] The result of the request
+        #   Entry identified by `index`. Depending on how requests are batched
+        #   during execution, it is possible for one Entry to fail due to an
+        #   error with another Entry. In the event that this occurs, the same
+        #   error will be reported for both entries.
+        #
+        # @example
+        #   require "google/cloud/bigtable"
+        #
+        #   bigtable = Google::Cloud::Bigtable.new
+        #
+        #   table = bigtable.table("my-instance", "my-table")
+        #
+        #   entries = []
+        #   entries << table.new_mutation_entry("row-1").set_cell("cf1", "field1", "XYZ")
+        #   entries << table.new_mutation_entry("row-2").set_cell("cf1", "field1", "ABC")
+        #   responses = table.mutate_rows(entries)
+        #
+        #   responses.each do |response|
+        #     puts response.status
+        #   end
+        #
+        class Response
+          attr_reader :index, :status
+
+          ##
+          # @private Creates a MutationEntry::Response object.
+          def initialize index, status
+            @index = index
+            @status = status
+          end
+
+          ##
+          # @private New MutationEntry::Response from a
+          # Google::Bigtable::V2::MutateRowsResponse::Entry object.
+          def self.from_grpc grpc
+            new grpc.index, Status.from_grpc(grpc.status)
+          end
         end
       end
     end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/status.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/status.rb
@@ -30,7 +30,7 @@ module Google
       #   For example, `INVALID_ARGUMENT`.
       # @attr [String] message A developer-facing error message, which should be
       #   in English.
-      # @attr [Array] details A list of messages that carry the error
+      # @attr [Array<String>] details A list of messages that carry the error
       #   details.
       #
       # @example

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/status.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/status.rb
@@ -30,7 +30,7 @@ module Google
       #   For example, `INVALID_ARGUMENT`.
       # @attr [String] message A developer-facing error message, which should be
       #   in English.
-      # @attr [Array, nil] details A list of messages that carry the error
+      # @attr [Array] details A list of messages that carry the error
       #   details.
       #
       # @example
@@ -46,7 +46,7 @@ module Google
       #   responses = table.mutate_rows(entries)
       #
       #   responses.each do |response|
-      #     puts response.status
+      #     puts response.status.description
       #   end
       #
       class Status

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/status.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/status.rb
@@ -1,0 +1,83 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Bigtable
+      ##
+      # # Status
+      #
+      # Represents a logical error model from the Bigtable service, containing an
+      # error code, an error message, and optional error details.
+      #
+      # @attr [Integer] code The status code, which should be an enum value of
+      #   [google.rpc.Code](https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto).
+      # @attr [String] description The human-readable description for the status
+      #   code, which should be an enum value of
+      #   [google.rpc.Code](https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto).
+      #   For example, `INVALID_ARGUMENT`.
+      # @attr [String] message A developer-facing error message, which should be
+      #   in English.
+      # @attr [Array, nil] details A list of messages that carry the error
+      #   details.
+      #
+      # @example
+      #   require "google/cloud/bigtable"
+      #
+      #   bigtable = Google::Cloud::Bigtable.new
+      #
+      #   table = bigtable.table("my-instance", "my-table")
+      #
+      #   entries = []
+      #   entries << table.new_mutation_entry("row-1").set_cell("cf1", "field1", "XYZ")
+      #   entries << table.new_mutation_entry("row-2").set_cell("cf1", "field1", "ABC")
+      #   responses = table.mutate_rows(entries)
+      #
+      #   responses.each do |response|
+      #     puts response.status
+      #   end
+      #
+      class Status
+        attr_reader :code, :description, :message, :details
+
+        ##
+        # @private Creates a Status object.
+        def initialize code, description, message, details
+          @code = code
+          @description = description
+          @message = message
+          @details = details
+        end
+
+        ##
+        # @private New Status from a Google::Rpc::Status object.
+        def self.from_grpc grpc
+          new grpc.code, description_for(grpc.code), grpc.message, grpc.details
+        end
+
+        # @private Get a descriptive symbol for a google.rpc.Code integer
+        def self.description_for code
+          descriptions = %w[
+            OK CANCELLED UNKNOWN INVALID_ARGUMENT DEADLINE_EXCEEDED NOT_FOUND
+            ALREADY_EXISTS PERMISSION_DENIED RESOURCE_EXHAUSTED
+            FAILED_PRECONDITION ABORTED OUT_OF_RANGE UNIMPLEMENTED INTERNAL
+            UNAVAILABLE DATA_LOSS UNAUTHENTICATED
+          ]
+          descriptions[code]
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-bigtable/support/doctest_helper.rb
+++ b/google-cloud-bigtable/support/doctest_helper.rb
@@ -399,6 +399,12 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigtable::MutationOperations::Response" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables|
+      mock.expect :mutate_rows, [], ["projects/my-project/instances/my-instance/tables/my-table", Array, Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigtable::Policy" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
       mocked_instances.expect :get_instance, instance_resp, ["projects/my-project/instances/my-instance"]
@@ -496,6 +502,12 @@ YARD::Doctest.configure do |doctest|
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
       mocked_tables.expect :get_table, table_resp, ["projects/my-project/instances/my-instance/tables/my-table", Hash]
       mock.expect :sample_row_keys, [], ["projects/my-project/instances/my-instance/tables/my-table", Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigtable::Status" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables|
+      mock.expect :mutate_rows, [], ["projects/my-project/instances/my-instance/tables/my-table", Array, Hash]
     end
   end
 


### PR DESCRIPTION
BREAKING CHANGES: Change return type of `MutationOperations#mutate_rows` from
lower-level API types to wrapper types. Remove `MutationEntry#mutations`
from documentation.

* Change return type of `MutationOperations#mutate_rows`.
* Mark `MutationEntry#mutations` as private for docs.

[refs #4146]