### PR TITLE
Fix MonitorMixin usage on Ruby 2.7

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -73,6 +73,9 @@ module Google
           # @private
           def initialize table, skip_invalid: nil, ignore_unknown: nil, max_bytes: 10_000_000, max_rows: 500,
                          interval: 10, threads: 4, &block
+           # init MonitorMixin
+           super()
+
             @table = table
             @skip_invalid = skip_invalid
             @ignore_unknown = ignore_unknown
@@ -88,9 +91,6 @@ module Google
             @thread_pool = Concurrent::ThreadPoolExecutor.new max_threads: @threads
 
             @cond = new_cond
-
-            # init MonitorMixin
-            super()
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -73,8 +73,8 @@ module Google
           # @private
           def initialize table, skip_invalid: nil, ignore_unknown: nil, max_bytes: 10_000_000, max_rows: 500,
                          interval: 10, threads: 4, &block
-           # init MonitorMixin
-           super()
+            # init MonitorMixin
+            super()
 
             @table = table
             @skip_invalid = skip_invalid

--- a/google-cloud-firestore/lib/google/cloud/firestore/watch/listener.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/watch/listener.rb
@@ -65,13 +65,13 @@ module Google
           end
 
           def initialize query, doc_ref, client, init_listen_req, &callback
+            super() # to init MonitorMixin
+
             @query = query
             @doc_ref = doc_ref
             @client = client
             @init_listen_req = init_listen_req
             @callback = callback
-
-            super() # to init MonitorMixin
           end
 
           def start

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -68,6 +68,9 @@ module Google
         def initialize logging, max_count: 10000, max_bytes: 10000000,
                        max_queue: 100, interval: 5, threads: 10,
                        partial_success: false
+          # init MonitorMixin
+          super()
+
           @logging = logging
 
           @max_count = max_count
@@ -84,9 +87,6 @@ module Google
 
           # Make sure all buffered messages are sent when process exits.
           at_exit { stop }
-
-          # init MonitorMixin
-          super()
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
@@ -72,6 +72,9 @@ module Google
         ##
         # @private Create a new instance of the object.
         def initialize topic_name, service, max_bytes: 10_000_000, max_messages: 1000, interval: 0.25, threads: {}
+          # init MonitorMixin
+          super()
+
           @topic_name = service.topic_path topic_name
           @service    = service
 
@@ -90,9 +93,6 @@ module Google
           @batches = {}
 
           @cond = new_cond
-
-          # init MonitorMixin
-          super()
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher/batch.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher/batch.rb
@@ -30,7 +30,7 @@ module Google
           def initialize publisher, ordering_key
             # init MonitorMixin
             super()
-          
+
             @publisher = publisher
             @ordering_key = ordering_key
             @items = []

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher/batch.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher/batch.rb
@@ -28,6 +28,9 @@ module Google
           attr_reader :items, :ordering_key
 
           def initialize publisher, ordering_key
+            # init MonitorMixin
+            super()
+          
             @publisher = publisher
             @ordering_key = ordering_key
             @items = []
@@ -37,9 +40,6 @@ module Google
             @publishing = false
             @stopping = false
             @canceled = false
-
-            # init MonitorMixin
-            super()
           end
 
           ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -80,6 +80,8 @@ module Google
         def initialize subscription_name, callback, deadline: nil,
                        message_ordering: nil, streams: nil, inventory: nil,
                        threads: {}, service: nil
+          super() # to init MonitorMixin
+
           @callback = callback
           @error_callbacks = []
           @subscription_name = subscription_name
@@ -102,8 +104,6 @@ module Google
           @stream_pool = stream_pool.map(&:value)
 
           @buffer = TimedUnaryBuffer.new self
-
-          super() # to init MonitorMixin
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
@@ -27,12 +27,12 @@ module Google
           attr_reader :stream, :limit
 
           def initialize stream, limit
+            super()
+
             @stream = stream
             @limit = limit
             @_ack_ids = []
             @wait_cond = new_cond
-
-            super()
           end
 
           def ack_ids

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/sequencer.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/sequencer.rb
@@ -32,10 +32,10 @@ module Google
           def initialize &block
             raise ArgumentError if block.nil?
 
+            super() # to init MonitorMixin
+
             @seq_hash = Hash.new { |hash, key| hash[key] = [] }
             @process_callback = block
-
-            super() # to init MonitorMixin
           end
 
           ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -49,6 +49,8 @@ module Google
           ##
           # @private Create an empty Subscriber::Stream object.
           def initialize subscriber
+            super() # to init MonitorMixin
+
             @subscriber = subscriber
 
             @request_queue = nil
@@ -68,8 +70,6 @@ module Google
               # push empty request every 30 seconds to keep stream alive
               push Google::Cloud::PubSub::V1::StreamingPullRequest.new unless inventory.empty?
             end.execute
-
-            super() # to init MonitorMixin
           end
 
           def start

--- a/google-cloud-speech/lib/google/cloud/speech/v1/stream.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/stream.rb
@@ -60,13 +60,14 @@ module Google
           # This must always be private, since it may change as the implementation
           # changes over time.
           def initialize streaming_config, streaming_call
+            super() # to init MonitorMixin
+
             @streaming_call = streaming_call
             @streaming_recognize_request = {
               streaming_config: streaming_config
             }
             @results = []
             @callbacks = Hash.new { |h, k| h[k] = [] }
-            super() # to init MonitorMixin
           end
 
           ##

--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/stream.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/stream.rb
@@ -60,13 +60,14 @@ module Google
           # This must always be private, since it may change as the implementation
           # changes over time.
           def initialize streaming_config, streaming_call
+            super() # to init MonitorMixin
+
             @streaming_call = streaming_call
             @streaming_recognize_request = {
               streaming_config: streaming_config
             }
             @results = []
             @callbacks = Hash.new { |h, k| h[k] = [] }
-            super() # to init MonitorMixin
           end
 
           ##

--- a/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
@@ -38,6 +38,9 @@ module Google
         # @private Creates a new AsyncReporter instance.
         def initialize service, max_count: 1000, max_bytes: 4000000,
                        max_queue: 100, interval: 5, threads: 10
+          # init MonitorMixin
+          super()
+
           @service = service
 
           @max_count = max_count
@@ -52,9 +55,6 @@ module Google
 
           # Make sure all buffered messages are sent when process exits.
           at_exit { stop! }
-
-          # init MonitorMixin
-          super()
         end
 
         ##


### PR DESCRIPTION
* Ruby 2.7 will error if new_cond is called before super().
* Make the call to super() be the first call in initialize
  when possible.