### PR TITLE
Add param types helper methods

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -201,6 +201,28 @@ module Google
         end
 
         ##
+        # The types of the fields in the data, obtained from the schema of the
+        # table from which the data was read. Types use the same format as the
+        # optional query parameter types.
+        #
+        # @return [Hash] A hash with field names as keys, and types as values.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   data = table.data
+        #
+        #   data.param_types
+        #
+        def param_types
+          schema.param_types
+        end
+
+        ##
         # The type of query statement, if valid. Possible values (new values
         # might be added in the future):
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/external.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/external.rb
@@ -964,6 +964,8 @@ module Google
           ##
           # The fields of the schema.
           #
+          # @return [Array<Schema::Field>] An array of field objects.
+          #
           def fields
             schema.fields
           end
@@ -971,8 +973,20 @@ module Google
           ##
           # The names of the columns in the schema.
           #
+          # @return [Array<Symbol>] An array of column names.
+          #
           def headers
             schema.headers
+          end
+
+          ##
+          # The types of the fields in the data in the schema, using the same
+          # format as the optional query parameter types.
+          #
+          # @return [Hash] A hash with field names as keys, and types as values.
+          #
+          def param_types
+            schema.param_types
           end
 
           ##
@@ -1095,6 +1109,8 @@ module Google
           ##
           # The fields of the schema.
           #
+          # @return [Array<Schema::Field>] An array of field objects.
+          #
           def fields
             schema.fields
           end
@@ -1102,8 +1118,20 @@ module Google
           ##
           # The names of the columns in the schema.
           #
+          # @return [Array<Symbol>] An array of column names.
+          #
           def headers
             schema.headers
+          end
+
+          ##
+          # The types of the fields in the data in the schema, using the same
+          # format as the optional query parameter types.
+          #
+          # @return [Hash] A hash with field names as keys, and types as values.
+          #
+          def param_types
+            schema.param_types
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -155,6 +155,27 @@ module Google
         end
 
         ##
+        # The types of the fields, using the same format as the optional query
+        # parameter types.
+        #
+        # @return [Hash] A hash with column names as keys, and types as values.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.create_table "my_table"
+        #
+        #   schema = table.schema
+        #
+        #   schema.param_types
+        #
+        def param_types
+          Hash[fields.map { |field| [field.name.to_sym, field.param_type] }]
+        end
+
+        ##
         # Retrieve a field by name.
         #
         # @return [Field] A field object.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -261,6 +261,7 @@ module Google
           def record?
             type == "RECORD" || type == "STRUCT"
           end
+          alias struct? record?
 
           ##
           # The nested fields if the type property is set to `RECORD`. Will be
@@ -286,6 +287,36 @@ module Google
           #
           def headers
             fields.map(&:name).map(&:to_sym)
+          end
+
+          ##
+          # The types of the field, using the same format as the optional query
+          # parameter types.
+          #
+          # The parameter types are one of the following BigQuery type codes:
+          #
+          # * `:BOOL`
+          # * `:INT64`
+          # * `:FLOAT64`
+          # * `:NUMERIC`
+          # * `:STRING`
+          # * `:DATETIME`
+          # * `:DATE`
+          # * `:TIMESTAMP`
+          # * `:TIME`
+          # * `:BYTES`
+          # * `Array` - Lists are specified by providing the type code in an array. For example, an array of integers
+          #   are specified as `[:INT64]`.
+          # * `Hash` - Types for STRUCT values (`Hash` objects) are specified using a `Hash` object, where the keys
+          #   are the nested field names, and the values are the the nested field types.
+          #
+          # @return [Symbol, Array, Hash] The type.
+          #
+          def param_type
+            param_type = type.to_sym
+            param_type = Hash[fields.map { |field| [field.name.to_sym, field.param_type] }] if record?
+            param_type = [param_type] if repeated?
+            param_type
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -871,6 +871,26 @@ module Google
         end
 
         ##
+        # The types of the fields in the table, obtained from its schema.
+        # Types use the same format as the optional query parameter types.
+        #
+        # @return [Hash] A hash with field names as keys, and types as values.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   table.param_types
+        #
+        def param_types
+          return nil if reference?
+          schema.param_types
+        end
+
+        ##
         # The {EncryptionConfiguration} object that represents the custom
         # encryption method used to protect the table. If not set,
         # {Dataset#default_encryption} is used.

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -160,6 +160,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::Data#param_types" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project", "my_dataset", "my_table", Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigquery::Dataset" do
     mock_bigquery do |mock|
       mock.expect :insert_dataset, dataset_full_gapi, ["my-project", Google::Apis::BigqueryV2::Dataset]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -111,6 +111,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.schema.must_be :frozen?
     data.fields.must_equal data.schema.fields
     data.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    data.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
   end
 
   it "handles missing rows and fields" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_csv_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_csv_source_test.rb
@@ -225,6 +225,8 @@ describe Google::Cloud::Bigquery::External::CsvSource do
     table.fields.must_equal table.schema.fields
     table.headers.must_equal table.schema.headers
     table.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    table.param_types.must_equal table.schema.param_types
+    table.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
     table.to_gapi.to_h.must_equal table_gapi.to_h
   end
@@ -274,6 +276,8 @@ describe Google::Cloud::Bigquery::External::CsvSource do
     table.fields.must_equal table.schema.fields
     table.headers.must_equal table.schema.headers
     table.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    table.param_types.must_equal table.schema.param_types
+    table.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
     table.to_gapi.to_h.must_equal table_gapi.to_h
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_json_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_json_source_test.rb
@@ -81,6 +81,8 @@ describe Google::Cloud::Bigquery::External::JsonSource do
     table.fields.must_equal table.schema.fields
     table.headers.must_equal table.schema.headers
     table.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    table.param_types.must_equal table.schema.param_types
+    table.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
     table.to_gapi.to_h.must_equal table_gapi.to_h
   end
@@ -129,6 +131,8 @@ describe Google::Cloud::Bigquery::External::JsonSource do
     table.fields.must_equal table.schema.fields
     table.headers.must_equal table.schema.headers
     table.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    table.param_types.must_equal table.schema.param_types
+    table.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
     table.to_gapi.to_h.must_equal table_gapi.to_h
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
@@ -96,6 +96,7 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
     table.schema.fields.wont_be :empty?
     table.fields.wont_be :empty?
     table.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    table.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
@@ -87,6 +87,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     table.schema.must_be_nil
     table.fields.must_be_nil
     table.headers.must_be_nil
+    table.param_types.must_be_nil
     table.external.must_be_nil
     table.buffer_bytes.must_be_nil
     table.buffer_rows.must_be_nil

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -127,6 +127,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.fields.count.must_equal 10
     table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
     table.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    table.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
   end
 
   it "sets a flat schema via a block with replace option true" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
@@ -96,6 +96,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.schema.must_be :frozen?
     table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
     table.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    table.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
   end
 
   it "knows its streaming buffer attributes" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
@@ -80,6 +80,7 @@ describe Google::Cloud::Bigquery::Table, :view, :attributes, :mock_bigquery do
     view.schema.fields.wont_be :empty?
     view.fields.wont_be :empty?
     view.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    view.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
@@ -61,6 +61,7 @@ describe Google::Cloud::Bigquery::Table, :view, :mock_bigquery do
     view.schema.must_be :frozen?
     view.fields.map(&:name).must_equal view.schema.fields.map(&:name)
     view.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    view.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
   end
 
   it "can test its existence" do


### PR DESCRIPTION
* Return the BigQuery field type code, using the same format as the
  optional query parameter types.
* Add Schema::Field#param_type
* Add Schema#param_types
* Add Data#param_types
* Add Table#param_types
* Add External::CvsSource#param_types
* Add External::JsonSource#param_types