### PR TITLE
[Syntax Review] Additional types of SampleGen code samples

### DIFF
--- a/google-cloud-language/samples/v1/samplegen_map_field_access.rb
+++ b/google-cloud-language/samples/v1/samplegen_map_field_access.rb
@@ -44,23 +44,24 @@ def sample_analyze_entities
   response = language_client.analyze_entities(document)
 
   response.entities.each do |entity|
-    # Each detected entity has a map of metadata:
-    map = entity.metadata
 
     # Access value by key:
-    puts "URL: #{map["wikipedia_url"]}"
+    puts "URL: #{entity.metadata["wikipedia_url"]}"
+
     # Loop over keys and values:
-    map.each do |key, value|
+    entity.metadata.each do |key, value|
       puts "#{key}: #{value}"
     end
 
+
     # Loop over just keys:
-    map.keys.each do |the_key|
+    entity.metadata.keys.each do |the_key|
       puts "Key: #{the_key}"
     end
 
+
     # Loop over just values:
-    map.values.each do |the_value|
+    entity.metadata.values.each do |the_value|
       puts "Value: #{the_value}"
     end
 

--- a/google-cloud-language/samples/v1/samplegen_map_field_access.rb
+++ b/google-cloud-language/samples/v1/samplegen_map_field_access.rb
@@ -1,0 +1,77 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_map_field_access")
+
+# sample-metadata
+#   title: This sample reads and loops over a map field in the response
+#   description: This sample reads and loops over a map field in the response
+#   bundle exec ruby samples/v1/samplegen_map_field_access.rb
+
+# This sample reads and loops over a map field in the response
+def sample_analyze_entities
+  # [START samplegen_map_field_access]
+  # Import client library
+  require "google/cloud/language"
+
+  # Instantiate a client
+  language_client = Google::Cloud::Language.new version: :v1
+
+  type = :PLAIN_TEXT
+
+  language = "en"
+
+  # The text content to analyze
+  content = "Googleplex is at 1600 Amphitheatre Parkway, Mountain View, CA."
+
+  document = {
+    type: type,
+    language: language,
+    content: content
+  }
+
+  response = language_client.analyze_entities(document)
+
+  response.entities.each do |entity|
+    # Each detected entity has a map of metadata:
+    map = entity.metadata
+
+    # Access value by key:
+    puts "URL: #{map["wikipedia_url"]}"
+    # Loop over keys and values:
+    map.each do |key, value|
+      puts "#{key}: #{value}"
+    end
+
+    # Loop over just keys:
+    map.keys.each do |the_key|
+      puts "Key: #{the_key}"
+    end
+
+    # Loop over just values:
+    map.values.each do |the_value|
+      puts "Value: #{the_value}"
+    end
+
+  end
+  # [END samplegen_map_field_access]
+end
+
+# Code below processes command-line arguments to execute this code sample.
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+  sample_analyze_entities
+end

--- a/google-cloud-speech/samples/v1p1beta1/samplegen_lro.rb
+++ b/google-cloud-speech/samples/v1p1beta1/samplegen_lro.rb
@@ -1,0 +1,60 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "samplegen_lro")
+
+# sample-metadata
+#   title: Calling Long-Running API method
+#   description: Calling Long-Running API method
+#   bundle exec ruby samples/v1p1beta1/samplegen_lro.rb
+
+# Calling Long-Running API method
+def sample_long_running_recognize
+  # [START samplegen_lro]
+  # Import client library
+  require "google/cloud/speech"
+
+  # Instantiate a client
+  speech_client = Google::Cloud::Speech.new version: :v1p1beta1
+
+  encoding = :MP3
+
+  config = { encoding: encoding }
+
+  uri = "gs://[BUCKET]/[FILENAME]"
+
+  audio = { uri: uri }
+
+  # Make the long-running operation request
+  operation = speech_client.long_running_recognize(config, audio)
+
+  # Block until operation complete
+  operation.wait_until_done!
+
+  raise operation.results.message if operation.error?
+
+  response = operation.response
+
+  # Your audio has been transcribed.
+  puts "Transcript: #{response.results[0].alternatives[0].transcript}"
+  # [END samplegen_lro]
+end
+
+# Code below processes command-line arguments to execute this code sample.
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+  sample_long_running_recognize
+end

--- a/google-cloud-speech/samples/v1p1beta1/samplegen_lro.rb
+++ b/google-cloud-speech/samples/v1p1beta1/samplegen_lro.rb
@@ -46,6 +46,7 @@ def sample_long_running_recognize
 
   response = operation.response
 
+
   # Your audio has been transcribed.
   puts "Transcript: #{response.results[0].alternatives[0].transcript}"
   # [END samplegen_lro]

--- a/google-cloud-speech/samples/v1p1beta1/samplegen_read_and_write_files.rb
+++ b/google-cloud-speech/samples/v1p1beta1/samplegen_read_and_write_files.rb
@@ -1,0 +1,55 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_read_and_write_files")
+
+# sample-metadata
+#   title: Showing repeated fields (in request and response)
+#   description: Showing repeated fields (in request and response)
+#   bundle exec ruby samples/v1p1beta1/samplegen_read_and_write_files.rb
+
+# Showing repeated fields (in request and response)
+def sample_recognize
+  # [START samplegen_read_and_write_files]
+  # Import client library
+  require "google/cloud/speech"
+
+  # Instantiate a client
+  speech_client = Google::Cloud::Speech.new version: :v1p1beta1
+
+  encoding = :MP3
+
+  config = { encoding: encoding }
+
+  # The bytes from this file will be read into `content`
+  content = File.binread "path/to/file.mp3"
+
+  audio = { content: content }
+
+  response = speech_client.recognize(config, audio)
+
+  # Your audio has been transcribed.
+  # Writing audio transcript to transcript.txt for demonstration:
+  File.write "transcript.txt", response.results[0].alternatives[0].transcript
+
+  # [END samplegen_read_and_write_files]
+end
+
+# Code below processes command-line arguments to execute this code sample.
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+  sample_recognize
+end

--- a/google-cloud-speech/samples/v1p1beta1/samplegen_read_and_write_files.rb
+++ b/google-cloud-speech/samples/v1p1beta1/samplegen_read_and_write_files.rb
@@ -15,11 +15,11 @@
 # DO NOT EDIT! This is a generated sample ("Request",  "samplegen_read_and_write_files")
 
 # sample-metadata
-#   title: Showing repeated fields (in request and response)
-#   description: Showing repeated fields (in request and response)
+#   title: Read binary file into bytes field & write string in response to file
+#   description: Read binary file into bytes field & write string in response to file
 #   bundle exec ruby samples/v1p1beta1/samplegen_read_and_write_files.rb
 
-# Showing repeated fields (in request and response)
+# Read binary file into bytes field & write string in response to file
 def sample_recognize
   # [START samplegen_read_and_write_files]
   # Import client library
@@ -39,7 +39,9 @@ def sample_recognize
 
   response = speech_client.recognize(config, audio)
 
+
   # Your audio has been transcribed.
+
   # Writing audio transcript to transcript.txt for demonstration:
   File.write "transcript.txt", response.results[0].alternatives[0].transcript
 

--- a/google-cloud-speech/samples/v1p1beta1/samplegen_repeated_fields.rb
+++ b/google-cloud-speech/samples/v1p1beta1/samplegen_repeated_fields.rb
@@ -49,8 +49,10 @@ def sample_recognize
 
   response = speech_client.recognize(config, audio)
 
+
   # Loop over all transcription results
   response.results.each do |result|
+
     # The first "alternative" of each result contains most likely transcription
     alternative = result.alternatives[0]
     puts "Transcription of result: #{alternative.transcript}"

--- a/google-cloud-speech/samples/v1p1beta1/samplegen_repeated_fields.rb
+++ b/google-cloud-speech/samples/v1p1beta1/samplegen_repeated_fields.rb
@@ -1,0 +1,67 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_repeated_fields")
+
+# sample-metadata
+#   title: Showing repeated fields (in request and response)
+#   description: Showing repeated fields (in request and response)
+#   bundle exec ruby samples/v1p1beta1/samplegen_repeated_fields.rb
+
+# Showing repeated fields (in request and response)
+def sample_recognize
+  # [START samplegen_repeated_fields]
+  # Import client library
+  require "google/cloud/speech"
+
+  # Instantiate a client
+  speech_client = Google::Cloud::Speech.new version: :v1p1beta1
+
+  encoding = :MP3
+
+  # A list of strings containing words and phrases "hints"
+  phrases_element = "Fox in socks"
+
+  phrases_element_2 = "Knox in box"
+
+  phrases = [phrases_element, phrases_element_2]
+
+  speech_contexts_element = { phrases: phrases }
+
+  speech_contexts = [speech_contexts_element]
+
+  config = { encoding: encoding, speech_contexts: speech_contexts }
+
+  uri = "gs://[BUCKET]/[FILENAME]"
+
+  audio = { uri: uri }
+
+  response = speech_client.recognize(config, audio)
+
+  # Loop over all transcription results
+  response.results.each do |result|
+    # The first "alternative" of each result contains most likely transcription
+    alternative = result.alternatives[0]
+    puts "Transcription of result: #{alternative.transcript}"
+  end
+  # [END samplegen_repeated_fields]
+end
+
+# Code below processes command-line arguments to execute this code sample.
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+  sample_recognize
+end

--- a/google-cloud-text_to_speech/samples/v1/samplegen_write_bytes_to_file.rb
+++ b/google-cloud-text_to_speech/samples/v1/samplegen_write_bytes_to_file.rb
@@ -1,0 +1,59 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_write_bytes_to_file")
+
+# sample-metadata
+#   title: Synthesize an .mp3 file with audio saying the provided phrase
+#   description: Synthesize an .mp3 file with audio saying the provided phrase
+#   bundle exec ruby samples/v1/samplegen_write_bytes_to_file.rb
+
+# Synthesize an .mp3 file with audio saying the provided phrase
+def sample_synthesize_speech
+  # [START samplegen_write_bytes_to_file]
+  # Import client library
+  require "google/cloud/text_to_speech"
+
+  # Instantiate a client
+  text_to_speech_client = Google::Cloud::TextToSpeech.new version: :v1
+
+  text = "Hello, world!"
+
+  input = { text: text }
+
+  language_code = "en"
+
+  voice = { language_code: language_code }
+
+  audio_encoding = :MP3
+
+  audio_config = { audio_encoding: audio_encoding }
+
+  response = text_to_speech_client.synthesize_speech(input, voice, audio_config)
+
+  puts "Writing the synthsized results to output.mp3"
+  File.open("output.mp3", "wb") do |file|
+    file.write(response.audio_content)
+  end
+
+  # [END samplegen_write_bytes_to_file]
+end
+
+# Code below processes command-line arguments to execute this code sample.
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+  sample_synthesize_speech
+end

--- a/google-cloud-vision/samples/v1/samplegen_basics.rb
+++ b/google-cloud-vision/samples/v1/samplegen_basics.rb
@@ -1,0 +1,61 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_basics")
+
+# sample-metadata
+#   title: This is the sample title
+#   description: This is the sample description
+#   bundle exec ruby samples/v1/samplegen_basics.rb [--display_name "This is the default value of the display_name request field"]
+
+# This is the sample description
+def sample_create_product_set display_name = "This is the default value of the display_name request field"
+  # [START samplegen_basics]
+  # Import client library
+  require "google/cloud/vision"
+
+  # Instantiate a client
+  product_search_client = Google::Cloud::Vision::ProductSearch.new version: :v1
+
+  # TODO(developer): Uncomment these variables before running the sample.
+  # display_name = "This is the default value of the display_name request field"
+
+  # The project and location in which the product set should be created.
+  formatted_parent = product_search_client.class.location_path("[PROJECT]", "[LOCATION]")
+
+  product_set = { display_name: display_name }
+
+  response = product_search_client.create_product_set(formatted_parent, product_set)
+
+  # The API response represents the created product set
+  product_set = response
+  puts "The full name of the created product set: #{product_set.name}"
+  # [END samplegen_basics]
+end
+
+# Code below processes command-line arguments to execute this code sample.
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+
+  display_name = "This is the default value of the display_name request field"
+
+  ARGV.options do |opts|
+    opts.on("--display_name=val") { |val| display_name = val }
+    opts.parse!
+  end
+
+  sample_create_product_set(display_name)
+end

--- a/google-cloud-vision/samples/v1/samplegen_basics.rb
+++ b/google-cloud-vision/samples/v1/samplegen_basics.rb
@@ -38,6 +38,7 @@ def sample_create_product_set display_name = "This is the default value of the d
 
   response = product_search_client.create_product_set(formatted_parent, product_set)
 
+
   # The API response represents the created product set
   product_set = response
   puts "The full name of the created product set: #{product_set.name}"

--- a/google-cloud-vision/samples/v1/samplegen_no_config.rb
+++ b/google-cloud-vision/samples/v1/samplegen_no_config.rb
@@ -1,0 +1,44 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_no_config")
+
+# sample-metadata
+#   title:
+#   bundle exec ruby samples/v1/samplegen_no_config.rb
+
+#
+def sample_create_product_set
+  # Import client library
+  require "google/cloud/vision"
+
+  # Instantiate a client
+  product_search_client = Google::Cloud::Vision::ProductSearch.new version: :v1
+
+  formatted_parent = product_search_client.class.location_path("[PROJECT]", "[LOCATION]")
+
+  product_set = {}
+
+  response = product_search_client.create_product_set(formatted_parent, product_set)
+
+  puts response.inspect
+end
+
+# Code below processes command-line arguments to execute this code sample.
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+  sample_create_product_set
+end

--- a/google-cloud-vision/samples/v1/samplegen_no_response.rb
+++ b/google-cloud-vision/samples/v1/samplegen_no_response.rb
@@ -32,7 +32,7 @@ def sample_delete_product_set
   formatted_name = product_search_client.class.product_set_path("[PROJECT]", "[LOCATION]", "[PRODUCT_SET]")
 
   product_search_client.delete_product_set(formatted_name)
-  # Deleted product set.
+  puts "Deleted product set."
   # [END samplegen_no_response]
 end
 

--- a/google-cloud-vision/samples/v1/samplegen_no_response.rb
+++ b/google-cloud-vision/samples/v1/samplegen_no_response.rb
@@ -1,0 +1,45 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_no_response")
+
+# sample-metadata
+#   title: Delete Product Set (returns Empty)
+#   description: Delete Product Set (returns Empty)
+#   bundle exec ruby samples/v1/samplegen_no_response.rb
+
+# Delete Product Set (returns Empty)
+def sample_delete_product_set
+  # [START samplegen_no_response]
+  # Import client library
+  require "google/cloud/vision"
+
+  # Instantiate a client
+  product_search_client = Google::Cloud::Vision::ProductSearch.new version: :v1
+
+  # The full name of the product set to delete
+  formatted_name = product_search_client.class.product_set_path("[PROJECT]", "[LOCATION]", "[PRODUCT_SET]")
+
+  product_search_client.delete_product_set(formatted_name)
+  # Deleted product set.
+  # [END samplegen_no_response]
+end
+
+# Code below processes command-line arguments to execute this code sample.
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+  sample_delete_product_set
+end

--- a/google-cloud-vision/samples/v1/samplegen_paged.rb
+++ b/google-cloud-vision/samples/v1/samplegen_paged.rb
@@ -33,6 +33,7 @@ def sample_list_product_sets
 
   # Iterate over all results.
   product_search_client.list_product_sets(formatted_parent).each do |element|
+
     # The entity in this iteration represents a product set
     product_set = element
     puts "The full name of this product set: #{product_set.name}"

--- a/google-cloud-vision/samples/v1/samplegen_paged.rb
+++ b/google-cloud-vision/samples/v1/samplegen_paged.rb
@@ -1,0 +1,49 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("RequestPagedAll",  "samplegen_paged")
+
+# sample-metadata
+#   title: List product sets
+#   description: List product sets
+#   bundle exec ruby samples/v1/samplegen_paged.rb
+
+# List product sets
+def sample_list_product_sets
+  # [START samplegen_paged]
+  # Import client library
+  require "google/cloud/vision"
+
+  # Instantiate a client
+  product_search_client = Google::Cloud::Vision::ProductSearch.new version: :v1
+
+  # The project and location where the product sets are contained.
+  formatted_parent = product_search_client.class.location_path("[PROJECT]", "[LOCATION]")
+
+  # Iterate over all results.
+  product_search_client.list_product_sets(formatted_parent).each do |element|
+    # The entity in this iteration represents a product set
+    product_set = element
+    puts "The full name of this product set: #{product_set.name}"
+  end
+  # [END samplegen_paged]
+end
+
+# Code below processes command-line arguments to execute this code sample.
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+  sample_list_product_sets
+end

--- a/google-cloud-vision/samples/v1/samplegen_resource_path.rb
+++ b/google-cloud-vision/samples/v1/samplegen_resource_path.rb
@@ -1,0 +1,62 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_resource_path")
+
+# sample-metadata
+#   title: Create product set (demonstrate resource paths)
+#   description: Create product set (demonstrate resource paths)
+#   bundle exec ruby samples/v1/samplegen_resource_path.rb [--project "[PROJECT ID]"]
+
+# Create product set (demonstrate resource paths)
+def sample_create_product_set project = "[PROJECT ID]"
+  # [START samplegen_resource_path]
+  # Import client library
+  require "google/cloud/vision"
+
+  # Instantiate a client
+  product_search_client = Google::Cloud::Vision::ProductSearch.new version: :v1
+
+  # TODO(developer): Uncomment these variables before running the sample.
+  # project = "[PROJECT ID]"
+
+  formatted_parent = product_search_client.class.location_path(project, "us-central1")
+
+  display_name = "[DISPLAY NAME]"
+
+  product_set = { display_name: display_name }
+
+  response = product_search_client.create_product_set(formatted_parent, product_set)
+
+  # The API response represents the created product set
+  product_set = response
+  puts "The full name of the created product set: #{product_set.name}"
+  # [END samplegen_resource_path]
+end
+
+# Code below processes command-line arguments to execute this code sample.
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+
+  project = "[PROJECT ID]"
+
+  ARGV.options do |opts|
+    opts.on("--project=val") { |val| project = val }
+    opts.parse!
+  end
+
+  sample_create_product_set(project)
+end

--- a/google-cloud-vision/samples/v1/samplegen_resource_path.rb
+++ b/google-cloud-vision/samples/v1/samplegen_resource_path.rb
@@ -39,6 +39,7 @@ def sample_create_product_set project = "[PROJECT ID]"
 
   response = product_search_client.create_product_set(formatted_parent, product_set)
 
+
   # The API response represents the created product set
   product_set = response
   puts "The full name of the created product set: #{product_set.name}"


### PR DESCRIPTION
> _Follow-up code review PR –_

To **evaluate the readiness** of 💎 **Ruby's GAPIC sample generator** for use on [cloud.google.com](https://cloud.google.com),  
this provides a full _**set of samples**_ which _**demonstrate the basic features**_ of generated samples.

> _The .yaml sample config files for these samples can all be found here: [.yaml sample configs](https://github.com/beccasaurus/googleapis/compare/samples-for-syntax-review)_

The [first review Pull Request](https://github.com/googleapis/google-cloud-ruby/pull/4264) contained samples to show the _basic structure_ as well as _LRO samples_.

> ℹ️ These samples are generated using [this open Ruby PR](https://github.com/googleapis/gapic-generator/pull/3041) of the GAPIC generator with various changes from the previous review (_will wait to merge that PR until this re-review is complete_)

This contains samples demonstrating those features and a few more use-cases for review –

| **Sample** | **Description** |
|------------|-----------------|
| [`samplegen_basics.rb`](https://github.com/googleapis/google-cloud-ruby/pull/4507/files#diff-811598a60c34b3da8b84367f1e09e12b) | Shows basic structure/anatomy of Ruby samples |
| [`samplegen_no_config.rb`](https://github.com/googleapis/google-cloud-ruby/pull/4507/files#diff-dce5e0b748f62f97e42df9716ea80070) | Minimal sample example (zero configuration) |
| [`samplegen_no_response.rb`](https://github.com/googleapis/google-cloud-ruby/pull/4507/files#diff-8a6345c80ea9b629f18e7cf1644a71ce) | API method which returns Empty |
| [`samplegen_paged.rb`](https://github.com/googleapis/google-cloud-ruby/pull/4507/files#diff-9a08b838b114bc13bb083839d175563a) | Paged API method (iterates over pages of results) |
| [`samplegen_resource_path.rb`](https://github.com/googleapis/google-cloud-ruby/pull/4507/files#diff-319e2bcfc610bdf187712faa5168c250) | Sample which requires user's Google Project ID |
| [`samplegen_map_field_access.rb`](https://github.com/googleapis/google-cloud-ruby/pull/4507/files#diff-4be574f91c99a67b158a381482664288) | Access map value by key and enumerate keys/values |
| [`samplegen_read_and_write_files.rb`](https://github.com/googleapis/google-cloud-ruby/pull/4507/files#diff-836f1dcac8137d96aacee49eda724d11) | Read binary file into bytes & write string to local file |
| [`samplegen_repeated_fields.rb`](https://github.com/googleapis/google-cloud-ruby/pull/4507/files#diff-4439acadb0a826f8fc257cd12731a35b) | Repeated request field & show loop/access by index |
| [`samplegen_write_bytes_to_file.rb`](https://github.com/googleapis/google-cloud-ruby/pull/4507/files#diff-0a250d8676bf521805458f6b7d3a0a7a) | Write bytes field in response to local file |
| [`samplegen_lro.rb`](https://github.com/googleapis/google-cloud-ruby/pull/4507/files#diff-ae5e8052821ca4ab362413e4f605e56f) | Call long-running operation API endpoint |

This Pull Request is focused on **feedback collection** & a similar PR is being sent to all languages.

Once you've completed your **review** and left **comments**, you may feel free to **close the PR!**

> _We will scope out making all of the requested changes and reach out to language team offline._

#### 🙏 Thanks in advance for your review!

----

P.S. **Nits welcome!** _We'd like to get these as polished as possible for usage on [cloud.google.com](https://cloud.google.com)._

> Please feel free to note in comments whether something is:  🛑 Blocker -vs- 📌 Nit

-----

#### 🔍 Known Issues

 1. Preference to use default parameter values instead of commented out variables (**UPDATED**)

> 📑 ([internal](http://go/samplegen-syntax))