### PR TITLE
feat(bigtable)!: Raise Google::Cloud::Error from Table#mutate_row and similar methods

### DIFF
--- a/google-cloud-bigtable/acceptance/bigtable/table/check_and_mutate_row_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/check_and_mutate_row_test.rb
@@ -46,4 +46,18 @@ describe "DataClient Check and Mutate Row", :bigtable do
 
     response.must_equal true
   end
+
+  it "raises Google::Cloud::InvalidArgumentError for invalid id for collection columnFamilies" do
+    row_key = "test-cm-#{random_str}"
+    qualifier = "checkmutate"
+    predicate_filter = table.filter.value("Value.*")
+    matched_mutations = table.new_mutation_entry.set_cell(
+      family + "&  *^(*&^%^%&^", qualifier, "predicate matched"
+    )
+    otherwise_mutations = table.new_mutation_entry.delete_from_family(family)
+
+    proc {
+      table.check_and_mutate_row row_key, predicate_filter, on_match: matched_mutations, otherwise: otherwise_mutations
+    }.must_raise Google::Cloud::InvalidArgumentError
+  end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
@@ -21,6 +21,17 @@ describe "DataClient Mutate Row", :bigtable do
   let(:family) { "cf" }
   let(:table) { bigtable_mutation_table }
 
+  it "raises Google::Cloud::InvalidArgumentError for invalid id for collection columnFamilies" do
+    postfix = random_str
+
+    # Set cell
+    entry = table.new_mutation_entry("setcell-#{postfix}")
+    entry.set_cell(family + "&  *^(*&^%^%&^", "mutate-row-#{postfix}", "mutatetest value #{postfix}")
+    proc {
+      table.mutate_row(entry)
+    }.must_raise Google::Cloud::InvalidArgumentError
+  end
+
   it "set cell and delete cells" do
     postfix = random_str
     row_key = "setcell-#{postfix}"
@@ -107,7 +118,7 @@ describe "DataClient Mutate Row", :bigtable do
     )
     err = expect do
       table.mutate_row(entry)
-    end.must_raise Google::Gax::RetryError
+    end.must_raise Google::Cloud::InvalidArgumentError
     err.message.must_match /Timestamp granularity mismatch. Expected a multiple of 1000 \(millisecond granularity\), but got #{timestamp_micros}/
   end
 
@@ -127,7 +138,7 @@ describe "DataClient Mutate Row", :bigtable do
     )
     err = expect do
       table.mutate_row(entry)
-    end.must_raise Google::Gax::RetryError
+    end.must_raise Google::Cloud::InvalidArgumentError
     err.message.must_match /Timestamp granularity mismatch. Expected a multiple of 1000 \(millisecond granularity\), but got #{timestamp_millis}/
   end
 

--- a/google-cloud-bigtable/acceptance/bigtable/table/read_modify_write_row_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/read_modify_write_row_test.rb
@@ -52,4 +52,16 @@ describe "DataClient Read Modify Write Row", :bigtable do
     row = table.read_modify_write_row(row_key, rule)
     row.cells[family].first.to_i.must_equal 101
   end
+
+  it "raises Google::Cloud::InvalidArgumentError for invalid id for collection columnFamilies" do
+    row_key = "readmodify-#{random_str}"
+    qualifier = "readmodify"
+    rule = Google::Cloud::Bigtable::ReadModifyWriteRule.increment(
+      family + "&  *^(*&^%^%&^", qualifier, 1
+    )
+
+    proc {
+      table.read_modify_write_row(row_key, rule)
+    }.must_raise Google::Cloud::InvalidArgumentError
+  end
 end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/chunk_processor.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/chunk_processor.rb
@@ -19,7 +19,7 @@ module Google
   module Cloud
     module Bigtable
       # @private
-      # # RowsMutator
+      # # ChunkProcessor
       #
       # Read a chunk of data and merge it based on states and build rows and cells
       #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
@@ -76,7 +76,7 @@ module Google
         #   table.mutate_row(entry)
         #
         def mutate_row entry
-          client.mutate_row path, entry.row_key, entry.mutations, app_profile_id: @app_profile_id
+          service.mutate_row path, entry.row_key, entry.mutations, app_profile_id: @app_profile_id
           true
         end
 
@@ -158,7 +158,7 @@ module Google
         #   puts row.cells
         #
         def read_modify_write_row key, rules
-          res_row = client.read_modify_write_row(
+          res_row = service.read_modify_write_row(
             path,
             key,
             Array(rules).map(&:to_grpc),
@@ -243,7 +243,7 @@ module Google
         def check_and_mutate_row key, predicate, on_match: nil, otherwise: nil
           true_mutations = on_match.mutations if on_match
           false_mutations = otherwise.mutations if otherwise
-          response = client.check_and_mutate_row(
+          response = service.check_and_mutate_row(
             path,
             key,
             predicate_filter: predicate.to_grpc,
@@ -252,41 +252,6 @@ module Google
             app_profile_id:   @app_profile_id
           )
           response.predicate_matched
-        end
-
-        ##
-        # Read sample row keys.
-        #
-        # Returns a sample of row keys in the table. The returned row keys will
-        # delimit contiguous sections of the table of approximately equal size. The
-        # sections can be used to break up the data for distributed tasks like
-        # MapReduces.
-        #
-        # @yieldreturn [Google::Cloud::Bigtable::SampleRowKey]
-        # @return [:yields: sample_row_key]
-        #   Yield block for each processed SampleRowKey.
-        #
-        # @example
-        #   require "google/cloud/bigtable"
-        #
-        #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table")
-        #
-        #   table.sample_row_keys.each do |sample_row_key|
-        #     p sample_row_key.key # user00116
-        #     p sample_row_key.offset # 805306368
-        #   end
-        #
-        def sample_row_keys
-          return enum_for :sample_row_keys unless block_given?
-
-          response = client.sample_row_keys(
-            path,
-            app_profile_id: @app_profile_id
-          )
-          response.each do |grpc|
-            yield SampleRowKey.from_grpc grpc
-          end
         end
 
         ##

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/read_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/read_operations.rb
@@ -60,7 +60,7 @@ module Google
         def sample_row_keys
           return enum_for :sample_row_keys unless block_given?
 
-          response = client.sample_row_keys path, app_profile_id: @app_profile_id
+          response = service.sample_row_keys path, app_profile_id: @app_profile_id
           response.each do |grpc|
             yield SampleRowKey.from_grpc grpc
           end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/rows_mutator.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/rows_mutator.rb
@@ -83,14 +83,10 @@ module Google
         # @return [Array<Google::Bigtable::V2::MutateRowsResponse::Entry>]
         #
         def mutate_rows entries
-          response = @table.client.mutate_rows @table.path, entries, app_profile_id: @table.app_profile_id
+          response = @table.service.mutate_rows @table.path, entries, app_profile_id: @table.app_profile_id
           response.each_with_object [] do |res, statuses|
             statuses.concat res.entries
           end
-        rescue Google::Gax::GaxError => e
-          raise Google::Cloud::Error.from_error(e.cause)
-        rescue GRPC::BadStatus => e
-          raise Google::Cloud::Error.from_error(e)
         end
 
         ##

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/rows_reader.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/rows_reader.rb
@@ -75,8 +75,9 @@ module Google
         #   Array of row or yield block for each processed row.
         #
         def read rows: nil, filter: nil, rows_limit: nil
-          response = @table.client.read_rows(
-            @table.path,
+          response = @table.service.read_rows(
+            @table.instance_id,
+            @table.table_id,
             rows:           rows,
             filter:         filter,
             rows_limit:     rows_limit,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
@@ -640,6 +640,48 @@ module Google
           end
         end
 
+        def read_rows instance_id, table_id, app_profile_id: nil, rows: nil, filter: nil, rows_limit: nil
+          # execute is not used because error handling is in ReadOperations#read_rows
+          client.read_rows table_path(instance_id, table_id),
+                           rows:           rows,
+                           filter:         filter,
+                           rows_limit:     rows_limit,
+                           app_profile_id: app_profile_id
+        end
+
+        def sample_row_keys table_name, app_profile_id: nil
+          execute do
+            client.sample_row_keys table_name, app_profile_id: app_profile_id
+          end
+        end
+
+        def mutate_row table_name, row_key, mutations, app_profile_id: nil
+          execute do
+            client.mutate_row table_name, row_key, mutations, app_profile_id: app_profile_id
+          end
+        end
+
+        def mutate_rows table_name, entries, app_profile_id: nil
+          execute do
+            client.mutate_rows table_name, entries, app_profile_id: app_profile_id
+          end
+        end
+
+        def check_and_mutate_row table_name, row_key, app_profile_id: nil, predicate_filter: nil, true_mutations: nil,
+                                 false_mutations: nil
+          execute do
+            client.check_and_mutate_row table_name, row_key, app_profile_id: app_profile_id,
+                                        predicate_filter: predicate_filter, true_mutations: true_mutations,
+                                        false_mutations: false_mutations
+          end
+        end
+
+        def read_modify_write_row table_name, row_key, rules, app_profile_id: nil
+          execute do
+            client.read_modify_write_row table_name, row_key, rules, app_profile_id: app_profile_id
+          end
+        end
+
         ##
         # Executes the API call and wrap errors to {Google::Cloud::Error}.
         #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
@@ -424,15 +424,6 @@ module Google
           status
         end
 
-        # @private
-        # Gets the data client instance.
-        #
-        # @return [Google::Cloud::Bigtable::V2::BigtableClient]
-        #
-        def client
-          service.client
-        end
-
         ##
         # Deletes all rows.
         #

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
@@ -61,7 +61,7 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
     rows.first.must_equal expected_row
   end
 
-  it "retry on retyable error" do
+  it "retry on retryable error" do
     chunks_base64 = [
       "CgJSSxIDCgFBGgMKAUMgZDILdmFsdWUtVkFMXzFIAA==",
       "IGIyC3ZhbHVlLVZBTF8ySAA=",


### PR DESCRIPTION
BREAKING CHANGES: The following methods now raise `Google::Cloud::Error` instead of
`Google::Gax::GaxError` and/or `GRPC::BadStatus`: `Table#mutate_row`,
`Table#read_modify_write_row`, `Table#check_and_mutate_row`, and `Table#sample_row_keys`.

* Refactor `Table#client` usages to `Table#service`.
* Add the following methods to `Service`: `read_rows`, `sample_row_keys`, `mutate_row`,
  `mutate_rows`, `check_and_mutate_row`, and `read_modify_write_row`.
* Remove duplicate module method definition `MutationOperations#sample_row_keys`.
* Update acceptance and unit tests to expect `Google::Cloud::Error`.

closes: #4138