### PR TITLE
Update minimum runtime dependencies

### DIFF
--- a/google-cloud-asset/google-cloud-asset.gemspec
+++ b/google-cloud-asset/google-cloud-asset.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -105,8 +105,14 @@ s.replace(
 # https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-asset.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"',
+        '  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"'
+    ])
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2232
 s.replace(

--- a/google-cloud-automl/google-cloud-automl.gemspec
+++ b/google-cloud-automl/google-cloud-automl.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-automl/synth.py
+++ b/google-cloud-automl/synth.py
@@ -152,8 +152,13 @@ s.replace(
 )
 s.replace(
     'google-cloud-automl.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):

--- a/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec
+++ b/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -94,8 +94,13 @@ s.replace(
 )
 s.replace(
     'google-cloud-bigquery-data_transfer.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 
 # PERMANENT: Use custom credentials env variable names
 s.replace(

--- a/google-cloud-bigtable/.rubocop.yml
+++ b/google-cloud-bigtable/.rubocop.yml
@@ -28,6 +28,7 @@ Metrics/ClassLength:
     - "lib/google/cloud/bigtable/table.rb"
 Metrics/BlockLength:
   Exclude:
+    - "google-cloud-bigtable.gemspec"
     - "Rakefile"
     - "lib/google-cloud-bigtable.rb"
 Naming/FileName:

--- a/google-cloud-bigtable/google-cloud-bigtable.gemspec
+++ b/google-cloud-bigtable/google-cloud-bigtable.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.1"
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/google-cloud-container/google-cloud-container.gemspec
+++ b/google-cloud-container/google-cloud-container.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -104,8 +104,13 @@ s.replace(
 )
 s.replace(
     'google-cloud-container.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 
 # Fix for tests that assume protos implement to_hash
 s.replace(

--- a/google-cloud-container_analysis/google-cloud-container_analysis.gemspec
+++ b/google-cloud-container_analysis/google-cloud-container_analysis.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "grafeas", "~> 0.1"
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-container_analysis/synth.py
+++ b/google-cloud-container_analysis/synth.py
@@ -103,8 +103,13 @@ s.replace(
 # Container analysis should depend on grafeas
 s.replace(
     'google-cloud-container_analysis.gemspec',
-    '\n\n  gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
-    '\n\n  gem.add_dependency "grafeas", "~> 0.1"\n  gem.add_dependency "google-gax", "~> 1.8"',
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "grafeas", "~> 0.1"',
+        '  gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
 )
 s.replace(
     'lib/google/cloud/container_analysis.rb',

--- a/google-cloud-dataproc/google-cloud-dataproc.gemspec
+++ b/google-cloud-dataproc/google-cloud-dataproc.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -118,8 +118,13 @@ s.replace(
 )
 s.replace(
     'google-cloud-dataproc.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):

--- a/google-cloud-datastore/google-cloud-datastore.gemspec
+++ b/google-cloud-datastore/google-cloud-datastore.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "google-gax", "~> 1.8"
-  gem.add_dependency "google-protobuf", "~> 3.3"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "google-cloud-logging", "~> 1.0"
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 

--- a/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
+++ b/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -144,7 +144,8 @@ s.replace(
     'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
         'gem.add_dependency "google-gax", "~> 1.8"',
-        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
     ])
 )
 

--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -139,7 +139,8 @@ s.replace(
     'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
         'gem.add_dependency "google-gax", "~> 1.8"',
-        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
     ])
 )
 

--- a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
+++ b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/google-cloud-firestore/google-cloud-firestore.gemspec
+++ b/google-cloud-firestore/google-cloud-firestore.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_dependency "rbtree", "~> 0.4.2"
 

--- a/google-cloud-irm/google-cloud-irm.gemspec
+++ b/google-cloud-irm/google-cloud-irm.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-irm/synth.py
+++ b/google-cloud-irm/synth.py
@@ -93,8 +93,13 @@ s.replace(
 )
 s.replace(
     'google-cloud-irm.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(

--- a/google-cloud-kms/google-cloud-kms.gemspec
+++ b/google-cloud-kms/google-cloud-kms.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -132,8 +132,13 @@ s.replace(
 )
 s.replace(
     'google-cloud-kms.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):

--- a/google-cloud-language/google-cloud-language.gemspec
+++ b/google-cloud-language/google-cloud-language.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -160,7 +160,8 @@ s.replace(
     'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
         'gem.add_dependency "google-gax", "~> 1.8"',
-        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
     ])
 )
 

--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "google-gax", "~> 1.8"
-  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/google-cloud-monitoring/google-cloud-monitoring.gemspec
+++ b/google-cloud-monitoring/google-cloud-monitoring.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
-  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -104,8 +104,13 @@ s.replace(
 # PERMANENT: Use a compatible version of googleapis-common-protos-types
 s.replace(
     'google-cloud-monitoring.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):

--- a/google-cloud-os_login/google-cloud-os_login.gemspec
+++ b/google-cloud-os_login/google-cloud-os_login.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -118,8 +118,13 @@ s.replace(
 )
 s.replace(
     'google-cloud-os_login.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(

--- a/google-cloud-phishing_protection/google-cloud-phishing_protection.gemspec
+++ b/google-cloud-phishing_protection/google-cloud-phishing_protection.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-phishing_protection/synth.py
+++ b/google-cloud-phishing_protection/synth.py
@@ -145,6 +145,7 @@ s.replace(
     "\n".join([
         'gem.add_dependency "google-gax", "~> 1.8"',
         '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"',
         '  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"'
     ])
 )

--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"

--- a/google-cloud-recaptcha_enterprise/google-cloud-recaptcha_enterprise.gemspec
+++ b/google-cloud-recaptcha_enterprise/google-cloud-recaptcha_enterprise.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-recaptcha_enterprise/synth.py
+++ b/google-cloud-recaptcha_enterprise/synth.py
@@ -97,8 +97,14 @@ s.replace(
 # https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-recaptcha_enterprise.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"',
+        '  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"'
+    ])
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):

--- a/google-cloud-redis/google-cloud-redis.gemspec
+++ b/google-cloud-redis/google-cloud-redis.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -170,7 +170,8 @@ s.replace(
     'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
         'gem.add_dependency "google-gax", "~> 1.8"',
-        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
     ])
 )
 

--- a/google-cloud-scheduler/google-cloud-scheduler.gemspec
+++ b/google-cloud-scheduler/google-cloud-scheduler.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-scheduler/synth.py
+++ b/google-cloud-scheduler/synth.py
@@ -159,7 +159,8 @@ s.replace(
     'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
         'gem.add_dependency "google-gax", "~> 1.8"',
-        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
     ])
 )
 

--- a/google-cloud-security_center/google-cloud-security_center.gemspec
+++ b/google-cloud-security_center/google-cloud-security_center.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-security_center/synth.py
+++ b/google-cloud-security_center/synth.py
@@ -120,8 +120,13 @@ s.replace(
 )
 s.replace(
     'google-cloud-security_center.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(

--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
 

--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -173,8 +173,13 @@ s.replace(
 )
 s.replace(
     'google-cloud-speech.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2122
 s.replace(

--- a/google-cloud-talent/google-cloud-talent.gemspec
+++ b/google-cloud-talent/google-cloud-talent.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-talent/synth.py
+++ b/google-cloud-talent/synth.py
@@ -100,14 +100,15 @@ s.replace(
     'port = self\\.class::DEFAULT_SERVICE_PORT',
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
-
-# https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-talent.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"\n\n'
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
 )
-
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
     'lib/google/cloud/talent/*/*_client.rb',

--- a/google-cloud-tasks/google-cloud-tasks.gemspec
+++ b/google-cloud-tasks/google-cloud-tasks.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -171,13 +171,13 @@ for version in ['v2beta2', 'v2beta3', 'v2']:
         ])
     )
 
-# https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-tasks.gemspec',
     'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
     "\n".join([
         'gem.add_dependency "google-gax", "~> 1.8"',
-        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"'
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
     ])
 )
 

--- a/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
+++ b/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -101,9 +101,13 @@ s.replace(
 )
 s.replace(
     'google-cloud-text_to_speech.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
-
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
     'lib/google/cloud/text_to_speech/*/*_client.rb',

--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
+++ b/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -126,8 +126,13 @@ s.replace(
 )
 s.replace(
     'google-cloud-video_intelligence.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 
 # PERMANENT: API name for videointelligence
 s.replace(

--- a/google-cloud-vision/google-cloud-vision.gemspec
+++ b/google-cloud-vision/google-cloud-vision.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -111,8 +111,13 @@ s.replace(
 )
 s.replace(
     'google-cloud-vision.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 
 # PERMANENT: Add migration guide to docs
 s.replace(

--- a/google-cloud-webrisk/google-cloud-webrisk.gemspec
+++ b/google-cloud-webrisk/google-cloud-webrisk.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-webrisk/synth.py
+++ b/google-cloud-webrisk/synth.py
@@ -92,8 +92,13 @@ s.replace(
 )
 s.replace(
     'google-cloud-webrisk.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(

--- a/grafeas/grafeas.gemspec
+++ b/grafeas/grafeas.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/grafeas/synth.py
+++ b/grafeas/synth.py
@@ -122,8 +122,13 @@ s.replace(
 )
 s.replace(
     'grafeas.gemspec',
-    '\n  gem\\.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"\n',
-    '\n  gem.add_dependency "google-gax", "~> 1.8"\n')
+    'gem.add_dependency "google-gax", "~> 1\\.[\\d\\.]+"',
+    "\n".join([
+        'gem.add_dependency "google-gax", "~> 1.8"',
+        '  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"',
+        '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
+    ])
+)
 
 # Fix for tests that assume protos implement to_hash
 s.replace(


### PR DESCRIPTION
These gems are specifying an updated common protos dependency, but are missing an updated common protos types dependency needed for protos using the latest annotations. Since google-gax 1.8.0 does not specify an updated dependency, specify the dependency in the gemspec.

This PR includes all changes to the gemspec files needed, and running `synthtool` against the libraries makes no additional changes to the gemspec files.

[refs googleapis/gax-ruby#226]
[refs #4289]