### PR TITLE
Release google-cloud-spanner 1.12.1

### DIFF
--- a/google-cloud-spanner/CHANGELOG.md
+++ b/google-cloud-spanner/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Release History
 
+### 1.12.1 / 2019-11-12
+
+#### Features
+
+* Add InstanceConfig#replicas (ReplicaInfo) to the lower-level API.
+
+#### Documentation
+
+* Update lower-level API documentation.
+
+#### Bug Fixes
+
+* Update minimum runtime dependencies.
+
 ### 1.12.0 / 2019-10-29
 
 This release requires Ruby 2.4 or later.

--- a/google-cloud-spanner/lib/google/cloud/spanner/version.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Spanner
-      VERSION = "1.12.0".freeze
+      VERSION = "1.12.1".freeze
     end
   end
 end


### PR DESCRIPTION
#### Features

* Add InstanceConfig#replicas (ReplicaInfo) to the lower-level API.

#### Documentation

* Update lower-level API documentation.

#### Bug Fixes

* Update minimum runtime dependencies.

<details><summary>Commits since previous release</summary><pre><code>commit 2ef5fc4f506d88a991afd68b2e0f9471c8ff3723
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Tue Nov 12 11:21:09 2019 -0800

    docs(spanner): Update lower-level API docs

commit 0a54e42250fb3a8300152897dc4de88689346ded
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Thu Oct 31 10:51:53 2019 -0700

    feat(spanner): Add InstanceConfig#replicas (ReplicaInfo)
    
    * Update documentation.
    
    pr: #4358

commit a0464fe3d60e56b1874263e05ceec8c970abbc93
Author: Mike Moore <mike@blowmage.com>
Date:   Wed Oct 30 12:17:39 2019 -0600

    fix(translate): Update minimum runtime dependencies
    
    pr: #4327
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-spanner/google-cloud-spanner.gemspec b/google-cloud-spanner/google-cloud-spanner.gemspec
index bb04e8bb6..190fc9030 100644
--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "google-gax", "~> 1.8"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
 
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
index 9427d57ea..eaa861c7d 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
@@ -237,14 +237,6 @@ module Google
                   &Google::Spanner::Admin::Database::V1::DatabaseAdmin::Stub.method(:new)
                 )
 
-                @list_databases = Google::Gax.create_api_call(
-                  @database_admin_stub.method(:list_databases),
-                  defaults["list_databases"],
-                  exception_transformer: exception_transformer,
-                  params_extractor: proc do |request|
-                    {'parent' => request.parent}
-                  end
-                )
                 @create_database = Google::Gax.create_api_call(
                   @database_admin_stub.method(:create_database),
                   defaults["create_database"],
@@ -309,65 +301,18 @@ module Google
                     {'resource' => request.resource}
                   end
                 )
+                @list_databases = Google::Gax.create_api_call(
+                  @database_admin_stub.method(:list_databases),
+                  defaults["list_databases"],
+                  exception_transformer: exception_transformer,
+                  params_extractor: proc do |request|
+                    {'parent' => request.parent}
+                  end
+                )
               end
 
               # Service calls
 
-              # Lists Cloud Spanner databases.
-              #
-              # @param parent [String]
-              #   Required. The instance whose databases should be listed.
-              #   Values are of the form `projects/<project>/instances/<instance>`.
-              # @param page_size [Integer]
-              #   The maximum number of resources contained in the underlying API
-              #   response. If page streaming is performed per-resource, this
-              #   parameter does not affect the return value. If page streaming is
-              #   performed per-page, this determines the maximum number of
-              #   resources in a page.
-              # @param options [Google::Gax::CallOptions]
-              #   Overrides the default settings for this call, e.g, timeout,
-              #   retries, etc.
-              # @yield [result, operation] Access the result along with the RPC operation
-              # @yieldparam result [Google::Gax::PagedEnumerable<Google::Spanner::Admin::Database::V1::Database>]
-              # @yieldparam operation [GRPC::ActiveCall::Operation]
-              # @return [Google::Gax::PagedEnumerable<Google::Spanner::Admin::Database::V1::Database>]
-              #   An enumerable of Google::Spanner::Admin::Database::V1::Database instances.
-              #   See Google::Gax::PagedEnumerable documentation for other
-              #   operations such as per-page iteration or access to the response
-              #   object.
-              # @raise [Google::Gax::GaxError] if the RPC is aborted.
-              # @example
-              #   require "google/cloud/spanner/admin/database"
-              #
-              #   database_admin_client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
-              #   formatted_parent = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
-              #
-              #   # Iterate over all results.
-              #   database_admin_client.list_databases(formatted_parent).each do |element|
-              #     # Process element.
-              #   end
-              #
-              #   # Or iterate over results one page at a time.
-              #   database_admin_client.list_databases(formatted_parent).each_page do |page|
-              #     # Process each page at a time.
-              #     page.each do |element|
-              #       # Process element.
-              #     end
-              #   end
-
-              def list_databases \
-                  parent,
-                  page_size: nil,
-                  options: nil,
-                  &block
-                req = {
-                  parent: parent,
-                  page_size: page_size
-                }.delete_if { |_, v| v.nil? }
-                req = Google::Gax::to_proto(req, Google::Spanner::Admin::Database::V1::ListDatabasesRequest)
-                @list_databases.call(req, options, &block)
-              end
-
               # Creates a new Cloud Spanner database and starts to prepare it for serving.
               # The returned {Google::Longrunning::Operation long-running operation} will
               # have a name of the format `<database_name>/operations/<operation_id>` and
@@ -497,7 +442,7 @@ module Google
               # @param database [String]
               #   Required. The database to update.
               # @param statements [Array<String>]
-              #   DDL statements to be applied to the database.
+              #   Required. DDL statements to be applied to the database.
               # @param operation_id [String]
               #   If empty, the new update request is assigned an
               #   automatically-generated operation ID. Otherwise, `operation_id`
@@ -645,11 +590,11 @@ module Google
                 @get_database_ddl.call(req, options, &block)
               end
 
-              # Sets the access control policy on a database resource. Replaces any
-              # existing policy.
+              # Sets the access control policy on a database resource.
+              # Replaces any existing policy.
               #
-              # Authorization requires `spanner.databases.setIamPolicy` permission on
-              # {Google::Iam::V1::SetIamPolicyRequest#resource resource}.
+              # Authorization requires `spanner.databases.setIamPolicy`
+              # permission on {Google::Iam::V1::SetIamPolicyRequest#resource resource}.
               #
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being specified.
@@ -673,11 +618,13 @@ module Google
               #   require "google/cloud/spanner/admin/database"
               #
               #   database_admin_client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
-              #   formatted_resource = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
+              #
+              #   # TODO: Initialize `resource`:
+              #   resource = ''
               #
               #   # TODO: Initialize `policy`:
               #   policy = {}
-              #   response = database_admin_client.set_iam_policy(formatted_resource, policy)
+              #   response = database_admin_client.set_iam_policy(resource, policy)
 
               def set_iam_policy \
                   resource,
@@ -692,8 +639,9 @@ module Google
                 @set_iam_policy.call(req, options, &block)
               end
 
-              # Gets the access control policy for a database resource. Returns an empty
-              # policy if a database exists but does not have a policy set.
+              # Gets the access control policy for a database resource.
+              # Returns an empty policy if a database exists but does
+              # not have a policy set.
               #
               # Authorization requires `spanner.databases.getIamPolicy` permission on
               # {Google::Iam::V1::GetIamPolicyRequest#resource resource}.
@@ -718,8 +666,10 @@ module Google
               #   require "google/cloud/spanner/admin/database"
               #
               #   database_admin_client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
-              #   formatted_resource = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
-              #   response = database_admin_client.get_iam_policy(formatted_resource)
+              #
+              #   # TODO: Initialize `resource`:
+              #   resource = ''
+              #   response = database_admin_client.get_iam_policy(resource)
 
               def get_iam_policy \
                   resource,
@@ -736,10 +686,10 @@ module Google
 
               # Returns permissions that the caller has on the specified database resource.
               #
-              # Attempting this RPC on a non-existent Cloud Spanner database will result in
-              # a NOT_FOUND error if the user has `spanner.databases.list` permission on
-              # the containing Cloud Spanner instance. Otherwise returns an empty set of
-              # permissions.
+              # Attempting this RPC on a non-existent Cloud Spanner database will
+              # result in a NOT_FOUND error if the user has
+              # `spanner.databases.list` permission on the containing Cloud
+              # Spanner instance. Otherwise returns an empty set of permissions.
               #
               # @param resource [String]
               #   REQUIRED: The resource for which the policy detail is being requested.
@@ -761,15 +711,14 @@ module Google
               #   require "google/cloud/spanner/admin/database"
               #
               #   database_admin_client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
-              #   formatted_resource = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
               #
-              #   # TODO: Initialize `permissions`:
-              #   permissions = []
-              #   response = database_admin_client.test_iam_permissions(formatted_resource, permissions)
+              #   # TODO: Initialize `resource`:
+              #   resource = ''
+              #   response = database_admin_client.test_iam_permissions(resource)
 
               def test_iam_permissions \
                   resource,
-                  permissions,
+                  permissions: nil,
                   options: nil,
                   &block
                 req = {
@@ -779,6 +728,61 @@ module Google
                 req = Google::Gax::to_proto(req, Google::Iam::V1::TestIamPermissionsRequest)
                 @test_iam_permissions.call(req, options, &block)
               end
+
+              # Lists Cloud Spanner databases.
+              #
+              # @param parent [String]
+              #   Required. The instance whose databases should be listed.
+              #   Values are of the form `projects/<project>/instances/<instance>`.
+              # @param page_size [Integer]
+              #   The maximum number of resources contained in the underlying API
+              #   response. If page streaming is performed per-resource, this
+              #   parameter does not affect the return value. If page streaming is
+              #   performed per-page, this determines the maximum number of
+              #   resources in a page.
+              # @param options [Google::Gax::CallOptions]
+              #   Overrides the default settings for this call, e.g, timeout,
+              #   retries, etc.
+              # @yield [result, operation] Access the result along with the RPC operation
+              # @yieldparam result [Google::Gax::PagedEnumerable<Google::Spanner::Admin::Database::V1::Database>]
+              # @yieldparam operation [GRPC::ActiveCall::Operation]
+              # @return [Google::Gax::PagedEnumerable<Google::Spanner::Admin::Database::V1::Database>]
+              #   An enumerable of Google::Spanner::Admin::Database::V1::Database instances.
+              #   See Google::Gax::PagedEnumerable documentation for other
+              #   operations such as per-page iteration or access to the response
+              #   object.
+              # @raise [Google::Gax::GaxError] if the RPC is aborted.
+              # @example
+              #   require "google/cloud/spanner/admin/database"
+              #
+              #   database_admin_client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
+              #   formatted_parent = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+              #
+              #   # Iterate over all results.
+              #   database_admin_client.list_databases(formatted_parent).each do |element|
+              #     # Process element.
+              #   end
+              #
+              #   # Or iterate over results one page at a time.
+              #   database_admin_client.list_databases(formatted_parent).each_page do |page|
+              #     # Process each page at a time.
+              #     page.each do |element|
+              #       # Process element.
+              #     end
+              #   end
+
+              def list_databases \
+                  parent,
+                  page_size: nil,
+                  options: nil,
+                  &block
+                req = {
+                  parent: parent,
+                  page_size: page_size
+                }.delete_if { |_, v| v.nil? }
+                req = Google::Gax::to_proto(req, Google::Spanner::Admin::Database::V1::ListDatabasesRequest)
+                @list_databases.call(req, options, &block)
+              end
             end
           end
         end
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client_config.json b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client_config.json
index 76adf1003..16f601b83 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client_config.json
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client_config.json
@@ -20,11 +20,6 @@
         }
       },
       "methods": {
-        "ListDatabases": {
-          "timeout_millis": 30000,
-          "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
-        },
         "CreateDatabase": {
           "timeout_millis": 3600000,
           "retry_codes_name": "non_idempotent",
@@ -64,6 +59,11 @@
           "timeout_millis": 30000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "ListDatabases": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
         }
       }
     }
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
index d7cdf07b8..8cbde49eb 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
@@ -82,12 +82,13 @@ module Google
       #
       #     Operations affecting conditional bindings must specify version 3. This can
       #     be either setting a conditional policy, modifying a conditional binding,
-      #     or removing a conditional binding from the stored conditional policy.
+      #     or removing a binding (conditional or unconditional) from the stored
+      #     conditional policy.
       #     Operations on non-conditional policies may specify any valid value or
       #     leave the field unset.
       #
-      #     If no etag is provided in the call to `setIamPolicy`, any version
-      #     compliance checks on the incoming and/or stored policy is skipped.
+      #     If no etag is provided in the call to `setIamPolicy`, version compliance
+      #     checks against the stored policy is skipped.
       # @!attribute [rw] bindings
       #   @return [Array<Google::Iam::V1::Binding>]
       #     Associates a list of `members` to a `role`. Optionally may specify a
@@ -105,8 +106,8 @@ module Google
       #
       #     If no `etag` is provided in the call to `setIamPolicy`, then the existing
       #     policy is overwritten. Due to blind-set semantics of an etag-less policy,
-      #     'setIamPolicy' will not fail even if either of incoming or stored policy
-      #     does not meet the version requirements.
+      #     'setIamPolicy' will not fail even if the incoming policy version does not
+      #     meet the requirements for modifying the stored policy.
       class Policy; end
 
       # Associates `members` with a `role`.
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/spanner/admin/database/v1/spanner_database_admin.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/spanner/admin/database/v1/spanner_database_admin.rb
index c87483003..483ee1d44 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/spanner/admin/database/v1/spanner_database_admin.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/spanner/admin/database/v1/spanner_database_admin.rb
@@ -131,7 +131,7 @@ module Google
           #     Required. The database to update.
           # @!attribute [rw] statements
           #   @return [Array<String>]
-          #     DDL statements to be applied to the database.
+          #     Required. DDL statements to be applied to the database.
           # @!attribute [rw] operation_id
           #   @return [String]
           #     If empty, the new update request is assigned an
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
index d7cdf07b8..8cbde49eb 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
@@ -82,12 +82,13 @@ module Google
       #
       #     Operations affecting conditional bindings must specify version 3. This can
       #     be either setting a conditional policy, modifying a conditional binding,
-      #     or removing a conditional binding from the stored conditional policy.
+      #     or removing a binding (conditional or unconditional) from the stored
+      #     conditional policy.
       #     Operations on non-conditional policies may specify any valid value or
       #     leave the field unset.
       #
-      #     If no etag is provided in the call to `setIamPolicy`, any version
-      #     compliance checks on the incoming and/or stored policy is skipped.
+      #     If no etag is provided in the call to `setIamPolicy`, version compliance
+      #     checks against the stored policy is skipped.
       # @!attribute [rw] bindings
       #   @return [Array<Google::Iam::V1::Binding>]
       #     Associates a list of `members` to a `role`. Optionally may specify a
@@ -105,8 +106,8 @@ module Google
       #
       #     If no `etag` is provided in the call to `setIamPolicy`, then the existing
       #     policy is overwritten. Due to blind-set semantics of an etag-less policy,
-      #     'setIamPolicy' will not fail even if either of incoming or stored policy
-      #     does not meet the version requirements.
+      #     'setIamPolicy' will not fail even if the incoming policy version does not
+      #     meet the requirements for modifying the stored policy.
       class Policy; end
 
       # Associates `members` with a `role`.
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/spanner/admin/instance/v1/spanner_instance_admin.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/spanner/admin/instance/v1/spanner_instance_admin.rb
index 5ed8346c3..9bc819ccf 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/spanner/admin/instance/v1/spanner_instance_admin.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/spanner/admin/instance/v1/spanner_instance_admin.rb
@@ -18,6 +18,54 @@ module Google
     module Admin
       module Instance
         module V1
+          # @!attribute [rw] location
+          #   @return [String]
+          #     The location of the serving resources, e.g. "us-central1".
+          # @!attribute [rw] type
+          #   @return [Google::Spanner::Admin::Instance::V1::ReplicaInfo::ReplicaType]
+          #     The type of replica.
+          # @!attribute [rw] default_leader_location
+          #   @return [true, false]
+          #     If true, this location is designated as the default leader location where
+          #     leader replicas are placed. See the [region types
+          #     documentation](https://cloud.google.com/spanner/docs/instances#region_types)
+          #     for more details.
+          class ReplicaInfo
+            # Indicates the type of replica.  See the [replica types
+            # documentation](https://cloud.google.com/spanner/docs/replication#replica_types)
+            # for more details.
+            module ReplicaType
+              # Not specified.
+              TYPE_UNSPECIFIED = 0
+
+              # Read-write replicas support both reads and writes. These replicas:
+              #
+              # * Maintain a full copy of your data.
+              # * Serve reads.
+              # * Can vote whether to commit a write.
+              # * Participate in leadership election.
+              # * Are eligible to become a leader.
+              READ_WRITE = 1
+
+              # Read-only replicas only support reads (not writes). Read-only replicas:
+              #
+              # * Maintain a full copy of your data.
+              # * Serve reads.
+              # * Do not participate in voting to commit writes.
+              # * Are not eligible to become a leader.
+              READ_ONLY = 2
+
+              # Witness replicas don't support reads but do participate in voting to
+              # commit writes. Witness replicas:
+              #
+              # * Do not maintain a full copy of data.
+              # * Do not serve reads.
+              # * Vote whether to commit writes.
+              # * Participate in leader election but are not eligible to become leader.
+              WITNESS = 3
+            end
+          end
+
           # A possible configuration for a Cloud Spanner instance. Configurations
           # define the geographic placement of nodes and their replication.
           # @!attribute [rw] name
@@ -28,6 +76,10 @@ module Google
           # @!attribute [rw] display_name
           #   @return [String]
           #     The name of this instance configuration as it appears in UIs.
+          # @!attribute [rw] replicas
+          #   @return [Array<Google::Spanner::Admin::Instance::V1::ReplicaInfo>]
+          #     The geographic placement of nodes in this instance configuration and their
+          #     replication properties.
           class InstanceConfig; end
 
           # An isolated set of Cloud Spanner resources on which databases can be hosted.
@@ -36,7 +88,7 @@ module Google
           #     Required. A unique identifier for the instance, which cannot be changed
           #     after the instance is created. Values are of the form
           #     `projects/<project>/instances/[a-z][-a-z0-9]*[a-z0-9]`. The final
-          #     segment of the name must be between 6 and 30 characters in length.
+          #     segment of the name must be between 2 and 64 characters in length.
           # @!attribute [rw] config
           #   @return [String]
           #     Required. The name of the instance's configuration. Values are of the form
@@ -58,10 +110,10 @@ module Google
           # @!attribute [rw] state
           #   @return [Google::Spanner::Admin::Instance::V1::Instance::State]
           #     Output only. The current instance state. For
-          #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::CreateInstance CreateInstance},
-          #     the state must be either omitted or set to `CREATING`. For
-          #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::UpdateInstance UpdateInstance},
-          #     the state must be either omitted or set to `READY`.
+          #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::CreateInstance CreateInstance}, the state must be
+          #     either omitted or set to `CREATING`. For
+          #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::UpdateInstance UpdateInstance}, the state must be
+          #     either omitted or set to `READY`.
           # @!attribute [rw] labels
           #   @return [Hash{String => String}]
           #     Cloud Labels are a flexible and lightweight mechanism for organizing cloud
@@ -102,8 +154,7 @@ module Google
             end
           end
 
-          # The request for
-          # {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstanceConfigs ListInstanceConfigs}.
+          # The request for {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstanceConfigs ListInstanceConfigs}.
           # @!attribute [rw] parent
           #   @return [String]
           #     Required. The name of the project for which a list of supported instance
@@ -117,20 +168,18 @@ module Google
           #   @return [String]
           #     If non-empty, `page_token` should contain a
           #     {Google::Spanner::Admin::Instance::V1::ListInstanceConfigsResponse#next_page_token next_page_token}
-          #     from a previous
-          #     {Google::Spanner::Admin::Instance::V1::ListInstanceConfigsResponse ListInstanceConfigsResponse}.
+          #     from a previous {Google::Spanner::Admin::Instance::V1::ListInstanceConfigsResponse ListInstanceConfigsResponse}.
           class ListInstanceConfigsRequest; end
 
-          # The response for
-          # {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstanceConfigs ListInstanceConfigs}.
+          # The response for {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstanceConfigs ListInstanceConfigs}.
           # @!attribute [rw] instance_configs
           #   @return [Array<Google::Spanner::Admin::Instance::V1::InstanceConfig>]
           #     The list of requested instance configurations.
           # @!attribute [rw] next_page_token
           #   @return [String]
           #     `next_page_token` can be sent in a subsequent
-          #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstanceConfigs ListInstanceConfigs}
-          #     call to fetch more of the matching instance configurations.
+          #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstanceConfigs ListInstanceConfigs} call to
+          #     fetch more of the matching instance configurations.
           class ListInstanceConfigsResponse; end
 
           # The request for
@@ -141,16 +190,14 @@ module Google
           #     the form `projects/<project>/instanceConfigs/<config>`.
           class GetInstanceConfigRequest; end
 
-          # The request for
-          # {Google::Spanner::Admin::Instance::V1::InstanceAdmin::GetInstance GetInstance}.
+          # The request for {Google::Spanner::Admin::Instance::V1::InstanceAdmin::GetInstance GetInstance}.
           # @!attribute [rw] name
           #   @return [String]
           #     Required. The name of the requested instance. Values are of the form
           #     `projects/<project>/instances/<instance>`.
           class GetInstanceRequest; end
 
-          # The request for
-          # {Google::Spanner::Admin::Instance::V1::InstanceAdmin::CreateInstance CreateInstance}.
+          # The request for {Google::Spanner::Admin::Instance::V1::InstanceAdmin::CreateInstance CreateInstance}.
           # @!attribute [rw] parent
           #   @return [String]
           #     Required. The name of the project in which to create the instance. Values
@@ -158,7 +205,7 @@ module Google
           # @!attribute [rw] instance_id
           #   @return [String]
           #     Required. The ID of the instance to create.  Valid identifiers are of the
-          #     form `[a-z][-a-z0-9]*[a-z0-9]` and must be between 6 and 30 characters in
+          #     form `[a-z][-a-z0-9]*[a-z0-9]` and must be between 2 and 64 characters in
           #     length.
           # @!attribute [rw] instance
           #   @return [Google::Spanner::Admin::Instance::V1::Instance]
@@ -166,8 +213,7 @@ module Google
           #     specified must be `<parent>/instances/<instance_id>`.
           class CreateInstanceRequest; end
 
-          # The request for
-          # {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstances ListInstances}.
+          # The request for {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstances ListInstances}.
           # @!attribute [rw] parent
           #   @return [String]
           #     Required. The name of the project for which a list of instances is
@@ -179,9 +225,8 @@ module Google
           # @!attribute [rw] page_token
           #   @return [String]
           #     If non-empty, `page_token` should contain a
-          #     {Google::Spanner::Admin::Instance::V1::ListInstancesResponse#next_page_token next_page_token}
-          #     from a previous
-          #     {Google::Spanner::Admin::Instance::V1::ListInstancesResponse ListInstancesResponse}.
+          #     {Google::Spanner::Admin::Instance::V1::ListInstancesResponse#next_page_token next_page_token} from a
+          #     previous {Google::Spanner::Admin::Instance::V1::ListInstancesResponse ListInstancesResponse}.
           # @!attribute [rw] filter
           #   @return [String]
           #     An expression for filtering the results of the request. Filter rules are
@@ -205,38 +250,31 @@ module Google
           #         containing "dev".
           class ListInstancesRequest; end
 
-          # The response for
-          # {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstances ListInstances}.
+          # The response for {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstances ListInstances}.
           # @!attribute [rw] instances
           #   @return [Array<Google::Spanner::Admin::Instance::V1::Instance>]
           #     The list of requested instances.
           # @!attribute [rw] next_page_token
           #   @return [String]
           #     `next_page_token` can be sent in a subsequent
-          #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstances ListInstances}
-          #     call to fetch more of the matching instances.
+          #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstances ListInstances} call to fetch more
+          #     of the matching instances.
           class ListInstancesResponse; end
 
-          # The request for
-          # {Google::Spanner::Admin::Instance::V1::InstanceAdmin::UpdateInstance UpdateInstance}.
+          # The request for {Google::Spanner::Admin::Instance::V1::InstanceAdmin::UpdateInstance UpdateInstance}.
           # @!attribute [rw] instance
           #   @return [Google::Spanner::Admin::Instance::V1::Instance]
           #     Required. The instance to update, which must always include the instance
-          #     name.  Otherwise, only fields mentioned in
-          #     [][google.spanner.admin.instance.v1.UpdateInstanceRequest.field_mask] need
-          #     be included.
+          #     name.  Otherwise, only fields mentioned in [][google.spanner.admin.instance.v1.UpdateInstanceRequest.field_mask] need be included.
           # @!attribute [rw] field_mask
           #   @return [Google::Protobuf::FieldMask]
-          #     Required. A mask specifying which fields in
-          #     [][google.spanner.admin.instance.v1.UpdateInstanceRequest.instance] should
-          #     be updated. The field mask must always be specified; this prevents any
-          #     future fields in
-          #     [][google.spanner.admin.instance.v1.Instance] from being erased
-          #     accidentally by clients that do not know about them.
+          #     Required. A mask specifying which fields in [][google.spanner.admin.instance.v1.UpdateInstanceRequest.instance] should be updated.
+          #     The field mask must always be specified; this prevents any future fields in
+          #     [][google.spanner.admin.instance.v1.Instance] from being erased accidentally by clients that do not know
+          #     about them.
           class UpdateInstanceRequest; end
 
-          # The request for
-          # {Google::Spanner::Admin::Instance::V1::InstanceAdmin::DeleteInstance DeleteInstance}.
+          # The request for {Google::Spanner::Admin::Instance::V1::InstanceAdmin::DeleteInstance DeleteInstance}.
           # @!attribute [rw] name
           #   @return [String]
           #     Required. The name of the instance to be deleted. Values are of the form
@@ -251,8 +289,8 @@ module Google
           # @!attribute [rw] start_time
           #   @return [Google::Protobuf::Timestamp]
           #     The time at which the
-          #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::CreateInstance CreateInstance}
-          #     request was received.
+          #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::CreateInstance CreateInstance} request was
+          #     received.
           # @!attribute [rw] cancel_time
           #   @return [Google::Protobuf::Timestamp]
           #     The time at which this operation was cancelled. If set, this operation is
@@ -270,8 +308,7 @@ module Google
           #     The desired end state of the update.
           # @!attribute [rw] start_time
           #   @return [Google::Protobuf::Timestamp]
-          #     The time at which
-          #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::UpdateInstance UpdateInstance}
+          #     The time at which {Google::Spanner::Admin::Instance::V1::InstanceAdmin::UpdateInstance UpdateInstance}
           #     request was received.
           # @!attribute [rw] cancel_time
           #   @return [Google::Protobuf::Timestamp]
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
index 2f1838199..fec60cd5b 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
@@ -589,7 +589,7 @@ module Google
               #   are of the form `projects/<project>`.
               # @param instance_id [String]
               #   Required. The ID of the instance to create.  Valid identifiers are of the
-              #   form `[a-z][-a-z0-9]*[a-z0-9]` and must be between 6 and 30 characters in
+              #   form `[a-z][-a-z0-9]*[a-z0-9]` and must be between 2 and 64 characters in
               #   length.
               # @param instance [Google::Spanner::Admin::Instance::V1::Instance | Hash]
               #   Required. The instance to create.  The name may be omitted, but if
@@ -676,9 +676,9 @@ module Google
               # Until completion of the returned operation:
               #
               # * Cancelling the operation sets its metadata's
-              #   {Google::Spanner::Admin::Instance::V1::UpdateInstanceMetadata#cancel_time cancel_time},
-              #   and begins restoring resources to their pre-request values. The
-              #   operation is guaranteed to succeed at undoing all resource changes,
+              #   {Google::Spanner::Admin::Instance::V1::UpdateInstanceMetadata#cancel_time cancel_time}, and begins
+              #   restoring resources to their pre-request values. The operation
+              #   is guaranteed to succeed at undoing all resource changes,
               #   after which point it terminates with a `CANCELLED` status.
               #   * All other attempts to modify the instance are rejected.
               #   * Reading the instance via the API continues to give the pre-request
@@ -705,18 +705,14 @@ module Google
               #
               # @param instance [Google::Spanner::Admin::Instance::V1::Instance | Hash]
               #   Required. The instance to update, which must always include the instance
-              #   name.  Otherwise, only fields mentioned in
-              #   [][google.spanner.admin.instance.v1.UpdateInstanceRequest.field_mask] need
-              #   be included.
+              #   name.  Otherwise, only fields mentioned in [][google.spanner.admin.instance.v1.UpdateInstanceRequest.field_mask] need be included.
               #   A hash of the same form as `Google::Spanner::Admin::Instance::V1::Instance`
               #   can also be provided.
               # @param field_mask [Google::Protobuf::FieldMask | Hash]
-              #   Required. A mask specifying which fields in
-              #   [][google.spanner.admin.instance.v1.UpdateInstanceRequest.instance] should
-              #   be updated. The field mask must always be specified; this prevents any
-              #   future fields in
-              #   [][google.spanner.admin.instance.v1.Instance] from being erased
-              #   accidentally by clients that do not know about them.
+              #   Required. A mask specifying which fields in [][google.spanner.admin.instance.v1.UpdateInstanceRequest.instance] should be updated.
+              #   The field mask must always be specified; this prevents any future fields in
+              #   [][google.spanner.admin.instance.v1.Instance] from being erased accidentally by clients that do not know
+              #   about them.
               #   A hash of the same form as `Google::Protobuf::FieldMask`
               #   can also be provided.
               # @param options [Google::Gax::CallOptions]
@@ -851,11 +847,13 @@ module Google
               #   require "google/cloud/spanner/admin/instance"
               #
               #   instance_admin_client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
-              #   formatted_resource = Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+              #
+              #   # TODO: Initialize `resource`:
+              #   resource = ''
               #
               #   # TODO: Initialize `policy`:
               #   policy = {}
-              #   response = instance_admin_client.set_iam_policy(formatted_resource, policy)
+              #   response = instance_admin_client.set_iam_policy(resource, policy)
 
               def set_iam_policy \
                   resource,
@@ -896,8 +894,10 @@ module Google
               #   require "google/cloud/spanner/admin/instance"
               #
               #   instance_admin_client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
-              #   formatted_resource = Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
-              #   response = instance_admin_client.get_iam_policy(formatted_resource)
+              #
+              #   # TODO: Initialize `resource`:
+              #   resource = ''
+              #   response = instance_admin_client.get_iam_policy(resource)
 
               def get_iam_policy \
                   resource,
@@ -939,15 +939,14 @@ module Google
               #   require "google/cloud/spanner/admin/instance"
               #
               #   instance_admin_client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
-              #   formatted_resource = Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
               #
-              #   # TODO: Initialize `permissions`:
-              #   permissions = []
-              #   response = instance_admin_client.test_iam_permissions(formatted_resource, permissions)
+              #   # TODO: Initialize `resource`:
+              #   resource = ''
+              #   response = instance_admin_client.test_iam_permissions(resource)
 
               def test_iam_permissions \
                   resource,
-                  permissions,
+                  permissions: nil,
                   options: nil,
                   &block
                 req = {
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/keys.rb b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/keys.rb
index 1522e3a1a..46e95e1fe 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/keys.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/keys.rb
@@ -137,8 +137,8 @@ module Google
       #     encoded as described {Google::Spanner::V1::TypeCode here}.
       # @!attribute [rw] ranges
       #   @return [Array<Google::Spanner::V1::KeyRange>]
-      #     A list of key ranges. See {Google::Spanner::V1::KeyRange KeyRange} for more
-      #     information about key range specifications.
+      #     A list of key ranges. See {Google::Spanner::V1::KeyRange KeyRange} for more information about
+      #     key range specifications.
       # @!attribute [rw] all
       #   @return [true, false]
       #     For convenience `all` can be set to `true` to indicate that this
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/mutation.rb b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/mutation.rb
index 2e98c4e59..8dc648d2f 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/mutation.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/mutation.rb
@@ -29,32 +29,33 @@ module Google
       #     already exist, the transaction fails with error `NOT_FOUND`.
       # @!attribute [rw] insert_or_update
       #   @return [Google::Spanner::V1::Mutation::Write]
-      #     Like {Google::Spanner::V1::Mutation#insert insert}, except that if the row
-      #     already exists, then its column values are overwritten with the ones
-      #     provided. Any column values not explicitly written are preserved.
+      #     Like {Google::Spanner::V1::Mutation#insert insert}, except that if the row already exists, then
+      #     its column values are overwritten with the ones provided. Any
+      #     column values not explicitly written are preserved.
       # @!attribute [rw] replace
       #   @return [Google::Spanner::V1::Mutation::Write]
-      #     Like {Google::Spanner::V1::Mutation#insert insert}, except that if the row
-      #     already exists, it is deleted, and the column values provided are
-      #     inserted instead. Unlike
-      #     {Google::Spanner::V1::Mutation#insert_or_update insert_or_update}, this
-      #     means any values not explicitly written become `NULL`.
+      #     Like {Google::Spanner::V1::Mutation#insert insert}, except that if the row already exists, it is
+      #     deleted, and the column values provided are inserted
+      #     instead. Unlike {Google::Spanner::V1::Mutation#insert_or_update insert_or_update}, this means any values not
+      #     explicitly written become `NULL`.
+      #
+      #     In an interleaved table, if you create the child table with the
+      #     `ON DELETE CASCADE` annotation, then replacing a parent row
+      #     also deletes the child rows. Otherwise, you must delete the
+      #     child rows before you replace the parent row.
       # @!attribute [rw] delete
       #   @return [Google::Spanner::V1::Mutation::Delete]
       #     Delete rows from a table. Succeeds whether or not the named
       #     rows were present.
       class Mutation
-        # Arguments to {Google::Spanner::V1::Mutation#insert insert},
-        # {Google::Spanner::V1::Mutation#update update},
-        # {Google::Spanner::V1::Mutation#insert_or_update insert_or_update}, and
+        # Arguments to {Google::Spanner::V1::Mutation#insert insert}, {Google::Spanner::V1::Mutation#update update}, {Google::Spanner::V1::Mutation#insert_or_update insert_or_update}, and
         # {Google::Spanner::V1::Mutation#replace replace} operations.
         # @!attribute [rw] table
         #   @return [String]
         #     Required. The table whose rows will be written.
         # @!attribute [rw] columns
         #   @return [Array<String>]
-        #     The names of the columns in
-        #     {Google::Spanner::V1::Mutation::Write#table table} to be written.
+        #     The names of the columns in {Google::Spanner::V1::Mutation::Write#table table} to be written.
         #
         #     The list of columns must contain enough columns to allow
         #     Cloud Spanner to derive values for all primary key columns in the
@@ -64,13 +65,11 @@ module Google
         #     The values to be written. `values` can contain more than one
         #     list of values. If it does, then multiple rows are written, one
         #     for each entry in `values`. Each list in `values` must have
-        #     exactly as many entries as there are entries in
-        #     {Google::Spanner::V1::Mutation::Write#columns columns} above. Sending
-        #     multiple lists is equivalent to sending multiple `Mutation`s, each
-        #     containing one `values` entry and repeating
-        #     {Google::Spanner::V1::Mutation::Write#table table} and
-        #     {Google::Spanner::V1::Mutation::Write#columns columns}. Individual values in
-        #     each list are encoded as described {Google::Spanner::V1::TypeCode here}.
+        #     exactly as many entries as there are entries in {Google::Spanner::V1::Mutation::Write#columns columns}
+        #     above. Sending multiple lists is equivalent to sending multiple
+        #     `Mutation`s, each containing one `values` entry and repeating
+        #     {Google::Spanner::V1::Mutation::Write#table table} and {Google::Spanner::V1::Mutation::Write#columns columns}. Individual values in each list are
+        #     encoded as described {Google::Spanner::V1::TypeCode here}.
         class Write; end
 
         # Arguments to {Google::Spanner::V1::Mutation#delete delete} operations.
@@ -79,10 +78,9 @@ module Google
         #     Required. The table whose rows will be deleted.
         # @!attribute [rw] key_set
         #   @return [Google::Spanner::V1::KeySet]
-        #     Required. The primary keys of the rows within
-        #     {Google::Spanner::V1::Mutation::Delete#table table} to delete. Delete is
-        #     idempotent. The transaction will succeed even if some or all rows do not
-        #     exist.
+        #     Required. The primary keys of the rows within {Google::Spanner::V1::Mutation::Delete#table table} to delete.
+        #     Delete is idempotent. The transaction will succeed even if some or all
+        #     rows do not exist.
         class Delete; end
       end
     end
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/query_plan.rb b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/query_plan.rb
index 131e1bd74..90be3e70f 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/query_plan.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/query_plan.rb
@@ -16,19 +16,17 @@
 module Google
   module Spanner
     module V1
-      # Node information for nodes appearing in a
-      # {Google::Spanner::V1::QueryPlan#plan_nodes QueryPlan#plan_nodes}.
+      # Node information for nodes appearing in a {Google::Spanner::V1::QueryPlan#plan_nodes QueryPlan#plan_nodes}.
       # @!attribute [rw] index
       #   @return [Integer]
-      #     The `PlanNode`'s index in [node
-      #     list][google.spanner.v1.QueryPlan.plan_nodes].
+      #     The `PlanNode`'s index in {Google::Spanner::V1::QueryPlan#plan_nodes node list}.
       # @!attribute [rw] kind
       #   @return [Google::Spanner::V1::PlanNode::Kind]
       #     Used to determine the type of node. May be needed for visualizing
       #     different kinds of nodes differently. For example, If the node is a
-      #     {Google::Spanner::V1::PlanNode::Kind::SCALAR SCALAR} node, it will have a
-      #     condensed representation which can be used to directly embed a description
-      #     of the node in its parent.
+      #     {Google::Spanner::V1::PlanNode::Kind::SCALAR SCALAR} node, it will have a condensed representation
+      #     which can be used to directly embed a description of the node in its
+      #     parent.
       # @!attribute [rw] display_name
       #   @return [String]
       #     The display name for the node.
@@ -37,8 +35,7 @@ module Google
       #     List of child node `index`es and their relationship to this parent.
       # @!attribute [rw] short_representation
       #   @return [Google::Spanner::V1::PlanNode::ShortRepresentation]
-      #     Condensed representation for
-      #     {Google::Spanner::V1::PlanNode::Kind::SCALAR SCALAR} nodes.
+      #     Condensed representation for {Google::Spanner::V1::PlanNode::Kind::SCALAR SCALAR} nodes.
       # @!attribute [rw] metadata
       #   @return [Google::Protobuf::Struct]
       #     Attributes relevant to the node contained in a group of key-value pairs.
@@ -69,14 +66,14 @@ module Google
         #     with the output variable.
         # @!attribute [rw] variable
         #   @return [String]
-        #     Only present if the child node is
-        #     {Google::Spanner::V1::PlanNode::Kind::SCALAR SCALAR} and corresponds to an
-        #     output variable of the parent node. The field carries the name of the
-        #     output variable. For example, a `TableScan` operator that reads rows from
-        #     a table will have child links to the `SCALAR` nodes representing the
-        #     output variables created for each column that is read by the operator.
-        #     The corresponding `variable` fields will be set to the variable names
-        #     assigned to the columns.
+        #     Only present if the child node is {Google::Spanner::V1::PlanNode::Kind::SCALAR SCALAR} and corresponds
+        #     to an output variable of the parent node. The field carries the name of
+        #     the output variable.
+        #     For example, a `TableScan` operator that reads rows from a table will
+        #     have child links to the `SCALAR` nodes representing the output variables
+        #     created for each column that is read by the operator. The corresponding
+        #     `variable` fields will be set to the variable names assigned to the
+        #     columns.
         class ChildLink; end
 
         # Condensed representation of a node and its subtree. Only present for
@@ -93,8 +90,8 @@ module Google
         #     this node.
         class ShortRepresentation; end
 
-        # The kind of {Google::Spanner::V1::PlanNode PlanNode}. Distinguishes between
-        # the two different kinds of nodes that can appear in a query plan.
+        # The kind of {Google::Spanner::V1::PlanNode PlanNode}. Distinguishes between the two different kinds of
+        # nodes that can appear in a query plan.
         module Kind
           # Not specified.
           KIND_UNSPECIFIED = 0
@@ -116,8 +113,8 @@ module Google
       # @!attribute [rw] plan_nodes
       #   @return [Array<Google::Spanner::V1::PlanNode>]
       #     The nodes in the query plan. Plan nodes are returned in pre-order starting
-      #     with the plan root. Each {Google::Spanner::V1::PlanNode PlanNode}'s `id`
-      #     corresponds to its index in `plan_nodes`.
+      #     with the plan root. Each {Google::Spanner::V1::PlanNode PlanNode}'s `id` corresponds to its index in
+      #     `plan_nodes`.
       class QueryPlan; end
     end
   end
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/result_set.rb b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/result_set.rb
index d88ef39b8..0b46ba677 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/result_set.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/result_set.rb
@@ -24,10 +24,11 @@ module Google
       # @!attribute [rw] rows
       #   @return [Array<Google::Protobuf::ListValue>]
       #     Each element in `rows` is a row whose format is defined by
-      #     {Google::Spanner::V1::ResultSetMetadata#row_type metadata::row_type}. The ith
-      #     element in each row matches the ith field in
-      #     {Google::Spanner::V1::ResultSetMetadata#row_type metadata::row_type}. Elements
-      #     are encoded based on type as described {Google::Spanner::V1::TypeCode here}.
+      #     {Google::Spanner::V1::ResultSetMetadata#row_type metadata::row_type}. The ith element
+      #     in each row matches the ith field in
+      #     {Google::Spanner::V1::ResultSetMetadata#row_type metadata::row_type}. Elements are
+      #     encoded based on type as described
+      #     {Google::Spanner::V1::TypeCode here}.
       # @!attribute [rw] stats
       #   @return [Google::Spanner::V1::ResultSetStats]
       #     Query plan and execution statistics for the SQL statement that
@@ -35,8 +36,7 @@ module Google
       #     {Google::Spanner::V1::ExecuteSqlRequest#query_mode ExecuteSqlRequest#query_mode}.
       #     DML statements always produce stats containing the number of rows
       #     modified, unless executed using the
-      #     {Google::Spanner::V1::ExecuteSqlRequest::QueryMode::PLAN ExecuteSqlRequest::QueryMode::PLAN}
-      #     {Google::Spanner::V1::ExecuteSqlRequest#query_mode ExecuteSqlRequest#query_mode}.
+      #     {Google::Spanner::V1::ExecuteSqlRequest::QueryMode::PLAN ExecuteSqlRequest::QueryMode::PLAN} {Google::Spanner::V1::ExecuteSqlRequest#query_mode ExecuteSqlRequest#query_mode}.
       #     Other fields may or may not be populated, based on the
       #     {Google::Spanner::V1::ExecuteSqlRequest#query_mode ExecuteSqlRequest#query_mode}.
       class ResultSet; end
@@ -61,10 +61,9 @@ module Google
       #
       #     It is possible that the last value in values is "chunked",
       #     meaning that the rest of the value is sent in subsequent
-      #     `PartialResultSet`(s). This is denoted by the
-      #     {Google::Spanner::V1::PartialResultSet#chunked_value chunked_value} field.
-      #     Two or more chunked values can be merged to form a complete value as
-      #     follows:
+      #     `PartialResultSet`(s). This is denoted by the {Google::Spanner::V1::PartialResultSet#chunked_value chunked_value}
+      #     field. Two or more chunked values can be merged to form a
+      #     complete value as follows:
       #
       #     * `bool/number/null`: cannot be chunked
       #       * `string`: concatenate the strings
@@ -126,10 +125,9 @@ module Google
       #     field value `"World" = "W" + "orl" + "d"`.
       # @!attribute [rw] chunked_value
       #   @return [true, false]
-      #     If true, then the final value in
-      #     {Google::Spanner::V1::PartialResultSet#values values} is chunked, and must be
-      #     combined with more values from subsequent `PartialResultSet`s to obtain a
-      #     complete field value.
+      #     If true, then the final value in {Google::Spanner::V1::PartialResultSet#values values} is chunked, and must
+      #     be combined with more values from subsequent `PartialResultSet`s
+      #     to obtain a complete field value.
       # @!attribute [rw] resume_token
       #   @return [String]
       #     Streaming calls might be interrupted for a variety of reasons, such
@@ -141,13 +139,13 @@ module Google
       #   @return [Google::Spanner::V1::ResultSetStats]
       #     Query plan and execution statistics for the statement that produced this
       #     streaming result set. These can be requested by setting
-      #     {Google::Spanner::V1::ExecuteSqlRequest#query_mode ExecuteSqlRequest#query_mode}
-      #     and are sent only once with the last response in the stream. This field
-      #     will also be present in the last response for DML statements.
+      #     {Google::Spanner::V1::ExecuteSqlRequest#query_mode ExecuteSqlRequest#query_mode} and are sent
+      #     only once with the last response in the stream.
+      #     This field will also be present in the last response for DML
+      #     statements.
       class PartialResultSet; end
 
-      # Metadata about a {Google::Spanner::V1::ResultSet ResultSet} or
-      # {Google::Spanner::V1::PartialResultSet PartialResultSet}.
+      # Metadata about a {Google::Spanner::V1::ResultSet ResultSet} or {Google::Spanner::V1::PartialResultSet PartialResultSet}.
       # @!attribute [rw] row_type
       #   @return [Google::Spanner::V1::StructType]
       #     Indicates the field names and types for the rows in the result
@@ -164,12 +162,10 @@ module Google
       #     information about the new transaction is yielded here.
       class ResultSetMetadata; end
 
-      # Additional statistics about a {Google::Spanner::V1::ResultSet ResultSet} or
-      # {Google::Spanner::V1::PartialResultSet PartialResultSet}.
+      # Additional statistics about a {Google::Spanner::V1::ResultSet ResultSet} or {Google::Spanner::V1::PartialResultSet PartialResultSet}.
       # @!attribute [rw] query_plan
       #   @return [Google::Spanner::V1::QueryPlan]
-      #     {Google::Spanner::V1::QueryPlan QueryPlan} for the query associated with this
-      #     result.
+      #     {Google::Spanner::V1::QueryPlan QueryPlan} for the query associated with this result.
       # @!attribute [rw] query_stats
       #   @return [Google::Protobuf::Struct]
       #     Aggregated statistics from the execution of the query. Only present when
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/spanner.rb b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/spanner.rb
index 1053b861a..7cd6ee2d7 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/spanner.rb
@@ -138,30 +138,28 @@ module Google
       #     For queries, if none is provided, the default is a temporary read-only
       #     transaction with strong concurrency.
       #
-      #     Standard DML statements require a ReadWrite transaction. Single-use
-      #     transactions are not supported (to avoid replay).  The caller must
-      #     either supply an existing transaction ID or begin a new transaction.
+      #     Standard DML statements require a read-write transaction. To protect
+      #     against replays, single-use transactions are not supported.  The caller
+      #     must either supply an existing transaction ID or begin a new transaction.
       #
-      #     Partitioned DML requires an existing PartitionedDml transaction ID.
+      #     Partitioned DML requires an existing Partitioned DML transaction ID.
       # @!attribute [rw] sql
       #   @return [String]
       #     Required. The SQL string.
       # @!attribute [rw] params
       #   @return [Google::Protobuf::Struct]
-      #     The SQL string can contain parameter placeholders. A parameter
-      #     placeholder consists of `'@'` followed by the parameter
-      #     name. Parameter names consist of any combination of letters,
-      #     numbers, and underscores.
+      #     Parameter names and values that bind to placeholders in the SQL string.
+      #
+      #     A parameter placeholder consists of the `@` character followed by the
+      #     parameter name (for example, `@firstName`). Parameter names can contain
+      #     letters, numbers, and underscores.
       #
       #     Parameters can appear anywhere that a literal value is expected.  The same
       #     parameter name can be used more than once, for example:
-      #       `"WHERE id > @msg_id AND id < @msg_id + 100"`
       #
-      #     It is an error to execute an SQL statement with unbound parameters.
+      #     `"WHERE id > @msg_id AND id < @msg_id + 100"`
       #
-      #     Parameter values are specified using `params`, which is a JSON
-      #     object whose keys are parameter names, and whose values are the
-      #     corresponding parameter values.
+      #     It is an error to execute a SQL statement with unbound parameters.
       # @!attribute [rw] param_types
       #   @return [Hash{String => Google::Spanner::V1::Type}]
       #     It is not always possible for Cloud Spanner to infer the right SQL type
@@ -197,7 +195,7 @@ module Google
       #     PartitionQueryRequest message used to create this partition_token.
       # @!attribute [rw] seqno
       #   @return [Integer]
-      #     A per-transaction sequence number used to identify this request. This
+      #     A per-transaction sequence number used to identify this request. This field
       #     makes each request idempotent such that if the request is received multiple
       #     times, at most one will succeed.
       #
@@ -223,29 +221,35 @@ module Google
         end
       end
 
-      # The request for {Google::Spanner::V1::Spanner::ExecuteBatchDml ExecuteBatchDml}
+      # The request for {Google::Spanner::V1::Spanner::ExecuteBatchDml ExecuteBatchDml}.
       # @!attribute [rw] session
       #   @return [String]
       #     Required. The session in which the DML statements should be performed.
       # @!attribute [rw] transaction
       #   @return [Google::Spanner::V1::TransactionSelector]
-      #     The transaction to use. A ReadWrite transaction is required. Single-use
-      #     transactions are not supported (to avoid replay).  The caller must either
-      #     supply an existing transaction ID or begin a new transaction.
+      #     Required. The transaction to use. Must be a read-write transaction.
+      #
+      #     To protect against replays, single-use transactions are not supported. The
+      #     caller must either supply an existing transaction ID or begin a new
+      #     transaction.
       # @!attribute [rw] statements
       #   @return [Array<Google::Spanner::V1::ExecuteBatchDmlRequest::Statement>]
-      #     The list of statements to execute in this batch. Statements are executed
-      #     serially, such that the effects of statement i are visible to statement
-      #     i+1. Each statement must be a DML statement. Execution will stop at the
-      #     first failed statement; the remaining statements will not run.
+      #     Required. The list of statements to execute in this batch. Statements are
+      #     executed serially, such that the effects of statement `i` are visible to
+      #     statement `i+1`. Each statement must be a DML statement. Execution stops at
+      #     the first failed statement; the remaining statements are not executed.
       #
-      #     REQUIRES: statements_size() > 0.
+      #     Callers must provide at least one statement.
       # @!attribute [rw] seqno
       #   @return [Integer]
-      #     A per-transaction sequence number used to identify this request. This is
-      #     used in the same space as the seqno in
-      #     {Spanner::ExecuteSqlRequest ExecuteSqlRequest}. See more details
-      #     in {Spanner::ExecuteSqlRequest ExecuteSqlRequest}.
+      #     Required. A per-transaction sequence number used to identify this request.
+      #     This field makes each request idempotent such that if the request is
+      #     received multiple times, at most one will succeed.
+      #
+      #     The sequence number must be monotonically increasing within the
+      #     transaction. If a request arrives for the first time with an out-of-order
+      #     sequence number, the transaction may be aborted. Replays of previously
+      #     handled requests will yield the same response as the first execution.
       class ExecuteBatchDmlRequest
         # A single DML statement.
         # @!attribute [rw] sql
@@ -253,20 +257,18 @@ module Google
         #     Required. The DML string.
         # @!attribute [rw] params
         #   @return [Google::Protobuf::Struct]
-        #     The DML string can contain parameter placeholders. A parameter
-        #     placeholder consists of `'@'` followed by the parameter
-        #     name. Parameter names consist of any combination of letters,
-        #     numbers, and underscores.
+        #     Parameter names and values that bind to placeholders in the DML string.
+        #
+        #     A parameter placeholder consists of the `@` character followed by the
+        #     parameter name (for example, `@firstName`). Parameter names can contain
+        #     letters, numbers, and underscores.
         #
         #     Parameters can appear anywhere that a literal value is expected.  The
         #     same parameter name can be used more than once, for example:
-        #       `"WHERE id > @msg_id AND id < @msg_id + 100"`
         #
-        #     It is an error to execute an SQL statement with unbound parameters.
+        #     `"WHERE id > @msg_id AND id < @msg_id + 100"`
         #
-        #     Parameter values are specified using `params`, which is a JSON
-        #     object whose keys are parameter names, and whose values are the
-        #     corresponding parameter values.
+        #     It is an error to execute a SQL statement with unbound parameters.
         # @!attribute [rw] param_types
         #   @return [Hash{String => Google::Spanner::V1::Type}]
         #     It is not always possible for Cloud Spanner to infer the right SQL type
@@ -284,39 +286,49 @@ module Google
 
       # The response for
       # {Google::Spanner::V1::Spanner::ExecuteBatchDml ExecuteBatchDml}. Contains a list
-      # of {Google::Spanner::V1::ResultSet ResultSet}, one for each DML statement that
-      # has successfully executed. If a statement fails, the error is returned as
-      # part of the response payload. Clients can determine whether all DML
-      # statements have run successfully, or if a statement failed, using one of the
-      # following approaches:
-      #
-      #   1. Check if 'status' field is OkStatus.
-      #   2. Check if result_sets_size() equals the number of statements in
-      #      {Spanner::ExecuteBatchDmlRequest ExecuteBatchDmlRequest}.
-      #
-      # Example 1: A request with 5 DML statements, all executed successfully.
-      # Result: A response with 5 ResultSets, one for each statement in the same
-      # order, and an OK status.
-      #
-      # Example 2: A request with 5 DML statements. The 3rd statement has a syntax
-      # error.
-      # Result: A response with 2 ResultSets, for the first 2 statements that
-      # run successfully, and a syntax error (INVALID_ARGUMENT) status. From
-      # result_set_size() client can determine that the 3rd statement has failed.
+      # of {Google::Spanner::V1::ResultSet ResultSet} messages, one for each DML
+      # statement that has successfully executed, in the same order as the statements
+      # in the request. If a statement fails, the status in the response body
+      # identifies the cause of the failure.
+      #
+      # To check for DML statements that failed, use the following approach:
+      #
+      # 1. Check the status in the response message. The
+      # {Google::Rpc::Code} enum
+      #    value `OK` indicates that all statements were executed successfully.
+      # 2. If the status was not `OK`, check the number of result sets in the
+      #    response. If the response contains `N`
+      #    {Google::Spanner::V1::ResultSet ResultSet} messages, then statement `N+1` in
+      #    the request failed.
+      #
+      # Example 1:
+      #
+      # * Request: 5 DML statements, all executed successfully.
+      # * Response: 5 {Google::Spanner::V1::ResultSet ResultSet} messages, with the
+      #   status `OK`.
+      #
+      # Example 2:
+      #
+      # * Request: 5 DML statements. The third statement has a syntax error.
+      # * Response: 2 {Google::Spanner::V1::ResultSet ResultSet} messages, and a syntax
+      #   error (`INVALID_ARGUMENT`)
+      #   status. The number of {Google::Spanner::V1::ResultSet ResultSet} messages
+      #   indicates that the third statement failed, and the fourth and fifth
+      #   statements were not executed.
       # @!attribute [rw] result_sets
       #   @return [Array<Google::Spanner::V1::ResultSet>]
-      #     ResultSets, one for each statement in the request that ran successfully, in
-      #     the same order as the statements in the request. Each
-      #     {Google::Spanner::V1::ResultSet ResultSet} will not contain any rows. The
-      #     {Google::Spanner::V1::ResultSetStats ResultSetStats} in each
-      #     {Google::Spanner::V1::ResultSet ResultSet} will contain the number of rows
+      #     One {Google::Spanner::V1::ResultSet ResultSet} for each statement in the
+      #     request that ran successfully, in the same order as the statements in the
+      #     request. Each {Google::Spanner::V1::ResultSet ResultSet} does not contain any
+      #     rows. The {Google::Spanner::V1::ResultSetStats ResultSetStats} in each
+      #     {Google::Spanner::V1::ResultSet ResultSet} contain the number of rows
       #     modified by the statement.
       #
-      #     Only the first ResultSet in the response contains a valid
-      #     {Google::Spanner::V1::ResultSetMetadata ResultSetMetadata}.
+      #     Only the first {Google::Spanner::V1::ResultSet ResultSet} in the response
+      #     contains valid {Google::Spanner::V1::ResultSetMetadata ResultSetMetadata}.
       # @!attribute [rw] status
       #   @return [Google::Rpc::Status]
-      #     If all DML statements are executed successfully, status will be OK.
+      #     If all DML statements are executed successfully, the status is `OK`.
       #     Otherwise, the error status of the first failed statement.
       class ExecuteBatchDmlResponse; end
 
@@ -352,8 +364,8 @@ module Google
       #     transactions are not.
       # @!attribute [rw] sql
       #   @return [String]
-      #     The query request to generate partitions for. The request will fail if
-      #     the query is not root partitionable. The query plan of a root
+      #     Required. The query request to generate partitions for. The request will
+      #     fail if the query is not root partitionable. The query plan of a root
       #     partitionable query has a single distributed union operator. A distributed
       #     union operator conceptually divides one or more tables into multiple
       #     splits, remotely evaluates a subquery independently on each split, and
@@ -365,20 +377,18 @@ module Google
       #     PartitionedDml transaction for large, partition-friendly DML operations.
       # @!attribute [rw] params
       #   @return [Google::Protobuf::Struct]
-      #     The SQL query string can contain parameter placeholders. A parameter
-      #     placeholder consists of `'@'` followed by the parameter
-      #     name. Parameter names consist of any combination of letters,
-      #     numbers, and underscores.
+      #     Parameter names and values that bind to placeholders in the SQL string.
+      #
+      #     A parameter placeholder consists of the `@` character followed by the
+      #     parameter name (for example, `@firstName`). Parameter names can contain
+      #     letters, numbers, and underscores.
       #
       #     Parameters can appear anywhere that a literal value is expected.  The same
       #     parameter name can be used more than once, for example:
-      #       `"WHERE id > @msg_id AND id < @msg_id + 100"`
       #
-      #     It is an error to execute an SQL query with unbound parameters.
+      #     `"WHERE id > @msg_id AND id < @msg_id + 100"`
       #
-      #     Parameter values are specified using `params`, which is a JSON
-      #     object whose keys are parameter names, and whose values are the
-      #     corresponding parameter values.
+      #     It is an error to execute a SQL statement with unbound parameters.
       # @!attribute [rw] param_types
       #   @return [Hash{String => Google::Spanner::V1::Type}]
       #     It is not always possible for Cloud Spanner to infer the right SQL type
@@ -476,8 +486,8 @@ module Google
       #     information.
       # @!attribute [rw] columns
       #   @return [Array<String>]
-      #     The columns of {Google::Spanner::V1::ReadRequest#table table} to be returned
-      #     for each row matching this request.
+      #     Required. The columns of {Google::Spanner::V1::ReadRequest#table table} to be
+      #     returned for each row matching this request.
       # @!attribute [rw] key_set
       #   @return [Google::Spanner::V1::KeySet]
       #     Required. `key_set` identifies the rows to be yielded. `key_set` names the
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/transaction.rb b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/transaction.rb
index 2b51a89a0..f237e9ceb 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/transaction.rb
@@ -172,8 +172,7 @@ module Google
       # reads should be executed within a transaction or at an exact read
       # timestamp.
       #
-      # See
-      # {Google::Spanner::V1::TransactionOptions::ReadOnly#strong TransactionOptions::ReadOnly#strong}.
+      # See {Google::Spanner::V1::TransactionOptions::ReadOnly#strong TransactionOptions::ReadOnly#strong}.
       #
       # === Exact Staleness
       #
@@ -194,9 +193,7 @@ module Google
       # equivalent boundedly stale concurrency modes. On the other hand,
       # boundedly stale reads usually return fresher results.
       #
-      # See
-      # {Google::Spanner::V1::TransactionOptions::ReadOnly#read_timestamp TransactionOptions::ReadOnly#read_timestamp}
-      # and
+      # See {Google::Spanner::V1::TransactionOptions::ReadOnly#read_timestamp TransactionOptions::ReadOnly#read_timestamp} and
       # {Google::Spanner::V1::TransactionOptions::ReadOnly#exact_staleness TransactionOptions::ReadOnly#exact_staleness}.
       #
       # === Bounded Staleness
@@ -226,9 +223,7 @@ module Google
       # which rows will be read, it can only be used with single-use
       # read-only transactions.
       #
-      # See
-      # {Google::Spanner::V1::TransactionOptions::ReadOnly#max_staleness TransactionOptions::ReadOnly#max_staleness}
-      # and
+      # See {Google::Spanner::V1::TransactionOptions::ReadOnly#max_staleness TransactionOptions::ReadOnly#max_staleness} and
       # {Google::Spanner::V1::TransactionOptions::ReadOnly#min_read_timestamp TransactionOptions::ReadOnly#min_read_timestamp}.
       #
       # === Old Read Timestamps and Garbage Collection
@@ -388,8 +383,7 @@ module Google
         # @!attribute [rw] return_read_timestamp
         #   @return [true, false]
         #     If true, the Cloud Spanner-selected read timestamp is included in
-        #     the {Google::Spanner::V1::Transaction Transaction} message that describes
-        #     the transaction.
+        #     the {Google::Spanner::V1::Transaction Transaction} message that describes the transaction.
         class ReadOnly; end
       end
 
@@ -418,8 +412,7 @@ module Google
       # {Google::Spanner::V1::Spanner::Read Read} or
       # {Google::Spanner::V1::Spanner::ExecuteSql ExecuteSql} call runs.
       #
-      # See {Google::Spanner::V1::TransactionOptions TransactionOptions} for more
-      # information about transactions.
+      # See {Google::Spanner::V1::TransactionOptions TransactionOptions} for more information about transactions.
       # @!attribute [rw] single_use
       #   @return [Google::Spanner::V1::TransactionOptions]
       #     Execute the read or SQL query in a temporary transaction.
@@ -432,8 +425,7 @@ module Google
       #   @return [Google::Spanner::V1::TransactionOptions]
       #     Begin a new transaction and execute this read or SQL query in
       #     it. The transaction ID of the new transaction is returned in
-      #     {Google::Spanner::V1::ResultSetMetadata#transaction ResultSetMetadata#transaction},
-      #     which is a {Google::Spanner::V1::Transaction Transaction}.
+      #     {Google::Spanner::V1::ResultSetMetadata#transaction ResultSetMetadata#transaction}, which is a {Google::Spanner::V1::Transaction Transaction}.
       class TransactionSelector; end
     end
   end
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/type.rb b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/type.rb
index 2dbbde6a4..af6796095 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/type.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/type.rb
@@ -23,26 +23,23 @@ module Google
       #     Required. The {Google::Spanner::V1::TypeCode TypeCode} for this type.
       # @!attribute [rw] array_element_type
       #   @return [Google::Spanner::V1::Type]
-      #     If {Google::Spanner::V1::Type#code code} ==
-      #     {Google::Spanner::V1::TypeCode::ARRAY ARRAY}, then `array_element_type` is the
-      #     type of the array elements.
+      #     If {Google::Spanner::V1::Type#code code} == {Google::Spanner::V1::TypeCode::ARRAY ARRAY}, then `array_element_type`
+      #     is the type of the array elements.
       # @!attribute [rw] struct_type
       #   @return [Google::Spanner::V1::StructType]
-      #     If {Google::Spanner::V1::Type#code code} ==
-      #     {Google::Spanner::V1::TypeCode::STRUCT STRUCT}, then `struct_type` provides
-      #     type information for the struct's fields.
+      #     If {Google::Spanner::V1::Type#code code} == {Google::Spanner::V1::TypeCode::STRUCT STRUCT}, then `struct_type`
+      #     provides type information for the struct's fields.
       class Type; end
 
-      # `StructType` defines the fields of a
-      # {Google::Spanner::V1::TypeCode::STRUCT STRUCT} type.
+      # `StructType` defines the fields of a {Google::Spanner::V1::TypeCode::STRUCT STRUCT} type.
       # @!attribute [rw] fields
       #   @return [Array<Google::Spanner::V1::StructType::Field>]
       #     The list of fields that make up this struct. Order is
       #     significant, because values of this struct type are represented as
       #     lists, where the order of field values matches the order of
-      #     fields in the {Google::Spanner::V1::StructType StructType}. In turn, the
-      #     order of fields matches the order of columns in a read request, or the
-      #     order of fields in the `SELECT` clause of a query.
+      #     fields in the {Google::Spanner::V1::StructType StructType}. In turn, the order of fields
+      #     matches the order of columns in a read request, or the order of
+      #     fields in the `SELECT` clause of a query.
       class StructType
         # Message representing a single field of a struct.
         # @!attribute [rw] name
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
index f5575001f..35ddb7d8c 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
@@ -356,8 +356,8 @@ module Google
           # transaction internally, and count toward the one transaction
           # limit.
           #
-          # Cloud Spanner limits the number of sessions that can exist at any given
-          # time; thus, it is a good idea to delete idle and/or unneeded sessions.
+          # Active sessions use additional server resources, so it is a good idea to
+          # delete idle and unneeded sessions.
           # Aside from explicit deletes, Cloud Spanner can delete sessions for which no
           # operations are sent for more than an hour. If a session is deleted,
           # requests to it return `NOT_FOUND`.
@@ -605,28 +605,26 @@ module Google
           #   For queries, if none is provided, the default is a temporary read-only
           #   transaction with strong concurrency.
           #
-          #   Standard DML statements require a ReadWrite transaction. Single-use
-          #   transactions are not supported (to avoid replay).  The caller must
-          #   either supply an existing transaction ID or begin a new transaction.
+          #   Standard DML statements require a read-write transaction. To protect
+          #   against replays, single-use transactions are not supported.  The caller
+          #   must either supply an existing transaction ID or begin a new transaction.
           #
-          #   Partitioned DML requires an existing PartitionedDml transaction ID.
+          #   Partitioned DML requires an existing Partitioned DML transaction ID.
           #   A hash of the same form as `Google::Spanner::V1::TransactionSelector`
           #   can also be provided.
           # @param params [Google::Protobuf::Struct | Hash]
-          #   The SQL string can contain parameter placeholders. A parameter
-          #   placeholder consists of `'@'` followed by the parameter
-          #   name. Parameter names consist of any combination of letters,
-          #   numbers, and underscores.
+          #   Parameter names and values that bind to placeholders in the SQL string.
+          #
+          #   A parameter placeholder consists of the `@` character followed by the
+          #   parameter name (for example, `@firstName`). Parameter names can contain
+          #   letters, numbers, and underscores.
           #
           #   Parameters can appear anywhere that a literal value is expected.  The same
           #   parameter name can be used more than once, for example:
-          #     `"WHERE id > @msg_id AND id < @msg_id + 100"`
           #
-          #   It is an error to execute an SQL statement with unbound parameters.
+          #   `"WHERE id > @msg_id AND id < @msg_id + 100"`
           #
-          #   Parameter values are specified using `params`, which is a JSON
-          #   object whose keys are parameter names, and whose values are the
-          #   corresponding parameter values.
+          #   It is an error to execute a SQL statement with unbound parameters.
           #   A hash of the same form as `Google::Protobuf::Struct`
           #   can also be provided.
           # @param param_types [Hash{String => Google::Spanner::V1::Type | Hash}]
@@ -661,7 +659,7 @@ module Google
           #   match for the values of fields common to this message and the
           #   PartitionQueryRequest message used to create this partition_token.
           # @param seqno [Integer]
-          #   A per-transaction sequence number used to identify this request. This
+          #   A per-transaction sequence number used to identify this request. This field
           #   makes each request idempotent such that if the request is received multiple
           #   times, at most one will succeed.
           #
@@ -732,28 +730,26 @@ module Google
           #   For queries, if none is provided, the default is a temporary read-only
           #   transaction with strong concurrency.
           #
-          #   Standard DML statements require a ReadWrite transaction. Single-use
-          #   transactions are not supported (to avoid replay).  The caller must
-          #   either supply an existing transaction ID or begin a new transaction.
+          #   Standard DML statements require a read-write transaction. To protect
+          #   against replays, single-use transactions are not supported.  The caller
+          #   must either supply an existing transaction ID or begin a new transaction.
           #
-          #   Partitioned DML requires an existing PartitionedDml transaction ID.
+          #   Partitioned DML requires an existing Partitioned DML transaction ID.
           #   A hash of the same form as `Google::Spanner::V1::TransactionSelector`
           #   can also be provided.
           # @param params [Google::Protobuf::Struct | Hash]
-          #   The SQL string can contain parameter placeholders. A parameter
-          #   placeholder consists of `'@'` followed by the parameter
-          #   name. Parameter names consist of any combination of letters,
-          #   numbers, and underscores.
+          #   Parameter names and values that bind to placeholders in the SQL string.
+          #
+          #   A parameter placeholder consists of the `@` character followed by the
+          #   parameter name (for example, `@firstName`). Parameter names can contain
+          #   letters, numbers, and underscores.
           #
           #   Parameters can appear anywhere that a literal value is expected.  The same
           #   parameter name can be used more than once, for example:
-          #     `"WHERE id > @msg_id AND id < @msg_id + 100"`
           #
-          #   It is an error to execute an SQL statement with unbound parameters.
+          #   `"WHERE id > @msg_id AND id < @msg_id + 100"`
           #
-          #   Parameter values are specified using `params`, which is a JSON
-          #   object whose keys are parameter names, and whose values are the
-          #   corresponding parameter values.
+          #   It is an error to execute a SQL statement with unbound parameters.
           #   A hash of the same form as `Google::Protobuf::Struct`
           #   can also be provided.
           # @param param_types [Hash{String => Google::Spanner::V1::Type | Hash}]
@@ -788,7 +784,7 @@ module Google
           #   match for the values of fields common to this message and the
           #   PartitionQueryRequest message used to create this partition_token.
           # @param seqno [Integer]
-          #   A per-transaction sequence number used to identify this request. This
+          #   A per-transaction sequence number used to identify this request. This field
           #   makes each request idempotent such that if the request is received multiple
           #   times, at most one will succeed.
           #
@@ -847,45 +843,43 @@ module Google
           # to be run with lower latency than submitting them sequentially with
           # {Google::Spanner::V1::Spanner::ExecuteSql ExecuteSql}.
           #
-          # Statements are executed in order, sequentially.
-          # {Spanner::ExecuteBatchDmlResponse ExecuteBatchDmlResponse} will contain a
-          # {Google::Spanner::V1::ResultSet ResultSet} for each DML statement that has
-          # successfully executed. If a statement fails, its error status will be
-          # returned as part of the
-          # {Spanner::ExecuteBatchDmlResponse ExecuteBatchDmlResponse}. Execution will
-          # stop at the first failed statement; the remaining statements will not run.
+          # Statements are executed in sequential order. A request can succeed even if
+          # a statement fails. The
+          # {Google::Spanner::V1::ExecuteBatchDmlResponse#status ExecuteBatchDmlResponse#status}
+          # field in the response provides information about the statement that failed.
+          # Clients must inspect this field to determine whether an error occurred.
           #
-          # ExecuteBatchDml is expected to return an OK status with a response even if
-          # there was an error while processing one of the DML statements. Clients must
-          # inspect response.status to determine if there were any errors while
-          # processing the request.
-          #
-          # See more details in
-          # {Spanner::ExecuteBatchDmlRequest ExecuteBatchDmlRequest} and
-          # {Spanner::ExecuteBatchDmlResponse ExecuteBatchDmlResponse}.
+          # Execution stops after the first failed statement; the remaining statements
+          # are not executed.
           #
           # @param session [String]
           #   Required. The session in which the DML statements should be performed.
           # @param transaction [Google::Spanner::V1::TransactionSelector | Hash]
-          #   The transaction to use. A ReadWrite transaction is required. Single-use
-          #   transactions are not supported (to avoid replay).  The caller must either
-          #   supply an existing transaction ID or begin a new transaction.
+          #   Required. The transaction to use. Must be a read-write transaction.
+          #
+          #   To protect against replays, single-use transactions are not supported. The
+          #   caller must either supply an existing transaction ID or begin a new
+          #   transaction.
           #   A hash of the same form as `Google::Spanner::V1::TransactionSelector`
           #   can also be provided.
           # @param statements [Array<Google::Spanner::V1::ExecuteBatchDmlRequest::Statement | Hash>]
-          #   The list of statements to execute in this batch. Statements are executed
-          #   serially, such that the effects of statement i are visible to statement
-          #   i+1. Each statement must be a DML statement. Execution will stop at the
-          #   first failed statement; the remaining statements will not run.
+          #   Required. The list of statements to execute in this batch. Statements are
+          #   executed serially, such that the effects of statement `i` are visible to
+          #   statement `i+1`. Each statement must be a DML statement. Execution stops at
+          #   the first failed statement; the remaining statements are not executed.
           #
-          #   REQUIRES: statements_size() > 0.
+          #   Callers must provide at least one statement.
           #   A hash of the same form as `Google::Spanner::V1::ExecuteBatchDmlRequest::Statement`
           #   can also be provided.
           # @param seqno [Integer]
-          #   A per-transaction sequence number used to identify this request. This is
-          #   used in the same space as the seqno in
-          #   {Spanner::ExecuteSqlRequest ExecuteSqlRequest}. See more details
-          #   in {Spanner::ExecuteSqlRequest ExecuteSqlRequest}.
+          #   Required. A per-transaction sequence number used to identify this request.
+          #   This field makes each request idempotent such that if the request is
+          #   received multiple times, at most one will succeed.
+          #
+          #   The sequence number must be monotonically increasing within the
+          #   transaction. If a request arrives for the first time with an out-of-order
+          #   sequence number, the transaction may be aborted. Replays of previously
+          #   handled requests will yield the same response as the first execution.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -947,8 +941,8 @@ module Google
           # @param table [String]
           #   Required. The name of the table in the database to be read.
           # @param columns [Array<String>]
-          #   The columns of {Google::Spanner::V1::ReadRequest#table table} to be returned
-          #   for each row matching this request.
+          #   Required. The columns of {Google::Spanner::V1::ReadRequest#table table} to be
+          #   returned for each row matching this request.
           # @param key_set [Google::Spanner::V1::KeySet | Hash]
           #   Required. `key_set` identifies the rows to be yielded. `key_set` names the
           #   primary keys of the rows in {Google::Spanner::V1::ReadRequest#table table} to
@@ -1058,8 +1052,8 @@ module Google
           # @param table [String]
           #   Required. The name of the table in the database to be read.
           # @param columns [Array<String>]
-          #   The columns of {Google::Spanner::V1::ReadRequest#table table} to be returned
-          #   for each row matching this request.
+          #   Required. The columns of {Google::Spanner::V1::ReadRequest#table table} to be
+          #   returned for each row matching this request.
           # @param key_set [Google::Spanner::V1::KeySet | Hash]
           #   Required. `key_set` identifies the rows to be yielded. `key_set` names the
           #   primary keys of the rows in {Google::Spanner::V1::ReadRequest#table table} to
@@ -1212,12 +1206,6 @@ module Google
           #
           # @param session [String]
           #   Required. The session in which the transaction to be committed is running.
-          # @param mutations [Array<Google::Spanner::V1::Mutation | Hash>]
-          #   The mutations to be executed when this transaction commits. All
-          #   mutations are applied atomically, in the order they appear in
-          #   this list.
-          #   A hash of the same form as `Google::Spanner::V1::Mutation`
-          #   can also be provided.
           # @param transaction_id [String]
           #   Commit a previously-started transaction.
           # @param single_use_transaction [Google::Spanner::V1::TransactionOptions | Hash]
@@ -1232,6 +1220,12 @@ module Google
           #   {Google::Spanner::V1::Spanner::Commit Commit} instead.
           #   A hash of the same form as `Google::Spanner::V1::TransactionOptions`
           #   can also be provided.
+          # @param mutations [Array<Google::Spanner::V1::Mutation | Hash>]
+          #   The mutations to be executed when this transaction commits. All
+          #   mutations are applied atomically, in the order they appear in
+          #   this list.
+          #   A hash of the same form as `Google::Spanner::V1::Mutation`
+          #   can also be provided.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1245,23 +1239,20 @@ module Google
           #
           #   spanner_client = Google::Cloud::Spanner::V1::SpannerClient.new
           #   formatted_session = Google::Cloud::Spanner::V1::SpannerClient.session_path("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]")
-          #
-          #   # TODO: Initialize `mutations`:
-          #   mutations = []
-          #   response = spanner_client.commit(formatted_session, mutations)
+          #   response = spanner_client.commit(formatted_session)
 
           def commit \
               session,
-              mutations,
               transaction_id: nil,
               single_use_transaction: nil,
+              mutations: nil,
               options: nil,
               &block
             req = {
               session: session,
-              mutations: mutations,
               transaction_id: transaction_id,
-              single_use_transaction: single_use_transaction
+              single_use_transaction: single_use_transaction,
+              mutations: mutations
             }.delete_if { |_, v| v.nil? }
             req = Google::Gax::to_proto(req, Google::Spanner::V1::CommitRequest)
             @commit.call(req, options, &block)
@@ -1328,8 +1319,8 @@ module Google
           # @param session [String]
           #   Required. The session used to create the partitions.
           # @param sql [String]
-          #   The query request to generate partitions for. The request will fail if
-          #   the query is not root partitionable. The query plan of a root
+          #   Required. The query request to generate partitions for. The request will
+          #   fail if the query is not root partitionable. The query plan of a root
           #   partitionable query has a single distributed union operator. A distributed
           #   union operator conceptually divides one or more tables into multiple
           #   splits, remotely evaluates a subquery independently on each split, and
@@ -1345,20 +1336,18 @@ module Google
           #   A hash of the same form as `Google::Spanner::V1::TransactionSelector`
           #   can also be provided.
           # @param params [Google::Protobuf::Struct | Hash]
-          #   The SQL query string can contain parameter placeholders. A parameter
-          #   placeholder consists of `'@'` followed by the parameter
-          #   name. Parameter names consist of any combination of letters,
-          #   numbers, and underscores.
+          #   Parameter names and values that bind to placeholders in the SQL string.
+          #
+          #   A parameter placeholder consists of the `@` character followed by the
+          #   parameter name (for example, `@firstName`). Parameter names can contain
+          #   letters, numbers, and underscores.
           #
           #   Parameters can appear anywhere that a literal value is expected.  The same
           #   parameter name can be used more than once, for example:
-          #     `"WHERE id > @msg_id AND id < @msg_id + 100"`
           #
-          #   It is an error to execute an SQL query with unbound parameters.
+          #   `"WHERE id > @msg_id AND id < @msg_id + 100"`
           #
-          #   Parameter values are specified using `params`, which is a JSON
-          #   object whose keys are parameter names, and whose values are the
-          #   corresponding parameter values.
+          #   It is an error to execute a SQL statement with unbound parameters.
           #   A hash of the same form as `Google::Protobuf::Struct`
           #   can also be provided.
           # @param param_types [Hash{String => Google::Spanner::V1::Type | Hash}]
diff --git a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json
index cbe4698b1..f0dc07b5a 100644
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json
@@ -15,18 +15,18 @@
           "initial_retry_delay_millis": 250,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 32000,
-          "initial_rpc_timeout_millis": 360000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 360000,
+          "max_rpc_timeout_millis": 3600000,
           "total_timeout_millis": 3600000
         },
         "streaming": {
           "initial_retry_delay_millis": 250,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 32000,
-          "initial_rpc_timeout_millis": 360000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 360000,
+          "max_rpc_timeout_millis": 3600000,
           "total_timeout_millis": 3600000
         },
         "long_running": {
diff --git a/google-cloud-spanner/lib/google/spanner/admin/database/v1/spanner_database_admin_pb.rb b/google-cloud-spanner/lib/google/spanner/admin/database/v1/spanner_database_admin_pb.rb
index 6bd380e1a..5904c3280 100644
--- a/google-cloud-spanner/lib/google/spanner/admin/database/v1/spanner_database_admin_pb.rb
+++ b/google-cloud-spanner/lib/google/spanner/admin/database/v1/spanner_database_admin_pb.rb
@@ -5,6 +5,9 @@
 require 'google/protobuf'
 
 require 'google/api/annotations_pb'
+require 'google/api/client_pb'
+require 'google/api/field_behavior_pb'
+require 'google/api/resource_pb'
 require 'google/iam/v1/iam_policy_pb'
 require 'google/iam/v1/policy_pb'
 require 'google/longrunning/operations_pb'
diff --git a/google-cloud-spanner/lib/google/spanner/admin/database/v1/spanner_database_admin_services_pb.rb b/google-cloud-spanner/lib/google/spanner/admin/database/v1/spanner_database_admin_services_pb.rb
index d550c7f9b..9dd956834 100644
--- a/google-cloud-spanner/lib/google/spanner/admin/database/v1/spanner_database_admin_services_pb.rb
+++ b/google-cloud-spanner/lib/google/spanner/admin/database/v1/spanner_database_admin_services_pb.rb
@@ -1,7 +1,7 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
 # Source: google/spanner/admin/database/v1/spanner_database_admin.proto for package 'google.spanner.admin.database.v1'
 # Original file comments:
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+#
 
 
 require 'grpc'
@@ -67,24 +68,25 @@ module Google
               # DDL statements. This method does not show pending schema updates, those may
               # be queried using the [Operations][google.longrunning.Operations] API.
               rpc :GetDatabaseDdl, GetDatabaseDdlRequest, GetDatabaseDdlResponse
-              # Sets the access control policy on a database resource. Replaces any
-              # existing policy.
+              # Sets the access control policy on a database resource.
+              # Replaces any existing policy.
               #
-              # Authorization requires `spanner.databases.setIamPolicy` permission on
-              # [resource][google.iam.v1.SetIamPolicyRequest.resource].
+              # Authorization requires `spanner.databases.setIamPolicy`
+              # permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
               rpc :SetIamPolicy, Google::Iam::V1::SetIamPolicyRequest, Google::Iam::V1::Policy
-              # Gets the access control policy for a database resource. Returns an empty
-              # policy if a database exists but does not have a policy set.
+              # Gets the access control policy for a database resource.
+              # Returns an empty policy if a database exists but does
+              # not have a policy set.
               #
               # Authorization requires `spanner.databases.getIamPolicy` permission on
               # [resource][google.iam.v1.GetIamPolicyRequest.resource].
               rpc :GetIamPolicy, Google::Iam::V1::GetIamPolicyRequest, Google::Iam::V1::Policy
               # Returns permissions that the caller has on the specified database resource.
               #
-              # Attempting this RPC on a non-existent Cloud Spanner database will result in
-              # a NOT_FOUND error if the user has `spanner.databases.list` permission on
-              # the containing Cloud Spanner instance. Otherwise returns an empty set of
-              # permissions.
+              # Attempting this RPC on a non-existent Cloud Spanner database will
+              # result in a NOT_FOUND error if the user has
+              # `spanner.databases.list` permission on the containing Cloud
+              # Spanner instance. Otherwise returns an empty set of permissions.
               rpc :TestIamPermissions, Google::Iam::V1::TestIamPermissionsRequest, Google::Iam::V1::TestIamPermissionsResponse
             end
 
diff --git a/google-cloud-spanner/lib/google/spanner/admin/instance/v1/spanner_instance_admin_pb.rb b/google-cloud-spanner/lib/google/spanner/admin/instance/v1/spanner_instance_admin_pb.rb
index c18853a4e..0ddca62d3 100644
--- a/google-cloud-spanner/lib/google/spanner/admin/instance/v1/spanner_instance_admin_pb.rb
+++ b/google-cloud-spanner/lib/google/spanner/admin/instance/v1/spanner_instance_admin_pb.rb
@@ -5,6 +5,9 @@
 require 'google/protobuf'
 
 require 'google/api/annotations_pb'
+require 'google/api/client_pb'
+require 'google/api/field_behavior_pb'
+require 'google/api/resource_pb'
 require 'google/iam/v1/iam_policy_pb'
 require 'google/iam/v1/policy_pb'
 require 'google/longrunning/operations_pb'
@@ -12,9 +15,21 @@ require 'google/protobuf/empty_pb'
 require 'google/protobuf/field_mask_pb'
 require 'google/protobuf/timestamp_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
+  add_message "google.spanner.admin.instance.v1.ReplicaInfo" do
+    optional :location, :string, 1
+    optional :type, :enum, 2, "google.spanner.admin.instance.v1.ReplicaInfo.ReplicaType"
+    optional :default_leader_location, :bool, 3
+  end
+  add_enum "google.spanner.admin.instance.v1.ReplicaInfo.ReplicaType" do
+    value :TYPE_UNSPECIFIED, 0
+    value :READ_WRITE, 1
+    value :READ_ONLY, 2
+    value :WITNESS, 3
+  end
   add_message "google.spanner.admin.instance.v1.InstanceConfig" do
     optional :name, :string, 1
     optional :display_name, :string, 2
+    repeated :replicas, :message, 3, "google.spanner.admin.instance.v1.ReplicaInfo"
   end
   add_message "google.spanner.admin.instance.v1.Instance" do
     optional :name, :string, 1
@@ -85,6 +100,8 @@ module Google
     module Admin
       module Instance
         module V1
+          ReplicaInfo = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.spanner.admin.instance.v1.ReplicaInfo").msgclass
+          ReplicaInfo::ReplicaType = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.spanner.admin.instance.v1.ReplicaInfo.ReplicaType").enummodule
           InstanceConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.spanner.admin.instance.v1.InstanceConfig").msgclass
           Instance = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.spanner.admin.instance.v1.Instance").msgclass
           Instance::State = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.spanner.admin.instance.v1.Instance.State").enummodule
diff --git a/google-cloud-spanner/lib/google/spanner/admin/instance/v1/spanner_instance_admin_services_pb.rb b/google-cloud-spanner/lib/google/spanner/admin/instance/v1/spanner_instance_admin_services_pb.rb
index ca35b394a..6bc1f97b2 100644
--- a/google-cloud-spanner/lib/google/spanner/admin/instance/v1/spanner_instance_admin_services_pb.rb
+++ b/google-cloud-spanner/lib/google/spanner/admin/instance/v1/spanner_instance_admin_services_pb.rb
@@ -1,7 +1,7 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
 # Source: google/spanner/admin/instance/v1/spanner_instance_admin.proto for package 'google.spanner.admin.instance.v1'
 # Original file comments:
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+#
 
 
 require 'grpc'
@@ -112,9 +113,9 @@ module Google
               # Until completion of the returned operation:
               #
               #   * Cancelling the operation sets its metadata's
-              #     [cancel_time][google.spanner.admin.instance.v1.UpdateInstanceMetadata.cancel_time],
-              #     and begins restoring resources to their pre-request values. The
-              #     operation is guaranteed to succeed at undoing all resource changes,
+              #     [cancel_time][google.spanner.admin.instance.v1.UpdateInstanceMetadata.cancel_time], and begins
+              #     restoring resources to their pre-request values. The operation
+              #     is guaranteed to succeed at undoing all resource changes,
               #     after which point it terminates with a `CANCELLED` status.
               #   * All other attempts to modify the instance are rejected.
               #   * Reading the instance via the API continues to give the pre-request
diff --git a/google-cloud-spanner/lib/google/spanner/v1/keys_pb.rb b/google-cloud-spanner/lib/google/spanner/v1/keys_pb.rb
index d7c40be6c..4b90b7d94 100644
--- a/google-cloud-spanner/lib/google/spanner/v1/keys_pb.rb
+++ b/google-cloud-spanner/lib/google/spanner/v1/keys_pb.rb
@@ -4,8 +4,8 @@
 
 require 'google/protobuf'
 
-require 'google/api/annotations_pb'
 require 'google/protobuf/struct_pb'
+require 'google/api/annotations_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.spanner.v1.KeyRange" do
     oneof :start_key_type do
diff --git a/google-cloud-spanner/lib/google/spanner/v1/mutation_pb.rb b/google-cloud-spanner/lib/google/spanner/v1/mutation_pb.rb
index 53918217f..49538595f 100644
--- a/google-cloud-spanner/lib/google/spanner/v1/mutation_pb.rb
+++ b/google-cloud-spanner/lib/google/spanner/v1/mutation_pb.rb
@@ -4,9 +4,9 @@
 
 require 'google/protobuf'
 
-require 'google/api/annotations_pb'
 require 'google/protobuf/struct_pb'
 require 'google/spanner/v1/keys_pb'
+require 'google/api/annotations_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.spanner.v1.Mutation" do
     oneof :operation do
diff --git a/google-cloud-spanner/lib/google/spanner/v1/query_plan_pb.rb b/google-cloud-spanner/lib/google/spanner/v1/query_plan_pb.rb
index 65c3bc279..c79c22e44 100644
--- a/google-cloud-spanner/lib/google/spanner/v1/query_plan_pb.rb
+++ b/google-cloud-spanner/lib/google/spanner/v1/query_plan_pb.rb
@@ -4,8 +4,8 @@
 
 require 'google/protobuf'
 
-require 'google/api/annotations_pb'
 require 'google/protobuf/struct_pb'
+require 'google/api/annotations_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.spanner.v1.PlanNode" do
     optional :index, :int32, 1
diff --git a/google-cloud-spanner/lib/google/spanner/v1/result_set_pb.rb b/google-cloud-spanner/lib/google/spanner/v1/result_set_pb.rb
index 6630e4732..f14ba78e9 100644
--- a/google-cloud-spanner/lib/google/spanner/v1/result_set_pb.rb
+++ b/google-cloud-spanner/lib/google/spanner/v1/result_set_pb.rb
@@ -4,11 +4,11 @@
 
 require 'google/protobuf'
 
-require 'google/api/annotations_pb'
 require 'google/protobuf/struct_pb'
 require 'google/spanner/v1/query_plan_pb'
 require 'google/spanner/v1/transaction_pb'
 require 'google/spanner/v1/type_pb'
+require 'google/api/annotations_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.spanner.v1.ResultSet" do
     optional :metadata, :message, 1, "google.spanner.v1.ResultSetMetadata"
diff --git a/google-cloud-spanner/lib/google/spanner/v1/spanner_pb.rb b/google-cloud-spanner/lib/google/spanner/v1/spanner_pb.rb
index fc56f7235..f89f62d41 100644
--- a/google-cloud-spanner/lib/google/spanner/v1/spanner_pb.rb
+++ b/google-cloud-spanner/lib/google/spanner/v1/spanner_pb.rb
@@ -5,6 +5,9 @@
 require 'google/protobuf'
 
 require 'google/api/annotations_pb'
+require 'google/api/client_pb'
+require 'google/api/field_behavior_pb'
+require 'google/api/resource_pb'
 require 'google/protobuf/empty_pb'
 require 'google/protobuf/struct_pb'
 require 'google/protobuf/timestamp_pb'
diff --git a/google-cloud-spanner/lib/google/spanner/v1/spanner_services_pb.rb b/google-cloud-spanner/lib/google/spanner/v1/spanner_services_pb.rb
index 5a7707f52..8b13bcea7 100644
--- a/google-cloud-spanner/lib/google/spanner/v1/spanner_services_pb.rb
+++ b/google-cloud-spanner/lib/google/spanner/v1/spanner_services_pb.rb
@@ -48,8 +48,8 @@ module Google
           # transaction internally, and count toward the one transaction
           # limit.
           #
-          # Cloud Spanner limits the number of sessions that can exist at any given
-          # time; thus, it is a good idea to delete idle and/or unneeded sessions.
+          # Active sessions use additional server resources, so it is a good idea to
+          # delete idle and unneeded sessions.
           # Aside from explicit deletes, Cloud Spanner can delete sessions for which no
           # operations are sent for more than an hour. If a session is deleted,
           # requests to it return `NOT_FOUND`.
@@ -96,22 +96,14 @@ module Google
           # to be run with lower latency than submitting them sequentially with
           # [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql].
           #
-          # Statements are executed in order, sequentially.
-          # [ExecuteBatchDmlResponse][Spanner.ExecuteBatchDmlResponse] will contain a
-          # [ResultSet][google.spanner.v1.ResultSet] for each DML statement that has
-          # successfully executed. If a statement fails, its error status will be
-          # returned as part of the
-          # [ExecuteBatchDmlResponse][Spanner.ExecuteBatchDmlResponse]. Execution will
-          # stop at the first failed statement; the remaining statements will not run.
+          # Statements are executed in sequential order. A request can succeed even if
+          # a statement fails. The
+          # [ExecuteBatchDmlResponse.status][google.spanner.v1.ExecuteBatchDmlResponse.status]
+          # field in the response provides information about the statement that failed.
+          # Clients must inspect this field to determine whether an error occurred.
           #
-          # ExecuteBatchDml is expected to return an OK status with a response even if
-          # there was an error while processing one of the DML statements. Clients must
-          # inspect response.status to determine if there were any errors while
-          # processing the request.
-          #
-          # See more details in
-          # [ExecuteBatchDmlRequest][Spanner.ExecuteBatchDmlRequest] and
-          # [ExecuteBatchDmlResponse][Spanner.ExecuteBatchDmlResponse].
+          # Execution stops after the first failed statement; the remaining statements
+          # are not executed.
           rpc :ExecuteBatchDml, ExecuteBatchDmlRequest, ExecuteBatchDmlResponse
           # Reads rows from the database using key lookups and scans, as a
           # simple key/value style alternative to
diff --git a/google-cloud-spanner/lib/google/spanner/v1/transaction_pb.rb b/google-cloud-spanner/lib/google/spanner/v1/transaction_pb.rb
index d9270a089..3608d6531 100644
--- a/google-cloud-spanner/lib/google/spanner/v1/transaction_pb.rb
+++ b/google-cloud-spanner/lib/google/spanner/v1/transaction_pb.rb
@@ -4,9 +4,9 @@
 
 require 'google/protobuf'
 
-require 'google/api/annotations_pb'
 require 'google/protobuf/duration_pb'
 require 'google/protobuf/timestamp_pb'
+require 'google/api/annotations_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.spanner.v1.TransactionOptions" do
     oneof :mode do
diff --git a/google-cloud-spanner/synth.metadata b/google-cloud-spanner/synth.metadata
index 4b9c017c7..f3cb1289c 100644
--- a/google-cloud-spanner/synth.metadata
+++ b/google-cloud-spanner/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-02T10:42:57.475021Z",
+  "updateTime": "2019-11-12T11:45:29.954265Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.37.1",
-        "dockerImage": "googleapis/artman@sha256:6068f67900a3f0bdece596b97bda8fc70406ca0e137a941f4c81d3217c994a80"
+        "version": "0.41.1",
+        "dockerImage": "googleapis/artman@sha256:545c758c76c3f779037aa259023ec3d1ef2d57d2c8cd00a222cb187d63ceac5e"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "2123bcae97debe57e0870fca157cdf21e32bf3fb",
-        "internalRef": "272289410"
+        "sha": "f69562be0608904932bdcfbc5ad8b9a22d9dceb8",
+        "internalRef": "279774957"
       }
     }
   ],
diff --git a/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb b/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb
index 61d646efc..831278e21 100644
--- a/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb
@@ -68,78 +68,6 @@ end
 
 describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
 
-  describe 'list_databases' do
-    custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient#list_databases."
-
-    it 'invokes list_databases without error' do
-      # Create request parameters
-      formatted_parent = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
-
-      # Create expected grpc response
-      next_page_token = ""
-      databases_element = {}
-      databases = [databases_element]
-      expected_response = { next_page_token: next_page_token, databases: databases }
-      expected_response = Google::Gax::to_proto(expected_response, Google::Spanner::Admin::Database::V1::ListDatabasesResponse)
-
-      # Mock Grpc layer
-      mock_method = proc do |request|
-        assert_instance_of(Google::Spanner::Admin::Database::V1::ListDatabasesRequest, request)
-        assert_equal(formatted_parent, request.parent)
-        OpenStruct.new(execute: expected_response)
-      end
-      mock_stub = MockGrpcClientStub_v1.new(:list_databases, mock_method)
-
-      # Mock auth layer
-      mock_credentials = MockDatabaseAdminCredentials_v1.new("list_databases")
-
-      Google::Spanner::Admin::Database::V1::DatabaseAdmin::Stub.stub(:new, mock_stub) do
-        Google::Cloud::Spanner::Admin::Database::V1::Credentials.stub(:default, mock_credentials) do
-          client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
-
-          # Call method
-          response = client.list_databases(formatted_parent)
-
-          # Verify the response
-          assert(response.instance_of?(Google::Gax::PagedEnumerable))
-          assert_equal(expected_response, response.page.response)
-          assert_nil(response.next_page)
-          assert_equal(expected_response.databases.to_a, response.to_a)
-        end
-      end
-    end
-
-    it 'invokes list_databases with error' do
-      # Create request parameters
-      formatted_parent = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
-
-      # Mock Grpc layer
-      mock_method = proc do |request|
-        assert_instance_of(Google::Spanner::Admin::Database::V1::ListDatabasesRequest, request)
-        assert_equal(formatted_parent, request.parent)
-        raise custom_error
-      end
-      mock_stub = MockGrpcClientStub_v1.new(:list_databases, mock_method)
-
-      # Mock auth layer
-      mock_credentials = MockDatabaseAdminCredentials_v1.new("list_databases")
-
-      Google::Spanner::Admin::Database::V1::DatabaseAdmin::Stub.stub(:new, mock_stub) do
-        Google::Cloud::Spanner::Admin::Database::V1::Credentials.stub(:default, mock_credentials) do
-          client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
-
-          # Call method
-          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
-            client.list_databases(formatted_parent)
-          end
-
-          # Verify the GaxError wrapped the custom error that was raised.
-          assert_match(custom_error.message, err.message)
-        end
-      end
-    end
-  end
-
   describe 'create_database' do
     custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient#create_database."
 
@@ -598,7 +526,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
 
     it 'invokes set_iam_policy without error' do
       # Create request parameters
-      formatted_resource = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
+      resource = ''
       policy = {}
 
       # Create expected grpc response
@@ -610,7 +538,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::SetIamPolicyRequest, request)
-        assert_equal(formatted_resource, request.resource)
+        assert_equal(resource, request.resource)
         assert_equal(Google::Gax::to_proto(policy, Google::Iam::V1::Policy), request.policy)
         OpenStruct.new(execute: expected_response)
       end
@@ -624,13 +552,13 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          response = client.set_iam_policy(formatted_resource, policy)
+          response = client.set_iam_policy(resource, policy)
 
           # Verify the response
           assert_equal(expected_response, response)
 
           # Call method with block
-          client.set_iam_policy(formatted_resource, policy) do |response, operation|
+          client.set_iam_policy(resource, policy) do |response, operation|
             # Verify the response
             assert_equal(expected_response, response)
             refute_nil(operation)
@@ -641,13 +569,13 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
 
     it 'invokes set_iam_policy with error' do
       # Create request parameters
-      formatted_resource = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
+      resource = ''
       policy = {}
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::SetIamPolicyRequest, request)
-        assert_equal(formatted_resource, request.resource)
+        assert_equal(resource, request.resource)
         assert_equal(Google::Gax::to_proto(policy, Google::Iam::V1::Policy), request.policy)
         raise custom_error
       end
@@ -662,7 +590,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
 
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
-            client.set_iam_policy(formatted_resource, policy)
+            client.set_iam_policy(resource, policy)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.
@@ -677,7 +605,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
 
     it 'invokes get_iam_policy without error' do
       # Create request parameters
-      formatted_resource = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
+      resource = ''
 
       # Create expected grpc response
       version = 351608024
@@ -688,7 +616,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::GetIamPolicyRequest, request)
-        assert_equal(formatted_resource, request.resource)
+        assert_equal(resource, request.resource)
         OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub_v1.new(:get_iam_policy, mock_method)
@@ -701,13 +629,13 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          response = client.get_iam_policy(formatted_resource)
+          response = client.get_iam_policy(resource)
 
           # Verify the response
           assert_equal(expected_response, response)
 
           # Call method with block
-          client.get_iam_policy(formatted_resource) do |response, operation|
+          client.get_iam_policy(resource) do |response, operation|
             # Verify the response
             assert_equal(expected_response, response)
             refute_nil(operation)
@@ -718,12 +646,12 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
 
     it 'invokes get_iam_policy with error' do
       # Create request parameters
-      formatted_resource = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
+      resource = ''
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::GetIamPolicyRequest, request)
-        assert_equal(formatted_resource, request.resource)
+        assert_equal(resource, request.resource)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v1.new(:get_iam_policy, mock_method)
@@ -737,7 +665,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
 
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
-            client.get_iam_policy(formatted_resource)
+            client.get_iam_policy(resource)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.
@@ -752,8 +680,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
 
     it 'invokes test_iam_permissions without error' do
       # Create request parameters
-      formatted_resource = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
-      permissions = []
+      resource = ''
 
       # Create expected grpc response
       expected_response = {}
@@ -762,8 +689,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::TestIamPermissionsRequest, request)
-        assert_equal(formatted_resource, request.resource)
-        assert_equal(permissions, request.permissions)
+        assert_equal(resource, request.resource)
         OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub_v1.new(:test_iam_permissions, mock_method)
@@ -776,13 +702,13 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
           client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
 
           # Call method
-          response = client.test_iam_permissions(formatted_resource, permissions)
+          response = client.test_iam_permissions(resource)
 
           # Verify the response
           assert_equal(expected_response, response)
 
           # Call method with block
-          client.test_iam_permissions(formatted_resource, permissions) do |response, operation|
+          client.test_iam_permissions(resource) do |response, operation|
             # Verify the response
             assert_equal(expected_response, response)
             refute_nil(operation)
@@ -793,14 +719,12 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
 
     it 'invokes test_iam_permissions with error' do
       # Create request parameters
-      formatted_resource = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
-      permissions = []
+      resource = ''
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::TestIamPermissionsRequest, request)
-        assert_equal(formatted_resource, request.resource)
-        assert_equal(permissions, request.permissions)
+        assert_equal(resource, request.resource)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v1.new(:test_iam_permissions, mock_method)
@@ -814,7 +738,79 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
 
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
-            client.test_iam_permissions(formatted_resource, permissions)
+            client.test_iam_permissions(resource)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'list_databases' do
+    custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient#list_databases."
+
+    it 'invokes list_databases without error' do
+      # Create request parameters
+      formatted_parent = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+
+      # Create expected grpc response
+      next_page_token = ""
+      databases_element = {}
+      databases = [databases_element]
+      expected_response = { next_page_token: next_page_token, databases: databases }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Spanner::Admin::Database::V1::ListDatabasesResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Spanner::Admin::Database::V1::ListDatabasesRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:list_databases, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockDatabaseAdminCredentials_v1.new("list_databases")
+
+      Google::Spanner::Admin::Database::V1::DatabaseAdmin::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Spanner::Admin::Database::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
+
+          # Call method
+          response = client.list_databases(formatted_parent)
+
+          # Verify the response
+          assert(response.instance_of?(Google::Gax::PagedEnumerable))
+          assert_equal(expected_response, response.page.response)
+          assert_nil(response.next_page)
+          assert_equal(expected_response.databases.to_a, response.to_a)
+        end
+      end
+    end
+
+    it 'invokes list_databases with error' do
+      # Create request parameters
+      formatted_parent = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Spanner::Admin::Database::V1::ListDatabasesRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:list_databases, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockDatabaseAdminCredentials_v1.new("list_databases")
+
+      Google::Spanner::Admin::Database::V1::DatabaseAdmin::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Spanner::Admin::Database::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.list_databases(formatted_parent)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.
diff --git a/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb b/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb
index 5dfa1e07d..873f16c10 100644
--- a/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb
@@ -715,7 +715,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
 
     it 'invokes set_iam_policy without error' do
       # Create request parameters
-      formatted_resource = Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+      resource = ''
       policy = {}
 
       # Create expected grpc response
@@ -727,7 +727,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::SetIamPolicyRequest, request)
-        assert_equal(formatted_resource, request.resource)
+        assert_equal(resource, request.resource)
         assert_equal(Google::Gax::to_proto(policy, Google::Iam::V1::Policy), request.policy)
         OpenStruct.new(execute: expected_response)
       end
@@ -741,13 +741,13 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          response = client.set_iam_policy(formatted_resource, policy)
+          response = client.set_iam_policy(resource, policy)
 
           # Verify the response
           assert_equal(expected_response, response)
 
           # Call method with block
-          client.set_iam_policy(formatted_resource, policy) do |response, operation|
+          client.set_iam_policy(resource, policy) do |response, operation|
             # Verify the response
             assert_equal(expected_response, response)
             refute_nil(operation)
@@ -758,13 +758,13 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
 
     it 'invokes set_iam_policy with error' do
       # Create request parameters
-      formatted_resource = Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+      resource = ''
       policy = {}
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::SetIamPolicyRequest, request)
-        assert_equal(formatted_resource, request.resource)
+        assert_equal(resource, request.resource)
         assert_equal(Google::Gax::to_proto(policy, Google::Iam::V1::Policy), request.policy)
         raise custom_error
       end
@@ -779,7 +779,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
 
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
-            client.set_iam_policy(formatted_resource, policy)
+            client.set_iam_policy(resource, policy)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.
@@ -794,7 +794,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
 
     it 'invokes get_iam_policy without error' do
       # Create request parameters
-      formatted_resource = Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+      resource = ''
 
       # Create expected grpc response
       version = 351608024
@@ -805,7 +805,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::GetIamPolicyRequest, request)
-        assert_equal(formatted_resource, request.resource)
+        assert_equal(resource, request.resource)
         OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub_v1.new(:get_iam_policy, mock_method)
@@ -818,13 +818,13 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          response = client.get_iam_policy(formatted_resource)
+          response = client.get_iam_policy(resource)
 
           # Verify the response
           assert_equal(expected_response, response)
 
           # Call method with block
-          client.get_iam_policy(formatted_resource) do |response, operation|
+          client.get_iam_policy(resource) do |response, operation|
             # Verify the response
             assert_equal(expected_response, response)
             refute_nil(operation)
@@ -835,12 +835,12 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
 
     it 'invokes get_iam_policy with error' do
       # Create request parameters
-      formatted_resource = Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+      resource = ''
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::GetIamPolicyRequest, request)
-        assert_equal(formatted_resource, request.resource)
+        assert_equal(resource, request.resource)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v1.new(:get_iam_policy, mock_method)
@@ -854,7 +854,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
 
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
-            client.get_iam_policy(formatted_resource)
+            client.get_iam_policy(resource)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.
@@ -869,8 +869,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
 
     it 'invokes test_iam_permissions without error' do
       # Create request parameters
-      formatted_resource = Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
-      permissions = []
+      resource = ''
 
       # Create expected grpc response
       expected_response = {}
@@ -879,8 +878,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::TestIamPermissionsRequest, request)
-        assert_equal(formatted_resource, request.resource)
-        assert_equal(permissions, request.permissions)
+        assert_equal(resource, request.resource)
         OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub_v1.new(:test_iam_permissions, mock_method)
@@ -893,13 +891,13 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
           client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
 
           # Call method
-          response = client.test_iam_permissions(formatted_resource, permissions)
+          response = client.test_iam_permissions(resource)
 
           # Verify the response
           assert_equal(expected_response, response)
 
           # Call method with block
-          client.test_iam_permissions(formatted_resource, permissions) do |response, operation|
+          client.test_iam_permissions(resource) do |response, operation|
             # Verify the response
             assert_equal(expected_response, response)
             refute_nil(operation)
@@ -910,14 +908,12 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
 
     it 'invokes test_iam_permissions with error' do
       # Create request parameters
-      formatted_resource = Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
-      permissions = []
+      resource = ''
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::TestIamPermissionsRequest, request)
-        assert_equal(formatted_resource, request.resource)
-        assert_equal(permissions, request.permissions)
+        assert_equal(resource, request.resource)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v1.new(:test_iam_permissions, mock_method)
@@ -931,7 +927,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
 
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
-            client.test_iam_permissions(formatted_resource, permissions)
+            client.test_iam_permissions(resource)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.
diff --git a/google-cloud-spanner/test/google/cloud/spanner/v1/spanner_client_test.rb b/google-cloud-spanner/test/google/cloud/spanner/v1/spanner_client_test.rb
index f36481ff0..70e888a56 100644
--- a/google-cloud-spanner/test/google/cloud/spanner/v1/spanner_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/v1/spanner_client_test.rb
@@ -964,7 +964,6 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
     it 'invokes commit without error' do
       # Create request parameters
       formatted_session = Google::Cloud::Spanner::V1::SpannerClient.session_path("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]")
-      mutations = []
 
       # Create expected grpc response
       expected_response = {}
@@ -974,10 +973,6 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Spanner::V1::CommitRequest, request)
         assert_equal(formatted_session, request.session)
-        mutations = mutations.map do |req|
-          Google::Gax::to_proto(req, Google::Spanner::V1::Mutation)
-        end
-        assert_equal(mutations, request.mutations)
         OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub_v1.new(:commit, mock_method)
@@ -990,13 +985,13 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
           client = Google::Cloud::Spanner::V1::SpannerClient.new
 
           # Call method
-          response = client.commit(formatted_session, mutations)
+          response = client.commit(formatted_session)
 
           # Verify the response
           assert_equal(expected_response, response)
 
           # Call method with block
-          client.commit(formatted_session, mutations) do |response, operation|
+          client.commit(formatted_session) do |response, operation|
             # Verify the response
             assert_equal(expected_response, response)
             refute_nil(operation)
@@ -1008,16 +1003,11 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
     it 'invokes commit with error' do
       # Create request parameters
       formatted_session = Google::Cloud::Spanner::V1::SpannerClient.session_path("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]")
-      mutations = []
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Spanner::V1::CommitRequest, request)
         assert_equal(formatted_session, request.session)
-        mutations = mutations.map do |req|
-          Google::Gax::to_proto(req, Google::Spanner::V1::Mutation)
-        end
-        assert_equal(mutations, request.mutations)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v1.new(:commit, mock_method)
@@ -1031,7 +1021,7 @@ describe Google::Cloud::Spanner::V1::SpannerClient do
 
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
-            client.commit(formatted_session, mutations)
+            client.commit(formatted_session)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

```

</details>

This pull request was generated using releasetool.