### PR TITLE
Fix GcRule#max_age precision

### DIFF
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/gc_rule.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/gc_rule.rb
@@ -109,7 +109,7 @@ module Google
         # (TTL) for data. Cloud Bigtable looks at each column family during
         # garbage collection and removes any cells that have expired.
         #
-        # @param age [Integer] Max age in seconds. Values must be at least one
+        # @param age [Numeric] Max age in seconds. Values must be at least one
         #   millisecond, and will be truncated to microsecond granularity.
         #
         def max_age= age
@@ -122,7 +122,7 @@ module Google
         # (TTL) for data. Cloud Bigtable looks at each column family during
         # garbage collection and removes any cells that have expired.
         #
-        # @return [Integer, nil] Max age in seconds.
+        # @return [Numeric, nil] Max age in seconds.
         #
         # @example
         #   require "google/cloud/bigtable"
@@ -136,7 +136,7 @@ module Google
         #   puts table.column_families["cf1"].gc_rule.max_age
         #
         def max_age
-          @grpc.max_age&.seconds
+          Convert.duration_to_number @grpc.max_age
         end
 
         ##

--- a/google-cloud-bigtable/test/google/cloud/bigtable/gc_rule_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/gc_rule_test.rb
@@ -40,6 +40,19 @@ describe Google::Cloud::Bigtable::GcRule, :mock_bigtable do
     gc_rule.to_grpc.must_equal expected_grpc
   end
 
+  it "updates a max age gc rule using microseconds" do
+    gc_rule = Google::Cloud::Bigtable::GcRule.max_age(100.001)
+
+    gc_rule.max_age.must_equal 100.001
+    gc_rule.max_age = 200.999999999
+
+    gc_rule.max_age.must_equal 200.999999999
+    expected_grpc = Google::Bigtable::Admin::V2::GcRule.new(
+      max_age: Google::Protobuf::Duration.new(seconds: 200, nanos: 999999999)
+    )
+    gc_rule.to_grpc.must_equal expected_grpc
+  end
+
   it "creates a max versions gc rule" do
     gc_rule = Google::Cloud::Bigtable::GcRule.max_versions(3)
 


### PR DESCRIPTION
The documentation for GcRule's max_age mentions microsecond precision,
but the value was always rounded down to the lowest whole second.
Update the code to allow for fractional seconds.