### PR TITLE
Allow row inserts to skip insert_id generation

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -2100,6 +2100,12 @@ module Google
         #   a new table with the given `table_id`, if no table is found for
         #   `table_id`. The default value is false.
         #
+        # @yield [table] a block for setting the table
+        # @yieldparam [Google::Cloud::Bigquery::Table::Updater] table An updater
+        #   to set additional properties on the table in the API request to
+        #   create it. Only used when `autocreate` is set and the table does not
+        #   already exist.
+        #
         # @return [Google::Cloud::Bigquery::InsertResponse] An insert response
         #   object.
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -211,11 +211,15 @@ module Google
         def insert_tabledata_json_rows dataset_id, table_id, json_rows, options = {}
           rows_and_ids = Array(json_rows).zip Array(options[:insert_ids])
           insert_rows = rows_and_ids.map do |json_row, insert_id|
-            insert_id ||= SecureRandom.uuid
-            {
-              insertId: insert_id,
-              json:     json_row
-            }
+            if insert_id == :skip
+              { json: json_row }
+            else
+              insert_id ||= SecureRandom.uuid
+              {
+                insertId: insert_id,
+                json:     json_row
+              }
+            end
           end
 
           insert_req = {

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1978,12 +1978,13 @@ module Google
         #
         # @param [Hash, Array<Hash>] rows A hash object or array of hash objects
         #   containing the data. Required.
-        # @param [Array<String>] insert_ids A unique ID for each row. BigQuery
-        #   uses this property to detect duplicate insertion requests on a
-        #   best-effort basis. For more information, see [data
-        #   consistency](https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataconsistency).
-        #   Optional. If not provided, the client library will assign a UUID to
-        #   each row before the request is sent.
+        # @param [Array<String|Symbol>, Symbol] insert_ids A unique ID for each row. BigQuery uses this property to
+        #   detect duplicate insertion requests on a best-effort basis. For more information, see [data
+        #   consistency](https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataconsistency). Optional. If
+        #   not provided, the client library will assign a UUID to each row before the request is sent.
+        #
+        #  The value `:skip` can be provided to skip the generation of IDs for all rows, or to skip the generation of an
+        #  ID for a specific row in the array.
         # @param [Boolean] skip_invalid Insert all valid rows of a request, even
         #   if invalid rows exist. The default value is `false`, which causes
         #   the entire request to fail if any invalid rows exist.
@@ -2023,12 +2024,14 @@ module Google
         #
         def insert rows, insert_ids: nil, skip_invalid: nil, ignore_unknown: nil
           rows = [rows] if rows.is_a? Hash
+          raise ArgumentError, "No rows provided" if rows.empty?
+
+          insert_ids = Array.new(rows.count) { :skip } if insert_ids == :skip
           insert_ids = Array insert_ids
           if insert_ids.count.positive? && insert_ids.count != rows.count
             raise ArgumentError, "insert_ids must be the same size as rows"
           end
-          rows = [rows] if rows.is_a? Hash
-          raise ArgumentError, "No rows provided" if rows.empty?
+
           ensure_service!
           options = { skip_invalid: skip_invalid, ignore_unknown: ignore_unknown, insert_ids: insert_ids }
           gapi = service.insert_tabledata dataset_id, table_id, rows, options

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
@@ -37,6 +37,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
                                           json: row
                                       }
                                     end }
+  let(:rows_without_insert_ids) { rows.map { |row| { json: row } } }
 
   let(:table_id) { "table_id" }
   let(:table_hash) { random_table_hash dataset_id, table_id }
@@ -284,6 +285,24 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
     insert_ids.pop # Remove one of the insert_ids to cause error.
 
     expect { dataset.insert table_id, rows, insert_ids: insert_ids }.must_raise ArgumentError
+  end
+
+  it "can skip insert_ids" do
+    mock = Minitest::Mock.new
+    insert_req = {
+        rows: rows_without_insert_ids, ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+                [project, dataset_id, table_id, insert_req, options: { skip_serialization: true }]
+    dataset.service.mocked_service = mock
+
+    result = dataset.insert table_id, rows, insert_ids: :skip
+
+    mock.verify
+
+    result.must_be :success?
+    result.insert_count.must_equal 3
+    result.error_count.must_equal 0
   end
 
   def success_table_insert_gapi


### PR DESCRIPTION
* Streaming inserts using an insert_id are not able to be inserted as fast as inserts without an insert_id.
* Add the ability for users to skip insert_id generation in order to speed up the inserts.
* The default behavior continues to generate insert_id values for each row inserted.

[closes #4452]