### PR TITLE
Add optional query parameter types

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
@@ -19,40 +19,110 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
     rows = bigquery.query "SELECT @value AS value", params: { value: "hello" }
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :string?
     rows.count.must_equal 1
     rows.first[:value].must_equal "hello"
+  end
+
+  it "queries the data with a nil parameter and string type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :STRING }
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :string?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with an integer parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: 999 }
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :integer?
     rows.count.must_equal 1
     rows.first[:value].must_equal 999
+  end
+
+  it "queries the data with a nil parameter and integer type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :INT64 }
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :integer?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a float parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: 12.0 }
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :float?
     rows.count.must_equal 1
     rows.first[:value].must_equal 12.0
+  end
+
+  it "queries the data with a nil parameter and float type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :FLOAT64 }
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :float?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a numeric parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: BigDecimal("123456789.123456789") }
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :numeric?
     rows.count.must_equal 1
     rows.first[:value].must_equal BigDecimal("123456789.123456789")
+  end
+
+  it "queries the data with a nil parameter and numeric type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :NUMERIC }
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :numeric?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a boolean parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: false }
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :boolean?
     rows.count.must_equal 1
     rows.first[:value].must_equal false
+  end
+
+  it "queries the data with a nil parameter and boolean type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :BOOL }
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :boolean?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a date parameter" do
@@ -60,8 +130,22 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
     rows = bigquery.query "SELECT @value AS value", params: { value: today }
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :date?
     rows.count.must_equal 1
     rows.first[:value].must_equal Date.today
+  end
+
+  it "queries the data with a nil parameter and boolean type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :DATE }
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :date?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a datetime parameter" do
@@ -69,10 +153,24 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
     rows = bigquery.query "SELECT @value AS value", params: { value: now }
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :datetime?
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of DateTime
     rows.first[:value].must_be_close_to now
     # rows.first[:value].must_equal now.to_s
+  end
+
+  it "queries the data with a nil parameter and boolean type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :DATETIME }
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :datetime?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a timestamp parameter" do
@@ -80,33 +178,79 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
     rows = bigquery.query "SELECT @value AS value", params: { value: now }
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :timestamp?
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of ::Time
     rows.first[:value].must_be_close_to now
+  end
+
+  it "queries the data with a nil parameter and boolean type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :TIMESTAMP }
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :timestamp?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a time parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: bigquery.time(12, 30, 0) }
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :time?
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of Google::Cloud::Bigquery::Time
     rows.first[:value].value.must_equal "12:30:00"
+  end
+
+  it "queries the data with a nil parameter and boolean type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :TIME }
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :time?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a bytes parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: StringIO.new("hello world!") }
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :bytes?
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of StringIO
     rows.first[:value].read.must_equal "hello world!"
+  end
+
+  it "queries the data with a nil parameter and boolean type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :BYTES }
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :bytes?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with an array of integers parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: [1, 2, 3, 4] }
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :integer?
+    rows.fields.first.must_be :repeated?
     rows.count.must_equal 1
     rows.first[:value].must_equal [1, 2, 3, 4]
   end
@@ -119,11 +263,77 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
     rows.first[:value].must_equal ["foo", "bar", "baz"]
   end
 
-  it "queries the data with a struct parameter" do
-    rows = bigquery.query "SELECT @hitchhiker.message, @hitchhiker.repeat", params: { hitchhiker: { message: "hello", repeat: 1 } }
+  it "queries the data with an empty array of integers and type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: [] }, types: { value: [:INT64] }
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :integer?
+    rows.fields.first.must_be :repeated?
     rows.count.must_equal 1
-    rows.first.must_equal({ message: "hello", repeat: 1 })
+    rows.first[:value].must_equal []
+  end
+
+  it "queries the data with a nil parameter and ARRAY type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: [:INT64] }
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :integer?
+    rows.fields.first.must_be :repeated?
+    rows.count.must_equal 1
+    # rows.first[:value].must_be_nil
+    rows.first[:value].must_equal []
+  end
+
+  it "queries the data with a struct parameter" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: { message: "hello", repeat: 1 } }
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :record?
+    rows.fields.first.fields.count.must_equal 2
+    rows.fields.first.fields.first.name.must_equal "message"
+    rows.fields.first.fields.first.must_be :string?
+    rows.fields.first.fields.last.name.must_equal "repeat"
+    rows.fields.first.fields.last.must_be :integer?
+    rows.count.must_equal 1
+    rows.first[:value].must_equal({ message: "hello", repeat: 1 })
+  end
+
+  it "queries the data with a empty parameter and STRUCT type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: {} }, types: { value: { message: :STRING, repeat: :INT64 } }
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :record?
+    rows.fields.first.fields.count.must_equal 2
+    rows.fields.first.fields.first.name.must_equal "message"
+    rows.fields.first.fields.first.must_be :string?
+    rows.fields.first.fields.last.name.must_equal "repeat"
+    rows.fields.first.fields.last.must_be :integer?
+    rows.count.must_equal 1
+    # rows.first[:value].must_equal({})
+    rows.first[:value].must_be_nil
+  end
+
+  it "queries the data with a nil parameter and STRUCT type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: { message: :STRING, repeat: :INT64 } }
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :record?
+    rows.fields.first.fields.count.must_equal 2
+    rows.fields.first.fields.first.name.must_equal "message"
+    rows.fields.first.fields.first.must_be :string?
+    rows.fields.first.fields.last.name.must_equal "repeat"
+    rows.fields.first.fields.last.must_be :integer?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
@@ -19,40 +19,110 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
     rows = bigquery.query "SELECT ? AS value", params: ["hello"]
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :string?
     rows.count.must_equal 1
     rows.first[:value].must_equal "hello"
+  end
+
+  it "queries the data with a nil parameter and string type" do
+    rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:STRING]
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :string?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with an integer parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [999]
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :integer?
     rows.count.must_equal 1
     rows.first[:value].must_equal 999
+  end
+
+  it "queries the data with a nil parameter and integer type" do
+    rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:INT64]
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :integer?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a float parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [12.0]
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :float?
     rows.count.must_equal 1
     rows.first[:value].must_equal 12.0
+  end
+
+  it "queries the data with a nil parameter and float type" do
+    rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:FLOAT64]
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :float?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a numeric parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [BigDecimal("123456789.123456789")]
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :numeric?
     rows.count.must_equal 1
     rows.first[:value].must_equal BigDecimal("123456789.123456789")
+  end
+
+  it "queries the data with a nil parameter and numeric type" do
+    rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:NUMERIC]
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :numeric?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a boolean parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [false]
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :boolean?
     rows.count.must_equal 1
     rows.first[:value].must_equal false
+  end
+
+  it "queries the data with a nil parameter and boolean type" do
+    rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:BOOL]
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :boolean?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a date parameter" do
@@ -60,8 +130,22 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
     rows = bigquery.query "SELECT ? AS value", params: [today]
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :date?
     rows.count.must_equal 1
     rows.first[:value].must_equal Date.today
+  end
+
+  it "queries the data with a nil parameter and boolean type" do
+    rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:DATE]
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :date?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a datetime parameter" do
@@ -69,10 +153,24 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
     rows = bigquery.query "SELECT ? AS value", params: [now]
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :datetime?
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of DateTime
     rows.first[:value].must_be_close_to now
     # rows.first[:value].must_equal now.to_s
+  end
+
+  it "queries the data with a nil parameter and boolean type" do
+    rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:DATETIME]
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :datetime?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a timestamp parameter" do
@@ -80,33 +178,79 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
     rows = bigquery.query "SELECT ? AS value", params: [now]
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :timestamp?
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of ::Time
     rows.first[:value].must_be_close_to now
+  end
+
+  it "queries the data with a nil parameter and boolean type" do
+    rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:TIMESTAMP]
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :timestamp?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a time parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [bigquery.time(12, 30, 0)]
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :time?
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of Google::Cloud::Bigquery::Time
     rows.first[:value].value.must_equal "12:30:00"
+  end
+
+  it "queries the data with a nil parameter and boolean type" do
+    rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:TIME]
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :time?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with a bytes parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [StringIO.new("hello world!")]
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :bytes?
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of StringIO
     rows.first[:value].read.must_equal "hello world!"
+  end
+
+  it "queries the data with a nil parameter and boolean type" do
+    rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:BYTES]
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :bytes?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 
   it "queries the data with an array of integers parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [[1, 2, 3, 4]]
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :integer?
+    rows.fields.first.must_be :repeated?
     rows.count.must_equal 1
     rows.first[:value].must_equal [1, 2, 3, 4]
   end
@@ -119,11 +263,77 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
     rows.first[:value].must_equal ["foo", "bar", "baz"]
   end
 
-  it "queries the data with a struct parameter" do
-    rows = bigquery.query "SELECT ?.message, ?.repeat", params: [{ message: "hello" }, { repeat: 1 }]
+  it "queries the data with an empty array of integers and type" do
+    rows = bigquery.query "SELECT ? AS value", params: [[]], types: [[:INT64]]
 
     rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :integer?
+    rows.fields.first.must_be :repeated?
     rows.count.must_equal 1
-    rows.first.must_equal({ message: "hello", repeat: 1 })
+    rows.first[:value].must_equal []
+  end
+
+  it "queries the data with a nil parameter and ARRAY type" do
+    rows = bigquery.query "SELECT ? AS value", params: [nil], types: [[:INT64]]
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :integer?
+    rows.fields.first.must_be :repeated?
+    rows.count.must_equal 1
+    # rows.first[:value].must_be_nil
+    rows.first[:value].must_equal []
+  end
+
+  it "queries the data with a struct parameter" do
+    rows = bigquery.query "SELECT ? AS value", params: [{ message: "hello", repeat: 1 }]
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :record?
+    rows.fields.first.fields.count.must_equal 2
+    rows.fields.first.fields.first.name.must_equal "message"
+    rows.fields.first.fields.first.must_be :string?
+    rows.fields.first.fields.last.name.must_equal "repeat"
+    rows.fields.first.fields.last.must_be :integer?
+    rows.count.must_equal 1
+    rows.first[:value].must_equal({ message: "hello", repeat: 1 })
+  end
+
+  it "queries the data with a empty parameter and STRUCT type" do
+    rows = bigquery.query "SELECT ? AS value", params: [{}], types: [{ message: :STRING, repeat: :INT64 }]
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :record?
+    rows.fields.first.fields.count.must_equal 2
+    rows.fields.first.fields.first.name.must_equal "message"
+    rows.fields.first.fields.first.must_be :string?
+    rows.fields.first.fields.last.name.must_equal "repeat"
+    rows.fields.first.fields.last.must_be :integer?
+    rows.count.must_equal 1
+    # rows.first[:value].must_equal({})
+    rows.first[:value].must_be_nil
+  end
+
+  it "queries the data with a nil parameter and STRUCT type" do
+    rows = bigquery.query "SELECT ? AS value", params: [nil], types: [{ message: :STRING, repeat: :INT64 }]
+
+    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.fields.count.must_equal 1
+    rows.fields.first.name.must_equal "value"
+    rows.fields.first.must_be :record?
+    rows.fields.first.fields.count.must_equal 2
+    rows.fields.first.fields.first.name.must_equal "message"
+    rows.fields.first.fields.first.must_be :string?
+    rows.fields.first.fields.last.name.must_equal "repeat"
+    rows.fields.first.fields.last.must_be :integer?
+    rows.count.must_equal 1
+    rows.first[:value].must_be_nil
   end
 end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1046,6 +1046,24 @@ module Google
         #     end
         #   end
         #
+        # @example Query using named query parameters with types:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #
+        #   job = dataset.query_job "SELECT name FROM my_table " \
+        #                           "WHERE id IN UNNEST(@ids)",
+        #                           params: { ids: [] },
+        #                           types: { ids: [:INT64] }
+        #
+        #   job.wait_until_done!
+        #   if !job.failed?
+        #     job.data.each do |row|
+        #       puts row[:name]
+        #     end
+        #   end
+        #
         # @example Execute a DDL statement:
         #   require "google/cloud/bigquery"
         #
@@ -1276,6 +1294,21 @@ module Google
         #
         #   data = dataset.query "SELECT name FROM my_table WHERE id = @id",
         #                        params: { id: 1 }
+        #
+        #   data.each do |row|
+        #     puts row[:name]
+        #   end
+        #
+        # @example Query using named query parameters with types:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #
+        #   data = dataset.query "SELECT name FROM my_table " \
+        #                        "WHERE id IN UNNEST(@ids)",
+        #                        params: { ids: [] },
+        #                        types: { ids: [:INT64] }
         #
         #   data.each do |row|
         #     puts row[:name]

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -824,27 +824,6 @@ module Google
         # Sets the current dataset as the default dataset in the query. Useful
         # for using unqualified table names.
         #
-        # When using standard SQL and passing arguments using `params`, Ruby
-        # types are mapped to BigQuery types as follows:
-        #
-        # | BigQuery    | Ruby           | Notes  |
-        # |-------------|----------------|---|
-        # | `BOOL`      | `true`/`false` | |
-        # | `INT64`     | `Integer`      | |
-        # | `FLOAT64`   | `Float`        | |
-        # | `NUMERIC`   | `BigDecimal`   | Will be rounded to 9 decimal places |
-        # | `STRING`    | `String`       | |
-        # | `DATETIME`  | `DateTime`  | `DATETIME` does not support time zone. |
-        # | `DATE`      | `Date`         | |
-        # | `TIMESTAMP` | `Time`         | |
-        # | `TIME`      | `Google::Cloud::BigQuery::Time` | |
-        # | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
-        # | `ARRAY` | `Array` | Nested arrays, `nil` values are not supported. |
-        # | `STRUCT`    | `Hash`        | Hash keys may be strings or symbols. |
-        #
-        # See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types)
-        # for an overview of each BigQuery data type, including allowed values.
-        #
         # The geographic location for the job ("US", "EU", etc.) can be set via
         # {QueryJob::Updater#location=} in a block passed to this method. If the
         # dataset is a full resource representation (see {#resource_full?}), the
@@ -855,13 +834,55 @@ module Google
         #   syntax](https://cloud.google.com/bigquery/query-reference), of the
         #   query to execute. Example: "SELECT count(f1) FROM
         #   [myProjectId:myDatasetId.myTableId]".
-        # @param [Array, Hash] params Standard SQL only. Used to pass query
-        #   arguments when the `query` string contains either positional (`?`)
-        #   or named (`@myparam`) query parameters. If value passed is an array
-        #   `["foo"]`, the query must use positional query parameters. If value
-        #   passed is a hash `{ myparam: "foo" }`, the query must use named
-        #   query parameters. When set, `legacy_sql` will automatically be set
-        #   to false and `standard_sql` to true.
+        # @param [Array, Hash] params Standard SQL only. Used to pass query arguments when the `query` string contains
+        #   either positional (`?`) or named (`@myparam`) query parameters. If value passed is an array `["foo"]`, the
+        #   query must use positional query parameters. If value passed is a hash `{ myparam: "foo" }`, the query must
+        #   use named query parameters. When set, `legacy_sql` will automatically be set to false and `standard_sql` to
+        #   true.
+        #
+        #   Ruby types are mapped to BigQuery types as follows:
+        #
+        #   | BigQuery    | Ruby                                 | Notes                                          |
+        #   |-------------|--------------------------------------|------------------------------------------------|
+        #   | `BOOL`      | `true`/`false`                       |                                                |
+        #   | `INT64`     | `Integer`                            |                                                |
+        #   | `FLOAT64`   | `Float`                              |                                                |
+        #   | `NUMERIC`   | `BigDecimal`                         | Will be rounded to 9 decimal places            |
+        #   | `STRING`    | `String`                             |                                                |
+        #   | `DATETIME`  | `DateTime`                           | `DATETIME` does not support time zone.         |
+        #   | `DATE`      | `Date`                               |                                                |
+        #   | `TIMESTAMP` | `Time`                               |                                                |
+        #   | `TIME`      | `Google::Cloud::BigQuery::Time`      |                                                |
+        #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar |                                                |
+        #   | `ARRAY`     | `Array`                              | Nested arrays, `nil` values are not supported. |
+        #   | `STRUCT`    | `Hash`                               | Hash keys may be strings or symbols.           |
+        #
+        #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
+        #   of each BigQuery data type, including allowed values.
+        # @param [Array, Hash] types Standard SQL only. Types of the SQL parameters in `params`. It is not always to
+        #   infer the right SQL type from a value in `params`. In these cases, `types` must be used to specify the SQL
+        #   type for these values.
+        #
+        #   Must match the value type passed to `params`. This must be an `Array` when the query uses positional query
+        #   parameters. This must be an `Hash` when the query uses named query parameters. The values should be BigQuery
+        #   type codes from the following list:
+        #
+        #   * `:BOOL`
+        #   * `:INT64`
+        #   * `:FLOAT64`
+        #   * `:NUMERIC`
+        #   * `:STRING`
+        #   * `:DATETIME`
+        #   * `:DATE`
+        #   * `:TIMESTAMP`
+        #   * `:TIME`
+        #   * `:BYTES`
+        #   * `Array` - Lists are specified by providing the type code in an array. For example, an array of integers
+        #     are specified as `[:INT64]`.
+        #   * `Hash` - Types for STRUCT values (`Hash` objects) are specified using a `Hash` object, where the keys
+        #     match the `params` hash, and the values are the types value that matches the data.
+        #
+        #   Types are optional.
         # @param [Hash<String|Symbol, External::DataSource>] external A Hash
         #   that represents the mapping of the external tables to the table
         #   names used in the SQL query. The hash keys are the table names, and
@@ -1077,16 +1098,16 @@ module Google
         #
         # @!group Data
         #
-        def query_job query, params: nil, external: nil, priority: "INTERACTIVE", cache: true, table: nil, create: nil,
-                      write: nil, dryrun: nil, standard_sql: nil, legacy_sql: nil, large_results: nil, flatten: nil,
-                      maximum_billing_tier: nil, maximum_bytes_billed: nil, job_id: nil, prefix: nil, labels: nil,
-                      udfs: nil
+        def query_job query, params: nil, types: nil, external: nil, priority: "INTERACTIVE", cache: true, table: nil,
+                      create: nil, write: nil, dryrun: nil, standard_sql: nil, legacy_sql: nil, large_results: nil,
+                      flatten: nil, maximum_billing_tier: nil, maximum_bytes_billed: nil, job_id: nil, prefix: nil,
+                      labels: nil, udfs: nil
           ensure_service!
-          options = { priority: priority, cache: cache, table: table, create: create, write: write, dryrun: dryrun,
-                      large_results: large_results, flatten: flatten, legacy_sql: legacy_sql,
-                      standard_sql: standard_sql, maximum_billing_tier: maximum_billing_tier,
-                      maximum_bytes_billed: maximum_bytes_billed, job_id: job_id, prefix: prefix, params: params,
-                      external: external, labels: labels, udfs: udfs }
+          options = { params: params, types: types, external: external, priority: priority, cache: cache, table: table,
+                      create: create, write: write, dryrun: dryrun, standard_sql: standard_sql, legacy_sql: legacy_sql,
+                      large_results: large_results, flatten: flatten, maximum_billing_tier: maximum_billing_tier,
+                      maximum_bytes_billed: maximum_bytes_billed, job_id: job_id, prefix: prefix, labels: labels,
+                      udfs: udfs }
 
           updater = QueryJob::Updater.from_options service, query, options
           updater.dataset = self
@@ -1108,27 +1129,6 @@ module Google
         # Sets the current dataset as the default dataset in the query. Useful
         # for using unqualified table names.
         #
-        # When using standard SQL and passing arguments using `params`, Ruby
-        # types are mapped to BigQuery types as follows:
-        #
-        # | BigQuery    | Ruby           | Notes  |
-        # |-------------|----------------|---|
-        # | `BOOL`      | `true`/`false` | |
-        # | `INT64`     | `Integer`      | |
-        # | `FLOAT64`   | `Float`        | |
-        # | `NUMERIC`   | `BigDecimal`   | Will be rounded to 9 decimal places |
-        # | `STRING`    | `String`       | |
-        # | `DATETIME`  | `DateTime`  | `DATETIME` does not support time zone. |
-        # | `DATE`      | `Date`         | |
-        # | `TIMESTAMP` | `Time`         | |
-        # | `TIME`      | `Google::Cloud::BigQuery::Time` | |
-        # | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
-        # | `ARRAY` | `Array` | Nested arrays, `nil` values are not supported. |
-        # | `STRUCT`    | `Hash`        | Hash keys may be strings or symbols. |
-        #
-        # See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types)
-        # for an overview of each BigQuery data type, including allowed values.
-        #
         # The geographic location for the job ("US", "EU", etc.) can be set via
         # {QueryJob::Updater#location=} in a block passed to this method. If the
         # dataset is a full resource representation (see {#resource_full?}), the
@@ -1141,13 +1141,55 @@ module Google
         #   syntax](https://cloud.google.com/bigquery/query-reference), of the
         #   query to execute. Example: "SELECT count(f1) FROM
         #   [myProjectId:myDatasetId.myTableId]".
-        # @param [Array, Hash] params Standard SQL only. Used to pass query
-        #   arguments when the `query` string contains either positional (`?`)
-        #   or named (`@myparam`) query parameters. If value passed is an array
-        #   `["foo"]`, the query must use positional query parameters. If value
-        #   passed is a hash `{ myparam: "foo" }`, the query must use named
-        #   query parameters. When set, `legacy_sql` will automatically be set
-        #   to false and `standard_sql` to true.
+        # @param [Array, Hash] params Standard SQL only. Used to pass query arguments when the `query` string contains
+        #   either positional (`?`) or named (`@myparam`) query parameters. If value passed is an array `["foo"]`, the
+        #   query must use positional query parameters. If value passed is a hash `{ myparam: "foo" }`, the query must
+        #   use named query parameters. When set, `legacy_sql` will automatically be set to false and `standard_sql` to
+        #   true.
+        #
+        #   Ruby types are mapped to BigQuery types as follows:
+        #
+        #   | BigQuery    | Ruby                                 | Notes                                          |
+        #   |-------------|--------------------------------------|------------------------------------------------|
+        #   | `BOOL`      | `true`/`false`                       |                                                |
+        #   | `INT64`     | `Integer`                            |                                                |
+        #   | `FLOAT64`   | `Float`                              |                                                |
+        #   | `NUMERIC`   | `BigDecimal`                         | Will be rounded to 9 decimal places            |
+        #   | `STRING`    | `String`                             |                                                |
+        #   | `DATETIME`  | `DateTime`                           | `DATETIME` does not support time zone.         |
+        #   | `DATE`      | `Date`                               |                                                |
+        #   | `TIMESTAMP` | `Time`                               |                                                |
+        #   | `TIME`      | `Google::Cloud::BigQuery::Time`      |                                                |
+        #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar |                                                |
+        #   | `ARRAY`     | `Array`                              | Nested arrays, `nil` values are not supported. |
+        #   | `STRUCT`    | `Hash`                               | Hash keys may be strings or symbols.           |
+        #
+        #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
+        #   of each BigQuery data type, including allowed values.
+        # @param [Array, Hash] types Standard SQL only. Types of the SQL parameters in `params`. It is not always to
+        #   infer the right SQL type from a value in `params`. In these cases, `types` must be used to specify the SQL
+        #   type for these values.
+        #
+        #   Must match the value type passed to `params`. This must be an `Array` when the query uses positional query
+        #   parameters. This must be an `Hash` when the query uses named query parameters. The values should be BigQuery
+        #   type codes from the following list:
+        #
+        #   * `:BOOL`
+        #   * `:INT64`
+        #   * `:FLOAT64`
+        #   * `:NUMERIC`
+        #   * `:STRING`
+        #   * `:DATETIME`
+        #   * `:DATE`
+        #   * `:TIMESTAMP`
+        #   * `:TIME`
+        #   * `:BYTES`
+        #   * `Array` - Lists are specified by providing the type code in an array. For example, an array of integers
+        #     are specified as `[:INT64]`.
+        #   * `Hash` - Types for STRUCT values (`Hash` objects) are specified using a `Hash` object, where the keys
+        #     match the `params` hash, and the values are the types value that matches the data.
+        #
+        #   Types are optional.
         # @param [Hash<String|Symbol, External::DataSource>] external A Hash
         #   that represents the mapping of the external tables to the table
         #   names used in the SQL query. The hash keys are the table names, and
@@ -1282,9 +1324,10 @@ module Google
         #
         # @!group Data
         #
-        def query query, params: nil, external: nil, max: nil, cache: true, standard_sql: nil, legacy_sql: nil, &block
-          job = query_job query, params: params, external: external, cache: cache, standard_sql: standard_sql,
-                                 legacy_sql: legacy_sql, &block
+        def query query, params: nil, types: nil, external: nil, max: nil, cache: true,
+                  standard_sql: nil, legacy_sql: nil, &block
+          job = query_job query, params: params, types: types, external: external, cache: cache,
+                                 standard_sql: standard_sql, legacy_sql: legacy_sql, &block
           job.wait_until_done!
           ensure_job_succeeded! job
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -470,8 +470,8 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   job = bigquery.query_job "SELECT name FROM " \
-        #                            "`my_dataset.my_table`" \
-        #                            " WHERE id = ?",
+        #                            "`my_dataset.my_table` " \
+        #                            "WHERE id = ?",
         #                            params: [1]
         #
         #   job.wait_until_done!
@@ -487,9 +487,27 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   job = bigquery.query_job "SELECT name FROM " \
-        #                            "`my_dataset.my_table`" \
-        #                            " WHERE id = @id",
+        #                            "`my_dataset.my_table` " \
+        #                            "WHERE id = @id",
         #                            params: { id: 1 }
+        #
+        #   job.wait_until_done!
+        #   if !job.failed?
+        #     job.data.each do |row|
+        #       puts row[:name]
+        #     end
+        #   end
+        #
+        # @example Query using named query parameters with types:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   job = bigquery.query_job "SELECT name FROM " \
+        #                            "`my_dataset.my_table` " \
+        #                            "WHERE id IN UNNEST(@ids)",
+        #                            params: { ids: [] },
+        #                            types: { ids: [:INT64] }
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -724,7 +742,7 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   data = bigquery.query "SELECT name " \
-        #                         "FROM `my_dataset.my_table`" \
+        #                         "FROM `my_dataset.my_table` " \
         #                         "WHERE id = ?",
         #                         params: [1]
         #
@@ -738,9 +756,24 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   data = bigquery.query "SELECT name " \
-        #                         "FROM `my_dataset.my_table`" \
+        #                         "FROM `my_dataset.my_table` " \
         #                         "WHERE id = @id",
         #                         params: { id: 1 }
+        #
+        #   data.each do |row|
+        #     puts row[:name]
+        #   end
+        #
+        # @example Query using named query parameters with types:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   data = bigquery.query "SELECT name FROM " \
+        #                         "`my_dataset.my_table` " \
+        #                         "WHERE id IN UNNEST(@ids)",
+        #                         params: { ids: [] },
+        #                         types: { ids: [:INT64] }
         #
         #   data.each do |row|
         #     puts row[:name]

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -269,27 +269,6 @@ module Google
         # Queries data by creating a [query
         # job](https://cloud.google.com/bigquery/docs/query-overview#query_jobs).
         #
-        # When using standard SQL and passing arguments using `params`, Ruby
-        # types are mapped to BigQuery types as follows:
-        #
-        # | BigQuery    | Ruby           | Notes  |
-        # |-------------|----------------|---|
-        # | `BOOL`      | `true`/`false` | |
-        # | `INT64`     | `Integer`      | |
-        # | `FLOAT64`   | `Float`        | |
-        # | `NUMERIC`   | `BigDecimal`   | Will be rounded to 9 decimal places |
-        # | `STRING`    | `String`       | |
-        # | `DATETIME`  | `DateTime`  | `DATETIME` does not support time zone. |
-        # | `DATE`      | `Date`         | |
-        # | `TIMESTAMP` | `Time`         | |
-        # | `TIME`      | `Google::Cloud::BigQuery::Time` | |
-        # | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
-        # | `ARRAY` | `Array` | Nested arrays, `nil` values are not supported. |
-        # | `STRUCT`    | `Hash`        | Hash keys may be strings or symbols. |
-        #
-        # See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types)
-        # for an overview of each BigQuery data type, including allowed values.
-        #
         # The geographic location for the job ("US", "EU", etc.) can be set via
         # {QueryJob::Updater#location=} in a block passed to this method.
         #
@@ -297,13 +276,55 @@ module Google
         #   syntax](https://cloud.google.com/bigquery/query-reference), of the
         #   query to execute. Example: "SELECT count(f1) FROM
         #   [myProjectId:myDatasetId.myTableId]".
-        # @param [Array, Hash] params Standard SQL only. Used to pass query
-        #   arguments when the `query` string contains either positional (`?`)
-        #   or named (`@myparam`) query parameters. If value passed is an array
-        #   `["foo"]`, the query must use positional query parameters. If value
-        #   passed is a hash `{ myparam: "foo" }`, the query must use named
-        #   query parameters. When set, `legacy_sql` will automatically be set
-        #   to false and `standard_sql` to true.
+        # @param [Array, Hash] params Standard SQL only. Used to pass query arguments when the `query` string contains
+        #   either positional (`?`) or named (`@myparam`) query parameters. If value passed is an array `["foo"]`, the
+        #   query must use positional query parameters. If value passed is a hash `{ myparam: "foo" }`, the query must
+        #   use named query parameters. When set, `legacy_sql` will automatically be set to false and `standard_sql` to
+        #   true.
+        #
+        #   Ruby types are mapped to BigQuery types as follows:
+        #
+        #   | BigQuery    | Ruby                                 | Notes                                          |
+        #   |-------------|--------------------------------------|------------------------------------------------|
+        #   | `BOOL`      | `true`/`false`                       |                                                |
+        #   | `INT64`     | `Integer`                            |                                                |
+        #   | `FLOAT64`   | `Float`                              |                                                |
+        #   | `NUMERIC`   | `BigDecimal`                         | Will be rounded to 9 decimal places            |
+        #   | `STRING`    | `String`                             |                                                |
+        #   | `DATETIME`  | `DateTime`                           | `DATETIME` does not support time zone.         |
+        #   | `DATE`      | `Date`                               |                                                |
+        #   | `TIMESTAMP` | `Time`                               |                                                |
+        #   | `TIME`      | `Google::Cloud::BigQuery::Time`      |                                                |
+        #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar |                                                |
+        #   | `ARRAY`     | `Array`                              | Nested arrays, `nil` values are not supported. |
+        #   | `STRUCT`    | `Hash`                               | Hash keys may be strings or symbols.           |
+        #
+        #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
+        #   of each BigQuery data type, including allowed values.
+        # @param [Array, Hash] types Standard SQL only. Types of the SQL parameters in `params`. It is not always to
+        #   infer the right SQL type from a value in `params`. In these cases, `types` must be used to specify the SQL
+        #   type for these values.
+        #
+        #   Must match the value type passed to `params`. This must be an `Array` when the query uses positional query
+        #   parameters. This must be an `Hash` when the query uses named query parameters. The values should be BigQuery
+        #   type codes from the following list:
+        #
+        #   * `:BOOL`
+        #   * `:INT64`
+        #   * `:FLOAT64`
+        #   * `:NUMERIC`
+        #   * `:STRING`
+        #   * `:DATETIME`
+        #   * `:DATE`
+        #   * `:TIMESTAMP`
+        #   * `:TIME`
+        #   * `:BYTES`
+        #   * `Array` - Lists are specified by providing the type code in an array. For example, an array of integers
+        #     are specified as `[:INT64]`.
+        #   * `Hash` - Types for STRUCT values (`Hash` objects) are specified using a `Hash` object, where the keys
+        #     match the `params` hash, and the values are the types value that matches the data.
+        #
+        #   Types are optional.
         # @param [Hash<String|Symbol, External::DataSource>] external A Hash
         #   that represents the mapping of the external tables to the table
         #   names used in the SQL query. The hash keys are the table names, and
@@ -530,16 +551,17 @@ module Google
         #     end
         #   end
         #
-        def query_job query, params: nil, external: nil, priority: "INTERACTIVE", cache: true, table: nil, create: nil,
-                      write: nil, dryrun: nil, dataset: nil, project: nil, standard_sql: nil, legacy_sql: nil,
-                      large_results: nil, flatten: nil, maximum_billing_tier: nil, maximum_bytes_billed: nil,
-                      job_id: nil, prefix: nil, labels: nil, udfs: nil
+        def query_job query, params: nil, types: nil, external: nil, priority: "INTERACTIVE", cache: true, table: nil,
+                      create: nil, write: nil, dryrun: nil, dataset: nil, project: nil, standard_sql: nil,
+                      legacy_sql: nil, large_results: nil, flatten: nil, maximum_billing_tier: nil,
+                      maximum_bytes_billed: nil, job_id: nil, prefix: nil, labels: nil, udfs: nil
           ensure_service!
-          options = { priority: priority, cache: cache, table: table, create: create, write: write, dryrun: dryrun,
-                      large_results: large_results, flatten: flatten, dataset: dataset,
-                      project: (project || self.project), legacy_sql: legacy_sql, standard_sql: standard_sql,
-                      maximum_billing_tier: maximum_billing_tier, maximum_bytes_billed: maximum_bytes_billed,
-                      external: external, job_id: job_id, prefix: prefix, labels: labels, udfs: udfs, params: params }
+          options = { params: params, types: types, external: external, priority: priority, cache: cache, table: table,
+                      create: create, write: write, dryrun: dryrun, dataset: dataset,
+                      project: (project || self.project), standard_sql: standard_sql, legacy_sql: legacy_sql,
+                      large_results: large_results, flatten: flatten, maximum_billing_tier: maximum_billing_tier,
+                      maximum_bytes_billed: maximum_bytes_billed, job_id: job_id, prefix: prefix, labels: labels,
+                      udfs: udfs }
 
           updater = QueryJob::Updater.from_options service, query, options
 
@@ -556,27 +578,6 @@ module Google
         # as needed to complete the query. When used for executing DDL/DML
         # statements, this method does not return row data.
         #
-        # When using standard SQL and passing arguments using `params`, Ruby
-        # types are mapped to BigQuery types as follows:
-        #
-        # | BigQuery    | Ruby           | Notes  |
-        # |-------------|----------------|---|
-        # | `BOOL`      | `true`/`false` | |
-        # | `INT64`     | `Integer`      | |
-        # | `FLOAT64`   | `Float`        | |
-        # | `NUMERIC`   | `BigDecimal`   | Will be rounded to 9 decimal places |
-        # | `STRING`    | `String`       | |
-        # | `DATETIME`  | `DateTime`  | `DATETIME` does not support time zone. |
-        # | `DATE`      | `Date`         | |
-        # | `TIMESTAMP` | `Time`         | |
-        # | `TIME`      | `Google::Cloud::BigQuery::Time` | |
-        # | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
-        # | `ARRAY` | `Array` | Nested arrays, `nil` values are not supported. |
-        # | `STRUCT`    | `Hash`        | Hash keys may be strings or symbols. |
-        #
-        # See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types)
-        # for an overview of each BigQuery data type, including allowed values.
-        #
         # The geographic location for the job ("US", "EU", etc.) can be set via
         # {QueryJob::Updater#location=} in a block passed to this method.
         #
@@ -586,13 +587,55 @@ module Google
         #   syntax](https://cloud.google.com/bigquery/query-reference), of the
         #   query to execute. Example: "SELECT count(f1) FROM
         #   [myProjectId:myDatasetId.myTableId]".
-        # @param [Array, Hash] params Standard SQL only. Used to pass query
-        #   arguments when the `query` string contains either positional (`?`)
-        #   or named (`@myparam`) query parameters. If value passed is an array
-        #   `["foo"]`, the query must use positional query parameters. If value
-        #   passed is a hash `{ myparam: "foo" }`, the query must use named
-        #   query parameters. When set, `legacy_sql` will automatically be set
-        #   to false and `standard_sql` to true.
+        # @param [Array, Hash] params Standard SQL only. Used to pass query arguments when the `query` string contains
+        #   either positional (`?`) or named (`@myparam`) query parameters. If value passed is an array `["foo"]`, the
+        #   query must use positional query parameters. If value passed is a hash `{ myparam: "foo" }`, the query must
+        #   use named query parameters. When set, `legacy_sql` will automatically be set to false and `standard_sql` to
+        #   true.
+        #
+        #   Ruby types are mapped to BigQuery types as follows:
+        #
+        #   | BigQuery    | Ruby                                 | Notes                                          |
+        #   |-------------|--------------------------------------|------------------------------------------------|
+        #   | `BOOL`      | `true`/`false`                       |                                                |
+        #   | `INT64`     | `Integer`                            |                                                |
+        #   | `FLOAT64`   | `Float`                              |                                                |
+        #   | `NUMERIC`   | `BigDecimal`                         | Will be rounded to 9 decimal places            |
+        #   | `STRING`    | `String`                             |                                                |
+        #   | `DATETIME`  | `DateTime`                           | `DATETIME` does not support time zone.         |
+        #   | `DATE`      | `Date`                               |                                                |
+        #   | `TIMESTAMP` | `Time`                               |                                                |
+        #   | `TIME`      | `Google::Cloud::BigQuery::Time`      |                                                |
+        #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar |                                                |
+        #   | `ARRAY`     | `Array`                              | Nested arrays, `nil` values are not supported. |
+        #   | `STRUCT`    | `Hash`                               | Hash keys may be strings or symbols.           |
+        #
+        #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
+        #   of each BigQuery data type, including allowed values.
+        # @param [Array, Hash] types Standard SQL only. Types of the SQL parameters in `params`. It is not always to
+        #   infer the right SQL type from a value in `params`. In these cases, `types` must be used to specify the SQL
+        #   type for these values.
+        #
+        #   Must match the value type passed to `params`. This must be an `Array` when the query uses positional query
+        #   parameters. This must be an `Hash` when the query uses named query parameters. The values should be BigQuery
+        #   type codes from the following list:
+        #
+        #   * `:BOOL`
+        #   * `:INT64`
+        #   * `:FLOAT64`
+        #   * `:NUMERIC`
+        #   * `:STRING`
+        #   * `:DATETIME`
+        #   * `:DATE`
+        #   * `:TIMESTAMP`
+        #   * `:TIME`
+        #   * `:BYTES`
+        #   * `Array` - Lists are specified by providing the type code in an array. For example, an array of integers
+        #     are specified as `[:INT64]`.
+        #   * `Hash` - Types for STRUCT values (`Hash` objects) are specified using a `Hash` object, where the keys
+        #     match the `params` hash, and the values are the types value that matches the data.
+        #
+        #   Types are optional.
         # @param [Hash<String|Symbol, External::DataSource>] external A Hash
         #   that represents the mapping of the external tables to the table
         #   names used in the SQL query. The hash keys are the table names, and
@@ -744,10 +787,10 @@ module Google
         #     puts row[:name]
         #   end
         #
-        def query query, params: nil, external: nil, max: nil, cache: true, dataset: nil, project: nil,
+        def query query, params: nil, types: nil, external: nil, max: nil, cache: true, dataset: nil, project: nil,
                   standard_sql: nil, legacy_sql: nil, &block
-          job = query_job query, params: params, external: external, cache: cache, dataset: dataset, project: project,
-                                 standard_sql: standard_sql, legacy_sql: legacy_sql, &block
+          job = query_job query, params: params, types: types, external: external, cache: cache, dataset: dataset,
+                                 project: project, standard_sql: standard_sql, legacy_sql: legacy_sql, &block
           job.wait_until_done!
 
           if job.failed?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/convert_to_query_param_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/convert_to_query_param_test.rb
@@ -1,0 +1,570 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Convert, :to_query_param do
+  describe :BOOL do
+    it "identifies by value" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOL"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "true"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param true
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows string when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOL"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "true"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param "true", :BOOL
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows nil when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOL"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: nil
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param nil, :BOOL
+      assert_equal expected.to_h, actual.to_h
+    end
+  end
+
+  describe :INT64 do
+    it "identifies by value" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "42"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param 42
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows string when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "42"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param "42", :INT64
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows nil when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: nil
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param nil, :INT64
+      assert_equal expected.to_h, actual.to_h
+    end
+  end
+
+  describe :FLOAT64 do
+    it "identifies by value" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "3.14"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param 3.14
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows string when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "3.14"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param "3.14", :FLOAT64
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows nil when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: nil
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param nil, :FLOAT64
+      assert_equal expected.to_h, actual.to_h
+    end
+  end
+
+  describe :NUMERIC do
+    it "identifies by value" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "NUMERIC"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "123456798.987654321"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param BigDecimal("123456798.98765432100001")
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows string when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "NUMERIC"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "123456798.987654321"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param "123456798.987654321", :NUMERIC
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows nil when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "NUMERIC"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: nil
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param nil, :NUMERIC
+      assert_equal expected.to_h, actual.to_h
+    end
+  end
+
+  describe :STRING do
+    it "identifies by value" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "foobar"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param "foobar"
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows nil when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: nil
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param nil, :STRING
+      assert_equal expected.to_h, actual.to_h
+    end
+  end
+
+  describe :DATETIME do
+    it "identifies by value" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATETIME"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "2001-12-19 23:59:59.000000"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param Time.parse("2001-12-19T23:59:59 UTC").utc.to_datetime
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows string when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATETIME"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "2001-12-19 23:59:59.000000"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param "2001-12-19 23:59:59.000000", :DATETIME
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows nil when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATETIME"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: nil
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param nil, :DATETIME
+      assert_equal expected.to_h, actual.to_h
+    end
+  end
+
+  describe :DATE do
+    it "identifies by value" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "1968-10-20"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param Date.parse("1968-10-20")
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows string when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "1968-10-20"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param "1968-10-20", :DATE
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows nil when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: nil
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param nil, :DATE
+      assert_equal expected.to_h, actual.to_h
+    end
+  end
+
+  describe :TIMESTAMP do
+    it "identifies by value" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "2001-12-19 23:59:59.000000+00:00"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param Time.parse("2001-12-19T23:59:59 UTC").utc
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows string when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "2001-12-19 23:59:59.000000+00:00"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param "2001-12-19 23:59:59.000000+00:00", :TIMESTAMP
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows nil when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: nil
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param nil, :TIMESTAMP
+      assert_equal expected.to_h, actual.to_h
+    end
+  end
+
+  describe :TIME do
+    it "identifies by value" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIME"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "04:00:00"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param Google::Cloud::Bigquery::Time.new("04:00:00")
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows string when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIME"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "04:00:00"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param "04:00:00", :TIME
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows nil when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIME"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: nil
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param nil, :TIME
+      assert_equal expected.to_h, actual.to_h
+    end
+  end
+
+  describe :BYTES do
+    it "identifies by value" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BYTES"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: Base64.strict_encode64(File.binread("acceptance/data/logo.jpg"))
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param StringIO.new(File.binread("acceptance/data/logo.jpg"))
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows string when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BYTES"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: Base64.strict_encode64(File.binread("acceptance/data/logo.jpg"))
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param Base64.strict_encode64(File.binread("acceptance/data/logo.jpg")), :BYTES
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows nil when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BYTES"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: nil
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param nil, :BYTES
+      assert_equal expected.to_h, actual.to_h
+    end
+  end
+
+  describe :ARRAY do
+    it "identifies by value" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "INT64"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "1"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "2"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "3")
+          ]
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param [1, 2, 3]
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows empty when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "INT64"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: []
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param [], [:INT64]
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows nil when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "INT64"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: nil
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param nil, [:INT64]
+      assert_equal expected.to_h, actual.to_h
+    end
+  end
+
+  describe :STRUCT do
+    it "identifies by value" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "foo",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(
+                type: "STRING"
+              )
+            )
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          struct_values: {
+            "foo" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "bar")
+          }
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param({ foo: :bar })
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows empty when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "foo",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(
+                type: "STRING"
+              )
+            )
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          struct_values: {}
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param({}, { foo: :STRING })
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows nil when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "foo",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(
+                type: "STRING"
+              )
+            )
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: nil
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param(nil, { foo: :STRING })
+      assert_equal expected.to_h, actual.to_h
+    end
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -62,7 +62,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       )
     ]
@@ -86,7 +86,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       )
     ]
@@ -134,7 +134,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       )
     ]
@@ -158,7 +158,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: false
+          value: "false"
         )
       )
     ]
@@ -356,7 +356,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -365,7 +365,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -374,7 +374,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -475,10 +475,10 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           struct_values: {
-            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+            "name"   => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42"),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "false"),
+            "score"  => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "98.7")
           }
         )
       )

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -60,7 +60,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       )
     ]
@@ -83,7 +83,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       )
     ]
@@ -129,7 +129,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       )
     ]
@@ -152,7 +152,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: false
+          value: "false"
         )
       )
     ]
@@ -341,7 +341,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -349,7 +349,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -357,7 +357,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -449,10 +449,10 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           struct_values: {
-            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+            "name"   => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42"),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "false"),
+            "score"  => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "98.7")
           }
         )
       )

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -64,7 +64,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       )
     ]
@@ -96,7 +96,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       )
     ]
@@ -160,7 +160,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       )
     ]
@@ -192,7 +192,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: false
+          value: "false"
         )
       )
     ]
@@ -446,7 +446,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -455,7 +455,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -464,7 +464,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -581,10 +581,10 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           struct_values: {
-            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+            "name"   => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42"),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "false"),
+            "score"  => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "98.7")
           }
         )
       )

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       )
     ]
@@ -94,7 +94,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       )
     ]
@@ -156,7 +156,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       )
     ]
@@ -187,7 +187,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: false
+          value: "false"
         )
       )
     ]
@@ -432,7 +432,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -440,7 +440,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -448,7 +448,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -556,10 +556,10 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           struct_values: {
-            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+            "name"   => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42"),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "false"),
+            "score"  => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "98.7")
           }
         )
       )

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -65,7 +65,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       )
     ]
@@ -89,7 +89,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       )
     ]
@@ -137,7 +137,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       )
     ]
@@ -161,7 +161,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: false
+          value: "false"
         )
       )
     ]
@@ -359,7 +359,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -368,7 +368,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -377,7 +377,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -478,10 +478,10 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           struct_values: {
-            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+            "name"   => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42"),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "false"),
+            "score"  => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "98.7")
           }
         )
       )

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       )
     ]
@@ -86,7 +86,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       )
     ]
@@ -132,7 +132,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       )
     ]
@@ -155,7 +155,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: false
+          value: "false"
         )
       )
     ]
@@ -344,7 +344,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -352,7 +352,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -360,7 +360,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -452,10 +452,10 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           struct_values: {
-            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+            "name"   => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42"),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "false"),
+            "score"  => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "98.7")
           }
         )
       )

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -67,7 +67,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       )
     ]
@@ -99,7 +99,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       )
     ]
@@ -163,7 +163,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       )
     ]
@@ -195,7 +195,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: false
+          value: "false"
         )
       )
     ]
@@ -449,7 +449,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -458,7 +458,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -467,7 +467,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -584,10 +584,10 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           struct_values: {
-            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+            "name"   => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42"),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "false"),
+            "score"  => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "98.7")
           }
         )
       )

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -66,7 +66,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       )
     ]
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       )
     ]
@@ -159,7 +159,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       )
     ]
@@ -190,7 +190,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: false
+          value: "false"
         )
       )
     ]
@@ -435,7 +435,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
           type: "INT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 35
+          value: "35"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -443,7 +443,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
           type: "FLOAT64"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: 90.0
+          value: "90.0"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -451,7 +451,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
           type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: true
+          value: "true"
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -559,10 +559,10 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           struct_values: {
-            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+            "name"   => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42"),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "false"),
+            "score"  => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "98.7")
           }
         )
       )


### PR DESCRIPTION
* Allow query parameters to be nil/NULL when providing an optional
  type notation.
* Add types argument to the following methods:
  * Project#query
  * Project#query_job
  * Dataset#query
  * Dataset#query_job