### PR TITLE
Add Subscriber inventory settings

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -86,7 +86,7 @@ module Google
           @inventory = { limit: @inventory } unless inventory.is_a? Hash
           @inventory[:limit] = Integer(@inventory[:limit] || 1000)
           @inventory[:bytesize] = Integer(@inventory[:bytesize] || 100_000)
-          @inventory[:extension] = Integer(@inventory[:extension] || 60)
+          @inventory[:extension] = Integer(@inventory[:extension] || 3600)
           @message_ordering = message_ordering
           @callback_threads = Integer(threads[:callback] || 8)
           @push_threads = Integer(threads[:push] || 4)
@@ -296,7 +296,7 @@ module Google
         end
 
         ##
-        # The number of minutes that received messages can be held awaiting processing. Default is 60 (1 hour).
+        # The number of seconds that received messages can be held awaiting processing. Default is 3,600 (1 hour).
         def inventory_extension
           @inventory[:extension]
         end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -286,7 +286,7 @@ module Google
         def inventory_limit
           @inventory[:limit]
         end
-        # @deprecated Use {inventory_limit}.
+        # @deprecated Use {#inventory_limit}.
         alias inventory inventory_limit
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -302,7 +302,7 @@ module Google
         end
 
         ##
-        # private
+        # @private
         def stream_inventory
           {
             limit:     @inventory[:limit].fdiv(@streams).ceil,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -85,7 +85,7 @@ module Google
           @inventory = inventory
           @inventory = { limit: @inventory } unless inventory.is_a? Hash
           @inventory[:limit] = Integer(@inventory[:limit] || 1000)
-          @inventory[:bytesize] = Integer(@inventory[:bytesize] || 100_000)
+          @inventory[:bytesize] = Integer(@inventory[:bytesize] || 100_000_000)
           @inventory[:extension] = Integer(@inventory[:extension] || 3600)
           @message_ordering = message_ordering
           @callback_threads = Integer(threads[:callback] || 8)
@@ -290,7 +290,7 @@ module Google
         alias inventory inventory_limit
 
         ##
-        # The total bytesize of received messages to be collected by subscriber. Default is 100,000 (100MB).
+        # The total bytesize of received messages to be collected by subscriber. Default is 100,000,000 (100MB).
         def inventory_bytesize
           @inventory[:bytesize]
         end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -556,8 +556,16 @@ module Google
         #   argument is not provided. See {#reference?}.
         # @param [Integer] streams The number of concurrent streams to open to
         #   pull messages from the subscription. Default is 4. Optional.
-        # @param [Integer] inventory The number of received messages to be
-        #   collected by subscriber. Default is 1,000. Optional.
+        # @param [Hash, Integer] inventory The settings to control how received messages are to be handled by the
+        #   subscriber. When provided as an Integer instead of a Hash only the `limit` will be set. Optional.
+        #
+        #   Hash keys and values may include the following:
+        #
+        #     * `:limit` (Integer) The number of received messages to be collected by subscriber. Default is 1,000.
+        #     * `:bytesize` (Integer) The total bytesize of received messages to be collected by subscriber. Default is
+        #       100,000 (100MB).
+        #     * `:extension` (Integer) The number of minutes that received messages can be held awaiting processing.
+        #       Default is 60 (1 hour).
         # @param [Hash] threads The number of threads to create to handle
         #   concurrent calls by each stream opened by the subscriber. Optional.
         #

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -563,7 +563,7 @@ module Google
         #
         #     * `:limit` (Integer) The number of received messages to be collected by subscriber. Default is 1,000.
         #     * `:bytesize` (Integer) The total bytesize of received messages to be collected by subscriber. Default is
-        #       100,000 (100MB).
+        #       100,000,000 (100MB).
         #     * `:extension` (Integer) The number of seconds that received messages can be held awaiting processing.
         #       Default is 3,600 (1 hour).
         # @param [Hash] threads The number of threads to create to handle

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -564,8 +564,8 @@ module Google
         #     * `:limit` (Integer) The number of received messages to be collected by subscriber. Default is 1,000.
         #     * `:bytesize` (Integer) The total bytesize of received messages to be collected by subscriber. Default is
         #       100,000 (100MB).
-        #     * `:extension` (Integer) The number of minutes that received messages can be held awaiting processing.
-        #       Default is 60 (1 hour).
+        #     * `:extension` (Integer) The number of seconds that received messages can be held awaiting processing.
+        #       Default is 3,600 (1 hour).
         # @param [Hash] threads The number of threads to create to handle
         #   concurrent calls by each stream opened by the subscriber. Optional.
         #

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
@@ -156,7 +156,7 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
 
   it "knows its count limit" do
     subscriber_mock = Minitest::Mock.new
-    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 2, bytesize: 100_000, extension: 60
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 2, bytesize: 100_000, extension: 3600
 
     inventory.add rec_msg1_grpc
     inventory.wont_be :full?
@@ -168,7 +168,7 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
 
   it "knows its bytesize limit" do
     subscriber_mock = Minitest::Mock.new
-    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100, extension: 60
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100, extension: 3600
 
     inventory.add rec_msg1_grpc
     inventory.wont_be :full?
@@ -180,9 +180,9 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
 
   it "removes expired items" do
     subscriber_mock = Minitest::Mock.new
-    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100_000, extension: 60
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100_000, extension: 3600
 
-    expired_time = Time.now - 120
+    expired_time = Time.now - 7200
 
     Time.stub :now, expired_time do
       inventory.add rec_msg1_grpc

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -32,9 +32,9 @@ describe Google::Cloud::PubSub::Subscriber, :mock_pubsub do
     subscriber.streams.must_equal streams
     subscriber.inventory.must_equal inventory
     subscriber.inventory_limit.must_equal inventory
-    subscriber.inventory_bytesize.must_equal 100_000
+    subscriber.inventory_bytesize.must_equal 100_000_000
     subscriber.inventory_extension.must_equal 3600
-    subscriber.stream_inventory.must_equal({limit: 250, bytesize: 12500, extension: 3600})
+    subscriber.stream_inventory.must_equal({limit: 250, bytesize: 12500000, extension: 3600})
     subscriber.callback_threads.must_equal callback_threads
     subscriber.push_threads.must_equal push_threads
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -31,7 +31,10 @@ describe Google::Cloud::PubSub::Subscriber, :mock_pubsub do
     subscriber.deadline.must_equal deadline
     subscriber.streams.must_equal streams
     subscriber.inventory.must_equal inventory
-    subscriber.stream_inventory.must_equal 250
+    subscriber.inventory_limit.must_equal inventory
+    subscriber.inventory_bytesize.must_equal 100_000
+    subscriber.inventory_extension.must_equal 60
+    subscriber.stream_inventory.must_equal({limit: 250, bytesize: 12500, extension: 60})
     subscriber.callback_threads.must_equal callback_threads
     subscriber.push_threads.must_equal push_threads
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -33,8 +33,8 @@ describe Google::Cloud::PubSub::Subscriber, :mock_pubsub do
     subscriber.inventory.must_equal inventory
     subscriber.inventory_limit.must_equal inventory
     subscriber.inventory_bytesize.must_equal 100_000
-    subscriber.inventory_extension.must_equal 60
-    subscriber.stream_inventory.must_equal({limit: 250, bytesize: 12500, extension: 60})
+    subscriber.inventory_extension.must_equal 3600
+    subscriber.stream_inventory.must_equal({limit: 250, bytesize: 12500, extension: 3600})
     subscriber.callback_threads.must_equal callback_threads
     subscriber.push_threads.must_equal push_threads
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
@@ -28,7 +28,11 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
     subscriber.subscription_name.must_equal subscription.name
     subscriber.deadline.must_equal 60
-    subscriber.streams.must_equal 4
+    subscriber.streams.must_equal 2
+    subscriber.inventory.must_equal 1000
+    subscriber.inventory_limit.must_equal 1000
+    subscriber.inventory_bytesize.must_equal 100000
+    subscriber.inventory_extension.must_equal 60
   end
 
   it "will set deadline while creating a Subscriber" do
@@ -38,7 +42,11 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
     subscriber.subscription_name.must_equal subscription.name
     subscriber.deadline.must_equal 120
-    subscriber.streams.must_equal 4
+    subscriber.streams.must_equal 2
+    subscriber.inventory.must_equal 1000
+    subscriber.inventory_limit.must_equal 1000
+    subscriber.inventory_bytesize.must_equal 100000
+    subscriber.inventory_extension.must_equal 60
   end
 
   it "will set deadline while creating a Subscriber" do
@@ -49,5 +57,65 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.subscription_name.must_equal subscription.name
     subscriber.deadline.must_equal 60
     subscriber.streams.must_equal 2
+    subscriber.inventory.must_equal 1000
+    subscriber.inventory_limit.must_equal 1000
+    subscriber.inventory_bytesize.must_equal 100000
+    subscriber.inventory_extension.must_equal 60
+  end
+
+  it "will set inventory (deprecated) while creating a Subscriber" do
+    subscriber = subscription.listen inventory: 500 do |msg|
+      puts msg.msg_id
+    end
+    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
+    subscriber.subscription_name.must_equal subscription.name
+    subscriber.deadline.must_equal 60
+    subscriber.streams.must_equal 2
+    subscriber.inventory.must_equal 500
+    subscriber.inventory_limit.must_equal 500
+    subscriber.inventory_bytesize.must_equal 100000
+    subscriber.inventory_extension.must_equal 60
+  end
+
+  it "will set inventory while creating a Subscriber" do
+    subscriber = subscription.listen(inventory: { limit: 500 }) do |msg|
+      puts msg.msg_id
+    end
+    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
+    subscriber.subscription_name.must_equal subscription.name
+    subscriber.deadline.must_equal 60
+    subscriber.streams.must_equal 2
+    subscriber.inventory.must_equal 500
+    subscriber.inventory_limit.must_equal 500
+    subscriber.inventory_bytesize.must_equal 100000
+    subscriber.inventory_extension.must_equal 60
+  end
+
+  it "will set inventory while creating a Subscriber" do
+    subscriber = subscription.listen(inventory: { bytesize: 50_000 }) do |msg|
+      puts msg.msg_id
+    end
+    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
+    subscriber.subscription_name.must_equal subscription.name
+    subscriber.deadline.must_equal 60
+    subscriber.streams.must_equal 2
+    subscriber.inventory.must_equal 1000
+    subscriber.inventory_limit.must_equal 1000
+    subscriber.inventory_bytesize.must_equal 50_000
+    subscriber.inventory_extension.must_equal 60
+  end
+
+  it "will set inventory while creating a Subscriber" do
+    subscriber = subscription.listen(inventory: { extension: 120 }) do |msg|
+      puts msg.msg_id
+    end
+    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
+    subscriber.subscription_name.must_equal subscription.name
+    subscriber.deadline.must_equal 60
+    subscriber.streams.must_equal 2
+    subscriber.inventory.must_equal 1000
+    subscriber.inventory_limit.must_equal 1000
+    subscriber.inventory_bytesize.must_equal 100000
+    subscriber.inventory_extension.must_equal 120
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.streams.must_equal 2
     subscriber.inventory.must_equal 1000
     subscriber.inventory_limit.must_equal 1000
-    subscriber.inventory_bytesize.must_equal 100000
+    subscriber.inventory_bytesize.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
   end
 
@@ -45,7 +45,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.streams.must_equal 2
     subscriber.inventory.must_equal 1000
     subscriber.inventory_limit.must_equal 1000
-    subscriber.inventory_bytesize.must_equal 100000
+    subscriber.inventory_bytesize.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
   end
 
@@ -59,7 +59,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.streams.must_equal 2
     subscriber.inventory.must_equal 1000
     subscriber.inventory_limit.must_equal 1000
-    subscriber.inventory_bytesize.must_equal 100000
+    subscriber.inventory_bytesize.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
   end
 
@@ -73,7 +73,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.streams.must_equal 2
     subscriber.inventory.must_equal 500
     subscriber.inventory_limit.must_equal 500
-    subscriber.inventory_bytesize.must_equal 100000
+    subscriber.inventory_bytesize.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
   end
 
@@ -87,7 +87,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.streams.must_equal 2
     subscriber.inventory.must_equal 500
     subscriber.inventory_limit.must_equal 500
-    subscriber.inventory_bytesize.must_equal 100000
+    subscriber.inventory_bytesize.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
   end
 
@@ -115,7 +115,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.streams.must_equal 2
     subscriber.inventory.must_equal 1000
     subscriber.inventory_limit.must_equal 1000
-    subscriber.inventory_bytesize.must_equal 100000
+    subscriber.inventory_bytesize.must_equal 100000000
     subscriber.inventory_extension.must_equal 7200
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
@@ -32,7 +32,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.inventory.must_equal 1000
     subscriber.inventory_limit.must_equal 1000
     subscriber.inventory_bytesize.must_equal 100000
-    subscriber.inventory_extension.must_equal 60
+    subscriber.inventory_extension.must_equal 3600
   end
 
   it "will set deadline while creating a Subscriber" do
@@ -46,7 +46,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.inventory.must_equal 1000
     subscriber.inventory_limit.must_equal 1000
     subscriber.inventory_bytesize.must_equal 100000
-    subscriber.inventory_extension.must_equal 60
+    subscriber.inventory_extension.must_equal 3600
   end
 
   it "will set deadline while creating a Subscriber" do
@@ -60,7 +60,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.inventory.must_equal 1000
     subscriber.inventory_limit.must_equal 1000
     subscriber.inventory_bytesize.must_equal 100000
-    subscriber.inventory_extension.must_equal 60
+    subscriber.inventory_extension.must_equal 3600
   end
 
   it "will set inventory (deprecated) while creating a Subscriber" do
@@ -74,7 +74,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.inventory.must_equal 500
     subscriber.inventory_limit.must_equal 500
     subscriber.inventory_bytesize.must_equal 100000
-    subscriber.inventory_extension.must_equal 60
+    subscriber.inventory_extension.must_equal 3600
   end
 
   it "will set inventory while creating a Subscriber" do
@@ -88,7 +88,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.inventory.must_equal 500
     subscriber.inventory_limit.must_equal 500
     subscriber.inventory_bytesize.must_equal 100000
-    subscriber.inventory_extension.must_equal 60
+    subscriber.inventory_extension.must_equal 3600
   end
 
   it "will set inventory while creating a Subscriber" do
@@ -102,11 +102,11 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.inventory.must_equal 1000
     subscriber.inventory_limit.must_equal 1000
     subscriber.inventory_bytesize.must_equal 50_000
-    subscriber.inventory_extension.must_equal 60
+    subscriber.inventory_extension.must_equal 3600
   end
 
   it "will set inventory while creating a Subscriber" do
-    subscriber = subscription.listen(inventory: { extension: 120 }) do |msg|
+    subscriber = subscription.listen(inventory: { extension: 7_200 }) do |msg|
       puts msg.msg_id
     end
     subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
@@ -116,6 +116,6 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.inventory.must_equal 1000
     subscriber.inventory_limit.must_equal 1000
     subscriber.inventory_bytesize.must_equal 100000
-    subscriber.inventory_extension.must_equal 120
+    subscriber.inventory_extension.must_equal 7200
   end
 end


### PR DESCRIPTION
Add the following settings to Subscriber:
  * Subscriber#inventory_limit
  * Subscriber#inventory_bytesize
  * Subscriber#extension
* Allow Subscription#listen inventory argument to be a hash.