### PR TITLE
chore(spanner): Use legacy artman config for spanner

### DIFF
--- a/google-cloud-spanner/synth.py
+++ b/google-cloud-spanner/synth.py
@@ -25,7 +25,7 @@ gapic = gcp.GAPICGenerator()
 
 v1_library = gapic.ruby_library(
     'spanner', 'v1',
-    config_path='/google/spanner/artman_spanner.yaml',
+    config_path='/google/spanner/artman_spanner.legacy.yaml',
     artman_output_name='google-cloud-ruby/google-cloud-spanner'
 )
 s.copy(v1_library / 'lib/google/cloud/spanner/v1')
@@ -34,7 +34,7 @@ s.copy(v1_library / 'test/google/cloud/spanner/v1')
 
 v1_database_library = gapic.ruby_library(
     'spanneradmindatabase', 'v1',
-    config_path='/google/spanner/admin/database/artman_spanner_admin_database.yaml',
+    config_path='/google/spanner/admin/database/artman_spanner_admin_database.legacy.yaml',
     artman_output_name='google-cloud-ruby/google-cloud-spanner_admin_database')
 s.copy(v1_database_library / 'lib/google/cloud/spanner/admin/database.rb')
 s.copy(v1_database_library / 'lib/google/cloud/spanner/admin/database/v1.rb')
@@ -44,7 +44,7 @@ s.copy(v1_database_library / 'test/google/cloud/spanner/admin/database/v1')
 
 v1_instance_library = gapic.ruby_library(
     'spanneradmininstance', 'v1',
-    config_path='/google/spanner/admin/instance/artman_spanner_admin_instance.yaml',
+    config_path='/google/spanner/admin/instance/artman_spanner_admin_instance.legacy.yaml',
     artman_output_name='google-cloud-ruby/google-cloud-spanner_admin_instance')
 s.copy(v1_instance_library / 'lib/google/cloud/spanner/admin/instance.rb')
 s.copy(v1_instance_library / 'lib/google/cloud/spanner/admin/instance/v1.rb')


### PR DESCRIPTION
Synthesize spanner using a legacy gapic config that specifies the original flattening for the `commit` and `test_iam_permissions` methods. Should reverse the breaking changes in https://github.com/googleapis/google-cloud-ruby/commit/2ef5fc4f506d88a991afd68b2e0f9471c8ff3723 in the next synth.