### PR TITLE
Allow passing an empty array as a value for params

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -199,10 +199,16 @@ module Google
             )
           elsif Array === value
             array_params = value.map { |param| Convert.to_query_param param }
+            array_type =
+              if array_params.empty?
+                Google::Apis::BigqueryV2::QueryParameterType.new(type: "STRING")
+              else
+                array_params.first.parameter_type
+              end
             return Google::Apis::BigqueryV2::QueryParameter.new(
               parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
                 type: "ARRAY",
-                array_type: array_params.first.parameter_type
+                array_type: array_type
               ),
               parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
                 array_values: array_params.map(&:parameter_value)

--- a/google-cloud-bigquery/test/google/cloud/bigquery/convert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/convert_test.rb
@@ -63,4 +63,24 @@ describe Google::Cloud::Bigquery::Convert do
       f.must_be :nan?
     end
   end
+
+  describe :to_query_param do
+    it "converts an array correctly" do
+      f = Google::Cloud::Bigquery::Convert.to_query_param([1, 2])
+      f.must_be_kind_of Google::Apis::BigqueryV2::QueryParameter
+      f.to_h.must_equal({
+        parameter_type: { array_type: { type: "INT64" }, type: "ARRAY" },
+        parameter_value: { array_values: [{ value: 1 }, { value: 2 }] }
+      })
+    end
+
+    it "converts an empty array correctly" do
+      f = Google::Cloud::Bigquery::Convert.to_query_param([])
+      f.must_be_kind_of Google::Apis::BigqueryV2::QueryParameter
+      f.to_h.must_equal({
+        parameter_type: { array_type: { type: "STRING" }, type: "ARRAY" },
+        parameter_value: { array_values: [] }
+      })
+    end
+  end
 end


### PR DESCRIPTION
Currently passing an empty array causes the following error:
```
NoMethodError: undefined method `parameter_type' for nil:NilClass
```
This is due to Convert.to_query_param trying to use the type of the first element as array_type without checking if a given array has an element.

This PR adds the necessary check.