### PR TITLE
chore(scheduler): Reinstate project_path helper in synth

### DIFF
--- a/google-cloud-scheduler/synth.py
+++ b/google-cloud-scheduler/synth.py
@@ -110,6 +110,14 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# TEMP: Re-add project_path helper which was earlier mistakenly generated but
+# is no longer. This helper method is likely unused, and we will remove it
+# when switching to the microgenerator.
+s.replace(
+    'lib/google/cloud/scheduler/v*/cloud_scheduler_client.rb',
+    'attr_reader :cloud_scheduler_stub\n',
+    'attr_reader :cloud_scheduler_stub\n\n          # @deprecated\n          def self.project_path project; "projects/#{project}"; end\n'
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2279
 s.replace(


### PR DESCRIPTION
Synth hack to re-instate the `project_path` helper. This helper is not needed and was mistakenly generated by the Ruby generator using the gapic v1 configs. With the change to v2 configs, this no longer generates, but that would be a breaking change. (See #4270) We re-instate the method for now but mark it as deprecated. It looks like this:

```ruby
# @deprecated
def self.project_path project; "projects/#{project}"; end
```

The method will disappear when we move to the microgenerator.