### PR TITLE
feat(storage): Add force_copy_metadata to File#copy and #rewrite

### DIFF
--- a/google-cloud-storage/acceptance/storage/file_encryption_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_encryption_test.rb
@@ -102,13 +102,14 @@ describe Google::Cloud::Storage::File, :storage do
     end
 
     it "should add, rotate, and remove customer-supplied encryption keys for an existing file" do
-      uploaded = bucket.create_file file_path, file_name
+      uploaded = bucket.create_file file_path, file_name, content_language: "en"
 
       rewritten = try_with_backoff "add encryption key" do
         uploaded.rotate new_encryption_key: encryption_key
       end
       rewritten.name.must_equal uploaded.name
       rewritten.size.must_equal uploaded.size
+      rewritten.content_language.must_equal "en"
 
       rewritten2 = try_with_backoff "rotate encryption keys" do
         uploaded.rotate encryption_key: encryption_key, new_encryption_key: encryption_key_2

--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -477,13 +477,18 @@ describe Google::Cloud::Storage::File, :storage do
   end
 
   it "should copy an existing file" do
-    uploaded = bucket.create_file files[:logo][:path], "CloudLogo"
+    uploaded = bucket.create_file files[:logo][:path], "CloudLogo",
+                                  content_language: "en"
+    uploaded.content_language.must_equal "en"
+
     copied = try_with_backoff "copying existing file" do
       uploaded.copy "CloudLogoCopy"
     end
 
     uploaded.name.must_equal "CloudLogo"
+    uploaded.content_language.must_equal "en"
     copied.name.must_equal "CloudLogoCopy"
+    copied.content_language.must_equal "en"
     copied.size.must_equal uploaded.size
 
     Tempfile.open ["CloudLogo", ".png"] do |tmpfile1|

--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -477,8 +477,7 @@ describe Google::Cloud::Storage::File, :storage do
   end
 
   it "should copy an existing file" do
-    uploaded = bucket.create_file files[:logo][:path], "CloudLogo",
-                                  content_language: "en"
+    uploaded = bucket.create_file files[:logo][:path], "CloudLogo", content_language: "en"
     uploaded.content_language.must_equal "en"
 
     copied = try_with_backoff "copying existing file" do
@@ -508,9 +507,9 @@ describe Google::Cloud::Storage::File, :storage do
   end
 
   it "should copy an existing file, with updates" do
-    uploaded = bucket.create_file files[:logo][:path], "CloudLogo",
-                                  content_language: "en"
+    uploaded = bucket.create_file files[:logo][:path], "CloudLogo", content_language: "en", content_type: "image/png"
     uploaded.content_language.must_equal "en"
+    uploaded.content_type.must_equal "image/png"
 
     copied = try_with_backoff "copying existing file" do
       uploaded.copy "CloudLogoCopy" do |copy|
@@ -519,6 +518,41 @@ describe Google::Cloud::Storage::File, :storage do
     end
     uploaded.content_language.must_equal "en"
     copied.content_language.must_equal "de"
+    copied.content_type.must_be :nil?
+
+    uploaded.name.must_equal "CloudLogo"
+    copied.name.must_equal "CloudLogoCopy"
+    copied.size.must_equal uploaded.size
+
+    Tempfile.open ["CloudLogo", ".png"] do |tmpfile1|
+      tmpfile1.binmode
+      Tempfile.open ["CloudLogoCopy", ".png"] do |tmpfile2|
+        tmpfile2.binmode
+        downloaded1 = uploaded.download tmpfile1
+        downloaded2 = copied.download tmpfile2
+        downloaded1.size.must_equal downloaded2.size
+
+        File.read(downloaded1.path, mode: "rb").must_equal File.read(downloaded2.path, mode: "rb")
+      end
+    end
+
+    uploaded.delete
+    copied.delete
+  end
+
+  it "should copy an existing file, with force_copy_metadata set to true" do
+    uploaded = bucket.create_file files[:logo][:path], "CloudLogo", content_language: "en", content_type: "image/png"
+    uploaded.content_language.must_equal "en"
+    uploaded.content_type.must_equal "image/png"
+
+    copied = try_with_backoff "copying existing file" do
+      uploaded.copy "CloudLogoCopy", force_copy_metadata: true do |copy|
+        copy.content_language = "de"
+      end
+    end
+    uploaded.content_language.must_equal "en"
+    copied.content_language.must_equal "de"
+    copied.content_type.must_equal "image/png"
 
     uploaded.name.must_equal "CloudLogo"
     copied.name.must_equal "CloudLogoCopy"
@@ -547,6 +581,41 @@ describe Google::Cloud::Storage::File, :storage do
 
     copied = try_with_backoff "rewriting existing file" do
       uploaded.rewrite "CloudLogoCopy.png" do |f|
+        f.cache_control = "public, max-age: 7200"
+      end
+    end
+    uploaded.cache_control.must_be :nil?
+    uploaded.content_type.must_equal "image/png"
+    copied.cache_control.must_equal "public, max-age: 7200"
+    copied.content_type.must_be :nil?
+
+    uploaded.name.must_equal "CloudLogo.png"
+    copied.name.must_equal "CloudLogoCopy.png"
+    copied.size.must_equal uploaded.size
+
+    Tempfile.open ["CloudLogo", ".png"] do |tmpfile1|
+      tmpfile1.binmode
+      Tempfile.open ["CloudLogoCopy", ".png"] do |tmpfile2|
+        tmpfile2.binmode
+        downloaded1 = uploaded.download tmpfile1
+        downloaded2 = copied.download tmpfile2
+        downloaded1.size.must_equal downloaded2.size
+
+        File.read(downloaded1.path, mode: "rb").must_equal File.read(downloaded2.path, mode: "rb")
+      end
+    end
+
+    uploaded.delete
+    copied.delete
+  end
+
+  it "should rewrite an existing file, with force_copy_metadata set to true" do
+    uploaded = bucket.create_file files[:logo][:path], "CloudLogo.png"
+    uploaded.cache_control.must_be :nil?
+    uploaded.content_type.must_equal "image/png"
+
+    copied = try_with_backoff "rewriting existing file" do
+      uploaded.rewrite "CloudLogoCopy.png", force_copy_metadata: true do |f|
         f.cache_control = "public, max-age: 7200"
       end
     end

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -1199,11 +1199,11 @@ module Google
 
           update_gapi = nil
           if block_given?
-            updater = Updater.new gapi
+            updater = Updater.new gapi.dup
             yield updater
             updater.check_for_changed_metadata!
             if updater.updates.any?
-              update_gapi = gapi_from_attrs updater.updates
+              update_gapi = updater.gapi
             end
           end
 
@@ -1791,7 +1791,7 @@ module Google
         # Yielded to a block to accumulate changes for a patch request.
         class Updater < File
           # @private
-          attr_reader :updates
+          attr_reader :updates, :gapi
 
           ##
           # @private Create an Updater object.

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -776,15 +776,15 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     it "can copy itself while updating its attributes" do
       mock = Minitest::Mock.new
-      update_file_gapi = Google::Apis::StorageV1::Object.new(
-        cache_control: "private, max-age=0, no-cache",
-        content_disposition: "inline; filename=filename.ext",
-        content_encoding: "deflate",
-        content_language: "de",
-        content_type: "application/json",
-        metadata: { "player" => "Bob", "score" => "10" },
-        storage_class: "NEARLINE"
-      )
+      update_file_gapi = file_gapi.dup
+      update_file_gapi.cache_control = "private, max-age=0, no-cache"
+      update_file_gapi.content_disposition = "inline; filename=filename.ext"
+      update_file_gapi.content_encoding = "deflate"
+      update_file_gapi.content_language = "de"
+      update_file_gapi.content_type = "application/json"
+      update_file_gapi.metadata = { "player" => "Bob", "score" => "10" }
+      update_file_gapi.storage_class = "NEARLINE"
+
       mock.expect :rewrite_object, done_rewrite(file_gapi),
         [bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
 
@@ -806,15 +806,15 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     it "can copy itself while updating its attributes with user_project set to true" do
       mock = Minitest::Mock.new
-      update_file_gapi = Google::Apis::StorageV1::Object.new(
-        cache_control: "private, max-age=0, no-cache",
-        content_disposition: "inline; filename=filename.ext",
-        content_encoding: "deflate",
-        content_language: "de",
-        content_type: "application/json",
-        metadata: { "player" => "Bob", "score" => "10" },
-        storage_class: "NEARLINE"
-      )
+      update_file_gapi = file_gapi.dup
+      update_file_gapi.cache_control = "private, max-age=0, no-cache"
+      update_file_gapi.content_disposition = "inline; filename=filename.ext"
+      update_file_gapi.content_encoding = "deflate"
+      update_file_gapi.content_language = "de"
+      update_file_gapi.content_type = "application/json"
+      update_file_gapi.metadata = { "player" => "Bob", "score" => "10" }
+      update_file_gapi.storage_class = "NEARLINE"
+
       mock.expect :rewrite_object, done_rewrite(file_gapi),
         [bucket.name, file_user_project.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
 
@@ -1045,17 +1045,17 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     it "can rewrite itself while updating its attributes" do
       mock = Minitest::Mock.new
-      update_file_gapi = Google::Apis::StorageV1::Object.new(
-        cache_control: "private, max-age=0, no-cache",
-        content_disposition: "inline; filename=filename.ext",
-        content_encoding: "deflate",
-        content_language: "de",
-        content_type: "application/json",
-        metadata: { "player" => "Bob", "score" => "10" },
-        storage_class: "NEARLINE"
-      )
+      update_file_gapi = file_gapi.dup
+      update_file_gapi.cache_control = "private, max-age=0, no-cache"
+      update_file_gapi.content_disposition = "inline; filename=filename.ext"
+      update_file_gapi.content_encoding = "deflate"
+      update_file_gapi.content_language = "de"
+      update_file_gapi.content_type = "application/json"
+      update_file_gapi.metadata = { "player" => "Bob", "score" => "10" }
+      update_file_gapi.storage_class = "NEARLINE"
+
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+                  [bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
 
       file.service.mocked_service = mock
 
@@ -1075,21 +1075,21 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     it "can rewrite itself while updating its attributes with user_project set to true" do
       mock = Minitest::Mock.new
-      update_file_gapi = Google::Apis::StorageV1::Object.new(
-        cache_control: "private, max-age=0, no-cache",
-        content_disposition: "inline; filename=filename.ext",
-        content_encoding: "deflate",
-        content_language: "de",
-        content_type: "application/json",
-        metadata: { "player" => "Bob", "score" => "10" },
-        storage_class: "NEARLINE"
-      )
+      update_file_gapi = file_gapi.dup
+      update_file_gapi.cache_control = "private, max-age=0, no-cache"
+      update_file_gapi.content_disposition = "inline; filename=filename.ext"
+      update_file_gapi.content_encoding = "deflate"
+      update_file_gapi.content_language = "de"
+      update_file_gapi.content_type = "application/json"
+      update_file_gapi.metadata = { "player" => "Bob", "score" => "10" }
+      update_file_gapi.storage_class = "NEARLINE"
+
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file_user_project.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+                  [bucket.name, file_user_project.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
 
       file_user_project.service.mocked_service = mock
 
-      copied = file_user_project.copy "new-file.ext" do |f|
+      copied = file_user_project.rewrite "new-file.ext" do |f|
         f.cache_control = "private, max-age=0, no-cache"
         f.content_disposition = "inline; filename=filename.ext"
         f.content_encoding = "deflate"

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -776,7 +776,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     it "can copy itself while updating its attributes" do
       mock = Minitest::Mock.new
-      update_file_gapi = file_gapi.dup
+      update_file_gapi = Google::Apis::StorageV1::Object.new
       update_file_gapi.cache_control = "private, max-age=0, no-cache"
       update_file_gapi.content_disposition = "inline; filename=filename.ext"
       update_file_gapi.content_encoding = "deflate"
@@ -804,9 +804,39 @@ describe Google::Cloud::Storage::File, :mock_storage do
       mock.verify
     end
 
-    it "can copy itself while updating its attributes with user_project set to true" do
+    it "can copy itself while updating its attributes with force_copy_metadata set to true" do
       mock = Minitest::Mock.new
       update_file_gapi = file_gapi.dup
+      update_file_gapi.cache_control = "private, max-age=0, no-cache"
+      update_file_gapi.content_disposition = "inline; filename=filename.ext"
+      update_file_gapi.content_encoding = "deflate"
+      update_file_gapi.content_language = "de"
+      update_file_gapi.content_type = "application/json"
+      update_file_gapi.metadata = { "player" => "Bob", "score" => "10" }
+      update_file_gapi.storage_class = "NEARLINE"
+
+      mock.expect :rewrite_object, done_rewrite(file_gapi),
+                  [bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+
+      file.service.mocked_service = mock
+
+      file.copy "new-file.ext", force_copy_metadata: true do |f|
+        f.cache_control = "private, max-age=0, no-cache"
+        f.content_disposition = "inline; filename=filename.ext"
+        f.content_encoding = "deflate"
+        f.content_language = "de"
+        f.content_type = "application/json"
+        f.metadata["player"] = "Bob"
+        f.metadata["score"] = "10"
+        f.storage_class = :nearline
+      end
+
+      mock.verify
+    end
+
+    it "can copy itself while updating its attributes with user_project set to true" do
+      mock = Minitest::Mock.new
+      update_file_gapi = Google::Apis::StorageV1::Object.new
       update_file_gapi.cache_control = "private, max-age=0, no-cache"
       update_file_gapi.content_disposition = "inline; filename=filename.ext"
       update_file_gapi.content_encoding = "deflate"
@@ -1045,7 +1075,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     it "can rewrite itself while updating its attributes" do
       mock = Minitest::Mock.new
-      update_file_gapi = file_gapi.dup
+      update_file_gapi = Google::Apis::StorageV1::Object.new
       update_file_gapi.cache_control = "private, max-age=0, no-cache"
       update_file_gapi.content_disposition = "inline; filename=filename.ext"
       update_file_gapi.content_encoding = "deflate"
@@ -1073,9 +1103,39 @@ describe Google::Cloud::Storage::File, :mock_storage do
       mock.verify
     end
 
-    it "can rewrite itself while updating its attributes with user_project set to true" do
+    it "can rewrite itself while updating its attributes with force_copy_metadata set to true" do
       mock = Minitest::Mock.new
       update_file_gapi = file_gapi.dup
+      update_file_gapi.cache_control = "private, max-age=0, no-cache"
+      update_file_gapi.content_disposition = "inline; filename=filename.ext"
+      update_file_gapi.content_encoding = "deflate"
+      update_file_gapi.content_language = "de"
+      update_file_gapi.content_type = "application/json"
+      update_file_gapi.metadata = { "player" => "Bob", "score" => "10" }
+      update_file_gapi.storage_class = "NEARLINE"
+
+      mock.expect :rewrite_object, done_rewrite(file_gapi),
+                  [bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+
+      file.service.mocked_service = mock
+
+      file.rewrite "new-file.ext", force_copy_metadata: true do |f|
+        f.cache_control = "private, max-age=0, no-cache"
+        f.content_disposition = "inline; filename=filename.ext"
+        f.content_encoding = "deflate"
+        f.content_language = "de"
+        f.content_type = "application/json"
+        f.metadata["player"] = "Bob"
+        f.metadata["score"] = "10"
+        f.storage_class = :nearline
+      end
+
+      mock.verify
+    end
+
+    it "can rewrite itself while updating its attributes with user_project set to true" do
+      mock = Minitest::Mock.new
+      update_file_gapi = Google::Apis::StorageV1::Object.new
       update_file_gapi.cache_control = "private, max-age=0, no-cache"
       update_file_gapi.content_disposition = "inline; filename=filename.ext"
       update_file_gapi.content_encoding = "deflate"

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -806,7 +806,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     it "can copy itself while updating its attributes with force_copy_metadata set to true" do
       mock = Minitest::Mock.new
-      update_file_gapi = file_gapi.dup
+      update_file_gapi = Google::Apis::StorageV1::Object.new
       update_file_gapi.cache_control = "private, max-age=0, no-cache"
       update_file_gapi.content_disposition = "inline; filename=filename.ext"
       update_file_gapi.content_encoding = "deflate"
@@ -1105,7 +1105,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     it "can rewrite itself while updating its attributes with force_copy_metadata set to true" do
       mock = Minitest::Mock.new
-      update_file_gapi = file_gapi.dup
+      update_file_gapi = Google::Apis::StorageV1::Object.new
       update_file_gapi.cache_control = "private, max-age=0, no-cache"
       update_file_gapi.content_disposition = "inline; filename=filename.ext"
       update_file_gapi.content_encoding = "deflate"

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
@@ -657,7 +657,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
   it "can copy itself while updating its attributes" do
     mock = Minitest::Mock.new
-    update_file_gapi = file.gapi.dup
+    update_file_gapi = Google::Apis::StorageV1::Object.new
     update_file_gapi.cache_control = "private, max-age=0, no-cache"
     update_file_gapi.content_disposition = "inline; filename=filename.ext"
     update_file_gapi.content_encoding = "deflate"
@@ -667,7 +667,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     update_file_gapi.storage_class = "NEARLINE"
 
     mock.expect :rewrite_object, rewrite_response,
-      [bucket_name, file_name, bucket_name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+                [bucket_name, file_name, bucket_name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -685,9 +685,39 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     mock.verify
   end
 
-  it "can copy itself while updating its attributes with user_project set to true" do
+  it "can copy itself while updating its attributes with force_copy_metadata set to true" do
     mock = Minitest::Mock.new
     update_file_gapi = file.gapi.dup
+    update_file_gapi.cache_control = "private, max-age=0, no-cache"
+    update_file_gapi.content_disposition = "inline; filename=filename.ext"
+    update_file_gapi.content_encoding = "deflate"
+    update_file_gapi.content_language = "de"
+    update_file_gapi.content_type = "application/json"
+    update_file_gapi.metadata = { "player" => "Bob", "score" => "10" }
+    update_file_gapi.storage_class = "NEARLINE"
+
+    mock.expect :rewrite_object, rewrite_response,
+                [bucket_name, file_name, bucket_name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+
+    file.service.mocked_service = mock
+
+    file.copy "new-file.ext", force_copy_metadata: true do |f|
+      f.cache_control = "private, max-age=0, no-cache"
+      f.content_disposition = "inline; filename=filename.ext"
+      f.content_encoding = "deflate"
+      f.content_language = "de"
+      f.content_type = "application/json"
+      f.metadata["player"] = "Bob"
+      f.metadata["score"] = "10"
+      f.storage_class = :nearline
+    end
+
+    mock.verify
+  end
+
+  it "can copy itself while updating its attributes with user_project set to true" do
+    mock = Minitest::Mock.new
+    update_file_gapi = Google::Apis::StorageV1::Object.new
     update_file_gapi.cache_control = "private, max-age=0, no-cache"
     update_file_gapi.content_disposition = "inline; filename=filename.ext"
     update_file_gapi.content_encoding = "deflate"

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
@@ -687,7 +687,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
   it "can copy itself while updating its attributes with force_copy_metadata set to true" do
     mock = Minitest::Mock.new
-    update_file_gapi = file.gapi.dup
+    update_file_gapi = Google::Apis::StorageV1::Object.new
     update_file_gapi.cache_control = "private, max-age=0, no-cache"
     update_file_gapi.content_disposition = "inline; filename=filename.ext"
     update_file_gapi.content_encoding = "deflate"

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
@@ -657,15 +657,15 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
   it "can copy itself while updating its attributes" do
     mock = Minitest::Mock.new
-    update_file_gapi = Google::Apis::StorageV1::Object.new(
-      cache_control: "private, max-age=0, no-cache",
-      content_disposition: "inline; filename=filename.ext",
-      content_encoding: "deflate",
-      content_language: "de",
-      content_type: "application/json",
-      metadata: { "player" => "Bob", "score" => "10" },
-      storage_class: "NEARLINE"
-    )
+    update_file_gapi = file.gapi.dup
+    update_file_gapi.cache_control = "private, max-age=0, no-cache"
+    update_file_gapi.content_disposition = "inline; filename=filename.ext"
+    update_file_gapi.content_encoding = "deflate"
+    update_file_gapi.content_language = "de"
+    update_file_gapi.content_type = "application/json"
+    update_file_gapi.metadata = { "player" => "Bob", "score" => "10" }
+    update_file_gapi.storage_class = "NEARLINE"
+
     mock.expect :rewrite_object, rewrite_response,
       [bucket_name, file_name, bucket_name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
 
@@ -687,15 +687,15 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
   it "can copy itself while updating its attributes with user_project set to true" do
     mock = Minitest::Mock.new
-    update_file_gapi = Google::Apis::StorageV1::Object.new(
-      cache_control: "private, max-age=0, no-cache",
-      content_disposition: "inline; filename=filename.ext",
-      content_encoding: "deflate",
-      content_language: "de",
-      content_type: "application/json",
-      metadata: { "player" => "Bob", "score" => "10" },
-      storage_class: "NEARLINE"
-    )
+    update_file_gapi = file.gapi.dup
+    update_file_gapi.cache_control = "private, max-age=0, no-cache"
+    update_file_gapi.content_disposition = "inline; filename=filename.ext"
+    update_file_gapi.content_encoding = "deflate"
+    update_file_gapi.content_language = "de"
+    update_file_gapi.content_type = "application/json"
+    update_file_gapi.metadata = { "player" => "Bob", "score" => "10" }
+    update_file_gapi.storage_class = "NEARLINE"
+
     mock.expect :rewrite_object, rewrite_response,
       [bucket.name, file_user_project.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
 


### PR DESCRIPTION
feat(storage): Add `force_copy_metadata` to `File#copy` and `#rewrite`.

```ruby 
        # @param [Boolean] force_copy_metadata Optional. If `true` and if updates
        #   are made in a block, the following fields will be copied from the
        #   source file to the destination file (except when changed by updates):
        #
        #   * `cache_control`
        #   * `content_disposition`
        #   * `content_encoding`
        #   * `content_language`
        #   * `content_type`
        #   * `metadata`
        #
        #   If `nil` or `false`, only the updates made in the yielded block will
        #   be applied to the destination object. The default is `nil`.
```

[closes #4254]

API docs for [Objects: rewrite](https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite) specify that:

> Request body
> In the request body, optionally supply metadata to apply to the rewritten object using an object resource.

The current implementation passes a patch-type resource representation that only contains the attributes to be **changed**. It seems that a full representation is needed, or else data is lost as observed in the updated acceptance tests in this PR and in #4254. This PR changes the Updater's `gapi` object to a full duplicate of the origin file's `gapi` state.