### PR TITLE
Prefix error message with the error name instead of the first line of the backtrace

### DIFF
--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
@@ -213,14 +213,12 @@ module Google
         #   from the given exception.
         def self.from_exception exception
           backtrace = exception.backtrace
-          message = "#{exception.message} (#{exception.class})"
+          message = "#{exception.class}: #{exception.message}"
 
           if !backtrace.nil? && !backtrace.empty?
-            error_location = backtrace.first
+            message = "#{message}\n\t" + backtrace.join("\n\t")
 
-            message = "#{error_location}: #{message}\n\t" +
-                      backtrace.drop(1).join("\n\t")
-            file_path, line_number, function_name = error_location.split ":"
+            file_path, line_number, function_name = backtrace.first.split ":"
             function_name = function_name.to_s[/`(.*)'/, 1]
           end
 

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud::ErrorReporting::ErrorEvent, :mock_error_reporting do
   describe ".from_exception" do
     let(:exception_message) { "A serious error from application" }
     let(:exception) { StandardError.new exception_message }
-    let(:error_message) { "#{exception_message} (#{exception.class})" }
+    let(:error_message) { "StandardError: A serious error from application" }
 
     it "includes exception message when backtrace isn't present" do
       error_event =


### PR DESCRIPTION
### Summary
This PR is related to this issue https://github.com/googleapis/google-cloud-ruby/issues/4356.

It prefixes the error message with the error name and message instead of the first line of the backtrace.

Before:
```
test/test_more.rb:123:`<testee_sub>': A serious error from application (StandardError)
```

Now:
```
StandardError: A serious error from application
	test/test_more.rb:123:`<testee_sub>'
```