### PR TITLE
Update default endpoint for google-cloud-storage

### DIFF
--- a/google-cloud-storage/lib/google-cloud-storage.rb
+++ b/google-cloud-storage/lib/google-cloud-storage.rb
@@ -138,5 +138,6 @@ Google::Cloud.configure.add_config! :storage do |config|
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :retries, nil, match: Integer
   config.add_field! :timeout, nil, match: Integer
-  config.add_field! :endpoint, nil, match: String
+  # Update default endpoint to use updated endpoint.
+  config.add_field! :endpoint, 'https://storage.googleapis.com', match: String
 end

--- a/google-cloud-storage/lib/google-cloud-storage.rb
+++ b/google-cloud-storage/lib/google-cloud-storage.rb
@@ -139,5 +139,5 @@ Google::Cloud.configure.add_config! :storage do |config|
   config.add_field! :retries, nil, match: Integer
   config.add_field! :timeout, nil, match: Integer
   # Update default endpoint to use updated endpoint.
-  config.add_field! :endpoint, 'https://storage.googleapis.com', match: String
+  config.add_field! :endpoint, "https://storage.googleapis.com/", match: String
 end

--- a/google-cloud-storage/lib/google-cloud-storage.rb
+++ b/google-cloud-storage/lib/google-cloud-storage.rb
@@ -138,6 +138,6 @@ Google::Cloud.configure.add_config! :storage do |config|
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :retries, nil, match: Integer
   config.add_field! :timeout, nil, match: Integer
-  # Update default endpoint to use updated endpoint.
+  # TODO: Remove once discovery document is updated.
   config.add_field! :endpoint, "https://storage.googleapis.com/", match: String
 end

--- a/google-cloud-storage/test/google/cloud/storage_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage_test.rb
@@ -105,7 +105,8 @@ describe Google::Cloud do
         credentials.must_equal "storage-credentials"
         retries.must_be :nil?
         timeout.must_be :nil?
-        host.must_be :nil?
+        # TODO: Remove once discovery document is updated.
+        host.must_equal "https://storage.googleapis.com/"
         OpenStruct.new project: project
       }
 
@@ -208,7 +209,8 @@ describe Google::Cloud do
         credentials.must_equal "storage-credentials"
         retries.must_be :nil?
         timeout.must_be :nil?
-        host.must_be :nil?
+        # TODO: Remove once discovery document is updated.
+        host.must_equal "https://storage.googleapis.com/"
         OpenStruct.new project: project
       }
 
@@ -240,7 +242,8 @@ describe Google::Cloud do
         credentials.must_equal "storage-credentials"
         retries.must_be :nil?
         timeout.must_be :nil?
-        host.must_be :nil?
+        # TODO: Remove once discovery document is updated.
+        host.must_equal "https://storage.googleapis.com/"
         OpenStruct.new project: project
       }
 
@@ -273,7 +276,8 @@ describe Google::Cloud do
         credentials.project_id.must_equal "project-id"
         retries.must_be :nil?
         timeout.must_be :nil?
-        host.must_be :nil?
+        # TODO: Remove once discovery document is updated.
+        host.must_equal "https://storage.googleapis.com/"
         OpenStruct.new project: project
       }
       empty_env = OpenStruct.new
@@ -316,7 +320,8 @@ describe Google::Cloud do
         credentials.must_equal "storage-credentials"
         retries.must_be :nil?
         timeout.must_be :nil?
-        host.must_be :nil?
+        # TODO: Remove once discovery document is updated.
+        host.must_equal "https://storage.googleapis.com/"
         OpenStruct.new project: project
       }
 
@@ -354,7 +359,8 @@ describe Google::Cloud do
         credentials.must_equal "storage-credentials"
         retries.must_be :nil?
         timeout.must_be :nil?
-        host.must_be :nil?
+        # TODO: Remove once discovery document is updated.
+        host.must_equal "https://storage.googleapis.com/"
         OpenStruct.new project: project
       }
 
@@ -392,7 +398,8 @@ describe Google::Cloud do
         credentials.must_equal "storage-credentials"
         retries.must_equal 3
         timeout.must_equal 42
-        host.must_be :nil?
+        # TODO: Remove once discovery document is updated.
+        host.must_equal "https://storage.googleapis.com/"
         OpenStruct.new project: project
       }
 


### PR DESCRIPTION
Updating default endpoint prior to discovery document being updated for GCS libraries. 

The change is updating the endpoint from: `https://www.googleapis.com/` to the new endpoint for the JSON API `https://storage.googleapis.com/`. The old endpoint will continue to work. 

This is a temporary change until the auto-generated client is updated when the discovery document is updated.