### PR TITLE
feat(dns): Support dnsName parameter when listing managed zones

### DIFF
--- a/google-cloud-dns/lib/google/cloud/dns/project.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/project.rb
@@ -155,6 +155,8 @@ module Google
         # @param [String] token A previously-returned page token representing
         #   part of the larger set of results to view.
         # @param [Integer] max Maximum number of zones to return.
+        # @param [String] dns_name Restricts the list to return only zones
+        #   with this domain name.
         #
         # @return [Array<Google::Cloud::Dns::Zone>] (See
         # {Google::Cloud::Dns::Zone::List})
@@ -177,10 +179,10 @@ module Google
         #     puts zone.name
         #   end
         #
-        def zones token: nil, max: nil
+        def zones token: nil, max: nil, dns_name: nil
           ensure_service!
-          gapi = service.list_zones token: token, max: max
-          Zone::List.from_gapi gapi, service, max
+          gapi = service.list_zones token: token, max: max, dns_name: dns_name
+          Zone::List.from_gapi gapi, service, max, dns_name
         end
         alias find_zones zones
 

--- a/google-cloud-dns/lib/google/cloud/dns/service.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/service.rb
@@ -72,10 +72,11 @@ module Google
 
         ##
         # Returns Google::Apis::DnsV1::ListManagedZonesResponse
-        def list_zones token: nil, max: nil
+        def list_zones token: nil, max: nil, dns_name: nil
           execute do
             service.list_managed_zones @project, max_results: max,
-                                                 page_token: token
+                                                 page_token: token,
+                                                 dns_name: dns_name
           end
         end
 

--- a/google-cloud-dns/lib/google/cloud/dns/zone/list.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/zone/list.rb
@@ -70,8 +70,8 @@ module Google
           def next
             return nil unless next?
             ensure_service!
-            gapi = @service.list_zones token: token, max: @max
-            Zone::List.from_gapi gapi, @service, @max
+            gapi = @service.list_zones token: token, max: @max, dns_name: @dns_name
+            Zone::List.from_gapi gapi, @service, @max, @dns_name
           end
 
           ##
@@ -141,13 +141,14 @@ module Google
 
           ##
           # @private New Zones::List from a ListManagedZonesResponse object.
-          def self.from_gapi gapi, conn, max = nil
+          def self.from_gapi gapi, conn, max = nil, dns_name = nil
             zones = new(Array(gapi.managed_zones).map do |g|
               Zone.from_gapi g, conn
             end)
-            zones.instance_variable_set :@token,   gapi.next_page_token
-            zones.instance_variable_set :@service, conn
-            zones.instance_variable_set :@max,     max
+            zones.instance_variable_set :@token,    gapi.next_page_token
+            zones.instance_variable_set :@service,  conn
+            zones.instance_variable_set :@max,      max
+            zones.instance_variable_set :@dns_name, dns_name
             zones
           end
 

--- a/google-cloud-dns/support/doctest_helper.rb
+++ b/google-cloud-dns/support/doctest_helper.rb
@@ -109,13 +109,13 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Dns::Project#zones" do
     mock_dns do |mock|
-      mock.expect :list_managed_zones, list_zones_gapi, ["my-project", {:max_results=>nil, :page_token=>nil}]
+      mock.expect :list_managed_zones, list_zones_gapi, ["my-project", {:max_results=>nil, :page_token=>nil, :dns_name=>nil}]
     end
   end
 
   doctest.before "Google::Cloud::Dns::Project#find_zones" do
     mock_dns do |mock|
-      mock.expect :list_managed_zones, list_zones_gapi, ["my-project", {:max_results=>nil, :page_token=>nil}]
+      mock.expect :list_managed_zones, list_zones_gapi, ["my-project", {:max_results=>nil, :page_token=>nil, :dns_name=>nil}]
     end
   end
 
@@ -341,13 +341,13 @@ YARD::Doctest.configure do |doctest|
   # Doctest also matches `#next?`
   doctest.before "Google::Cloud::Dns::Zone::List#next" do
     mock_dns do |mock|
-      mock.expect :list_managed_zones, list_zones_gapi, ["my-project", {:max_results=>nil, :page_token=>nil}]
+      mock.expect :list_managed_zones, list_zones_gapi, ["my-project", {:max_results=>nil, :page_token=>nil, :dns_name=>nil}]
     end
   end
 
   doctest.before "Google::Cloud::Dns::Zone::List#all" do
     mock_dns do |mock|
-      mock.expect :list_managed_zones, list_zones_gapi, ["my-project", {:max_results=>nil, :page_token=>nil}]
+      mock.expect :list_managed_zones, list_zones_gapi, ["my-project", {:max_results=>nil, :page_token=>nil, :dns_name=>nil}]
     end
   end
 


### PR DESCRIPTION
For certain purposes, such as auditing, it's nice to search for all managed zones for a given domain name. This change adds support for this operation via an option to the existing `Google::Cloud::Dns::Project.zones` method