### PR TITLE
docs(storage): fix YARD warning in CHANGELOG.md

### DIFF
--- a/google-cloud-storage/CHANGELOG.md
+++ b/google-cloud-storage/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 #### Bug Fixes
 
-* Update #post_object to support special variable ${filename}
+* Update #post_object to support special variable `${filename}`
 
 ### 1.23.0 / 2019-11-05
 


### PR DESCRIPTION
The `{}` characters in the latest entry cause the ci build to fail:

```sh
[warn]: In file `CHANGELOG.md':14: Cannot resolve link to filename from text:
	...{filename}...
```