### PR TITLE
test(bigtable): Backfill missing unit tests

### DIFF
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/column_family.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/column_family.rb
@@ -53,14 +53,6 @@ module Google
         end
 
         # @private
-        # @return [Google::Bigtable::Admin::V2::ColumnFamily]
-        def to_grpc
-          grpc = Google::Bigtable::Admin::V2::ColumnFamily.new
-          grpc.gc_rule = gc_rule.to_grpc if gc_rule
-          grpc
-        end
-
-        # @private
         #
         # Create a new ColumnFamily instance from a {Google::Bigtable::Admin::V2::ColumnFamily}.
         #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
@@ -715,20 +715,6 @@ module Google
         end
 
         ##
-        # Creates a formatted snapshot path.
-        #
-        # @param instance_id [String]
-        # @param cluster_id [String]
-        # @param snapshot_id [String]
-        # @return [String]
-        #   Formatted snapshot path
-        #   +projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>+
-        #
-        def snapshot_path instance_id, cluster_id, snapshot_id
-          Admin::V2::BigtableTableAdminClient.snapshot_path project_id, instance_id, cluster_id, snapshot_id
-        end
-
-        ##
         # Creates a formatted app profile path.
         #
         # @param instance_id [String]

--- a/google-cloud-bigtable/test/google/cloud/bigtable/cluster_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/cluster_test.rb
@@ -16,33 +16,53 @@
 require "helper"
 
 describe Google::Cloud::Bigtable::Cluster, :mock_bigtable do
-  it "knows the identifiers" do
-    instance_id = "test-instance"
-    cluster_id = "test-cluster"
-    location = "us-east-1b"
-    nodes = 3
-
-    cluster_grpc = Google::Bigtable::Admin::V2::Cluster.new(
+  let(:instance_id) { "test-instance" }
+  let(:cluster_id) { "test-cluster" }
+  let(:location_id) { "us-east-1b" }
+  let(:nodes) { 3 }
+  let(:cluster_grpc) do
+    Google::Bigtable::Admin::V2::Cluster.new(
       name: cluster_path(instance_id, cluster_id),
       serve_nodes: nodes,
-      location: location_path(location),
+      location: location_path(location_id),
       default_storage_type: :SSD,
       state: :READY
     )
-    cluster = Google::Cloud::Bigtable::Cluster.from_grpc(cluster_grpc, bigtable.service)
+  end
+  let(:cluster) { Google::Cloud::Bigtable::Cluster.from_grpc(cluster_grpc, bigtable.service) }
 
+  it "knows the identifiers" do
     cluster.must_be_kind_of Google::Cloud::Bigtable::Cluster
     cluster.project_id.must_equal project_id
     cluster.instance_id.must_equal instance_id
     cluster.cluster_id.must_equal cluster_id
     cluster.path.must_equal cluster_path(instance_id, cluster_id)
     cluster.nodes.must_equal nodes
-    cluster.location.must_equal location
-    cluster.location_path.must_equal location_path(location)
+    cluster.location.must_equal location_id
+    cluster.location_path.must_equal location_path(location_id)
     cluster.state.must_equal :READY
     cluster.must_be :ready?
     cluster.wont_be :creating?
     cluster.wont_be :resizing?
     cluster.wont_be :disabled?
+  end
+
+  it "reloads its state" do
+    mock = Minitest::Mock.new
+    mock.expect :get_cluster, cluster_grpc, [cluster_path(instance_id, cluster_id)]
+    cluster.service.mocked_instances = mock
+
+    cluster.reload!
+
+    mock.verify
+
+    cluster.project_id.must_equal project_id
+    cluster.instance_id.must_equal instance_id
+    cluster.cluster_id.must_equal cluster_id
+    cluster.path.must_equal cluster_path(instance_id, cluster_id)
+    cluster.state.must_equal :READY
+    cluster.ready?.must_equal true
+    cluster.storage_type.must_equal :SSD
+    cluster.nodes.must_equal 3
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/app_profile_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/app_profile_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigtable::Instance, :cluster, :mock_bigtable do
+describe Google::Cloud::Bigtable::Instance, :app_profile, :mock_bigtable do
   let(:instance_id) { "test-instance" }
   let(:location_id) { "us-east-1b" }
   let(:instance_grpc){
@@ -25,41 +25,29 @@ describe Google::Cloud::Bigtable::Instance, :cluster, :mock_bigtable do
     Google::Cloud::Bigtable::Instance.from_grpc(instance_grpc, bigtable.service)
   }
 
-  it "gets an cluster" do
-    cluster_id = "found-cluster"
+  it "gets an app_profile" do
+    app_profile_id = "found-app_profile"
 
-    get_res = Google::Bigtable::Admin::V2::Cluster.new(
-      cluster_hash(
-        name: cluster_path(instance_id, cluster_id),
-        nodes: 3,
-        location: location_id,
-        storage_type: :SSD,
-        state: :READY
-      )
-    )
+    get_res = app_profile_grpc instance_id, app_profile_id
 
     mock = Minitest::Mock.new
-    mock.expect :get_cluster, get_res, [cluster_path(instance_id, cluster_id)]
+    mock.expect :get_app_profile, get_res, [app_profile_path(instance_id, app_profile_id)]
     bigtable.service.mocked_instances = mock
-    cluster = instance.cluster(cluster_id)
+    app_profile = instance.app_profile(app_profile_id)
 
     mock.verify
 
-    cluster.project_id.must_equal project_id
-    cluster.instance_id.must_equal instance_id
-    cluster.cluster_id.must_equal cluster_id
-    cluster.path.must_equal cluster_path(instance_id, cluster_id)
-    cluster.state.must_equal :READY
-    cluster.ready?.must_equal true
-    cluster.storage_type.must_equal :SSD
-    cluster.nodes.must_equal 3
+    app_profile.project_id.must_equal project_id
+    app_profile.instance_id.must_equal instance_id
+    app_profile.name.must_equal app_profile_id
+    app_profile.path.must_equal app_profile_path(instance_id, app_profile_id)
   end
 
-  it "returns nil when getting an non-existent cluster" do
-    not_found_cluster_id = "not-found-cluster"
+  it "returns nil when getting an non-existent app_profile" do
+    not_found_app_profile_id = "not-found-app_profile"
 
     stub = Object.new
-    def stub.get_cluster *args
+    def stub.get_app_profile *args
       gax_error = Google::Gax::GaxError.new "not found"
       gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
       raise gax_error
@@ -67,7 +55,7 @@ describe Google::Cloud::Bigtable::Instance, :cluster, :mock_bigtable do
 
     bigtable.service.mocked_instances = stub
 
-    cluster = instance.cluster(not_found_cluster_id)
-    cluster.must_be :nil?
+    app_profile = instance.app_profile(not_found_app_profile_id)
+    app_profile.must_be :nil?
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/app_profiles_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/app_profiles_test.rb
@@ -1,0 +1,95 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud::Bigtable::Instance, :app_profiles, :mock_bigtable do
+  let(:instance_id) { "test-instance" }
+  let(:instance_grpc){
+    Google::Bigtable::Admin::V2::Instance.new(name: instance_path(instance_id))
+  }
+  let(:instance) {
+    Google::Cloud::Bigtable::Instance.from_grpc(instance_grpc, bigtable.service)
+  }
+  let(:first_page) do
+    resp = app_profiles_grpc count: 3
+    resp.next_page_token = "next_page_token"
+    resp
+  end
+  let(:second_page) do
+    resp = app_profiles_grpc
+    resp.next_page_token = "next_page_token"
+    resp
+  end
+  let(:last_page) do
+    resp = app_profiles_grpc
+    resp
+  end
+
+  it "list app_profiles" do
+    get_res =  MockPagedEnumerable.new([first_page])
+    mock = Minitest::Mock.new
+    mock.expect :list_app_profiles, get_res, ["projects/test/instances/test-instance"]
+    bigtable.service.mocked_instances = mock
+
+    app_profiles = instance.app_profiles
+
+    mock.verify
+
+    app_profiles.size.must_equal 3
+  end
+
+  it "paginates app_profiles with next? and next" do
+    get_res =  MockPagedEnumerable.new([first_page, last_page])
+    mock = Minitest::Mock.new
+    mock.expect :list_app_profiles, get_res, ["projects/test/instances/test-instance"]
+    bigtable.service.mocked_instances = mock
+
+    list = instance.app_profiles
+
+    mock.verify
+
+    list.size.must_equal 3
+    list.next?.must_equal true
+    list.next.size.must_equal 2
+    list.next?.must_equal false
+  end
+
+  it "paginates app_profiles with all" do
+    get_res =  MockPagedEnumerable.new([first_page, last_page])
+    mock = Minitest::Mock.new
+    mock.expect :list_app_profiles, get_res, ["projects/test/instances/test-instance"]
+    bigtable.service.mocked_instances = mock
+
+    app_profiles = instance.app_profiles.all.to_a
+
+    mock.verify
+
+    app_profiles.size.must_equal 5
+  end
+
+  it "iterates app_profiles with all using Enumerator" do
+    get_res =  MockPagedEnumerable.new([first_page, last_page])
+    mock = Minitest::Mock.new
+    mock.expect :list_app_profiles, get_res, ["projects/test/instances/test-instance"]
+    bigtable.service.mocked_instances = mock
+
+    app_profiles = instance.app_profiles.all.take(5)
+
+    mock.verify
+
+    app_profiles.size.must_equal 5
+  end
+end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/create_app_profile_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/create_app_profile_test.rb
@@ -1,0 +1,54 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud::Bigtable::Instance, :create_app_profile, :mock_bigtable do
+  let(:instance_id) { "test-instance" }
+  let(:app_profile_id) { "test-app-profile" }
+  let(:path) { app_profile_path(instance_id, app_profile_id) }
+  let(:description) { "Test instance app profile" }
+  let(:app_profile_resp) {
+    Google::Bigtable::Admin::V2::AppProfile.new(
+      name: path,
+      description: description,
+      multi_cluster_routing_use_any: multi_cluster_routing_grpc
+    )
+  }
+
+  it "creates a app_profile" do
+    mock = Minitest::Mock.new
+    app_profile_req = app_profile_resp.dup
+    app_profile_req.name = ""
+    mock.expect :create_app_profile,
+                app_profile_resp,
+                [instance_path(instance_id), app_profile_id, app_profile_req, { ignore_warnings: false }]
+    bigtable.service.mocked_instances = mock
+
+    instance_grpc = Google::Bigtable::Admin::V2::Instance.new(name: instance_path(instance_id))
+    instance = Google::Cloud::Bigtable::Instance.from_grpc(instance_grpc, bigtable.service)
+
+    routing_policy = Google::Cloud::Bigtable::AppProfile.multi_cluster_routing
+    app_profile = instance.create_app_profile app_profile_id, routing_policy, description: description
+
+    app_profile.wont_be :nil?
+    app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
+    app_profile.path.must_equal path
+    app_profile.description.must_equal description
+    app_profile.routing_policy.must_be_kind_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
+
+    mock.verify
+  end
+end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance_test.rb
@@ -18,17 +18,21 @@ require "helper"
 describe Google::Cloud::Bigtable::Instance, :mock_bigtable do
   let(:instance_id) { "test-instance-id" }
   let(:display_name) { "Test instance" }
+  let(:instance_grpc) do
+    Google::Bigtable::Admin::V2::Instance.new(
+      instance_hash(
+        name: instance_id,
+        display_name: display_name,
+        state: :READY,
+        type: :PRODUCTION
+      )
+    )
+  end
+  let(:instance) do
+    Google::Cloud::Bigtable::Instance.from_grpc instance_grpc, service
+  end
 
   it "knows the identifiers" do
-    instance_grpc = Google::Bigtable::Admin::V2::Instance.new(
-      instance_hash(
-      name: instance_id,
-      display_name: display_name,
-      state: :READY,
-      type: :PRODUCTION
-    ))
-
-    instance = Google::Cloud::Bigtable::Instance.from_grpc(instance_grpc, bigtable.service)
     instance.must_be_kind_of Google::Cloud::Bigtable::Instance
     instance.project_id.must_equal project_id
     instance.instance_id.must_equal instance_id
@@ -42,14 +46,14 @@ describe Google::Cloud::Bigtable::Instance, :mock_bigtable do
     instance.must_be :production?
     instance.wont_be :development?
   end
-
   describe "#labels=" do
-    let(:instance){
+    let(:instance) do
       Google::Cloud::Bigtable::Instance.from_grpc(
-        Google::Bigtable::Admin::V2::Instance.new(name: instance_id),
+        Google::Bigtable::Admin::V2::Instance.new(name: instance_path(instance_id)),
         bigtable.service
       )
-    }
+    end
+
 
     it "set labels using hash" do
       instance.labels = { "env" => "test1" }
@@ -67,5 +71,24 @@ describe Google::Cloud::Bigtable::Instance, :mock_bigtable do
       instance.labels = nil
       instance.labels.length.must_equal 0
     end
+  end
+
+  it "reloads its state" do
+    mock = Minitest::Mock.new
+    instance.service.mocked_instances = mock
+    mock.expect :get_instance, instance_grpc, [instance_path(instance_id)]
+
+    instance.reload!
+
+    mock.verify
+
+    instance.project_id.must_equal project_id
+    instance.instance_id.must_equal instance_id
+    instance.path.must_equal instance_path(instance_id)
+    instance.display_name.must_equal "Test instance"
+    instance.state.must_equal :READY
+    instance.ready?.must_equal true
+    instance.type.must_equal :PRODUCTION
+    instance.production?.must_equal true
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/instance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/instance_test.rb
@@ -17,8 +17,8 @@
 
 require "helper"
 
-describe Google::Cloud::Bigtable::Instance, :cluster, :mock_bigtable do
-  it "gets a cluster" do
+describe Google::Cloud::Bigtable::Project, :instance, :mock_bigtable do
+  it "gets an instance" do
     instance_id = "found-instance"
 
     get_res = Google::Bigtable::Admin::V2::Instance.new(

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_filter/chain_filter_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_filter/chain_filter_test.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud::Bigtable::RowFilter::ChainFilter, :mock_bigtable do
+  let(:table) do
+    Google::Cloud::Bigtable::DataClient::Table.new(
+      Object.new, "dummy-table-path"
+    )
+  end
+  let(:chain_filter) { Google::Cloud::Bigtable::RowFilter.chain }
+
+  it "knows its attributes" do
+    chain_filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::ChainFilter
+    filters = chain_filter.filters
+    filters.must_be_kind_of Array
+    filters.must_be :frozen?
+    filters.must_be :empty?
+  end
+
+  it "creates a sink filter" do
+    chain_filter.filters.must_be :empty?
+    chain_filter.sink
+    assert_filter :sink
+  end
+
+  it "creates a pass filter" do
+    chain_filter.filters.must_be :empty?
+    chain_filter.pass
+    assert_filter :pass_all_filter
+  end
+
+  it "creates a block filter" do
+    chain_filter.filters.must_be :empty?
+    chain_filter.block
+    assert_filter :block_all_filter
+  end
+
+  it "creates a strip_value filter" do
+    chain_filter.filters.must_be :empty?
+    chain_filter.strip_value
+    assert_filter :strip_value_transformer
+  end
+
+  it "creates a key filter" do
+    regex = "user-*"
+    chain_filter.filters.must_be :empty?
+    chain_filter.key(regex)
+    filter = assert_filter :row_key_regex_filter
+    filter.to_grpc.row_key_regex_filter.must_equal regex
+  end
+
+  it "creates a family filter" do
+    regex = "cf-*"
+    chain_filter.filters.must_be :empty?
+    chain_filter.family(regex)
+    filter = assert_filter :family_name_regex_filter
+    filter.to_grpc.family_name_regex_filter.must_equal regex
+  end
+
+  it "creates a qualifier filter" do
+    regex = "field*"
+    chain_filter.filters.must_be :empty?
+    chain_filter.qualifier(regex)
+    filter = assert_filter :column_qualifier_regex_filter
+    filter.to_grpc.column_qualifier_regex_filter.must_equal regex
+  end
+
+  it "creates a value filter" do
+    regex = "abc*"
+    chain_filter.filters.must_be :empty?
+    chain_filter.value(regex)
+    filter = assert_filter :value_regex_filter
+    filter.to_grpc.value_regex_filter.must_equal regex
+  end
+
+  it "creates a label filter" do
+    label = "test"
+    chain_filter.filters.must_be :empty?
+    chain_filter.label(label)
+    filter = assert_filter :apply_label_transformer
+    filter.to_grpc.apply_label_transformer.must_equal label
+  end
+
+  it "creates a cells_per_row_offset filter" do
+    offset = 5
+    chain_filter.filters.must_be :empty?
+    chain_filter.cells_per_row_offset(offset)
+    filter = assert_filter :cells_per_row_offset_filter
+    filter.to_grpc.cells_per_row_offset_filter.must_equal offset
+  end
+
+  it "creates a cells_per_row filter" do
+    limit = 10
+    chain_filter.filters.must_be :empty?
+    chain_filter.cells_per_row(limit)
+    filter = assert_filter :cells_per_row_limit_filter
+    filter.to_grpc.cells_per_row_limit_filter.must_equal limit
+  end
+
+  it "creates a cells_per_column filter" do
+    limit = 10
+    chain_filter.filters.must_be :empty?
+    chain_filter.cells_per_column(limit)
+    filter = assert_filter :cells_per_column_limit_filter
+    filter.to_grpc.cells_per_column_limit_filter.must_equal limit
+  end
+
+  describe "timestamp_range" do
+    it "creates a timestamp_range filter" do
+      from = timestamp_micros - 3000000
+      to = timestamp_micros
+      chain_filter.filters.must_be :empty?
+      chain_filter.timestamp_range(from: from, to: to)
+      filter = assert_filter :timestamp_range_filter
+      range_grpc = Google::Bigtable::V2::TimestampRange.new(
+        start_timestamp_micros: from, end_timestamp_micros: to
+      )
+      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+    end
+
+    it "creates a timestamp_range filter with only from range" do
+      from = timestamp_micros - 3000000
+      chain_filter.filters.must_be :empty?
+      chain_filter.timestamp_range(from: from)
+      filter = assert_filter :timestamp_range_filter
+      range_grpc = Google::Bigtable::V2::TimestampRange.new(
+        start_timestamp_micros: from
+      )
+      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+    end
+
+    it "creates a timestamp_range filter with only to range" do
+      to = timestamp_micros
+      chain_filter.filters.must_be :empty?
+      chain_filter.timestamp_range(to: to)
+      filter = assert_filter :timestamp_range_filter
+      range_grpc = Google::Bigtable::V2::TimestampRange.new(
+        end_timestamp_micros: to
+      )
+      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+    end
+  end
+
+  describe "#value_range" do
+    it "creates a value_range filter" do
+      from_value = "abc"
+      to_value = "xyz"
+      range = Google::Cloud::Bigtable::ValueRange.new.from(from_value).to(to_value)
+      chain_filter.filters.must_be :empty?
+      chain_filter.value_range(range)
+      filter = assert_filter :value_range_filter
+      grpc = filter.to_grpc.value_range_filter
+      grpc.must_be_kind_of Google::Bigtable::V2::ValueRange
+      grpc.start_value_closed.must_equal from_value
+      grpc.end_value_open.must_equal to_value
+    end
+
+    it "range instance must be type of ValueRange" do
+      proc {
+        chain_filter.value_range(Object.new)
+      }.must_raise Google::Cloud::Bigtable::RowFilterError
+    end
+  end
+
+  describe "#column_range" do
+    it "creates a column_range filter" do
+      family = "cf"
+      from_value = "field0"
+      to_value = "field5"
+
+      range = Google::Cloud::Bigtable::ColumnRange.new(family).from(from_value).to(to_value)
+      chain_filter.filters.must_be :empty?
+      chain_filter.column_range(range)
+      filter = assert_filter :column_range_filter
+      grpc = filter.to_grpc.column_range_filter
+      grpc.must_be_kind_of Google::Bigtable::V2::ColumnRange
+      grpc.family_name.must_equal family
+      grpc.start_qualifier_closed.must_equal from_value
+      grpc.end_qualifier_open.must_equal to_value
+    end
+
+    it "range instance must be type of ColumnRange" do
+      proc {
+        chain_filter.column_range(Object.new)
+      }.must_raise Google::Cloud::Bigtable::RowFilterError
+    end
+  end
+
+  describe "#sample" do
+    it "creates a sample probability filter" do
+      probability = 0.5
+      chain_filter.filters.must_be :empty?
+      chain_filter.sample(probability)
+      filter = assert_filter :row_sample_filter
+      filter.to_grpc.row_sample_filter.must_equal probability
+    end
+
+    it "probability can not be greather then 1" do
+      proc {
+        chain_filter.sample(1.1)
+      }.must_raise Google::Cloud::Bigtable::RowFilterError
+    end
+
+    it "probability can not be equal to 1" do
+      proc {
+        chain_filter.sample(1)
+      }.must_raise Google::Cloud::Bigtable::RowFilterError
+    end
+
+    it "probability can not be equal to 0" do
+      proc {
+        chain_filter.sample(0)
+      }.must_raise Google::Cloud::Bigtable::RowFilterError
+    end
+
+    it "probability can not be less then 0" do
+      proc {
+        chain_filter.sample(-0.1)
+      }.must_raise Google::Cloud::Bigtable::RowFilterError
+    end
+  end
+
+  it "creates a chain filter" do
+    filter = Google::Cloud::Bigtable::RowFilter.chain
+    chain_filter.filters.must_be :empty?
+    chain_filter.chain filter
+    assert_filter :chain, Google::Cloud::Bigtable::RowFilter::ChainFilter
+  end
+
+  it "creates an interleave filter" do
+    filter = Google::Cloud::Bigtable::RowFilter.interleave
+    chain_filter.filters.must_be :empty?
+    chain_filter.interleave filter
+    assert_filter :interleave, Google::Cloud::Bigtable::RowFilter::InterleaveFilter
+  end
+
+  it "creates a condition filter" do
+    predicate = Google::Cloud::Bigtable::RowFilter.key("user-*")
+    filter = Google::Cloud::Bigtable::RowFilter.condition(predicate)
+    chain_filter.filters.must_be :empty?
+    chain_filter.condition filter
+    assert_filter :condition, Google::Cloud::Bigtable::RowFilter::ConditionFilter
+  end
+
+  def assert_filter method, type = Google::Cloud::Bigtable::RowFilter::SimpleFilter
+    chain_filter.filters.count.must_equal 1
+    filter = chain_filter.filters.find do |f|
+      t = f.to_grpc.send method
+      if t.kind_of? String # may be empty string in protobuf
+        !t.empty?
+      else
+        !t.nil?
+      end
+    end
+    filter.must_be_kind_of type
+    filter
+  end
+end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_filter/interleave_filter_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_filter/interleave_filter_test.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud::Bigtable::RowFilter::InterleaveFilter, :mock_bigtable do
+  let(:table) do
+    Google::Cloud::Bigtable::DataClient::Table.new(
+      Object.new, "dummy-table-path"
+    )
+  end
+  let(:interleave_filter) { Google::Cloud::Bigtable::RowFilter.interleave }
+
+  it "knows its attributes" do
+    interleave_filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::InterleaveFilter
+    filters = interleave_filter.filters
+    filters.must_be_kind_of Array
+    filters.must_be :frozen?
+    filters.must_be :empty?
+  end
+
+  it "creates a sink filter" do
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.sink
+    assert_filter :sink
+  end
+
+  it "creates a pass filter" do
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.pass
+    assert_filter :pass_all_filter
+  end
+
+  it "creates a block filter" do
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.block
+    assert_filter :block_all_filter
+  end
+
+  it "creates a strip_value filter" do
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.strip_value
+    assert_filter :strip_value_transformer
+  end
+
+  it "creates a key filter" do
+    regex = "user-*"
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.key(regex)
+    filter = assert_filter :row_key_regex_filter
+    filter.to_grpc.row_key_regex_filter.must_equal regex
+  end
+
+  it "creates a family filter" do
+    regex = "cf-*"
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.family(regex)
+    filter = assert_filter :family_name_regex_filter
+    filter.to_grpc.family_name_regex_filter.must_equal regex
+  end
+
+  it "creates a qualifier filter" do
+    regex = "field*"
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.qualifier(regex)
+    filter = assert_filter :column_qualifier_regex_filter
+    filter.to_grpc.column_qualifier_regex_filter.must_equal regex
+  end
+
+  it "creates a value filter" do
+    regex = "abc*"
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.value(regex)
+    filter = assert_filter :value_regex_filter
+    filter.to_grpc.value_regex_filter.must_equal regex
+  end
+
+  it "creates a label filter" do
+    label = "test"
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.label(label)
+    filter = assert_filter :apply_label_transformer
+    filter.to_grpc.apply_label_transformer.must_equal label
+  end
+
+  it "creates a cells_per_row_offset filter" do
+    offset = 5
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.cells_per_row_offset(offset)
+    filter = assert_filter :cells_per_row_offset_filter
+    filter.to_grpc.cells_per_row_offset_filter.must_equal offset
+  end
+
+  it "creates a cells_per_row filter" do
+    limit = 10
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.cells_per_row(limit)
+    filter = assert_filter :cells_per_row_limit_filter
+    filter.to_grpc.cells_per_row_limit_filter.must_equal limit
+  end
+
+  it "creates a cells_per_column filter" do
+    limit = 10
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.cells_per_column(limit)
+    filter = assert_filter :cells_per_column_limit_filter
+    filter.to_grpc.cells_per_column_limit_filter.must_equal limit
+  end
+
+  describe "timestamp_range" do
+    it "creates a timestamp_range filter" do
+      from = timestamp_micros - 3000000
+      to = timestamp_micros
+      interleave_filter.filters.must_be :empty?
+      interleave_filter.timestamp_range(from: from, to: to)
+      filter = assert_filter :timestamp_range_filter
+      range_grpc = Google::Bigtable::V2::TimestampRange.new(
+        start_timestamp_micros: from, end_timestamp_micros: to
+      )
+      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+    end
+
+    it "creates a timestamp_range filter with only from range" do
+      from = timestamp_micros - 3000000
+      interleave_filter.filters.must_be :empty?
+      interleave_filter.timestamp_range(from: from)
+      filter = assert_filter :timestamp_range_filter
+      range_grpc = Google::Bigtable::V2::TimestampRange.new(
+        start_timestamp_micros: from
+      )
+      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+    end
+
+    it "creates a timestamp_range filter with only to range" do
+      to = timestamp_micros
+      interleave_filter.filters.must_be :empty?
+      interleave_filter.timestamp_range(to: to)
+      filter = assert_filter :timestamp_range_filter
+      range_grpc = Google::Bigtable::V2::TimestampRange.new(
+        end_timestamp_micros: to
+      )
+      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+    end
+  end
+
+  describe "#value_range" do
+    it "creates a value_range filter" do
+      from_value = "abc"
+      to_value = "xyz"
+      range = Google::Cloud::Bigtable::ValueRange.new.from(from_value).to(to_value)
+      interleave_filter.filters.must_be :empty?
+      interleave_filter.value_range(range)
+      filter = assert_filter :value_range_filter
+      grpc = filter.to_grpc.value_range_filter
+      grpc.must_be_kind_of Google::Bigtable::V2::ValueRange
+      grpc.start_value_closed.must_equal from_value
+      grpc.end_value_open.must_equal to_value
+    end
+
+    it "range instance must be type of ValueRange" do
+      proc {
+        interleave_filter.value_range(Object.new)
+      }.must_raise Google::Cloud::Bigtable::RowFilterError
+    end
+  end
+
+  describe "#column_range" do
+    it "creates a column_range filter" do
+      family = "cf"
+      from_value = "field0"
+      to_value = "field5"
+
+      range = Google::Cloud::Bigtable::ColumnRange.new(family).from(from_value).to(to_value)
+      interleave_filter.filters.must_be :empty?
+      interleave_filter.column_range(range)
+      filter = assert_filter :column_range_filter
+      grpc = filter.to_grpc.column_range_filter
+      grpc.must_be_kind_of Google::Bigtable::V2::ColumnRange
+      grpc.family_name.must_equal family
+      grpc.start_qualifier_closed.must_equal from_value
+      grpc.end_qualifier_open.must_equal to_value
+    end
+
+    it "range instance must be type of ColumnRange" do
+      proc {
+        interleave_filter.column_range(Object.new)
+      }.must_raise Google::Cloud::Bigtable::RowFilterError
+    end
+  end
+
+  describe "#sample" do
+    it "creates a sample probability filter" do
+      probability = 0.5
+      interleave_filter.filters.must_be :empty?
+      interleave_filter.sample(probability)
+      filter = assert_filter :row_sample_filter
+      filter.to_grpc.row_sample_filter.must_equal probability
+    end
+
+    it "probability can not be greather then 1" do
+      proc {
+        interleave_filter.sample(1.1)
+      }.must_raise Google::Cloud::Bigtable::RowFilterError
+    end
+
+    it "probability can not be equal to 1" do
+      proc {
+        interleave_filter.sample(1)
+      }.must_raise Google::Cloud::Bigtable::RowFilterError
+    end
+
+    it "probability can not be equal to 0" do
+      proc {
+        interleave_filter.sample(0)
+      }.must_raise Google::Cloud::Bigtable::RowFilterError
+    end
+
+    it "probability can not be less then 0" do
+      proc {
+        interleave_filter.sample(-0.1)
+      }.must_raise Google::Cloud::Bigtable::RowFilterError
+    end
+  end
+
+  it "creates a chain filter" do
+    filter = Google::Cloud::Bigtable::RowFilter.chain
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.chain filter
+    assert_filter :chain, Google::Cloud::Bigtable::RowFilter::ChainFilter
+  end
+
+  it "creates an interleave filter" do
+    filter = Google::Cloud::Bigtable::RowFilter.interleave
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.interleave filter
+    assert_filter :interleave, Google::Cloud::Bigtable::RowFilter::InterleaveFilter
+  end
+
+  it "creates a condition filter" do
+    predicate = Google::Cloud::Bigtable::RowFilter.key("user-*")
+    filter = Google::Cloud::Bigtable::RowFilter.condition(predicate)
+    interleave_filter.filters.must_be :empty?
+    interleave_filter.condition filter
+    assert_filter :condition, Google::Cloud::Bigtable::RowFilter::ConditionFilter
+  end
+
+  def assert_filter method, type = Google::Cloud::Bigtable::RowFilter::SimpleFilter
+    interleave_filter.filters.count.must_equal 1
+    filter = interleave_filter.filters.find do |f|
+      t = f.to_grpc.send method
+      if t.kind_of? String # may be empty string in protobuf
+        !t.empty?
+      else
+        !t.nil?
+      end
+    end
+    filter.must_be_kind_of type
+    filter
+  end
+end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_filter_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_filter_test.rb
@@ -23,35 +23,35 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
       Object.new, "dummy-table-path"
     )
   }
-  it "create sink filter" do
+  it "creates a sink filter" do
     filter = Google::Cloud::Bigtable::RowFilter.sink
 
     filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
     filter.to_grpc.sink.must_equal true
   end
 
-  it "create pass filter" do
+  it "creates a pass filter" do
     filter = Google::Cloud::Bigtable::RowFilter.pass
 
     filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
     filter.to_grpc.pass_all_filter.must_equal true
   end
 
-  it "create block filter" do
+  it "creates a block filter" do
     filter = Google::Cloud::Bigtable::RowFilter.block
 
     filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
     filter.to_grpc.block_all_filter.must_equal true
   end
 
-  it "create strip_value filter" do
+  it "creates a strip_value filter" do
     filter = Google::Cloud::Bigtable::RowFilter.strip_value
 
     filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
     filter.to_grpc.strip_value_transformer.must_equal true
   end
 
-  it "create key filter" do
+  it "creates a key filter" do
     regex = "user-*"
     filter = Google::Cloud::Bigtable::RowFilter.key(regex)
 
@@ -59,7 +59,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     filter.to_grpc.row_key_regex_filter.must_equal regex
   end
 
-  it "create family filter" do
+  it "creates a family filter" do
     regex = "cf-*"
     filter = Google::Cloud::Bigtable::RowFilter.family(regex)
 
@@ -67,7 +67,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     filter.to_grpc.family_name_regex_filter.must_equal regex
   end
 
-  it "create qualifier filter" do
+  it "creates a qualifier filter" do
     regex = "field*"
     filter = Google::Cloud::Bigtable::RowFilter.qualifier(regex)
 
@@ -75,7 +75,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     filter.to_grpc.column_qualifier_regex_filter.must_equal(regex)
   end
 
-  it "create value filter" do
+  it "creates a value filter" do
     regex = "abc*"
     filter = Google::Cloud::Bigtable::RowFilter.value(regex)
 
@@ -83,7 +83,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     filter.to_grpc.value_regex_filter.must_equal regex
   end
 
-  it "create label filter" do
+  it "creates a label filter" do
     label = "test"
     filter = Google::Cloud::Bigtable::RowFilter.label(label)
 
@@ -91,7 +91,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     filter.to_grpc.apply_label_transformer.must_equal(label)
   end
 
-  it "create cells_per_row_offset filter" do
+  it "creates a cells_per_row_offset filter" do
     offset = 5
     filter = Google::Cloud::Bigtable::RowFilter.cells_per_row_offset(offset)
 
@@ -99,7 +99,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     filter.to_grpc.cells_per_row_offset_filter.must_equal offset
   end
 
-  it "create cells_per_row filter" do
+  it "creates a cells_per_row filter" do
     limit = 10
     filter = Google::Cloud::Bigtable::RowFilter.cells_per_row(limit)
 
@@ -107,7 +107,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     filter.to_grpc.cells_per_row_limit_filter.must_equal limit
   end
 
-  it "create cells_per_column filter" do
+  it "creates a cells_per_column filter" do
     limit = 10
     filter = Google::Cloud::Bigtable::RowFilter.cells_per_column(limit)
 
@@ -116,7 +116,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
   end
 
   describe "timestamp_range" do
-    it "create timestamp_range filter" do
+    it "creates a timestamp_range filter" do
       from = timestamp_micros - 3000000
       to = timestamp_micros
 
@@ -130,7 +130,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
       filter.to_grpc.timestamp_range_filter.must_equal range_grpc
     end
 
-    it "create timestamp_range filter with only from range" do
+    it "creates a timestamp_range filter with only from range" do
       from = timestamp_micros - 3000000
       filter = Google::Cloud::Bigtable::RowFilter.timestamp_range(from: from)
 
@@ -142,7 +142,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
       filter.to_grpc.timestamp_range_filter.must_equal range_grpc
     end
 
-    it "create timestamp_range filter with only to range" do
+    it "creates a timestamp_range filter with only to range" do
       to = timestamp_micros
       filter = Google::Cloud::Bigtable::RowFilter.timestamp_range(to: to)
 
@@ -156,7 +156,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
   end
 
   describe "#value_range" do
-    it "create value_range filter" do
+    it "creates a value_range filter" do
       from_value = "abc"
       to_value = "xyz"
       range = Google::Cloud::Bigtable::ValueRange.new.from(from_value).to(to_value)
@@ -178,7 +178,7 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
   end
 
   describe "#column_range" do
-    it "create column_range filter" do
+    it "creates a column_range filter" do
       family = "cf"
       from_value = "field0"
       to_value = "field5"
@@ -202,8 +202,8 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     end
   end
 
-  describe "#smaple" do
-    it "create sample probability filter" do
+  describe "#sample" do
+    it "creates a sample probability filter" do
       probability = 0.5
       filter = Google::Cloud::Bigtable::RowFilter.sample(probability)
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable 
   let(:timestamp) { 1564257960168000 }
   let(:labels) { ["test-labels"] }
   let(:qualifier) { "field01" }
-  let(:cell_value) { "xyz" }
+  let(:cell_value) { "AA213FD51B3801043FBC" } # hex "binary" to test .to_i
   let(:append_value) { "append-123" }
   let(:increment_amount) { 1 }
   let(:table) {
@@ -72,6 +72,8 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable 
     cell.family.must_equal family_name
     cell.qualifier.must_equal qualifier
     cell.timestamp.must_equal timestamp
+    cell.to_time.must_equal Time.at(timestamp/1000.0)
+    cell.to_i.must_equal 4702094672846537781
     cell.labels.must_equal labels
   end
 

--- a/google-cloud-bigtable/test/helper.rb
+++ b/google-cloud-bigtable/test/helper.rb
@@ -176,6 +176,19 @@ class MockBigtable < Minitest::Spec
    end
   end
 
+  def app_profile_grpc instance_id, app_profile_id
+    Google::Bigtable::Admin::V2::AppProfile.new(
+      name: "projects/test/instances/#{instance_id}/appProfiles/#{app_profile_id}"
+    )
+  end
+
+  def app_profiles_grpc count: 2
+    arr = Array.new(count) do |i|
+      app_profile_grpc "my-instance", "my-app-profile-#{i}"
+    end
+    Google::Bigtable::Admin::V2::ListAppProfilesResponse.new app_profiles: arr
+  end
+
   def project_path
     Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.project_path(project_id)
   end


### PR DESCRIPTION
NOTE: Removes unused private methods: `ColumnFamily#to_grpc` and `Service#snapshot_path`.

[closes #4135]

Coverage report for this PR:

<img width="1381" alt="Screen Shot 2019-10-29 at 11 31 35 AM" src="https://user-images.githubusercontent.com/205445/67793177-fada3980-fa3f-11e9-8783-32ba00152d85.png">
