### PR TITLE
Fix issue with mismatched dependencies

### DIFF
--- a/google-cloud-translate/google-cloud-translate.gemspec
+++ b/google-cloud-translate/google-cloud-translate.gemspec
@@ -32,7 +32,9 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "faraday", "~> 0.13"
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 1.7"
+  gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "google-style", "~> 1.24.0"


### PR DESCRIPTION
Add a specific common protos types dependency because this gem is using the latest protobuf annotations. Update the other runtime dependencies to match all other Google Cloud gems.

[fixes #4289]



Fixes an issue where required dependencies may not be used.