### PR TITLE
feat(storage): add IAM Conditions support

### DIFF
--- a/google-cloud-storage/.rubocop.yml
+++ b/google-cloud-storage/.rubocop.yml
@@ -24,6 +24,9 @@ Naming/FileName:
     - "lib/google-cloud-storage.rb"
 Style/IfUnlessModifier:
   Enabled: false
+Style/MethodDefParentheses:
+  Exclude:
+    - "lib/google/cloud/storage/policy.rb"
 Style/NumericPredicate:
   Enabled: false
 Style/SafeNavigation:

--- a/google-cloud-storage/acceptance/storage/bucket_policy_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_policy_test.rb
@@ -71,12 +71,12 @@ describe Google::Cloud::Storage::Bucket, :policy, :storage do
       expect { policy.bindings }.must_raise RuntimeError
 
       policy = bucket_policy_v3.policy requested_policy_version: 1
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.version.must_equal 1
-      expect { policy.roles }.must_raise RuntimeError
-      policy.bindings.count.must_equal 2
+      policy.roles.count.must_equal 2
+      expect { policy.bindings }.must_raise RuntimeError
 
-      bucket_policy_v3.policy requested_policy_version: 1 do |p|
+      bucket_policy_v3.policy requested_policy_version: 3 do |p|
         p.version.must_equal 1
         p.version = 3 # Won't be persisted by the service.
       end
@@ -146,9 +146,16 @@ describe Google::Cloud::Storage::Bucket, :policy, :storage do
       expect { policy.deep_dup }.must_raise RuntimeError
       policy.bindings.count.must_equal 3
       binding = policy.bindings.find do |b|
-        b[:role] == role
+        b.role == role
       end
       binding.wont_be :nil?
+      binding.role.must_equal role
+      binding.members.count.must_equal 1
+      binding.members[0].must_equal member
+      binding.condition.wont_be :nil?
+      binding.condition.title.must_equal "always-true"
+      binding.condition.description.must_equal "test condition always-true"
+      binding.condition.expression.must_equal "true"
     end
   end
 end

--- a/google-cloud-storage/acceptance/storage/bucket_policy_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_policy_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Storage::Bucket, :policy, :storage do
       permissions = bucket.test_permissions roles
       skip "Don't have permissions to get/set bucket's policy" unless permissions == roles
 
-      bucket.policy.must_be_kind_of Google::Cloud::Storage::Policy
+      bucket.policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
 
       # We need a valid service account in order to update the policy
       service_account = storage.service.credentials.client.issuer
@@ -65,13 +65,13 @@ describe Google::Cloud::Storage::Bucket, :policy, :storage do
       skip "Don't have permissions to get/set bucket's policy" unless permissions == roles
 
       policy = bucket_policy_v3.policy
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.version.must_equal 1
       policy.roles.count.must_equal 2
       expect { policy.bindings }.must_raise RuntimeError
 
       policy = bucket_policy_v3.policy requested_policy_version: 1
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.version.must_equal 1
       expect { policy.roles }.must_raise RuntimeError
       policy.bindings.count.must_equal 2
@@ -82,7 +82,7 @@ describe Google::Cloud::Storage::Bucket, :policy, :storage do
       end
 
       policy = bucket_policy_v3.policy requested_policy_version: 3
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.version.must_equal 1
       expect { policy.roles }.must_raise RuntimeError
       policy.bindings.count.must_equal 2
@@ -118,15 +118,15 @@ describe Google::Cloud::Storage::Bucket, :policy, :storage do
         expect { p.add role, member }.must_raise RuntimeError
         expect { p.remove role, member }.must_raise RuntimeError
         expect { p.role role }.must_raise RuntimeError
-        p.bindings.push({
-                          role: role,
-                          members: [member],
-                          condition: {
-                            title: "always-true",
-                            description: "test condition always-true",
-                            expression: "true"
-                          }
-                        })
+        p.bindings.insert({
+                            role: role,
+                            members: [member],
+                            condition: {
+                              title: "always-true",
+                              description: "test condition always-true",
+                              expression: "true"
+                            }
+                          })
         p.version = 3 # This must be set before update RPC, either before or after addition of binding with condition.
       end
 

--- a/google-cloud-storage/acceptance/storage/bucket_policy_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_policy_test.rb
@@ -1,0 +1,105 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "storage_helper"
+
+describe Google::Cloud::Storage::Bucket, :storage do
+  let(:bucket_name) { $bucket_names[1] } # Policy version 1
+  let :bucket do
+    storage.bucket(bucket_name) ||
+    safe_gcs_execute { storage.create_bucket(bucket_name) }
+  end
+  let(:bucket_name_policy_v3) { $bucket_names[2] }
+  let :bucket_policy_v3 do
+    storage.bucket(bucket_name_policy_v3) ||
+      safe_gcs_execute { storage.create_bucket(bucket_name_policy_v3) }
+  end
+
+  describe "Policy version 1" do
+    it "allows policy to be updated" do
+      # Check permissions first
+      roles = ["storage.buckets.getIamPolicy", "storage.buckets.setIamPolicy"]
+      permissions = bucket.test_permissions roles
+      skip "Don't have permissions to get/set bucket's policy" unless permissions == roles
+
+      bucket.policy.must_be_kind_of Google::Cloud::Storage::Policy
+
+      # We need a valid service account in order to update the policy
+      service_account = storage.service.credentials.client.issuer
+      service_account.wont_be :nil?
+      role = "roles/storage.objectCreator"
+      member = "serviceAccount:#{service_account}"
+      bucket.policy do |p|
+        p.add role, member
+        p.add role, member # duplicate member will not be added to request
+      end
+
+      role_member = bucket.policy.role(role).select { |x| x == member }
+      role_member.count.must_equal 1
+    end
+
+    it "allows permissions to be tested" do
+      roles = ["storage.buckets.delete", "storage.buckets.get"]
+      permissions = bucket.test_permissions roles
+      permissions.must_equal roles
+    end
+  end
+
+  describe "Policy version 3" do
+    it "allows policy version to be set to 3" do
+      bucket_policy_v3.uniform_bucket_level_access = true
+      # Check permissions first
+      roles = ["storage.buckets.getIamPolicy", "storage.buckets.setIamPolicy"]
+      permissions = bucket_policy_v3.test_permissions roles
+      skip "Don't have permissions to get/set bucket's policy" unless permissions == roles
+
+      policy = bucket_policy_v3.policy
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.version.must_equal 1
+      policy.roles.count.must_equal 2
+      expect { policy.bindings }.must_raise RuntimeError
+
+      # We need a valid service account in order to update the policy
+      service_account = storage.service.credentials.client.issuer
+      service_account.wont_be :nil?
+      role = "roles/storage.admin"
+      member = "serviceAccount:#{service_account}"
+      bucket_policy_v3.policy do |p|
+        p.version = 3
+        p.bindings.push({
+                          role: role,
+                          members: [member],
+                          condition: {
+                            title: "always-true",
+                            description: "test condition always-true",
+                            expression: "true"
+                          }
+                        })
+
+        expect { p.add role, member }.must_raise RuntimeError
+        expect { p.remove role, member }.must_raise RuntimeError
+        expect { p.role role }.must_raise RuntimeError
+      end
+
+      bucket_policy_v3 = storage.bucket bucket_name_policy_v3
+      # Requested policy version (1) cannot be less than the existing policy version (3).
+      # expect { bucket_policy_v3.policy requested_policy_version: 1 }.must_raise Google::Cloud::Error  TODO: uncomment after project is whitelisted
+      policy = bucket_policy_v3.policy requested_policy_version: 3
+      policy.version.must_equal 3
+      expect { policy.roles }.must_raise RuntimeError
+      expect { policy.deep_dup }.must_raise RuntimeError
+      policy.bindings.count.must_equal 3
+    end
+  end
+end

--- a/google-cloud-storage/acceptance/storage/bucket_policy_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_policy_test.rb
@@ -14,7 +14,7 @@
 
 require "storage_helper"
 
-describe Google::Cloud::Storage::Bucket, :storage do
+describe Google::Cloud::Storage::Bucket, :policy, :storage do
   let(:bucket_name) { $bucket_names[1] } # Policy version 1
   let :bucket do
     storage.bucket(bucket_name) ||
@@ -94,7 +94,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
 
       bucket_policy_v3 = storage.bucket bucket_name_policy_v3
       # Requested policy version (1) cannot be less than the existing policy version (3).
-      # expect { bucket_policy_v3.policy requested_policy_version: 1 }.must_raise Google::Cloud::Error  TODO: uncomment after project is whitelisted
+      # expect { bucket_policy_v3.policy requested_policy_version: 1 }.must_raise Google::Cloud::Error # TODO: uncomment after project is whitelisted
       policy = bucket_policy_v3.policy requested_policy_version: 3
       policy.version.must_equal 3
       expect { policy.roles }.must_raise RuntimeError

--- a/google-cloud-storage/acceptance/storage/bucket_requester_pays_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_requester_pays_test.rb
@@ -200,7 +200,7 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
       permissions = bucket.test_permissions roles
       skip "Don't have permissions to get/set bucket's policy" unless permissions == roles
 
-      bucket.policy.must_be_kind_of Google::Cloud::Storage::Policy
+      bucket.policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
 
       # We need a valid service account in order to update the policy
       service_account = storage.service.credentials.client.issuer

--- a/google-cloud-storage/acceptance/storage/bucket_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_test.rb
@@ -197,37 +197,6 @@ describe Google::Cloud::Storage::Bucket, :storage do
     random_bucket.must_be :nil?
   end
 
-  describe "IAM Policies and Permissions" do
-
-    it "allows policy to be updated on a bucket" do
-      # Check permissions first
-      roles = ["storage.buckets.getIamPolicy", "storage.buckets.setIamPolicy"]
-      permissions = bucket.test_permissions roles
-      skip "Don't have permissions to get/set bucket's policy" unless permissions == roles
-
-      bucket.policy.must_be_kind_of Google::Cloud::Storage::Policy
-
-      # We need a valid service account in order to update the policy
-      service_account = storage.service.credentials.client.issuer
-      service_account.wont_be :nil?
-      role = "roles/storage.objectCreator"
-      member = "serviceAccount:#{service_account}"
-      bucket.policy do |p|
-        p.add role, member
-        p.add role, member # duplicate member will not be added to request
-      end
-
-      role_member = bucket.policy.role(role).select { |x| x == member }
-      role_member.size.must_equal 1
-    end
-
-    it "allows permissions to be tested on a bucket" do
-      roles = ["storage.buckets.delete", "storage.buckets.get"]
-      permissions = bucket.test_permissions roles
-      permissions.must_equal roles
-    end
-  end
-
   describe "anonymous project" do
     it "raises when creating a bucket without authentication" do
       anonymous_storage = Google::Cloud::Storage.anonymous

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -89,16 +89,16 @@ module Acceptance
       end
     end
 
-    # def self.run_one_method klass, method_name, reporter
-    #   result = nil
-    #   reporter.prerecord klass, method_name
-    #   (1..3).each do |try|
-    #     result = Minitest.run_one_method(klass, method_name)
-    #     break if (result.passed? || result.skipped?)
-    #     puts "Retrying #{klass}##{method_name} (#{try})"
-    #   end
-    #   reporter.record result
-    # end
+    def self.run_one_method klass, method_name, reporter
+      result = nil
+      reporter.prerecord klass, method_name
+      (1..3).each do |try|
+        result = Minitest.run_one_method(klass, method_name)
+        break if (result.passed? || result.skipped?)
+        puts "Retrying #{klass}##{method_name} (#{try})"
+      end
+      reporter.record result
+    end
   end
 end
 

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -89,16 +89,16 @@ module Acceptance
       end
     end
 
-    def self.run_one_method klass, method_name, reporter
-      result = nil
-      reporter.prerecord klass, method_name
-      (1..3).each do |try|
-        result = Minitest.run_one_method(klass, method_name)
-        break if (result.passed? || result.skipped?)
-        puts "Retrying #{klass}##{method_name} (#{try})"
-      end
-      reporter.record result
-    end
+    # def self.run_one_method klass, method_name, reporter
+    #   result = nil
+    #   reporter.prerecord klass, method_name
+    #   (1..3).each do |try|
+    #     result = Minitest.run_one_method(klass, method_name)
+    #     break if (result.passed? || result.skipped?)
+    #     puts "Retrying #{klass}##{method_name} (#{try})"
+    #   end
+    #   reporter.record result
+    # end
   end
 end
 

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1748,16 +1748,16 @@ module Google
         #   retrieved from the Storage service when `true`. Deprecated because
         #   the latest policy is now always retrieved. The default is `nil`.
         # @attr [Integer] requested_policy_version The requested syntax schema version of
-        #   the policy. Optional. If `nil` or not provided, `Policy#roles` and related
+        #   the policy. Optional. If `1`, `nil` or not provided, `Policy#roles` and related
         #   helpers will be accessible, but attempts to call `Policy#bindings` will raise
-        #   a runtime error. If a value is provided, `Policy#bindings` will be accessible,
+        #   a runtime error. If `3` is provided, `Policy#bindings` will be accessible,
         #   but attempts to call `Policy#roles` and related helpers will raise a runtime
-        #   error. The value is A higher version indicates that the policy contains role
+        #   error. A higher version indicates that the policy contains role
         #   bindings with the newer syntax schema that is unsupported by earlier versions.
         #
         #   The following requested policy versions are valid:
         #
-        #   * 1 -  The first version of Cloud IAM policy schema. Supports binding one
+        #   * 1 - The first version of Cloud IAM policy schema. Supports binding one
         #     role to one or more members. Does not support conditional bindings.
         #   * 3 - Introduces the condition field in the role binding, which further
         #     constrains the role binding via context-based and attribute-based rules.
@@ -1782,14 +1782,14 @@ module Google
         #   policy.version # 1
         #   puts policy.roles["roles/storage.objectViewer"]
         #
-        # @example Retrieving a version 1 or 3 Policy using `requested_policy_version`:
+        # @example Retrieving a version 3 Policy using `requested_policy_version`:
         #   require "google/cloud/storage"
         #
         #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-todo-app"
         #
-        #   policy = bucket.policy requested_policy_version: 1
-        #   policy.version # 1
+        #   policy = bucket.policy requested_policy_version: 3
+        #   policy.version # 3
         #   puts policy.bindings.find do |b|
         #     b[:role] == "roles/storage.objectViewer"
         #   end
@@ -1813,7 +1813,7 @@ module Google
         #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-todo-app"
         #
-        #   bucket.policy requested_policy_version: 1 do |p|
+        #   bucket.policy requested_policy_version: 3 do |p|
         #     p.version # 1
         #     p.version = 3 # Must be explicitly set to opt-in to support for conditions.
         #     p.bindings.insert({
@@ -1851,7 +1851,7 @@ module Google
           ensure_service!
           gapi = service.get_bucket_policy name, requested_policy_version: requested_policy_version,
                                                  user_project: user_project
-          policy = if requested_policy_version.nil?
+          policy = if requested_policy_version.nil? || requested_policy_version == 1
                      PolicyV1.from_gapi gapi
                    else
                      PolicyV3.from_gapi gapi
@@ -1900,7 +1900,7 @@ module Google
         #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-todo-app"
         #
-        #   policy = bucket.policy requested_policy_version: 1
+        #   policy = bucket.policy requested_policy_version: 3
         #   policy.version # 1
         #   policy.version = 3
         #   policy.bindings.insert({

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1776,10 +1776,11 @@ module Google
         #     p.add "roles/owner", "user:owner@example.com"
         #   end
         #
-        def policy force: nil
+        def policy force: nil, requested_policy_version: nil
           warn "DEPRECATED: 'force' in Bucket#policy" unless force.nil?
           ensure_service!
-          gapi = service.get_bucket_policy name, user_project: user_project
+          gapi = service.get_bucket_policy name, requested_policy_version: requested_policy_version,
+                                                 user_project: user_project
           policy = Policy.from_gapi gapi
           return policy unless block_given?
           yield policy

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1816,15 +1816,15 @@ module Google
         #   bucket.policy requested_policy_version: 1 do |p|
         #     p.version # 1
         #     p.version = 3 # Must be explicitly set to opt-in to support for conditions.
-        #     p.bindings.push({
-        #                       role: "roles/storage.admin",
-        #                       members: ["user:owner@example.com"],
-        #                       condition: {
-        #                         title: "test-condition",
-        #                         description: "description of condition",
-        #                         expression: "expr1"
-        #                       }
-        #                     })
+        #     p.bindings.insert({
+        #                         role: "roles/storage.admin",
+        #                         members: ["user:owner@example.com"],
+        #                         condition: {
+        #                           title: "test-condition",
+        #                           description: "description of condition",
+        #                           expression: "expr1"
+        #                         }
+        #                       })
         #   end
         #
         # @example Updating a version 3 Policy:
@@ -1835,15 +1835,15 @@ module Google
         #
         #   bucket.policy requested_policy_version: 3 do |p|
         #     p.version # 3 indicates an existing binding with a condition.
-        #     p.bindings.push({
-        #                       role: "roles/storage.admin",
-        #                       members: ["user:owner@example.com"],
-        #                       condition: {
-        #                         title: "test-condition",
-        #                         description: "description of condition",
-        #                         expression: "expr1"
-        #                       }
-        #                     })
+        #     p.bindings.insert({
+        #                         role: "roles/storage.admin",
+        #                         members: ["user:owner@example.com"],
+        #                         condition: {
+        #                           title: "test-condition",
+        #                           description: "description of condition",
+        #                           expression: "expr1"
+        #                         }
+        #                       })
         #   end
         #
         def policy force: nil, requested_policy_version: nil
@@ -1903,15 +1903,15 @@ module Google
         #   policy = bucket.policy requested_policy_version: 1
         #   policy.version # 1
         #   policy.version = 3
-        #   policy.bindings.push({
-        #                         role: "roles/storage.admin",
-        #                         members: ["user:owner@example.com"],
-        #                         condition: {
-        #                           title: "test-condition",
-        #                           description: "description of condition",
-        #                           expression: "expr1"
-        #                         }
-        #                       })
+        #   policy.bindings.insert({
+        #                           role: "roles/storage.admin",
+        #                           members: ["user:owner@example.com"],
+        #                           condition: {
+        #                             title: "test-condition",
+        #                             description: "description of condition",
+        #                             expression: "expr1"
+        #                           }
+        #                         })
         #
         #   policy = bucket.update_policy policy
         #
@@ -1923,15 +1923,15 @@ module Google
         #
         #   policy = bucket.policy requested_policy_version: 3
         #   policy.version # 3 indicates an existing binding with a condition.
-        #   policy.bindings.push({
-        #                         role: "roles/storage.admin",
-        #                         members: ["user:owner@example.com"],
-        #                         condition: {
-        #                           title: "test-condition",
-        #                           description: "description of condition",
-        #                           expression: "expr1"
-        #                         }
-        #                       })
+        #   policy.bindings.insert({
+        #                           role: "roles/storage.admin",
+        #                           members: ["user:owner@example.com"],
+        #                           condition: {
+        #                             title: "test-condition",
+        #                             description: "description of condition",
+        #                             expression: "expr1"
+        #                           }
+        #                         })
         #
         #   policy = bucket.update_policy policy
         #

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1851,7 +1851,11 @@ module Google
           ensure_service!
           gapi = service.get_bucket_policy name, requested_policy_version: requested_policy_version,
                                                  user_project: user_project
-          policy = Policy.from_gapi gapi, use_bindings: !requested_policy_version.nil?
+          policy = if requested_policy_version.nil?
+                     PolicyV1.from_gapi gapi
+                   else
+                     PolicyV3.from_gapi gapi
+                   end
           return policy unless block_given?
           yield policy
           update_policy policy
@@ -1935,7 +1939,7 @@ module Google
           ensure_service!
           gapi = service.set_bucket_policy name, new_policy.to_gapi,
                                            user_project: user_project
-          Policy.from_gapi gapi, use_bindings: new_policy.use_bindings
+          new_policy.class.from_gapi gapi
         end
         alias policy= update_policy
 

--- a/google-cloud-storage/lib/google/cloud/storage/policy.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy.rb
@@ -64,7 +64,8 @@ module Google
       #     role to one or more members. Does not support conditional bindings.
       #   * 3 - Introduces the condition field in the role binding, which further
       #     constrains the role binding via context-based and attribute-based rules.
-      #     See [Conditions Overview](https://cloud.google.com/iam/docs/conditions-overview)
+      #     See [Understanding policies](https://cloud.google.com/iam/docs/policies)
+      #     and [Overview of Cloud IAM Conditions](https://cloud.google.com/iam/docs/conditions-overview)
       #     for more information.
       #
       class Policy
@@ -84,7 +85,7 @@ module Google
       # and related helpers. Attempts to call {#bindings} and {#version=} will
       # raise a runtime error. To update the Policy version and add bindings with a newer
       # syntax, use {Google::Cloud::Storage::PolicyV3} instead by calling
-      # {Google::Cloud::Storage::Bucket#policy} with a `requested_policy_version`. To
+      # {Google::Cloud::Storage::Bucket#policy} with `requested_policy_version: 3`. To
       # obtain instances of this class, call {Google::Cloud::Storage::Bucket#policy}
       # without the `requested_policy_version` keyword argument.
       #
@@ -99,10 +100,10 @@ module Google
       #   require "google/cloud/storage"
       #
       #   storage = Google::Cloud::Storage.new
-      #   bucket = storage.bucket "my-todo-app"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   bucket.policy do |p|
-      #     p.version # 1
+      #     p.version # the value is 1
       #     p.remove "roles/storage.admin", "user:owner@example.com"
       #     p.add "roles/storage.admin", "user:newowner@example.com"
       #     p.roles["roles/storage.objectViewer"] = ["allUsers"]
@@ -136,7 +137,7 @@ module Google
         #
         #   storage = Google::Cloud::Storage.new
         #
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.policy do |p|
         #     p.add "roles/storage.admin", "user:newowner@example.com"
@@ -164,7 +165,7 @@ module Google
         #
         #   storage = Google::Cloud::Storage.new
         #
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.policy do |p|
         #     p.remove "roles/storage.admin", "user:owner@example.com"
@@ -190,7 +191,7 @@ module Google
         #
         #   storage = Google::Cloud::Storage.new
         #
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.policy do |p|
         #     p.role("roles/storage.admin") << "user:owner@example.com"
@@ -275,7 +276,7 @@ module Google
       # and {version=}. Attempts to call {#roles} and relate helpers will raise a runtime
       # error. This class may be used to update the Policy version and add bindings with a newer
       # syntax. To obtain instances of this class, call {Google::Cloud::Storage::Bucket#policy}
-      # with a `requested_policy_version`.
+      # with `requested_policy_version: 3`.
       #
       # @attr [Bindings] bindings Returns the Policy's bindings object that associate roles with
       #   an array of members. Conditions can be configured on the {Binding} object. See
@@ -288,18 +289,22 @@ module Google
       #   require "google/cloud/storage"
       #
       #   storage = Google::Cloud::Storage.new
-      #   bucket = storage.bucket "my-todo-app"
+      #   bucket = storage.bucket "my-bucket"
+      #
+      #   bucket.uniform_bucket_level_access = true
       #
       #   bucket.policy requested_policy_version: 3 do |p|
-      #     p.version # 1
+      #     p.version # the value is 1
       #     p.version = 3
+      #
+      #     expr = "resource.name.startsWith(\"projects/_/buckets/bucket-name/objects/prefix-a-\")"
       #     p.bindings.insert({
       #                         role: "roles/storage.admin",
       #                         members: ["user:owner@example.com"],
       #                         condition: {
-      #                           title: "test-condition",
+      #                           title: "my-condition",
       #                           description: "description of condition",
-      #                           expression: "expr1"
+      #                           expression: expr
       #                         }
       #                       })
       #   end
@@ -308,17 +313,21 @@ module Google
       #   require "google/cloud/storage"
       #
       #   storage = Google::Cloud::Storage.new
-      #   bucket = storage.bucket "my-todo-app"
+      #   bucket = storage.bucket "my-bucket"
+      #
+      #   bucket.uniform_bucket_level_access? # true
       #
       #   bucket.policy requested_policy_version: 3 do |p|
-      #     p.version # 3
+      #     p.version = 3 # Must be explicitly set to opt-in to support for conditions.
+      #
+      #     expr = "resource.name.startsWith(\"projects/_/buckets/bucket-name/objects/prefix-a-\")"
       #     p.bindings.insert({
       #                         role: "roles/storage.admin",
       #                         members: ["user:owner@example.com"],
       #                         condition: {
-      #                           title: "test-condition",
+      #                           title: "my-condition",
       #                           description: "description of condition",
-      #                           expression: "expr1"
+      #                           expression: expr
       #                         }
       #                       })
       #   end
@@ -347,7 +356,8 @@ module Google
         #   role to one or more members. Does not support conditional bindings.
         # * 3 - Introduces the condition field in the role binding, which further
         #   constrains the role binding via context-based and attribute-based rules.
-        #   See [Conditions Overview](https://cloud.google.com/iam/docs/conditions-overview)
+        #   See [Understanding policies](https://cloud.google.com/iam/docs/policies)
+        #   and [Overview of Cloud IAM Conditions](https://cloud.google.com/iam/docs/conditions-overview)
         #   for more information.
         #
         # @param [Integer] new_version The syntax schema version of the policy.
@@ -358,18 +368,22 @@ module Google
         #   require "google/cloud/storage"
         #
         #   storage = Google::Cloud::Storage.new
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
+        #
+        #   bucket.uniform_bucket_level_access = true
         #
         #   bucket.policy requested_policy_version: 3 do |p|
-        #     p.version # 1
+        #     p.version # the value is 1
         #     p.version = 3
+        #
+        #     expr = "resource.name.startsWith(\"projects/_/buckets/bucket-name/objects/prefix-a-\")"
         #     p.bindings.insert({
         #                         role: "roles/storage.admin",
         #                         members: ["user:owner@example.com"],
         #                         condition: {
-        #                           title: "test-condition",
+        #                           title: "my-condition",
         #                           description: "description of condition",
-        #                           expression: "expr1"
+        #                           expression: expr
         #                         }
         #                       })
         #   end

--- a/google-cloud-storage/lib/google/cloud/storage/policy.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy.rb
@@ -23,7 +23,9 @@ module Google
       ##
       # # Policy
       #
-      # An abstract Cloud IAM Policy for the Cloud Storage service.
+      # An abstract Cloud IAM Policy for the Cloud Storage service. See concrete
+      # subclasses {Google::Cloud::Storage::PolicyV1} and
+      # {Google::Cloud::Storage::PolicyV3}.
       #
       # A common pattern for updating a resource's metadata, such as its Policy,
       # is to read the current data from the service, update the data locally,

--- a/google-cloud-storage/lib/google/cloud/storage/policy.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy.rb
@@ -231,7 +231,7 @@ module Google
         # @raise [RuntimeError] If called on this class.
         #
         def version=(*)
-          raise "Illegal operation unless using PolicyV3. Use #roles instead."
+          raise "Illegal operation unless using PolicyV3."
         end
 
         ##
@@ -288,7 +288,7 @@ module Google
       #   storage = Google::Cloud::Storage.new
       #   bucket = storage.bucket "my-todo-app"
       #
-      #   bucket.policy requested_policy_version: 1 do |p|
+      #   bucket.policy requested_policy_version: 3 do |p|
       #     p.version # 1
       #     p.version = 3
       #     p.bindings.insert({
@@ -358,7 +358,7 @@ module Google
         #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-todo-app"
         #
-        #   bucket.policy requested_policy_version: 1 do |p|
+        #   bucket.policy requested_policy_version: 3 do |p|
         #     p.version # 1
         #     p.version = 3
         #     p.bindings.insert({

--- a/google-cloud-storage/lib/google/cloud/storage/policy.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy.rb
@@ -15,6 +15,7 @@
 
 require "google/cloud/errors"
 require "google/apis/storage_v1"
+require "google/cloud/storage/policy/bindings"
 
 module Google
   module Cloud
@@ -274,8 +275,8 @@ module Google
       # syntax. To obtain instances of this class, call {Google::Cloud::Storage::Bucket#policy}
       # with a `requested_policy_version`.
       #
-      # @attr [Array<Hash>] bindings Returns the Policy's bindings as an array of hashes that
-      #   associate roles with an array of members. Conditions are allowed in the hashes. See
+      # @attr [Bindings] bindings Returns the Policy's bindings object that associate roles with
+      #   an array of members. Conditions can be configured on the {Binding} object. See
       #   [Understanding Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
       #   listing of primitive and curated roles. See [Buckets:
       #   setIamPolicy](https://cloud.google.com/storage/docs/json_api/v1/buckets/setIamPolicy)
@@ -290,15 +291,15 @@ module Google
       #   bucket.policy requested_policy_version: 1 do |p|
       #     p.version # 1
       #     p.version = 3
-      #     p.bindings.push({
-      #                       role: "roles/storage.admin",
-      #                       members: ["user:owner@example.com"],
-      #                       condition: {
-      #                         title: "test-condition",
-      #                         description: "description of condition",
-      #                         expression: "expr1"
-      #                       }
-      #                     })
+      #     p.bindings.insert({
+      #                         role: "roles/storage.admin",
+      #                         members: ["user:owner@example.com"],
+      #                         condition: {
+      #                           title: "test-condition",
+      #                           description: "description of condition",
+      #                           expression: "expr1"
+      #                         }
+      #                       })
       #   end
       #
       # @example Using Policy version 3:
@@ -309,15 +310,15 @@ module Google
       #
       #   bucket.policy requested_policy_version: 3 do |p|
       #     p.version # 3
-      #     p.bindings.push({
-      #                       role: "roles/storage.admin",
-      #                       members: ["user:owner@example.com"],
-      #                       condition: {
-      #                         title: "test-condition",
-      #                         description: "description of condition",
-      #                         expression: "expr1"
-      #                       }
-      #                     })
+      #     p.bindings.insert({
+      #                         role: "roles/storage.admin",
+      #                         members: ["user:owner@example.com"],
+      #                         condition: {
+      #                           title: "test-condition",
+      #                           description: "description of condition",
+      #                           expression: "expr1"
+      #                         }
+      #                       })
       #   end
       #
       class PolicyV3 < Policy
@@ -327,7 +328,8 @@ module Google
         # @private Creates a PolicyV3 object.
         def initialize etag, version, bindings
           super etag, version
-          @bindings = bindings
+          @bindings = Bindings.new
+          @bindings.insert(*bindings)
         end
 
         ##
@@ -359,15 +361,15 @@ module Google
         #   bucket.policy requested_policy_version: 1 do |p|
         #     p.version # 1
         #     p.version = 3
-        #     p.bindings.push({
-        #                       role: "roles/storage.admin",
-        #                       members: ["user:owner@example.com"],
-        #                       condition: {
-        #                         title: "test-condition",
-        #                         description: "description of condition",
-        #                         expression: "expr1"
-        #                       }
-        #                     })
+        #     p.bindings.insert({
+        #                         role: "roles/storage.admin",
+        #                         members: ["user:owner@example.com"],
+        #                         condition: {
+        #                           title: "test-condition",
+        #                           description: "description of condition",
+        #                           expression: "expr1"
+        #                         }
+        #                       })
         #   end
         #
         def version= new_version
@@ -423,13 +425,13 @@ module Google
         end
 
         ##
-        # @private Convert the Policy to a
+        # @private Convert the PolicyV3 to a
         # Google::Apis::StorageV1::Policy.
         def to_gapi
           Google::Apis::StorageV1::Policy.new(
             etag: etag,
             version: version,
-            bindings: bindings
+            bindings: bindings.to_gapi
           )
         end
 

--- a/google-cloud-storage/lib/google/cloud/storage/policy.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy.rb
@@ -217,7 +217,7 @@ module Google
         end
 
         ##
-        # Illegal operation in PolicyV1. Use {#roles} instead.
+        # @private Illegal operation in PolicyV1. Use {#roles} instead.
         #
         # @raise [RuntimeError] If called on this class.
         #
@@ -226,7 +226,7 @@ module Google
         end
 
         ##
-        # Illegal operation in PolicyV1. Use {Google::Cloud::Storage::PolicyV3#version=} instead.
+        # @private Illegal operation in PolicyV1. Use {Google::Cloud::Storage::PolicyV3#version=} instead.
         #
         # @raise [RuntimeError] If called on this class.
         #
@@ -380,7 +380,7 @@ module Google
         end
 
         ##
-        # Illegal operation in PolicyV3. Use {#bindings} instead.
+        # @private Illegal operation in PolicyV3. Use {#bindings} instead.
         #
         # @raise [RuntimeError] If called on this class.
         #
@@ -389,7 +389,7 @@ module Google
         end
 
         ##
-        # Illegal operation in PolicyV3. Use {#bindings} instead.
+        # @private Illegal operation in PolicyV3. Use {#bindings} instead.
         #
         # @raise [RuntimeError] If called on this class.
         #
@@ -398,7 +398,7 @@ module Google
         end
 
         ##
-        # Illegal operation in PolicyV3. Use {#bindings} instead.
+        # @private Illegal operation in PolicyV3. Use {#bindings} instead.
         #
         # @raise [RuntimeError] If called on this class.
         #
@@ -407,7 +407,7 @@ module Google
         end
 
         ##
-        # Illegal operation in PolicyV3. Use {#bindings} instead.
+        # @private Illegal operation in PolicyV3. Use {#bindings} instead.
         #
         # @raise [RuntimeError] If called on this class.
         #
@@ -416,7 +416,7 @@ module Google
         end
 
         ##
-        # Illegal operation in PolicyV3. Deprecated in PolicyV1.
+        # @private Illegal operation in PolicyV3. Deprecated in PolicyV1.
         #
         # @raise [RuntimeError] If called on this class.
         #

--- a/google-cloud-storage/lib/google/cloud/storage/policy.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy.rb
@@ -192,6 +192,17 @@ module Google
         #
         # @return [Hash{String => Array<String>}] The Policy version 1 bindings.
         #
+        # @example
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #   bucket = storage.bucket "my-todo-app"
+        #
+        #   bucket.policy do |p|
+        #     p.version # 1
+        #     p.roles["roles/storage.objectViewer"] = ["allUsers"]
+        #   end
+        #
         def roles
           ensure_version_1
           @roles
@@ -208,6 +219,25 @@ module Google
         # @raise [RuntimeError] If version is 1.
         #
         # @return [Array<Hash>] The Policy bindings.
+        #
+        # @example
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #   bucket = storage.bucket "my-todo-app"
+        #
+        #   bucket.policy(requested_policy_version: 3) do |p|
+        #     p.version # 3
+        #     p.bindings.push({
+        #                       role: "roles/storage.admin",
+        #                       members: ["user:owner@example.com"],
+        #                       condition: {
+        #                         title: "test-condition",
+        #                         description: "description of condition",
+        #                         expression: "expr1"
+        #                       }
+        #                     })
+        #   end
         #
         def bindings
           raise "Illegal operation for version 1. Use #roles instead." if version == 1

--- a/google-cloud-storage/lib/google/cloud/storage/policy/binding.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/binding.rb
@@ -47,17 +47,17 @@ module Google
         #     all the users of that domain. For example, `google.com` or
         #     `example.com`. Required.
         #
-        # @attr [Google::Cloud::Storage::Policy::Condition] condition The
-        #   condition that is associated with this binding. NOTE: An unsatisfied
-        #   condition will not allow user access via current binding. Different
-        #   bindings, including their conditions, are examined independently.
-        #   Optional.
+        # @attr [Google::Cloud::Storage::Policy::Condition, nil] condition The
+        #   condition that is associated with this binding, or `nil` if there is
+        #   no condition. NOTE: An unsatisfied condition will not allow user
+        #   access via current binding. Different bindings, including their
+        #   conditions, are examined independently.
         #
         # @example
         #   require "google/cloud/storage"
         #
         #   storage = Google::Cloud::Storage.new
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   policy = bucket.policy requested_policy_version: 3
         #   policy.bindings.each do |binding|
@@ -68,18 +68,22 @@ module Google
         #   require "google/cloud/storage"
         #
         #   storage = Google::Cloud::Storage.new
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
+        #
+        #   bucket.uniform_bucket_level_access = true
         #
         #   bucket.policy requested_policy_version: 3 do |p|
-        #     p.version # 1
+        #     p.version # the value is 1
         #     p.version = 3 # Must be explicitly set to opt-in to support for conditions.
+        #
+        #     expr = "resource.name.startsWith(\"projects/_/buckets/bucket-name/objects/prefix-a-\")"
         #     p.bindings.insert({
         #                         role: "roles/storage.admin",
         #                         members: ["user:owner@example.com"],
         #                         condition: {
-        #                           title: "test-condition",
+        #                           title: "my-condition",
         #                           description: "description of condition",
-        #                           expression: "expr1"
+        #                           expression: expr
         #                         }
         #                       })
         #   end
@@ -176,7 +180,7 @@ module Google
           #   condition will not allow user access via current binding. Different
           #   bindings, including their conditions, are examined independently.
           #   Optional.
-          # @overload new(title:, description: nil, expression:)
+          # @overload condition=(title:, description: nil, expression:)
           #   @param [String] title Used to identify the condition. Required.
           #   @param [String] description Used to document the condition. Optional.
           #   @param [String] expression Defines an attribute-based logic

--- a/google-cloud-storage/lib/google/cloud/storage/policy/binding.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/binding.rb
@@ -19,9 +19,65 @@ module Google
   module Cloud
     module Storage
       class Policy
+        ##
+        # # Binding
+        #
+        # Value object associating members and an optional condition with a role.
+        #
+        # @see https://cloud.google.com/iam/docs/overview Cloud IAM Overview
+        #
+        # @attr [String] role Role that is assigned to members. For example,
+        #   `roles/viewer`, `roles/editor`, or `roles/owner`. Required.
+        # @attr [Array<String>] members Specifies the identities requesting
+        #   access for a Cloud Platform resource. members can have the
+        #   following values. Required.
+        #
+        #   * `allUsers`: A special identifier that represents anyone who is on
+        #     the internet; with or without a Google account.
+        #   * `allAuthenticatedUsers`: A special identifier that represents
+        #      anyone who is authenticated with a Google account or a service
+        #      account.
+        #   * `user:{emailid}`: An email address that represents a specific
+        #     Google account. For example, `alice@example.com`.
+        #   * `serviceAccount:{emailid}`: An email address that represents a
+        #     service account. For example, `my-other-app@appspot.gserviceaccount.com`.
+        #   * `group:{emailid}`: An email address that represents a Google group.
+        #     For example, `admins@example.com`.
+        #   * `domain:{domain}`: The G Suite domain (primary) that represents
+        #     all the users of that domain. For example, `google.com` or
+        #     `example.com`. Required.
+        #
+        # @attr [Google::Cloud::Storage::Policy::Condition] condition The
+        #   condition that is associated with this binding. NOTE: An unsatisfied
+        #   condition will not allow user access via current binding. Different
+        #   bindings, including their conditions, are examined independently.
+        #   Optional.
+        #
+        # @example Updating a Policy from version 1 to version 3:
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #   bucket = storage.bucket "my-todo-app"
+        #
+        #   bucket.policy requested_policy_version: 1 do |p|
+        #     p.version # 1
+        #     p.version = 3 # Must be explicitly set to opt-in to support for conditions.
+        #     p.bindings.insert({
+        #                         role: "roles/storage.admin",
+        #                         members: ["user:owner@example.com"],
+        #                         condition: {
+        #                           title: "test-condition",
+        #                           description: "description of condition",
+        #                           expression: "expr1"
+        #                         }
+        #                       })
+        #   end
+        #
         class Binding
           attr_reader :role, :members, :condition
 
+          ##
+          # Creates a Binding object.
           def initialize role:, members:, condition: nil
             @role = String role
 

--- a/google-cloud-storage/lib/google/cloud/storage/policy/binding.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/binding.rb
@@ -1,0 +1,100 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/storage/policy/condition"
+
+module Google
+  module Cloud
+    module Storage
+      class Policy
+        class Binding
+          attr_reader :role, :members, :condition
+
+          def initialize role:, members:, condition: nil
+            @role = String role
+
+            @members = Array members
+            raise ArgumentError, "members is empty, must be provided" if @members.empty?
+
+            condition = Condition.new(**condition) if condition.is_a? Hash
+            if condition
+              raise ArgumentError, "expected Condition, not #{condition.inspect}" unless condition.is_a? Condition
+            end
+            @condition = condition
+          end
+
+          def role= new_role
+            @role = String new_role
+          end
+
+          def members= new_members
+            new_members = Array new_members
+            raise ArgumentError, "members is empty, must be provided" if new_members.empty?
+            @members = new_members
+          end
+
+          # TODO: overload method signature, showing a Condition and named arguments
+          def condition= new_condition
+            new_condition = Condition.new(**new_condition) if new_condition.is_a? Hash
+            if new_condition && !new_condition.is_a?(Condition)
+              raise ArgumentError, "expected Condition, not #{new_condition.inspect}"
+            end
+            @condition = new_condition
+          end
+
+          ##
+          # @private
+          def <=> other
+            return nil unless other.is_a? Binding
+
+            ret = role <=> other.role
+            return ret unless ret.zero?
+            ret = members <=> other.members
+            return ret unless ret.zero?
+            condition&.to_gapi <=> other.condition&.to_gapi
+          end
+
+          ##
+          # @private
+          def eql? other
+            role.eql?(other.role) &&
+              members.eql?(other.members) &&
+              condition&.to_gapi.eql?(other.condition&.to_gapi)
+          end
+
+          ##
+          # @private
+          def hash
+            [
+              @role,
+              @members,
+              @condition&.to_gapi
+            ].hash
+          end
+
+          ##
+          # @private
+          def to_gapi
+            Google::Apis::StorageV1::Policy::Binding.new({
+              role: @role,
+              members: @members,
+              condition: @condition&.to_gapi
+            }.delete_if { |_, v| v.nil? })
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-storage/lib/google/cloud/storage/policy/binding.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/binding.rb
@@ -53,6 +53,17 @@ module Google
         #   bindings, including their conditions, are examined independently.
         #   Optional.
         #
+        # @example
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #   bucket = storage.bucket "my-todo-app"
+        #
+        #   policy = bucket.policy requested_policy_version: 3
+        #   policy.bindings.each do |binding|
+        #     puts binding.role
+        #   end
+        #
         # @example Updating a Policy from version 1 to version 3:
         #   require "google/cloud/storage"
         #
@@ -78,6 +89,34 @@ module Google
 
           ##
           # Creates a Binding object.
+          #
+          # @param [String] role Role that is assigned to members. For example,
+          #   `roles/viewer`, `roles/editor`, or `roles/owner`. Required.
+          # @param [Array<String>] members Specifies the identities requesting
+          #   access for a Cloud Platform resource. members can have the
+          #   following values. Required.
+          #
+          #   * `allUsers`: A special identifier that represents anyone who is on
+          #     the internet; with or without a Google account.
+          #   * `allAuthenticatedUsers`: A special identifier that represents
+          #      anyone who is authenticated with a Google account or a service
+          #      account.
+          #   * `user:{emailid}`: An email address that represents a specific
+          #     Google account. For example, `alice@example.com`.
+          #   * `serviceAccount:{emailid}`: An email address that represents a
+          #     service account. For example, `my-other-app@appspot.gserviceaccount.com`.
+          #   * `group:{emailid}`: An email address that represents a Google group.
+          #     For example, `admins@example.com`.
+          #   * `domain:{domain}`: The G Suite domain (primary) that represents
+          #     all the users of that domain. For example, `google.com` or
+          #     `example.com`. Required.
+          #
+          # @param [Google::Cloud::Storage::Policy::Condition] condition The
+          #   condition that is associated with this binding. NOTE: An unsatisfied
+          #   condition will not allow user access via current binding. Different
+          #   bindings, including their conditions, are examined independently.
+          #   Optional.
+          #
           def initialize role:, members:, condition: nil
             @role = String role
 
@@ -91,17 +130,61 @@ module Google
             @condition = condition
           end
 
+          ##
+          # Sets the role for the binding.
+          #
+          # @param [String] new_role Role that is assigned to members. For example,
+          #   `roles/viewer`, `roles/editor`, or `roles/owner`. Required.
+          #
           def role= new_role
             @role = String new_role
           end
 
+          ##
+          # Sets the members for the binding.
+          #
+          # @param [Array<String>] new_members Specifies the identities requesting
+          #   access for a Cloud Platform resource. members can have the
+          #   following values. Required.
+          #
+          #   * `allUsers`: A special identifier that represents anyone who is on
+          #     the internet; with or without a Google account.
+          #   * `allAuthenticatedUsers`: A special identifier that represents
+          #      anyone who is authenticated with a Google account or a service
+          #      account.
+          #   * `user:{emailid}`: An email address that represents a specific
+          #     Google account. For example, `alice@example.com`.
+          #   * `serviceAccount:{emailid}`: An email address that represents a
+          #     service account. For example, `my-other-app@appspot.gserviceaccount.com`.
+          #   * `group:{emailid}`: An email address that represents a Google group.
+          #     For example, `admins@example.com`.
+          #   * `domain:{domain}`: The G Suite domain (primary) that represents
+          #     all the users of that domain. For example, `google.com` or
+          #     `example.com`. Required.
+          #
           def members= new_members
             new_members = Array new_members
             raise ArgumentError, "members is empty, must be provided" if new_members.empty?
             @members = new_members
           end
 
-          # TODO: overload method signature, showing a Condition and named arguments
+          ##
+          # Sets the condition for the binding.
+          #
+          # @param [Google::Cloud::Storage::Policy::Condition] new_condition The
+          #   condition that is associated with this binding. NOTE: An unsatisfied
+          #   condition will not allow user access via current binding. Different
+          #   bindings, including their conditions, are examined independently.
+          #   Optional.
+          # @overload new(title:, description: nil, expression:)
+          #   @param [String] title Used to identify the condition. Required.
+          #   @param [String] description Used to document the condition. Optional.
+          #   @param [String] expression Defines an attribute-based logic
+          #     expression using a subset of the Common Expression Language (CEL).
+          #     The condition expression can contain multiple statements, each uses
+          #     one attributes, and statements are combined using logic operators,
+          #     following CEL language specification. Required.
+          #
           def condition= new_condition
             new_condition = Condition.new(**new_condition) if new_condition.is_a? Hash
             if new_condition && !new_condition.is_a?(Condition)

--- a/google-cloud-storage/lib/google/cloud/storage/policy/binding.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/binding.rb
@@ -59,7 +59,7 @@ module Google
         #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-todo-app"
         #
-        #   bucket.policy requested_policy_version: 1 do |p|
+        #   bucket.policy requested_policy_version: 3 do |p|
         #     p.version # 1
         #     p.version = 3 # Must be explicitly set to opt-in to support for conditions.
         #     p.bindings.insert({

--- a/google-cloud-storage/lib/google/cloud/storage/policy/bindings.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/bindings.rb
@@ -31,18 +31,22 @@ module Google
         #   require "google/cloud/storage"
         #
         #   storage = Google::Cloud::Storage.new
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
+        #
+        #   bucket.uniform_bucket_level_access = true
         #
         #   bucket.policy requested_policy_version: 3 do |p|
-        #     p.version # 1
+        #     p.version # the value is 1
         #     p.version = 3 # Must be explicitly set to opt-in to support for conditions.
+        #
+        #     expr = "resource.name.startsWith(\"projects/_/buckets/bucket-name/objects/prefix-a-\")"
         #     p.bindings.insert({
         #                         role: "roles/storage.admin",
         #                         members: ["user:owner@example.com"],
         #                         condition: {
-        #                           title: "test-condition",
+        #                           title: "my-condition",
         #                           description: "description of condition",
-        #                           expression: "expr1"
+        #                           expression: expr
         #                         }
         #                       })
         #   end
@@ -57,25 +61,36 @@ module Google
           end
 
           ##
-          # Adds a binding or bindings to the collection.
+          # Adds a binding or bindings to the collection. The arguments may be
+          # {Google::Cloud::Storage::Policy::Binding} objects or equivalent hash
+          # objects that will be implicitly coerced to binding objects.
           #
-          # @param [Google::Cloud::Storage::Policy::Binding] bindings One or
-          #   more bindings to be added to the policy owning the collection.
+          # @param [Google::Cloud::Storage::Policy::Binding, Hash] bindings One
+          #   or more bindings to be added to the policy owning the collection.
+          #   The arguments may be {Google::Cloud::Storage::Policy::Binding}
+          #   objects or equivalent hash objects that will be implicitly coerced
+          #   to binding objects.
           #
-          # @example
+          # @example Updating a Policy from version 1 to version 3:
           #   require "google/cloud/storage"
           #
           #   storage = Google::Cloud::Storage.new
-          #   bucket = storage.bucket "my-todo-app"
+          #   bucket = storage.bucket "my-bucket"
+          #
+          #   bucket.uniform_bucket_level_access = true
           #
           #   bucket.policy requested_policy_version: 3 do |p|
+          #     p.version # the value is 1
+          #     p.version = 3 # Must be explicitly set to opt-in to support for conditions.
+          #
+          #     expr = "resource.name.startsWith(\"projects/_/buckets/bucket-name/objects/prefix-a-\")"
           #     p.bindings.insert({
           #                         role: "roles/storage.admin",
           #                         members: ["user:owner@example.com"],
           #                         condition: {
-          #                           title: "test-condition",
+          #                           title: "my-condition",
           #                           description: "description of condition",
-          #                           expression: "expr1"
+          #                           expression: expr
           #                         }
           #                       })
           #   end
@@ -86,27 +101,27 @@ module Google
           end
 
           ##
-          # Deletes a binding or bindings from the collection.
+          # Deletes the binding or bindings from the collection that are equal to
+          # the arguments. The specification arguments may be
+          # {Google::Cloud::Storage::Policy::Binding} objects or equivalent hash
+          # objects that will be implicitly coerced to binding objects.
           #
-          # @param [Google::Cloud::Storage::Policy::Binding] bindings One or
-          #   more bindings to be removed from the policy owning the
-          #   collection.
+          # @param [Google::Cloud::Storage::Policy::Binding, Hash] bindings One
+          #   or more specifications for bindings to be removed from the
+          #   collection. The arguments may be
+          #   {Google::Cloud::Storage::Policy::Binding} objects or equivalent
+          #   hash objects that will be implicitly coerced to binding objects.
           #
           # @example
           #   require "google/cloud/storage"
           #
           #   storage = Google::Cloud::Storage.new
-          #   bucket = storage.bucket "my-todo-app"
+          #   bucket = storage.bucket "my-bucket"
           #
           #   bucket.policy requested_policy_version: 3 do |p|
           #     p.bindings.remove({
           #                         role: "roles/storage.admin",
-          #                         members: ["user:owner@example.com"],
-          #                         condition: {
-          #                           title: "test-condition",
-          #                           description: "description of condition",
-          #                           expression: "expr1"
-          #                         }
+          #                         members: ["user:owner@example.com"]
           #                       })
           #   end
           #
@@ -117,13 +132,16 @@ module Google
 
           ##
           # Calls the block once for each binding in the collection, passing
-          # the binding object as parameter.
+          # a {Google::Cloud::Storage::Policy::Binding} object as parameter. A
+          # {Google::Cloud::Storage::Policy::Binding} object is passed even
+          # when the arguments to {#insert} were hash objects.
           #
           # If no block is given, an enumerator is returned instead.
           #
           # @yield [binding] A binding in this bindings collection.
           # @yieldparam [Google::Cloud::Storage::Policy::Binding] binding A
-          #   binding object.
+          #   binding object, even when the arguments to {#insert} were hash
+          #   objects.
           #
           # @return [Enumerator]
           #
@@ -131,7 +149,7 @@ module Google
           #   require "google/cloud/storage"
           #
           #   storage = Google::Cloud::Storage.new
-          #   bucket = storage.bucket "my-todo-app"
+          #   bucket = storage.bucket "my-bucket"
           #
           #   policy = bucket.policy requested_policy_version: 3
           #   policy.bindings.each do |binding|

--- a/google-cloud-storage/lib/google/cloud/storage/policy/bindings.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/bindings.rb
@@ -1,0 +1,62 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/storage/policy/binding"
+
+module Google
+  module Cloud
+    module Storage
+      class Policy
+        class Bindings
+          include Enumerable
+
+          def initialize
+            @bindings = []
+          end
+
+          def insert *bindings
+            bindings = coerce_bindings(*bindings)
+            @bindings += bindings
+          end
+
+          def remove *bindings
+            bindings = coerce_bindings(*bindings)
+            @bindings -= bindings
+          end
+
+          def each
+            return enum_for :each unless block_given?
+
+            @bindings.each { |binding| yield binding }
+          end
+
+          def to_gapi
+            @bindings.map(&:to_gapi)
+          end
+
+          protected
+
+          def coerce_bindings *bindings
+            bindings.map do |binding|
+              binding = Binding.new(**binding) if binding.is_a? Hash
+              raise ArgumentError, "expected Binding, not #{binding.inspect}" unless binding.is_a? Binding
+              binding
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-storage/lib/google/cloud/storage/policy/bindings.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/bindings.rb
@@ -33,7 +33,7 @@ module Google
         #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-todo-app"
         #
-        #   bucket.policy requested_policy_version: 1 do |p|
+        #   bucket.policy requested_policy_version: 3 do |p|
         #     p.version # 1
         #     p.version = 3 # Must be explicitly set to opt-in to support for conditions.
         #     p.bindings.insert({

--- a/google-cloud-storage/lib/google/cloud/storage/policy/bindings.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/bindings.rb
@@ -19,9 +19,39 @@ module Google
   module Cloud
     module Storage
       class Policy
+        ##
+        # # Bindings
+        #
+        # Enumerable object for managing Cloud IAM bindings associated with
+        # a bucket.
+        #
+        # @see https://cloud.google.com/iam/docs/overview Cloud IAM Overview
+        #
+        # @example Updating a Policy from version 1 to version 3:
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #   bucket = storage.bucket "my-todo-app"
+        #
+        #   bucket.policy requested_policy_version: 1 do |p|
+        #     p.version # 1
+        #     p.version = 3 # Must be explicitly set to opt-in to support for conditions.
+        #     p.bindings.insert({
+        #                         role: "roles/storage.admin",
+        #                         members: ["user:owner@example.com"],
+        #                         condition: {
+        #                           title: "test-condition",
+        #                           description: "description of condition",
+        #                           expression: "expr1"
+        #                         }
+        #                       })
+        #   end
+        #
         class Bindings
           include Enumerable
 
+          ##
+          # @private Creates a Bindings object.
           def initialize
             @bindings = []
           end

--- a/google-cloud-storage/lib/google/cloud/storage/policy/bindings.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/bindings.rb
@@ -56,22 +56,96 @@ module Google
             @bindings = []
           end
 
+          ##
+          # Adds a binding or bindings to the collection.
+          #
+          # @param [Google::Cloud::Storage::Policy::Binding] bindings One or
+          #   more bindings to be added to the policy owning the collection.
+          #
+          # @example
+          #   require "google/cloud/storage"
+          #
+          #   storage = Google::Cloud::Storage.new
+          #   bucket = storage.bucket "my-todo-app"
+          #
+          #   bucket.policy requested_policy_version: 3 do |p|
+          #     p.bindings.insert({
+          #                         role: "roles/storage.admin",
+          #                         members: ["user:owner@example.com"],
+          #                         condition: {
+          #                           title: "test-condition",
+          #                           description: "description of condition",
+          #                           expression: "expr1"
+          #                         }
+          #                       })
+          #   end
+          #
           def insert *bindings
             bindings = coerce_bindings(*bindings)
             @bindings += bindings
           end
 
+          ##
+          # Deletes a binding or bindings from the collection.
+          #
+          # @param [Google::Cloud::Storage::Policy::Binding] bindings One or
+          #   more bindings to be removed from the policy owning the
+          #   collection.
+          #
+          # @example
+          #   require "google/cloud/storage"
+          #
+          #   storage = Google::Cloud::Storage.new
+          #   bucket = storage.bucket "my-todo-app"
+          #
+          #   bucket.policy requested_policy_version: 3 do |p|
+          #     p.bindings.remove({
+          #                         role: "roles/storage.admin",
+          #                         members: ["user:owner@example.com"],
+          #                         condition: {
+          #                           title: "test-condition",
+          #                           description: "description of condition",
+          #                           expression: "expr1"
+          #                         }
+          #                       })
+          #   end
+          #
           def remove *bindings
             bindings = coerce_bindings(*bindings)
             @bindings -= bindings
           end
 
+          ##
+          # Calls the block once for each binding in the collection, passing
+          # the binding object as parameter.
+          #
+          # If no block is given, an enumerator is returned instead.
+          #
+          # @yield [binding] A binding in this bindings collection.
+          # @yieldparam [Google::Cloud::Storage::Policy::Binding] binding A
+          #   binding object.
+          #
+          # @return [Enumerator]
+          #
+          # @example
+          #   require "google/cloud/storage"
+          #
+          #   storage = Google::Cloud::Storage.new
+          #   bucket = storage.bucket "my-todo-app"
+          #
+          #   policy = bucket.policy requested_policy_version: 3
+          #   policy.bindings.each do |binding|
+          #     puts binding.role
+          #   end
+          #
           def each
             return enum_for :each unless block_given?
 
             @bindings.each { |binding| yield binding }
           end
 
+          ##
+          # @private
           def to_gapi
             @bindings.map(&:to_gapi)
           end

--- a/google-cloud-storage/lib/google/cloud/storage/policy/bindings.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/bindings.rb
@@ -71,6 +71,8 @@ module Google
           #   objects or equivalent hash objects that will be implicitly coerced
           #   to binding objects.
           #
+          # @return [Bindings] `self` for chaining.
+          #
           # @example Updating a Policy from version 1 to version 3:
           #   require "google/cloud/storage"
           #
@@ -98,6 +100,7 @@ module Google
           def insert *bindings
             bindings = coerce_bindings(*bindings)
             @bindings += bindings
+            self
           end
 
           ##
@@ -112,6 +115,8 @@ module Google
           #   {Google::Cloud::Storage::Policy::Binding} objects or equivalent
           #   hash objects that will be implicitly coerced to binding objects.
           #
+          # @return [Bindings] `self` for chaining.
+          #
           # @example
           #   require "google/cloud/storage"
           #
@@ -119,15 +124,22 @@ module Google
           #   bucket = storage.bucket "my-bucket"
           #
           #   bucket.policy requested_policy_version: 3 do |p|
+          #     expr = "resource.name.startsWith(\"projects/_/buckets/bucket-name/objects/prefix-a-\")"
           #     p.bindings.remove({
           #                         role: "roles/storage.admin",
-          #                         members: ["user:owner@example.com"]
+          #                         members: ["user:owner@example.com"],
+          #                         condition: {
+          #                           title: "my-condition",
+          #                           description: "description of condition",
+          #                           expression: expr
+          #                         }
           #                       })
           #   end
           #
           def remove *bindings
             bindings = coerce_bindings(*bindings)
             @bindings -= bindings
+            self
           end
 
           ##

--- a/google-cloud-storage/lib/google/cloud/storage/policy/condition.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/condition.rb
@@ -40,7 +40,7 @@ module Google
         #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-todo-app"
         #
-        #   bucket.policy requested_policy_version: 1 do |p|
+        #   bucket.policy requested_policy_version: 3 do |p|
         #     p.version # 1
         #     p.version = 3 # Must be explicitly set to opt-in to support for conditions.
         #     p.bindings.insert({

--- a/google-cloud-storage/lib/google/cloud/storage/policy/condition.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/condition.rb
@@ -17,8 +17,48 @@ module Google
   module Cloud
     module Storage
       class Policy
+        ##
+        # # Condition
+        #
+        # Value object accepting an attribute-based logic expression based on a
+        # subset of the Common Expression Language (CEL).
+        #
+        # @see https://cloud.google.com/iam/docs/conditions-overview Cloud IAM
+        #   policies with conditions
+        #
+        # @attr [String] title Used to identify the condition. Required.
+        # @attr [String] description Used to document the condition. Optional.
+        # @attr [String] expression Defines an attribute-based logic
+        #   expression using a subset of the Common Expression Language (CEL).
+        #   The condition expression can contain multiple statements, each uses
+        #   one attributes, and statements are combined using logic operators,
+        #   following CEL language specification. Required.
+        #
+        # @example Updating a Policy from version 1 to version 3 by adding a condition:
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #   bucket = storage.bucket "my-todo-app"
+        #
+        #   bucket.policy requested_policy_version: 1 do |p|
+        #     p.version # 1
+        #     p.version = 3 # Must be explicitly set to opt-in to support for conditions.
+        #     p.bindings.insert({
+        #                         role: "roles/storage.admin",
+        #                         members: ["user:owner@example.com"],
+        #                         condition: {
+        #                           title: "test-condition",
+        #                           description: "description of condition",
+        #                           expression: "expr1"
+        #                         }
+        #                       })
+        #   end
+        #
         class Condition
           attr_reader :title, :description, :expression
+
+          ##
+          # Creates a Binding object.
           def initialize title:, description:, expression:
             @title = String title
             @description = String description

--- a/google-cloud-storage/lib/google/cloud/storage/policy/condition.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/condition.rb
@@ -1,0 +1,51 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Storage
+      class Policy
+        class Condition
+          attr_reader :title, :description, :expression
+          def initialize title:, description:, expression:
+            @title = String title
+            @description = String description
+            @expression = String expression
+          end
+
+          def title= new_title
+            @title = String new_title
+          end
+
+          def description= new_description
+            @description = String new_description
+          end
+
+          def expression= new_expression
+            @expression = String new_expression
+          end
+
+          def to_gapi
+            {
+              title: @title,
+              description: @description,
+              expression: @expression
+            }.delete_if { |_, v| v.nil? }
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-storage/lib/google/cloud/storage/policy/condition.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/condition.rb
@@ -34,6 +34,17 @@ module Google
         #   one attributes, and statements are combined using logic operators,
         #   following CEL language specification. Required.
         #
+        # @example
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #   bucket = storage.bucket "my-todo-app"
+        #
+        #   policy = bucket.policy requested_policy_version: 3
+        #   policy.bindings.each do |binding|
+        #     puts binding.condition.title if binding.condition
+        #   end
+        #
         # @example Updating a Policy from version 1 to version 3 by adding a condition:
         #   require "google/cloud/storage"
         #
@@ -58,21 +69,51 @@ module Google
           attr_reader :title, :description, :expression
 
           ##
-          # Creates a Binding object.
-          def initialize title:, description:, expression:
+          # Creates a Condition object.
+          #
+          # @param [String] title Used to identify the condition. Required.
+          # @param [String] description Used to document the condition. Optional.
+          # @param [String] expression Defines an attribute-based logic
+          #   expression using a subset of the Common Expression Language (CEL).
+          #   The condition expression can contain multiple statements, each uses
+          #   one attributes, and statements are combined using logic operators,
+          #   following CEL language specification. Required.
+          #
+          def initialize title:, description: nil, expression:
             @title = String title
             @description = String description
             @expression = String expression
           end
 
+          ##
+          # The title used to identify the condition. Required.
+          #
+          # @param [String] new_title The new title.
+          #
           def title= new_title
             @title = String new_title
           end
 
+          ##
+          # The description to document the condition. Optional.
+          #
+          # @param [String] new_description The new description.
+          #
           def description= new_description
             @description = String new_description
           end
 
+          ##
+          # An attribute-based logic expression using a subset of the Common
+          # Expression Language (CEL). The condition expression can contain
+          # multiple statements, each uses one attributes, and statements are
+          # combined using logic operators, following CEL language
+          # specification. Required.
+          #
+          # @see https://cloud.google.com/iam/docs/conditions-overview CEL for conditions
+          #
+          # @param [String] new_expression The new expression.
+          #
           def expression= new_expression
             @expression = String new_expression
           end

--- a/google-cloud-storage/lib/google/cloud/storage/policy/condition.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/condition.rb
@@ -38,7 +38,7 @@ module Google
         #   require "google/cloud/storage"
         #
         #   storage = Google::Cloud::Storage.new
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   policy = bucket.policy requested_policy_version: 3
         #   policy.bindings.each do |binding|
@@ -49,18 +49,22 @@ module Google
         #   require "google/cloud/storage"
         #
         #   storage = Google::Cloud::Storage.new
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
+        #
+        #   bucket.uniform_bucket_level_access = true
         #
         #   bucket.policy requested_policy_version: 3 do |p|
-        #     p.version # 1
+        #     p.version # the value is 1
         #     p.version = 3 # Must be explicitly set to opt-in to support for conditions.
+        #
+        #     expr = "resource.name.startsWith(\"projects/_/buckets/bucket-name/objects/prefix-a-\")"
         #     p.bindings.insert({
         #                         role: "roles/storage.admin",
         #                         members: ["user:owner@example.com"],
         #                         condition: {
-        #                           title: "test-condition",
+        #                           title: "my-condition",
         #                           description: "description of condition",
-        #                           expression: "expr1"
+        #                           expression: expr
         #                         }
         #                       })
         #   end

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -202,12 +202,12 @@ module Google
 
         ##
         # Returns Google::Apis::StorageV1::Policy
-        def get_bucket_policy bucket_name, user_project: nil
+        def get_bucket_policy bucket_name, requested_policy_version: nil, user_project: nil
           # get_bucket_iam_policy(bucket, fields: nil, quota_user: nil,
           #                               user_ip: nil, options: nil)
           execute do
-            service.get_bucket_iam_policy \
-              bucket_name, user_project: user_project(user_project)
+            service.get_bucket_iam_policy bucket_name, options_requested_policy_version: requested_policy_version,
+                                                       user_project: user_project(user_project)
           end
         end
 

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -324,17 +324,10 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Bucket#policy" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
-      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-todo-app", Hash]
-      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
-    end
-  end
-
-  doctest.before "Google::Cloud::Storage::Bucket#policy" do
-    mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
-      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-todo-app", Hash]
-      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket", Hash]
+      mock.expect :patch_bucket, bucket_gapi("my-bucket"), ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-bucket", Hash]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-bucket", Google::Apis::StorageV1::Policy, Hash]
     end
   end
 
@@ -356,9 +349,10 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Bucket#update_policy" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
-      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-todo-app", Hash]
-      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket", Hash]
+      mock.expect :patch_bucket, bucket_gapi("my-bucket"), ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-bucket", Hash]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-bucket", Google::Apis::StorageV1::Policy, Hash]
     end
   end
   doctest.skip "Google::Cloud::Storage::Bucket#policy="
@@ -427,9 +421,9 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Bucket#test_permissions" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
-      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-todo-app", Hash]
-      mock.expect :test_bucket_iam_permissions, permissions_gapi, ["my-todo-app", ["storage.buckets.get", "storage.buckets.delete"], Hash]
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket", Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-bucket", Hash]
+      mock.expect :test_bucket_iam_permissions, permissions_gapi, ["my-bucket", ["storage.buckets.get", "storage.buckets.delete"], Hash]
     end
   end
 
@@ -653,17 +647,18 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Policy" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
-      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-todo-app", Hash]
-      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket", Hash]
+      mock.expect :patch_bucket, bucket_gapi("my-bucket"), ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-bucket", Hash]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-bucket", Google::Apis::StorageV1::Policy, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Policy#role" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
-      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-todo-app", Hash]
-      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket", Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-bucket", Hash]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-bucket", Google::Apis::StorageV1::Policy, Hash]
     end
   end
 

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -256,8 +256,8 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Storage::Bucket#create_notification" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_publisher.expect :create_topic, topic_gapi, ["projects/my-project/topics/my-topic", Hash]
-      mock_publisher.expect :get_iam_policy, policy_gapi, ["projects/my-project/topics/my-topic", Hash]
-      mock_publisher.expect :set_iam_policy, policy_gapi, ["projects/my-project/topics/my-topic", Google::Iam::V1::Policy, Hash]
+      mock_publisher.expect :get_iam_policy, policy_gapi_v1, ["projects/my-project/topics/my-topic", Hash]
+      mock_publisher.expect :set_iam_policy, policy_gapi_v1, ["projects/my-project/topics/my-topic", Google::Iam::V1::Policy, Hash]
     end
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
@@ -325,14 +325,15 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Storage::Bucket#policy" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app", Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-todo-app", Hash]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
     end
   end
 
-  doctest.before "Google::Cloud::Storage::Bucket#policy@Retrieve the latest policy and update it in a block:" do
+  doctest.before "Google::Cloud::Storage::Bucket#policy" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app", Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-todo-app", Hash]
       mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
     end
   end
@@ -356,7 +357,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Storage::Bucket#update_policy" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app", Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-todo-app", Hash]
       mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
     end
   end
@@ -427,7 +428,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Storage::Bucket#test_permissions" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app", Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-todo-app", Hash]
       mock.expect :test_bucket_iam_permissions, permissions_gapi, ["my-todo-app", ["storage.buckets.get", "storage.buckets.delete"], Hash]
     end
   end
@@ -653,7 +654,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Storage::Policy" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app", Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-todo-app", Hash]
       mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
     end
   end
@@ -661,7 +662,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Storage::Policy#role" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app", Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi_v1, ["my-todo-app", Hash]
       mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
     end
   end
@@ -1064,8 +1065,8 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Storage::Notification" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_publisher.expect :create_topic, topic_gapi, ["projects/my-project/topics/my-topic", Hash]
-      mock_publisher.expect :get_iam_policy, policy_gapi, ["projects/my-project/topics/my-topic", Hash]
-      mock_publisher.expect :set_iam_policy, policy_gapi, ["projects/my-project/topics/my-topic", Google::Iam::V1::Policy, Hash]
+      mock_publisher.expect :get_iam_policy, policy_gapi_v1, ["projects/my-project/topics/my-topic", Hash]
+      mock_publisher.expect :set_iam_policy, policy_gapi_v1, ["projects/my-project/topics/my-topic", Google::Iam::V1::Policy, Hash]
     end
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
@@ -1502,10 +1503,47 @@ def topic_gapi topic_name = "my-topic"
   Google::Pubsub::V1::Topic.new name: topic_path(topic_name)
 end
 
-def policy_gapi
-  Google::Iam::V1::Policy.new(
-    bindings: []
+def policy_gapi_v1
+  policy_gapi(
+    version: 1,
+    bindings: [
+      Google::Apis::StorageV1::Policy::Binding.new(
+        role: "roles/storage.objectViewer",
+        members: [
+          "user:viewer@example.com"
+        ]
+      )
+    ]
   )
+end
+
+def policy_gapi_v3
+  policy_gapi(
+    version: 3,
+    bindings: [
+      Google::Apis::StorageV1::Policy::Binding.new(
+        role: "roles/storage.objectViewer",
+        members: [
+          "user:viewer@example.com"
+        ]
+      ),
+      Google::Apis::StorageV1::Policy::Binding.new(
+        role: "roles/storage.objectViewer",
+        members: [
+          "serviceAccount:1234567890@developer.gserviceaccount.com"
+        ],
+        condition: {
+          title: "always-true",
+          description: "test condition always-true",
+          expression: "true"
+        }
+      )
+    ]
+  )
+end
+
+def policy_gapi etag: "CAE=", version: 1, bindings: []
+  Google::Apis::StorageV1::Policy.new etag: etag, version: version, bindings: bindings
 end
 
 def project_path

--- a/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
@@ -22,163 +22,403 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
   let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
   let(:bucket_user_project) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_project: true }
 
-  let(:old_policy_gapi) {
-    Google::Apis::StorageV1::Policy.new(
-      etag: "CAE=",
-      bindings: [
-        Google::Apis::StorageV1::Policy::Binding.new(
-          role: "roles/storage.objectViewer",
-          members: [
-            "user:viewer@example.com"
-          ]
-        )
-      ]
-    )
-  }
-  let(:updated_policy_gapi) {
-    Google::Apis::StorageV1::Policy.new(
-      etag: "CAE=",
-      bindings: [
-        Google::Apis::StorageV1::Policy::Binding.new(
-          role: "roles/storage.objectViewer",
-          members: [
-            "user:viewer@example.com",
-            "serviceAccount:1234567890@developer.gserviceaccount.com"
-          ]
-        )
-      ]
-    )
-  }
-  let(:new_policy_gapi) {
-    Google::Apis::StorageV1::Policy.new(
-      etag: "CAF=",
-      bindings: [
-        Google::Apis::StorageV1::Policy::Binding.new(
-          role: "roles/storage.objectViewer",
-          members: [
-            "user:viewer@example.com",
-            "serviceAccount:1234567890@developer.gserviceaccount.com"
-          ]
-        )
-      ]
-    )
-  }
-  let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
-  let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi }
-  let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
+  describe "version 1" do
+    let(:old_policy_gapi) {
+      policy_gapi(
+        bindings: [
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "user:viewer@example.com"
+            ]
+          )
+        ]
+      )
+    }
+    let(:updated_policy_gapi) {
+      policy_gapi(
+        bindings: [
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "user:viewer@example.com",
+              "serviceAccount:1234567890@developer.gserviceaccount.com"
+            ]
+          )
+        ]
+      )
+    }
+    let(:new_policy_gapi) {
+      policy_gapi(
+        etag: "CAF=",
+        bindings: [
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "user:viewer@example.com",
+              "serviceAccount:1234567890@developer.gserviceaccount.com"
+            ]
+          )
+        ]
+      )
+    }
+    let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
+    let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi }
+    let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
 
-  it "gets the policy" do
-    mock = Minitest::Mock.new
-    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: nil]
+    it "gets the policy" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: nil, user_project: nil]
 
-    storage.service.mocked_service = mock
-    policy = bucket.policy
-    mock.verify
+      storage.service.mocked_service = mock
+      policy = bucket.policy
+      mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.etag.must_equal "CAE="
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 1
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-  end
-
-  it "gets the policy with user_project set to true" do
-    mock = Minitest::Mock.new
-    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: "test"]
-
-    storage.service.mocked_service = mock
-    policy = bucket_user_project.policy
-    mock.verify
-
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.etag.must_equal "CAE="
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 1
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-  end
-
-  it "sets the policy" do
-    mock = Minitest::Mock.new
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
-
-    storage.service.mocked_service = mock
-    policy = bucket.update_policy updated_policy
-    mock.verify
-
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.etag.must_equal "CAF="
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 2
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-  end
-
-  it "sets the policy with user_project set to true" do
-    mock = Minitest::Mock.new
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
-
-    storage.service.mocked_service = mock
-    policy = bucket_user_project.update_policy updated_policy
-    mock.verify
-
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.etag.must_equal "CAF="
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 2
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-  end
-
-  it "sets the policy in a block" do
-    mock = Minitest::Mock.new
-    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: nil]
-
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
-
-    storage.service.mocked_service = mock
-    policy = bucket.policy do |p|
-      p.add "roles/storage.objectViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAE="
+      policy.version.must_equal 1
+      policy.roles.must_be_kind_of Hash
+      policy.roles.size.must_equal 1
+      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+      policy.roles["roles/storage.objectViewer"].count.must_equal 1
+      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
     end
-    mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.etag.must_equal "CAF="
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 2
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    it "gets the policy with user_project set to true" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: nil, user_project: "test"]
+
+      storage.service.mocked_service = mock
+      policy = bucket_user_project.policy
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAE="
+      policy.version.must_equal 1
+      policy.roles.must_be_kind_of Hash
+      policy.roles.size.must_equal 1
+      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+      policy.roles["roles/storage.objectViewer"].count.must_equal 1
+      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    end
+
+    it "sets the policy" do
+      mock = Minitest::Mock.new
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
+
+      storage.service.mocked_service = mock
+      policy = bucket.update_policy updated_policy
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 1
+      policy.roles.must_be_kind_of Hash
+      policy.roles.size.must_equal 1
+      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+      policy.roles["roles/storage.objectViewer"].count.must_equal 2
+      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    end
+
+    it "sets the policy with user_project set to true" do
+      mock = Minitest::Mock.new
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
+
+      storage.service.mocked_service = mock
+      policy = bucket_user_project.update_policy updated_policy
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 1
+      policy.roles.must_be_kind_of Hash
+      policy.roles.size.must_equal 1
+      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+      policy.roles["roles/storage.objectViewer"].count.must_equal 2
+      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    end
+
+    it "sets the policy in a block" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: nil, user_project: nil]
+
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
+
+      storage.service.mocked_service = mock
+      policy = bucket.policy do |p|
+        p.add "roles/storage.objectViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+      end
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 1
+      policy.roles.must_be_kind_of Hash
+      policy.roles.size.must_equal 1
+      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+      policy.roles["roles/storage.objectViewer"].count.must_equal 2
+      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    end
+
+    it "sets the policy in a block with user_project set to true" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: nil, user_project: "test"]
+
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
+
+      storage.service.mocked_service = mock
+      policy = bucket_user_project.policy do |p|
+        p.add "roles/storage.objectViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+      end
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 1
+      policy.roles.must_be_kind_of Hash
+      policy.roles.size.must_equal 1
+      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+      policy.roles["roles/storage.objectViewer"].count.must_equal 2
+      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    end
   end
 
-  it "sets the policy in a block with user_project set to true" do
-    mock = Minitest::Mock.new
-    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: "test"]
+  describe "version 3" do
+    let(:old_policy_gapi) {
+      policy_gapi(
+        version: 3,
+        bindings: [
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "user:viewer@example.com"
+            ]
+          )
+        ]
+      )
+    }
+    let(:updated_policy_gapi) {
+      policy_gapi(
+        version: 3,
+        bindings: [
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "user:viewer@example.com"
+            ]
+          ),
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "serviceAccount:1234567890@developer.gserviceaccount.com"
+            ],
+            condition: {
+              title: "always-true",
+              description: "test condition always-true",
+              expression: "true"
+            }
+          )
+        ]
+      )
+    }
+    let(:new_policy_gapi) {
+      policy_gapi(
+        etag: "CAF=",
+        version: 3,
+        bindings: [
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "user:viewer@example.com"
+            ]
+          ),
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "serviceAccount:1234567890@developer.gserviceaccount.com"
+            ],
+            condition: {
+              title: "always-true",
+              description: "test condition always-true",
+              expression: "true"
+            }
+          )
+        ]
+      )
+    }
+    let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
+    let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi }
+    let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
 
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
+    it "gets the policy" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: nil]
 
-    storage.service.mocked_service = mock
-    policy = bucket_user_project.policy do |p|
-      p.add "roles/storage.objectViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+      storage.service.mocked_service = mock
+      policy = bucket.policy requested_policy_version: 3
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAE="
+      policy.version.must_equal 3
+      policy.bindings.must_be_kind_of Array
+      policy.bindings.count.must_equal 1
+      policy.bindings[0].must_be_kind_of Hash
+      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[0][:members].count.must_equal 1
+      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
     end
-    mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.etag.must_equal "CAF="
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 2
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    it "gets the policy with user_project set to true" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: "test"]
+
+      storage.service.mocked_service = mock
+      policy = bucket_user_project.policy requested_policy_version: 3
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAE="
+      policy.version.must_equal 3
+      policy.bindings.must_be_kind_of Array
+      policy.bindings.count.must_equal 1
+      policy.bindings[0].must_be_kind_of Hash
+      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[0][:members].count.must_equal 1
+      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
+    end
+
+    it "sets the policy" do
+      mock = Minitest::Mock.new
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
+
+      storage.service.mocked_service = mock
+      policy = bucket.update_policy updated_policy
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 3
+      policy.bindings.must_be_kind_of Array
+      policy.bindings.count.must_equal 2
+      policy.bindings[0].must_be_kind_of Hash
+      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[0][:members].count.must_equal 1
+      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
+      policy.bindings[1].must_be_kind_of Hash
+      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[1][:members].count.must_equal 1
+      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      policy.bindings[1][:condition][:title].must_equal "always-true"
+      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
+      policy.bindings[1][:condition][:expression].must_equal "true"
+    end
+
+    it "sets the policy with user_project set to true" do
+      mock = Minitest::Mock.new
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
+
+      storage.service.mocked_service = mock
+      policy = bucket_user_project.update_policy updated_policy
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 3
+      policy.bindings.must_be_kind_of Array
+      policy.bindings.count.must_equal 2
+      policy.bindings[0].must_be_kind_of Hash
+      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[0][:members].count.must_equal 1
+      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
+      policy.bindings[1].must_be_kind_of Hash
+      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[1][:members].count.must_equal 1
+      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      policy.bindings[1][:condition][:title].must_equal "always-true"
+      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
+      policy.bindings[1][:condition][:expression].must_equal "true"
+    end
+
+    it "sets the policy in a block" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: nil]
+
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
+
+      storage.service.mocked_service = mock
+      policy = bucket.policy requested_policy_version: 3 do |p|
+        p.bindings.push({
+                          role: "roles/storage.objectViewer",
+                          members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],
+                          condition: {
+                            title: "always-true",
+                            description: "test condition always-true",
+                            expression: "true"
+                          }
+                        })
+      end
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 3
+      policy.bindings.must_be_kind_of Array
+      policy.bindings.count.must_equal 2
+      policy.bindings[0].must_be_kind_of Hash
+      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[0][:members].count.must_equal 1
+      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
+      policy.bindings[1].must_be_kind_of Hash
+      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[1][:members].count.must_equal 1
+      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      policy.bindings[1][:condition][:title].must_equal "always-true"
+      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
+      policy.bindings[1][:condition][:expression].must_equal "true"
+    end
+
+    it "sets the policy in a block with user_project set to true" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: "test"]
+
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
+
+      storage.service.mocked_service = mock
+      policy = bucket_user_project.policy requested_policy_version: 3 do |p|
+        p.bindings.push({
+                          role: "roles/storage.objectViewer",
+                          members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],
+                          condition: {
+                            title: "always-true",
+                            description: "test condition always-true",
+                            expression: "true"
+                          }
+                        })
+      end
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 3
+      policy.bindings.must_be_kind_of Array
+      policy.bindings.count.must_equal 2
+      policy.bindings[0].must_be_kind_of Hash
+      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[0][:members].count.must_equal 1
+      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
+      policy.bindings[1].must_be_kind_of Hash
+      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[1][:members].count.must_equal 1
+      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      policy.bindings[1][:condition][:title].must_equal "always-true"
+      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
+      policy.bindings[1][:condition][:expression].must_equal "true"
+    end
   end
 
   it "tests the permissions available" do

--- a/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
@@ -62,9 +62,9 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
         ]
       )
     }
-    let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
-    let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi }
-    let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
+    let(:old_policy) { Google::Cloud::Storage::PolicyV1.from_gapi old_policy_gapi }
+    let(:updated_policy) { Google::Cloud::Storage::PolicyV1.from_gapi updated_policy_gapi }
+    let(:new_policy) { Google::Cloud::Storage::PolicyV1.from_gapi new_policy_gapi }
 
     it "gets the policy" do
       mock = Minitest::Mock.new
@@ -74,7 +74,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket.policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.etag.must_equal "CAE="
       policy.version.must_equal 1
       policy.roles.must_be_kind_of Hash
@@ -92,7 +92,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket_user_project.policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.etag.must_equal "CAE="
       policy.version.must_equal 1
       policy.roles.must_be_kind_of Hash
@@ -110,7 +110,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.etag.must_equal "CAF="
       policy.version.must_equal 1
       policy.roles.must_be_kind_of Hash
@@ -129,7 +129,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket_user_project.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.etag.must_equal "CAF="
       policy.version.must_equal 1
       policy.roles.must_be_kind_of Hash
@@ -152,7 +152,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.etag.must_equal "CAF="
       policy.version.must_equal 1
       policy.roles.must_be_kind_of Hash
@@ -175,7 +175,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.etag.must_equal "CAF="
       policy.version.must_equal 1
       policy.roles.must_be_kind_of Hash
@@ -250,9 +250,9 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
         ]
       )
     }
-    let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
-    let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi, use_bindings: true }
-    let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
+    let(:old_policy) { Google::Cloud::Storage::PolicyV3.from_gapi old_policy_gapi }
+    let(:updated_policy) { Google::Cloud::Storage::PolicyV3.from_gapi updated_policy_gapi }
+    let(:new_policy) { Google::Cloud::Storage::PolicyV3.from_gapi new_policy_gapi }
 
     it "gets the policy" do
       mock = Minitest::Mock.new
@@ -262,7 +262,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket.policy requested_policy_version: 1
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAE="
       policy.version.must_equal 1
       policy.bindings.must_be_kind_of Array
@@ -281,7 +281,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket_user_project.policy requested_policy_version: 1
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAE="
       policy.version.must_equal 1
       policy.bindings.must_be_kind_of Array
@@ -300,7 +300,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
       policy.bindings.must_be_kind_of Array
@@ -326,7 +326,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket_user_project.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
       policy.bindings.must_be_kind_of Array
@@ -365,7 +365,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
       policy.bindings.must_be_kind_of Array
@@ -404,7 +404,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
       policy.bindings.must_be_kind_of Array

--- a/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
@@ -84,6 +84,24 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
     end
 
+    it "gets the policy with requested_policy_version: 1" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: nil]
+
+      storage.service.mocked_service = mock
+      policy = bucket.policy requested_policy_version: 1
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
+      policy.etag.must_equal "CAE="
+      policy.version.must_equal 1
+      policy.roles.must_be_kind_of Hash
+      policy.roles.size.must_equal 1
+      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+      policy.roles["roles/storage.objectViewer"].count.must_equal 1
+      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    end
+
     it "gets the policy with user_project set to true" do
       mock = Minitest::Mock.new
       mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: nil, user_project: "test"]
@@ -256,10 +274,10 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
 
     it "gets the policy" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: nil]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: nil]
 
       storage.service.mocked_service = mock
-      policy = bucket.policy requested_policy_version: 1
+      policy = bucket.policy requested_policy_version: 3
       mock.verify
 
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
@@ -275,10 +293,10 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
 
     it "gets the policy with user_project set to true" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: "test"]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: "test"]
 
       storage.service.mocked_service = mock
-      policy = bucket_user_project.policy requested_policy_version: 1
+      policy = bucket_user_project.policy requested_policy_version: 3
       mock.verify
 
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
@@ -346,12 +364,12 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
 
     it "sets the policy in a block" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: nil]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: nil]
 
       mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
 
       storage.service.mocked_service = mock
-      policy = bucket.policy requested_policy_version: 1 do |p|
+      policy = bucket.policy requested_policy_version: 3 do |p|
         p.version = 3
         p.bindings.insert({
                             role: "roles/storage.objectViewer",
@@ -385,12 +403,12 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
 
     it "sets the policy in a block with user_project set to true" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: "test"]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: "test"]
 
       mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
 
       storage.service.mocked_service = mock
-      policy = bucket_user_project.policy requested_policy_version: 1 do |p|
+      policy = bucket_user_project.policy requested_policy_version: 3 do |p|
         p.version = 3
         p.bindings.insert({
                             role: "roles/storage.objectViewer",

--- a/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
@@ -190,7 +190,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
   describe "version 3" do
     let(:old_policy_gapi) {
       policy_gapi(
-        version: 3,
+        version: 1,
         bindings: [
           Google::Apis::StorageV1::Policy::Binding.new(
             role: "roles/storage.objectViewer",
@@ -251,20 +251,20 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       )
     }
     let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
-    let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi }
+    let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi, use_bindings: true }
     let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
 
     it "gets the policy" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: nil]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: nil]
 
       storage.service.mocked_service = mock
-      policy = bucket.policy requested_policy_version: 3
+      policy = bucket.policy requested_policy_version: 1
       mock.verify
 
       policy.must_be_kind_of Google::Cloud::Storage::Policy
       policy.etag.must_equal "CAE="
-      policy.version.must_equal 3
+      policy.version.must_equal 1
       policy.bindings.must_be_kind_of Array
       policy.bindings.count.must_equal 1
       policy.bindings[0].must_be_kind_of Hash
@@ -275,15 +275,15 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
 
     it "gets the policy with user_project set to true" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: "test"]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: "test"]
 
       storage.service.mocked_service = mock
-      policy = bucket_user_project.policy requested_policy_version: 3
+      policy = bucket_user_project.policy requested_policy_version: 1
       mock.verify
 
       policy.must_be_kind_of Google::Cloud::Storage::Policy
       policy.etag.must_equal "CAE="
-      policy.version.must_equal 3
+      policy.version.must_equal 1
       policy.bindings.must_be_kind_of Array
       policy.bindings.count.must_equal 1
       policy.bindings[0].must_be_kind_of Hash
@@ -346,12 +346,13 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
 
     it "sets the policy in a block" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: nil]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: nil]
 
       mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
 
       storage.service.mocked_service = mock
-      policy = bucket.policy requested_policy_version: 3 do |p|
+      policy = bucket.policy requested_policy_version: 1 do |p|
+        p.version = 3
         p.bindings.push({
                           role: "roles/storage.objectViewer",
                           members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],
@@ -384,12 +385,13 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
 
     it "sets the policy in a block with user_project set to true" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: "test"]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: "test"]
 
       mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
 
       storage.service.mocked_service = mock
-      policy = bucket_user_project.policy requested_policy_version: 3 do |p|
+      policy = bucket_user_project.policy requested_policy_version: 1 do |p|
+        p.version = 3
         p.bindings.push({
                           role: "roles/storage.objectViewer",
                           members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],

--- a/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
@@ -265,12 +265,12 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAE="
       policy.version.must_equal 1
-      policy.bindings.must_be_kind_of Array
-      policy.bindings.count.must_equal 1
-      policy.bindings[0].must_be_kind_of Hash
-      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[0][:members].count.must_equal 1
-      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
+      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      policy.bindings.to_a.count.must_equal 1
+      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
+      policy.bindings.to_a[0].condition.must_be :nil?
     end
 
     it "gets the policy with user_project set to true" do
@@ -284,12 +284,12 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAE="
       policy.version.must_equal 1
-      policy.bindings.must_be_kind_of Array
-      policy.bindings.count.must_equal 1
-      policy.bindings[0].must_be_kind_of Hash
-      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[0][:members].count.must_equal 1
-      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
+      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      policy.bindings.to_a.count.must_equal 1
+      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
+      policy.bindings.to_a[0].condition.must_be :nil?
     end
 
     it "sets the policy" do
@@ -303,19 +303,19 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Array
-      policy.bindings.count.must_equal 2
-      policy.bindings[0].must_be_kind_of Hash
-      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[0][:members].count.must_equal 1
-      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
-      policy.bindings[1].must_be_kind_of Hash
-      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[1][:members].count.must_equal 1
-      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-      policy.bindings[1][:condition][:title].must_equal "always-true"
-      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
-      policy.bindings[1][:condition][:expression].must_equal "true"
+      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      policy.bindings.to_a.count.must_equal 2
+      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
+      policy.bindings.to_a[0].condition.must_be :nil?
+      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      policy.bindings.to_a[1].condition.title.must_equal "always-true"
+      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
+      policy.bindings.to_a[1].condition.expression.must_equal "true"
     end
 
     it "sets the policy with user_project set to true" do
@@ -329,19 +329,19 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Array
-      policy.bindings.count.must_equal 2
-      policy.bindings[0].must_be_kind_of Hash
-      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[0][:members].count.must_equal 1
-      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
-      policy.bindings[1].must_be_kind_of Hash
-      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[1][:members].count.must_equal 1
-      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-      policy.bindings[1][:condition][:title].must_equal "always-true"
-      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
-      policy.bindings[1][:condition][:expression].must_equal "true"
+      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      policy.bindings.to_a.count.must_equal 2
+      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
+      policy.bindings.to_a[0].condition.must_be :nil?
+      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      policy.bindings.to_a[1].condition.title.must_equal "always-true"
+      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
+      policy.bindings.to_a[1].condition.expression.must_equal "true"
     end
 
     it "sets the policy in a block" do
@@ -353,34 +353,34 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       storage.service.mocked_service = mock
       policy = bucket.policy requested_policy_version: 1 do |p|
         p.version = 3
-        p.bindings.push({
-                          role: "roles/storage.objectViewer",
-                          members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],
-                          condition: {
-                            title: "always-true",
-                            description: "test condition always-true",
-                            expression: "true"
-                          }
-                        })
+        p.bindings.insert({
+                            role: "roles/storage.objectViewer",
+                            members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],
+                            condition: {
+                              title: "always-true",
+                              description: "test condition always-true",
+                              expression: "true"
+                            }
+                          })
       end
       mock.verify
 
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Array
-      policy.bindings.count.must_equal 2
-      policy.bindings[0].must_be_kind_of Hash
-      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[0][:members].count.must_equal 1
-      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
-      policy.bindings[1].must_be_kind_of Hash
-      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[1][:members].count.must_equal 1
-      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-      policy.bindings[1][:condition][:title].must_equal "always-true"
-      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
-      policy.bindings[1][:condition][:expression].must_equal "true"
+      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      policy.bindings.to_a.count.must_equal 2
+      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
+      policy.bindings.to_a[0].condition.must_be :nil?
+      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      policy.bindings.to_a[1].condition.title.must_equal "always-true"
+      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
+      policy.bindings.to_a[1].condition.expression.must_equal "true"
     end
 
     it "sets the policy in a block with user_project set to true" do
@@ -392,34 +392,34 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       storage.service.mocked_service = mock
       policy = bucket_user_project.policy requested_policy_version: 1 do |p|
         p.version = 3
-        p.bindings.push({
-                          role: "roles/storage.objectViewer",
-                          members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],
-                          condition: {
-                            title: "always-true",
-                            description: "test condition always-true",
-                            expression: "true"
-                          }
-                        })
+        p.bindings.insert({
+                            role: "roles/storage.objectViewer",
+                            members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],
+                            condition: {
+                              title: "always-true",
+                              description: "test condition always-true",
+                              expression: "true"
+                            }
+                          })
       end
       mock.verify
 
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Array
-      policy.bindings.count.must_equal 2
-      policy.bindings[0].must_be_kind_of Hash
-      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[0][:members].count.must_equal 1
-      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
-      policy.bindings[1].must_be_kind_of Hash
-      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[1][:members].count.must_equal 1
-      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-      policy.bindings[1][:condition][:title].must_equal "always-true"
-      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
-      policy.bindings[1][:condition][:expression].must_equal "true"
+      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      policy.bindings.to_a.count.must_equal 2
+      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
+      policy.bindings.to_a[0].condition.must_be :nil?
+      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      policy.bindings.to_a[1].condition.title.must_equal "always-true"
+      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
+      policy.bindings.to_a[1].condition.expression.must_equal "true"
     end
   end
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
@@ -82,6 +82,24 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
     end
 
+    it "gets the policy with requested_policy_version: 1" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: nil]
+
+      storage.service.mocked_service = mock
+      policy = bucket.policy requested_policy_version: 1
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
+      policy.etag.must_equal "CAE="
+      policy.version.must_equal 1
+      policy.roles.must_be_kind_of Hash
+      policy.roles.size.must_equal 1
+      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+      policy.roles["roles/storage.objectViewer"].count.must_equal 1
+      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    end
+
     it "gets the policy with user_project set to true" do
       mock = Minitest::Mock.new
       mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: nil, user_project: "test"]
@@ -254,10 +272,10 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
 
     it "gets the policy" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: nil]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: nil]
 
       storage.service.mocked_service = mock
-      policy = bucket.policy requested_policy_version: 1
+      policy = bucket.policy requested_policy_version: 3
       mock.verify
 
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
@@ -274,10 +292,10 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
 
     it "gets the policy with user_project set to true" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: "test"]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: "test"]
 
       storage.service.mocked_service = mock
-      policy = bucket_user_project.policy requested_policy_version: 1
+      policy = bucket_user_project.policy requested_policy_version: 3
       mock.verify
 
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
@@ -345,12 +363,12 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
 
     it "sets the policy in a block" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: nil]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: nil]
 
       mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
 
       storage.service.mocked_service = mock
-      policy = bucket.policy requested_policy_version: 1 do |p|
+      policy = bucket.policy requested_policy_version: 3 do |p|
         p.version = 3
         p.bindings.insert({
                             role: "roles/storage.objectViewer",
@@ -384,12 +402,12 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
 
     it "sets the policy in a block with user_project set to true" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: "test"]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: "test"]
 
       mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
 
       storage.service.mocked_service = mock
-      policy = bucket_user_project.policy requested_policy_version: 1 do |p|
+      policy = bucket_user_project.policy requested_policy_version: 3 do |p|
         p.version = 3
         p.bindings.insert({
                             role: "roles/storage.objectViewer",

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
@@ -188,7 +188,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
   describe "version 3" do
     let(:old_policy_gapi) {
       policy_gapi(
-        version: 3,
+        version: 1,
         bindings: [
           Google::Apis::StorageV1::Policy::Binding.new(
             role: "roles/storage.objectViewer",
@@ -249,20 +249,20 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       )
     }
     let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
-    let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi }
+    let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi, use_bindings: true }
     let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
 
     it "gets the policy" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: nil]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: nil]
 
       storage.service.mocked_service = mock
-      policy = bucket.policy requested_policy_version: 3
+      policy = bucket.policy requested_policy_version: 1
       mock.verify
 
       policy.must_be_kind_of Google::Cloud::Storage::Policy
       policy.etag.must_equal "CAE="
-      policy.version.must_equal 3
+      policy.version.must_equal 1
       policy.bindings.must_be_kind_of Array
       policy.bindings.count.must_equal 1
       policy.bindings[0].must_be_kind_of Hash
@@ -273,15 +273,15 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
 
     it "gets the policy with user_project set to true" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: "test"]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: "test"]
 
       storage.service.mocked_service = mock
-      policy = bucket_user_project.policy requested_policy_version: 3
+      policy = bucket_user_project.policy requested_policy_version: 1
       mock.verify
 
       policy.must_be_kind_of Google::Cloud::Storage::Policy
       policy.etag.must_equal "CAE="
-      policy.version.must_equal 3
+      policy.version.must_equal 1
       policy.bindings.must_be_kind_of Array
       policy.bindings.count.must_equal 1
       policy.bindings[0].must_be_kind_of Hash
@@ -344,12 +344,13 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
 
     it "sets the policy in a block" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: nil]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: nil]
 
       mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
 
       storage.service.mocked_service = mock
-      policy = bucket.policy requested_policy_version: 3 do |p|
+      policy = bucket.policy requested_policy_version: 1 do |p|
+        p.version = 3
         p.bindings.push({
                           role: "roles/storage.objectViewer",
                           members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],
@@ -382,12 +383,13 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
 
     it "sets the policy in a block with user_project set to true" do
       mock = Minitest::Mock.new
-      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: "test"]
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 1, user_project: "test"]
 
       mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
 
       storage.service.mocked_service = mock
-      policy = bucket_user_project.policy requested_policy_version: 3 do |p|
+      policy = bucket_user_project.policy requested_policy_version: 1 do |p|
+        p.version = 3
         p.bindings.push({
                           role: "roles/storage.objectViewer",
                           members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
@@ -19,163 +19,404 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
   let(:bucket) { Google::Cloud::Storage::Bucket.new_lazy bucket_name, storage.service }
   let(:bucket_user_project) { Google::Cloud::Storage::Bucket.new_lazy bucket_name, storage.service, user_project: true }
 
-  let(:old_policy_gapi) {
-    Google::Apis::StorageV1::Policy.new(
-      etag: "CAE=",
-      bindings: [
-        Google::Apis::StorageV1::Policy::Binding.new(
-          role: "roles/storage.objectViewer",
-          members: [
-            "user:viewer@example.com"
-          ]
-        )
-      ]
-    )
-  }
-  let(:updated_policy_gapi) {
-    Google::Apis::StorageV1::Policy.new(
-      etag: "CAE=",
-      bindings: [
-        Google::Apis::StorageV1::Policy::Binding.new(
-          role: "roles/storage.objectViewer",
-          members: [
-            "user:viewer@example.com",
-            "serviceAccount:1234567890@developer.gserviceaccount.com"
-          ]
-        )
-      ]
-    )
-  }
-  let(:new_policy_gapi) {
-    Google::Apis::StorageV1::Policy.new(
-      etag: "CAF=",
-      bindings: [
-        Google::Apis::StorageV1::Policy::Binding.new(
-          role: "roles/storage.objectViewer",
-          members: [
-            "user:viewer@example.com",
-            "serviceAccount:1234567890@developer.gserviceaccount.com"
-          ]
-        )
-      ]
-    )
-  }
-  let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
-  let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi }
-  let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
+  describe "version 1" do
+    let(:old_policy_gapi) {
+      policy_gapi(
+        bindings: [
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "user:viewer@example.com"
+            ]
+          )
+        ]
+      )
+    }
+    let(:updated_policy_gapi) {
+      policy_gapi(
+        bindings: [
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "user:viewer@example.com",
+              "serviceAccount:1234567890@developer.gserviceaccount.com"
+            ]
+          )
+        ]
+      )
+    }
+    let(:new_policy_gapi) {
+      policy_gapi(
+        etag: "CAF=",
+      version: 1,
+        bindings: [
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "user:viewer@example.com",
+              "serviceAccount:1234567890@developer.gserviceaccount.com"
+            ]
+          )
+        ]
+      )
+    }
+    let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
+    let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi }
+    let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
 
-  it "gets the policy" do
-    mock = Minitest::Mock.new
-    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: nil]
+    it "gets the policy" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: nil, user_project: nil]
 
-    storage.service.mocked_service = mock
-    policy = bucket.policy
-    mock.verify
+      storage.service.mocked_service = mock
+      policy = bucket.policy
+      mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.etag.must_equal "CAE="
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 1
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-  end
-
-  it "gets the policy with user_project set to true" do
-    mock = Minitest::Mock.new
-    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: "test"]
-
-    storage.service.mocked_service = mock
-    policy = bucket_user_project.policy
-    mock.verify
-
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.etag.must_equal "CAE="
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 1
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-  end
-
-  it "sets the policy" do
-    mock = Minitest::Mock.new
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
-
-    storage.service.mocked_service = mock
-    policy = bucket.update_policy updated_policy
-    mock.verify
-
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.etag.must_equal "CAF="
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 2
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-  end
-
-  it "sets the policy with user_project set to true" do
-    mock = Minitest::Mock.new
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
-
-    storage.service.mocked_service = mock
-    policy = bucket_user_project.update_policy updated_policy
-    mock.verify
-
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.etag.must_equal "CAF="
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 2
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-  end
-
-  it "sets the policy in a block" do
-    mock = Minitest::Mock.new
-    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: nil]
-
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
-
-    storage.service.mocked_service = mock
-    policy = bucket.policy do |p|
-      p.add "roles/storage.objectViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAE="
+      policy.version.must_equal 1
+      policy.roles.must_be_kind_of Hash
+      policy.roles.size.must_equal 1
+      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+      policy.roles["roles/storage.objectViewer"].count.must_equal 1
+      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
     end
-    mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.etag.must_equal "CAF="
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 2
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    it "gets the policy with user_project set to true" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: nil, user_project: "test"]
+
+      storage.service.mocked_service = mock
+      policy = bucket_user_project.policy
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAE="
+      policy.version.must_equal 1
+      policy.roles.must_be_kind_of Hash
+      policy.roles.size.must_equal 1
+      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+      policy.roles["roles/storage.objectViewer"].count.must_equal 1
+      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    end
+
+    it "sets the policy" do
+      mock = Minitest::Mock.new
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
+
+      storage.service.mocked_service = mock
+      policy = bucket.update_policy updated_policy
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 1
+      policy.roles.must_be_kind_of Hash
+      policy.roles.size.must_equal 1
+      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+      policy.roles["roles/storage.objectViewer"].count.must_equal 2
+      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    end
+
+    it "sets the policy with user_project set to true" do
+      mock = Minitest::Mock.new
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
+
+      storage.service.mocked_service = mock
+      policy = bucket_user_project.update_policy updated_policy
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 1
+      policy.roles.must_be_kind_of Hash
+      policy.roles.size.must_equal 1
+      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+      policy.roles["roles/storage.objectViewer"].count.must_equal 2
+      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    end
+
+    it "sets the policy in a block" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: nil, user_project: nil]
+
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
+
+      storage.service.mocked_service = mock
+      policy = bucket.policy do |p|
+        p.add "roles/storage.objectViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+      end
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 1
+      policy.roles.must_be_kind_of Hash
+      policy.roles.size.must_equal 1
+      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+      policy.roles["roles/storage.objectViewer"].count.must_equal 2
+      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    end
+
+    it "sets the policy in a block with user_project set to true" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: nil, user_project: "test"]
+
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
+
+      storage.service.mocked_service = mock
+      policy = bucket_user_project.policy do |p|
+        p.add "roles/storage.objectViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+      end
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 1
+      policy.roles.must_be_kind_of Hash
+      policy.roles.size.must_equal 1
+      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+      policy.roles["roles/storage.objectViewer"].count.must_equal 2
+      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    end
   end
 
-  it "sets the policy in a block with user_project set to true" do
-    mock = Minitest::Mock.new
-    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: "test"]
+  describe "version 3" do
+    let(:old_policy_gapi) {
+      policy_gapi(
+        version: 3,
+        bindings: [
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "user:viewer@example.com"
+            ]
+          )
+        ]
+      )
+    }
+    let(:updated_policy_gapi) {
+      policy_gapi(
+        version: 3,
+        bindings: [
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "user:viewer@example.com"
+            ]
+          ),
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "serviceAccount:1234567890@developer.gserviceaccount.com"
+            ],
+            condition: {
+              title: "always-true",
+              description: "test condition always-true",
+              expression: "true"
+            }
+          )
+        ]
+      )
+    }
+    let(:new_policy_gapi) {
+      policy_gapi(
+        etag: "CAF=",
+        version: 3,
+        bindings: [
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "user:viewer@example.com"
+            ]
+          ),
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: "roles/storage.objectViewer",
+            members: [
+              "serviceAccount:1234567890@developer.gserviceaccount.com"
+            ],
+            condition: {
+              title: "always-true",
+              description: "test condition always-true",
+              expression: "true"
+            }
+          )
+        ]
+      )
+    }
+    let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
+    let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi }
+    let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
 
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
+    it "gets the policy" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: nil]
 
-    storage.service.mocked_service = mock
-    policy = bucket_user_project.policy do |p|
-      p.add "roles/storage.objectViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+      storage.service.mocked_service = mock
+      policy = bucket.policy requested_policy_version: 3
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAE="
+      policy.version.must_equal 3
+      policy.bindings.must_be_kind_of Array
+      policy.bindings.count.must_equal 1
+      policy.bindings[0].must_be_kind_of Hash
+      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[0][:members].count.must_equal 1
+      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
     end
-    mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.etag.must_equal "CAF="
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 2
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    it "gets the policy with user_project set to true" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: "test"]
+
+      storage.service.mocked_service = mock
+      policy = bucket_user_project.policy requested_policy_version: 3
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAE="
+      policy.version.must_equal 3
+      policy.bindings.must_be_kind_of Array
+      policy.bindings.count.must_equal 1
+      policy.bindings[0].must_be_kind_of Hash
+      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[0][:members].count.must_equal 1
+      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
+    end
+
+    it "sets the policy" do
+      mock = Minitest::Mock.new
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
+
+      storage.service.mocked_service = mock
+      policy = bucket.update_policy updated_policy
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 3
+      policy.bindings.must_be_kind_of Array
+      policy.bindings.count.must_equal 2
+      policy.bindings[0].must_be_kind_of Hash
+      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[0][:members].count.must_equal 1
+      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
+      policy.bindings[1].must_be_kind_of Hash
+      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[1][:members].count.must_equal 1
+      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      policy.bindings[1][:condition][:title].must_equal "always-true"
+      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
+      policy.bindings[1][:condition][:expression].must_equal "true"
+    end
+
+    it "sets the policy with user_project set to true" do
+      mock = Minitest::Mock.new
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
+
+      storage.service.mocked_service = mock
+      policy = bucket_user_project.update_policy updated_policy
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 3
+      policy.bindings.must_be_kind_of Array
+      policy.bindings.count.must_equal 2
+      policy.bindings[0].must_be_kind_of Hash
+      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[0][:members].count.must_equal 1
+      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
+      policy.bindings[1].must_be_kind_of Hash
+      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[1][:members].count.must_equal 1
+      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      policy.bindings[1][:condition][:title].must_equal "always-true"
+      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
+      policy.bindings[1][:condition][:expression].must_equal "true"
+    end
+
+    it "sets the policy in a block" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: nil]
+
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
+
+      storage.service.mocked_service = mock
+      policy = bucket.policy requested_policy_version: 3 do |p|
+        p.bindings.push({
+                          role: "roles/storage.objectViewer",
+                          members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],
+                          condition: {
+                            title: "always-true",
+                            description: "test condition always-true",
+                            expression: "true"
+                          }
+                        })
+      end
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 3
+      policy.bindings.must_be_kind_of Array
+      policy.bindings.count.must_equal 2
+      policy.bindings[0].must_be_kind_of Hash
+      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[0][:members].count.must_equal 1
+      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
+      policy.bindings[1].must_be_kind_of Hash
+      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[1][:members].count.must_equal 1
+      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      policy.bindings[1][:condition][:title].must_equal "always-true"
+      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
+      policy.bindings[1][:condition][:expression].must_equal "true"
+    end
+
+    it "sets the policy in a block with user_project set to true" do
+      mock = Minitest::Mock.new
+      mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, options_requested_policy_version: 3, user_project: "test"]
+
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
+
+      storage.service.mocked_service = mock
+      policy = bucket_user_project.policy requested_policy_version: 3 do |p|
+        p.bindings.push({
+                          role: "roles/storage.objectViewer",
+                          members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],
+                          condition: {
+                            title: "always-true",
+                            description: "test condition always-true",
+                            expression: "true"
+                          }
+                        })
+      end
+      mock.verify
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal "CAF="
+      policy.version.must_equal 3
+      policy.bindings.must_be_kind_of Array
+      policy.bindings.count.must_equal 2
+      policy.bindings[0].must_be_kind_of Hash
+      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[0][:members].count.must_equal 1
+      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
+      policy.bindings[1].must_be_kind_of Hash
+      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
+      policy.bindings[1][:members].count.must_equal 1
+      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      policy.bindings[1][:condition][:title].must_equal "always-true"
+      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
+      policy.bindings[1][:condition][:expression].must_equal "true"
+    end
   end
 
   it "tests the permissions available" do

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
@@ -263,12 +263,13 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAE="
       policy.version.must_equal 1
-      policy.bindings.must_be_kind_of Array
-      policy.bindings.count.must_equal 1
-      policy.bindings[0].must_be_kind_of Hash
-      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[0][:members].count.must_equal 1
-      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
+      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      policy.bindings.to_a.count.must_equal 1
+      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
+      policy.bindings.to_a[0].condition.must_be :nil?
+      policy.bindings.to_a[0].condition.must_be :nil?
     end
 
     it "gets the policy with user_project set to true" do
@@ -282,12 +283,12 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAE="
       policy.version.must_equal 1
-      policy.bindings.must_be_kind_of Array
-      policy.bindings.count.must_equal 1
-      policy.bindings[0].must_be_kind_of Hash
-      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[0][:members].count.must_equal 1
-      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
+      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      policy.bindings.to_a.count.must_equal 1
+      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
+      policy.bindings.to_a[0].condition.must_be :nil?
     end
 
     it "sets the policy" do
@@ -301,19 +302,19 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Array
-      policy.bindings.count.must_equal 2
-      policy.bindings[0].must_be_kind_of Hash
-      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[0][:members].count.must_equal 1
-      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
-      policy.bindings[1].must_be_kind_of Hash
-      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[1][:members].count.must_equal 1
-      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-      policy.bindings[1][:condition][:title].must_equal "always-true"
-      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
-      policy.bindings[1][:condition][:expression].must_equal "true"
+      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      policy.bindings.to_a.count.must_equal 2
+      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
+      policy.bindings.to_a[0].condition.must_be :nil?
+      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      policy.bindings.to_a[1].condition.title.must_equal "always-true"
+      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
+      policy.bindings.to_a[1].condition.expression.must_equal "true"
     end
 
     it "sets the policy with user_project set to true" do
@@ -327,19 +328,19 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Array
-      policy.bindings.count.must_equal 2
-      policy.bindings[0].must_be_kind_of Hash
-      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[0][:members].count.must_equal 1
-      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
-      policy.bindings[1].must_be_kind_of Hash
-      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[1][:members].count.must_equal 1
-      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-      policy.bindings[1][:condition][:title].must_equal "always-true"
-      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
-      policy.bindings[1][:condition][:expression].must_equal "true"
+      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      policy.bindings.to_a.count.must_equal 2
+      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
+      policy.bindings.to_a[0].condition.must_be :nil?
+      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      policy.bindings.to_a[1].condition.title.must_equal "always-true"
+      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
+      policy.bindings.to_a[1].condition.expression.must_equal "true"
     end
 
     it "sets the policy in a block" do
@@ -351,34 +352,34 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       storage.service.mocked_service = mock
       policy = bucket.policy requested_policy_version: 1 do |p|
         p.version = 3
-        p.bindings.push({
-                          role: "roles/storage.objectViewer",
-                          members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],
-                          condition: {
-                            title: "always-true",
-                            description: "test condition always-true",
-                            expression: "true"
-                          }
-                        })
+        p.bindings.insert({
+                            role: "roles/storage.objectViewer",
+                            members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],
+                            condition: {
+                              title: "always-true",
+                              description: "test condition always-true",
+                              expression: "true"
+                            }
+                          })
       end
       mock.verify
 
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Array
-      policy.bindings.count.must_equal 2
-      policy.bindings[0].must_be_kind_of Hash
-      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[0][:members].count.must_equal 1
-      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
-      policy.bindings[1].must_be_kind_of Hash
-      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[1][:members].count.must_equal 1
-      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-      policy.bindings[1][:condition][:title].must_equal "always-true"
-      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
-      policy.bindings[1][:condition][:expression].must_equal "true"
+      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      policy.bindings.to_a.count.must_equal 2
+      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
+      policy.bindings.to_a[0].condition.must_be :nil?
+      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      policy.bindings.to_a[1].condition.title.must_equal "always-true"
+      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
+      policy.bindings.to_a[1].condition.expression.must_equal "true"
     end
 
     it "sets the policy in a block with user_project set to true" do
@@ -390,34 +391,34 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       storage.service.mocked_service = mock
       policy = bucket_user_project.policy requested_policy_version: 1 do |p|
         p.version = 3
-        p.bindings.push({
-                          role: "roles/storage.objectViewer",
-                          members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],
-                          condition: {
-                            title: "always-true",
-                            description: "test condition always-true",
-                            expression: "true"
-                          }
-                        })
+        p.bindings.insert({
+                            role: "roles/storage.objectViewer",
+                            members: ["serviceAccount:1234567890@developer.gserviceaccount.com"],
+                            condition: {
+                              title: "always-true",
+                              description: "test condition always-true",
+                              expression: "true"
+                            }
+                          })
       end
       mock.verify
 
       policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Array
-      policy.bindings.count.must_equal 2
-      policy.bindings[0].must_be_kind_of Hash
-      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[0][:members].count.must_equal 1
-      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
-      policy.bindings[1].must_be_kind_of Hash
-      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[1][:members].count.must_equal 1
-      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-      policy.bindings[1][:condition][:title].must_equal "always-true"
-      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
-      policy.bindings[1][:condition][:expression].must_equal "true"
+      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      policy.bindings.to_a.count.must_equal 2
+      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
+      policy.bindings.to_a[0].condition.must_be :nil?
+      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      policy.bindings.to_a[1].condition.title.must_equal "always-true"
+      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
+      policy.bindings.to_a[1].condition.expression.must_equal "true"
     end
   end
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
@@ -60,9 +60,9 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
         ]
       )
     }
-    let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
-    let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi }
-    let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
+    let(:old_policy) { Google::Cloud::Storage::PolicyV1.from_gapi old_policy_gapi }
+    let(:updated_policy) { Google::Cloud::Storage::PolicyV1.from_gapi updated_policy_gapi }
+    let(:new_policy) { Google::Cloud::Storage::PolicyV1.from_gapi new_policy_gapi }
 
     it "gets the policy" do
       mock = Minitest::Mock.new
@@ -72,7 +72,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket.policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.etag.must_equal "CAE="
       policy.version.must_equal 1
       policy.roles.must_be_kind_of Hash
@@ -90,7 +90,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket_user_project.policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.etag.must_equal "CAE="
       policy.version.must_equal 1
       policy.roles.must_be_kind_of Hash
@@ -108,7 +108,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.etag.must_equal "CAF="
       policy.version.must_equal 1
       policy.roles.must_be_kind_of Hash
@@ -127,7 +127,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket_user_project.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.etag.must_equal "CAF="
       policy.version.must_equal 1
       policy.roles.must_be_kind_of Hash
@@ -150,7 +150,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.etag.must_equal "CAF="
       policy.version.must_equal 1
       policy.roles.must_be_kind_of Hash
@@ -173,7 +173,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.etag.must_equal "CAF="
       policy.version.must_equal 1
       policy.roles.must_be_kind_of Hash
@@ -248,9 +248,9 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
         ]
       )
     }
-    let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
-    let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi, use_bindings: true }
-    let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
+    let(:old_policy) { Google::Cloud::Storage::PolicyV3.from_gapi old_policy_gapi }
+    let(:updated_policy) { Google::Cloud::Storage::PolicyV3.from_gapi updated_policy_gapi }
+    let(:new_policy) { Google::Cloud::Storage::PolicyV3.from_gapi new_policy_gapi }
 
     it "gets the policy" do
       mock = Minitest::Mock.new
@@ -260,7 +260,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket.policy requested_policy_version: 1
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAE="
       policy.version.must_equal 1
       policy.bindings.must_be_kind_of Array
@@ -279,7 +279,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket_user_project.policy requested_policy_version: 1
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAE="
       policy.version.must_equal 1
       policy.bindings.must_be_kind_of Array
@@ -298,7 +298,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
       policy.bindings.must_be_kind_of Array
@@ -324,7 +324,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket_user_project.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
       policy.bindings.must_be_kind_of Array
@@ -363,7 +363,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
       policy.bindings.must_be_kind_of Array
@@ -402,7 +402,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal "CAF="
       policy.version.must_equal 3
       policy.bindings.must_be_kind_of Array

--- a/google-cloud-storage/test/google/cloud/storage/policy_binding_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_binding_test.rb
@@ -1,0 +1,96 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Storage::Policy::Binding do
+  let :simple_hash do
+    {
+      role: "roles/storage.objectViewer",
+      members: [
+        "user:viewer@example.com"
+      ]
+    }
+  end
+  let :complex_hash do
+    {
+      role: "roles/storage.objectViewer",
+      members: [
+        "serviceAccount:1234567890@developer.gserviceaccount.com"
+      ],
+      condition: {
+        title: "always-true",
+        description: "test condition always-true",
+        expression: "true"
+      }
+    }
+  end
+  let(:simple_binding) { Google::Cloud::Storage::Policy::Binding.new **simple_hash }
+  let(:complex_binding) { Google::Cloud::Storage::Policy::Binding.new **complex_hash }
+
+  it "knows itself" do
+    simple_binding.must_be_kind_of Google::Cloud::Storage::Policy::Binding
+    simple_binding.role.must_equal "roles/storage.objectViewer"
+    simple_binding.members.must_equal ["user:viewer@example.com"]
+    simple_binding.condition.must_be :nil?
+
+    complex_binding.must_be_kind_of Google::Cloud::Storage::Policy::Binding
+    complex_binding.role.must_equal "roles/storage.objectViewer"
+    complex_binding.members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+    complex_binding.condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
+    complex_binding.condition.title.must_equal "always-true"
+    complex_binding.condition.description.must_equal "test condition always-true"
+    complex_binding.condition.expression.must_equal "true"
+  end
+
+  it "can be changed" do
+    simple_binding.role = "roles/storage.objectOwner"
+    simple_binding.members = ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+    simple_binding.condition = {
+      title: "always-false",
+      description: "test condition always-false",
+      expression: "false"
+    }
+
+    simple_binding.must_be_kind_of Google::Cloud::Storage::Policy::Binding
+    simple_binding.role.must_equal "roles/storage.objectOwner"
+    simple_binding.members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+    simple_binding.condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
+    simple_binding.condition.title.must_equal "always-false"
+    simple_binding.condition.description.must_equal "test condition always-false"
+    simple_binding.condition.expression.must_equal "false"
+
+    simple_binding.role = "roles/storage.objectAdmin"
+    simple_binding.members = ["user:admin@example.com"]
+    simple_binding.condition = nil
+
+    simple_binding.must_be_kind_of Google::Cloud::Storage::Policy::Binding
+    simple_binding.role.must_equal "roles/storage.objectAdmin"
+    simple_binding.members.must_equal ["user:admin@example.com"]
+    simple_binding.condition.must_be :nil?
+
+    new_condition = Google::Cloud::Storage::Policy::Condition.new(
+      title: "always-true",
+      description: "test condition always-true",
+      expression: "true"
+    )
+
+    simple_binding.condition = new_condition
+
+    simple_binding.condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
+    simple_binding.condition.title.must_equal "always-true"
+    simple_binding.condition.description.must_equal "test condition always-true"
+    simple_binding.condition.expression.must_equal "true"
+  end
+end

--- a/google-cloud-storage/test/google/cloud/storage/policy_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_test.rb
@@ -108,7 +108,7 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
         ]
       )
     }
-    let(:policy) { Google::Cloud::Storage::Policy.from_gapi policy_gapi_v3 }
+    let(:policy) { Google::Cloud::Storage::Policy.from_gapi policy_gapi_v3, use_bindings: true }
 
     it "knows its attributes" do
       policy.must_be_kind_of Google::Cloud::Storage::Policy
@@ -143,7 +143,7 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
     it "creates from an empty Google::Apis::StorageV1::Policy object" do
       gapi = Google::Apis::StorageV1::Policy.new version: 3
 
-      policy = Google::Cloud::Storage::Policy.from_gapi gapi
+      policy = Google::Cloud::Storage::Policy.from_gapi gapi, use_bindings: true
 
       policy.must_be_kind_of Google::Cloud::Storage::Policy
       policy.etag.must_be :nil?

--- a/google-cloud-storage/test/google/cloud/storage/policy_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_test.rb
@@ -32,7 +32,7 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
         ]
       )
     }
-    let(:policy) { Google::Cloud::Storage::Policy.from_gapi policy_gapi_v1 }
+    let(:policy) { Google::Cloud::Storage::PolicyV1.from_gapi policy_gapi_v1 }
 
     it "knows its attributes" do
       policy.must_be_kind_of Google::Cloud::Storage::Policy
@@ -73,7 +73,7 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
     it "creates from an empty Google::Apis::StorageV1::Policy object" do
       gapi = Google::Apis::StorageV1::Policy.new version: 1
 
-      policy = Google::Cloud::Storage::Policy.from_gapi gapi
+      policy = Google::Cloud::Storage::PolicyV1.from_gapi gapi
 
       policy.must_be_kind_of Google::Cloud::Storage::Policy
       policy.etag.must_be :nil?
@@ -108,7 +108,7 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
         ]
       )
     }
-    let(:policy) { Google::Cloud::Storage::Policy.from_gapi policy_gapi_v3, use_bindings: true }
+    let(:policy) { Google::Cloud::Storage::PolicyV3.from_gapi policy_gapi_v3 }
 
     it "knows its attributes" do
       policy.must_be_kind_of Google::Cloud::Storage::Policy
@@ -143,7 +143,7 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
     it "creates from an empty Google::Apis::StorageV1::Policy object" do
       gapi = Google::Apis::StorageV1::Policy.new version: 3
 
-      policy = Google::Cloud::Storage::Policy.from_gapi gapi, use_bindings: true
+      policy = Google::Cloud::Storage::PolicyV3.from_gapi gapi
 
       policy.must_be_kind_of Google::Cloud::Storage::Policy
       policy.etag.must_be :nil?

--- a/google-cloud-storage/test/google/cloud/storage/policy_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_test.rb
@@ -35,7 +35,7 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
     let(:policy) { Google::Cloud::Storage::PolicyV1.from_gapi policy_gapi_v1 }
 
     it "knows its attributes" do
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.etag.must_equal etag
       policy.version.must_equal 1
     end
@@ -75,7 +75,7 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
 
       policy = Google::Cloud::Storage::PolicyV1.from_gapi gapi
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
       policy.etag.must_be :nil?
       policy.version.must_equal 1
       policy.roles.must_be :empty?
@@ -111,25 +111,25 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
     let(:policy) { Google::Cloud::Storage::PolicyV3.from_gapi policy_gapi_v3 }
 
     it "knows its attributes" do
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_equal etag
       policy.version.must_equal 3
     end
 
     it "knows its bindings" do
-      policy.bindings.must_be_kind_of Array
-      policy.bindings.count.must_equal 2
-      policy.bindings[0].must_be_kind_of Hash
-      policy.bindings[0][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[0][:members].count.must_equal 1
-      policy.bindings[0][:members][0].must_equal "user:viewer@example.com"
-      policy.bindings[1].must_be_kind_of Hash
-      policy.bindings[1][:role].must_equal "roles/storage.objectViewer"
-      policy.bindings[1][:members].count.must_equal 1
-      policy.bindings[1][:members][0].must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-      policy.bindings[1][:condition][:title].must_equal "always-true"
-      policy.bindings[1][:condition][:description].must_equal "test condition always-true"
-      policy.bindings[1][:condition][:expression].must_equal "true"
+      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      policy.bindings.to_a.count.must_equal 2
+      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
+      policy.bindings.to_a[0].condition.must_be :nil?
+      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
+      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      policy.bindings.to_a[1].condition.title.must_equal "always-true"
+      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
+      policy.bindings.to_a[1].condition.expression.must_equal "true"
     end
 
     it "raises for unsupported method calls" do
@@ -145,10 +145,10 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
 
       policy = Google::Cloud::Storage::PolicyV3.from_gapi gapi
 
-      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
       policy.etag.must_be :nil?
       policy.version.must_equal 3
-      policy.bindings.must_be :empty?
+      policy.bindings.to_a.must_be :empty?
     end
   end
 end

--- a/google-cloud-storage/test/google/cloud/storage/policy_v1_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_v1_test.rb
@@ -1,0 +1,64 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Storage::PolicyV1, :mock_storage do
+  let(:etag)       { "etag-1" }
+
+  let(:policy_gapi_v1) {
+    policy_gapi(
+      etag: etag,
+      version: 1,
+      bindings: [
+        Google::Apis::StorageV1::Policy::Binding.new(
+          role: "roles/viewer",
+          members: [
+            "allUsers"
+          ]
+        )
+      ]
+    )
+  }
+  let(:policy) { Google::Cloud::Storage::PolicyV1.from_gapi policy_gapi_v1 }
+
+  it "knows its attributes" do
+    policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
+    policy.etag.must_equal etag
+    policy.version.must_equal 1
+  end
+
+  it "knows its roles" do
+    policy.roles.keys.sort.must_equal ["roles/viewer"]
+    policy.roles.values.sort.must_equal [["allUsers"]]
+  end
+
+  it "returns an empty array for missing role" do
+    role = policy.role "roles/does-not-exist"
+    role.must_be_kind_of Array
+    role.must_be :empty?
+    role.frozen?.must_equal false
+  end
+
+  it "creates from an empty Google::Apis::StorageV1::Policy object" do
+    gapi = Google::Apis::StorageV1::Policy.new version: 1
+
+    policy = Google::Cloud::Storage::PolicyV1.from_gapi gapi
+
+    policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
+    policy.etag.must_be :nil?
+    policy.version.must_equal 1
+    policy.roles.must_be :empty?
+  end
+end

--- a/google-cloud-storage/test/google/cloud/storage/policy_v3_bindings_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_v3_bindings_test.rb
@@ -1,0 +1,139 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Storage::PolicyV3, :bindings do
+  let(:policy) { Google::Cloud::Storage::PolicyV3.new "etag", 3, [] }
+  let :simple_hash do
+    {
+      role: "roles/storage.objectViewer",
+      members: [
+        "user:viewer@example.com"
+      ]
+    }
+  end
+  let :complex_hash do
+    {
+      role: "roles/storage.objectViewer",
+      members: [
+        "serviceAccount:1234567890@developer.gserviceaccount.com"
+      ],
+      condition: {
+        title: "always-true",
+        description: "test condition always-true",
+        expression: "true"
+      }
+    }
+  end
+  let(:simple_binding) { Google::Cloud::Storage::Policy::Binding.new **simple_hash }
+  let(:complex_binding) { Google::Cloud::Storage::Policy::Binding.new **complex_hash }
+
+  it "bindings can be added and removed" do
+    policy.bindings.to_a.count.must_equal 0
+    policy.bindings.insert simple_binding
+    policy.bindings.to_a.count.must_equal 1
+    policy.bindings.insert complex_binding
+    policy.bindings.to_a.count.must_equal 2
+
+    policy.bindings.remove complex_binding
+    policy.bindings.to_a.count.must_equal 1
+    policy.bindings.remove simple_binding
+    policy.bindings.to_a.count.must_equal 0
+  end
+
+  it "multiple bindings can be added and removed in a single call" do
+    policy.bindings.to_a.count.must_equal 0
+    policy.bindings.insert simple_binding, complex_binding
+    policy.bindings.to_a.count.must_equal 2
+
+    policy.bindings.remove complex_binding, simple_binding
+    policy.bindings.to_a.count.must_equal 0
+  end
+
+  it "bindings can be added and removed using hashes" do
+    policy.bindings.to_a.count.must_equal 0
+    policy.bindings.insert simple_hash
+    policy.bindings.to_a.count.must_equal 1
+    policy.bindings.insert complex_hash
+    policy.bindings.to_a.count.must_equal 2
+
+    policy.bindings.remove complex_hash
+    policy.bindings.to_a.count.must_equal 1
+    policy.bindings.remove simple_hash
+    policy.bindings.to_a.count.must_equal 0
+  end
+
+  it "multiple bindings can be added and removed using hashes in a single call" do
+    policy.bindings.to_a.count.must_equal 0
+    policy.bindings.insert simple_hash, complex_hash
+    policy.bindings.to_a.count.must_equal 2
+
+    policy.bindings.remove complex_hash, simple_hash
+    policy.bindings.to_a.count.must_equal 0
+  end
+
+  it "bindings can be changed to create duplicates and all duplicates removed" do
+    simple_owner_hash = {
+      role: "roles/storage.objectOwner",
+      members: [
+        "user:owner@example.com"
+      ]
+    }
+    complex_owner_hash = {
+      role: "roles/storage.objectOwner",
+      members: [
+        "serviceAccount:1234567890@developer.gserviceaccount.com"
+      ],
+      condition: {
+        title: "always-false",
+        description: "test condition always-false",
+        expression: "false"
+      }
+    }
+
+    policy.bindings.to_a.count.must_equal 0
+    policy.bindings.insert simple_hash, simple_owner_hash
+    policy.bindings.to_a.count.must_equal 2
+    policy.bindings.insert complex_hash, complex_owner_hash
+    policy.bindings.to_a.count.must_equal 4
+
+    simple_owner_binding = policy.bindings.find { |b| b.role == simple_owner_hash[:role] && b.members == simple_owner_hash[:members] }
+    simple_owner_binding.must_be_kind_of Google::Cloud::Storage::PolicyV3::Binding
+    simple_owner_binding.role.must_equal "roles/storage.objectOwner"
+    simple_owner_binding.members.must_equal ["user:owner@example.com"]
+    simple_owner_binding.condition.must_be :nil?
+
+    complex_owner_binding = policy.bindings.find { |b| b.role == complex_owner_hash[:role] && b.members == complex_owner_hash[:members] }
+    complex_owner_binding.must_be_kind_of Google::Cloud::Storage::PolicyV3::Binding
+    complex_owner_binding.role.must_equal "roles/storage.objectOwner"
+    complex_owner_binding.members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+    complex_owner_binding.condition.must_be_kind_of Google::Cloud::Storage::PolicyV3::Condition
+
+    # change the binding to be the same as the simple binding
+    simple_owner_binding.role = simple_hash[:role]
+    simple_owner_binding.members = simple_hash[:members]
+
+    complex_owner_binding.role = complex_hash[:role]
+    complex_owner_binding.members = complex_hash[:members]
+    complex_owner_binding.condition = complex_hash[:condition]
+
+    # remove the now duplicate values by specifying only one binding value
+    policy.bindings.to_a.count.must_equal 4
+    policy.bindings.remove simple_hash
+    policy.bindings.to_a.count.must_equal 2
+    policy.bindings.remove complex_hash
+    policy.bindings.to_a.count.must_equal 0
+  end
+end

--- a/google-cloud-storage/test/google/cloud/storage/policy_v3_bindings_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_v3_bindings_test.rb
@@ -40,12 +40,23 @@ describe Google::Cloud::Storage::PolicyV3, :bindings do
   let(:simple_binding) { Google::Cloud::Storage::Policy::Binding.new **simple_hash }
   let(:complex_binding) { Google::Cloud::Storage::Policy::Binding.new **complex_hash }
 
-  it "bindings can be added and removed" do
+  it "bindings can be added, iterated and removed" do
     policy.bindings.to_a.count.must_equal 0
     policy.bindings.insert simple_binding
     policy.bindings.to_a.count.must_equal 1
     policy.bindings.insert complex_binding
     policy.bindings.to_a.count.must_equal 2
+
+    idx = 0
+    policy.bindings.each do |binding|
+      binding.must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      idx += 1
+    end
+    idx.must_equal 2
+
+    enumerator = policy.bindings.each
+    enumerator.next.must_equal simple_binding
+    enumerator.next.must_equal complex_binding
 
     policy.bindings.remove complex_binding
     policy.bindings.to_a.count.must_equal 1

--- a/google-cloud-storage/test/google/cloud/storage/policy_v3_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_v3_test.rb
@@ -1,0 +1,78 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Storage::PolicyV3, :mock_storage do
+  let(:etag)       { "etag-1" }
+  let(:policy_gapi_v3) {
+    policy_gapi(
+      etag: etag,
+      version: 3,
+      bindings: [
+        Google::Apis::StorageV1::Policy::Binding.new(
+          role: "roles/storage.objectViewer",
+          members: [
+            "user:viewer@example.com"
+          ]
+        ),
+        Google::Apis::StorageV1::Policy::Binding.new(
+          role: "roles/storage.objectViewer",
+          members: [
+            "serviceAccount:1234567890@developer.gserviceaccount.com"
+          ],
+          condition: {
+            title: "always-true",
+            description: "test condition always-true",
+            expression: "true"
+          }
+        )
+      ]
+    )
+  }
+  let(:policy) { Google::Cloud::Storage::PolicyV3.from_gapi policy_gapi_v3 }
+
+  it "knows its attributes" do
+    policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
+    policy.etag.must_equal etag
+    policy.version.must_equal 3
+  end
+
+  it "knows its bindings" do
+    policy.bindings.must_be_kind_of Google::Cloud::Storage::PolicyV3::Bindings
+    policy.bindings.to_a.count.must_equal 2
+    policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::PolicyV3::Binding
+    policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
+    policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
+    policy.bindings.to_a[0].condition.must_be :nil?
+    policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::PolicyV3::Binding
+    policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
+    policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+    policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::PolicyV3::Condition
+    policy.bindings.to_a[1].condition.title.must_equal "always-true"
+    policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
+    policy.bindings.to_a[1].condition.expression.must_equal "true"
+  end
+
+  it "creates from an empty Google::Apis::StorageV1::Policy object" do
+    gapi = Google::Apis::StorageV1::Policy.new version: 3
+
+    policy = Google::Cloud::Storage::PolicyV3.from_gapi gapi
+
+    policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
+    policy.etag.must_be :nil?
+    policy.version.must_equal 3
+    policy.bindings.to_a.must_be :empty?
+  end
+end

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -189,4 +189,8 @@ class MockStorage < Minitest::Spec
       uniform_bucket_level_access: ubla
     )
   end
+
+  def policy_gapi etag: "CAE=", version: 1, bindings: []
+    Google::Apis::StorageV1::Policy.new etag: etag, version: version, bindings: bindings
+  end
 end


### PR DESCRIPTION
NOTE: The local `Policy` in this PR does not currently support adding a condition to `bindings` unless `Bucket#policy` is called with `requested_policy_version`.

closes: #4442

```rb
      role = "roles/storage.admin"
      member = "serviceAccount:#{service_account}"
      bucket_policy_v3.policy requested_policy_version: 1 do |p|
        p.version = 3
        p.bindings.push({
                          role: role,
                          members: [member],
                          condition: {
                            title: "always-true",
                            description: "test condition always-true",
                            expression: "true"
                          }
                        })

        expect { p.add role, member }.must_raise RuntimeError
        expect { p.remove role, member }.must_raise RuntimeError
        expect { p.role role }.must_raise RuntimeError
      end

      bucket_policy_v3 = storage.bucket bucket_name_policy_v3
      # Requested policy version (1) cannot be less than the existing policy version (3).
      expect { bucket_policy_v3.policy requested_policy_version: 1 }.must_raise Google::Cloud::Error
      policy = bucket_policy_v3.policy requested_policy_version: 3
      policy.version.must_equal 3
      expect { policy.roles }.must_raise RuntimeError
      expect { policy.deep_dup }.must_raise RuntimeError
      policy.bindings.count.must_equal 3
```