### PR TITLE
chore(grafeas-client): Add .repo-metadata

### DIFF
--- a/grafeas-client/.repo-metadata.json
+++ b/grafeas-client/.repo-metadata.json
@@ -1,0 +1,8 @@
+{
+  "name": "grafeas-client",
+  "language": "ruby",
+  "distribution_name": "grafeas-client",
+  "module_name": "Grafeas",
+  "module_name_credentials": "Grafeas::V1",
+  "env_var_prefix": "GRAFEAS"
+}

--- a/grafeas-client/.repo-metadata.json
+++ b/grafeas-client/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "grafeas-client",
+  "name": "grafeas",
   "language": "ruby",
   "distribution_name": "grafeas-client",
   "module_name": "Grafeas",


### PR DESCRIPTION
I don't think `module_name` and `module_name_credentials` are even used if there's no synth. But I'm copying the values from `grafeas` anyway, just to make sure the schema is the same. We can clean it up later.