### PR TITLE
Release google-cloud 0.64.0

### DIFF
--- a/google-cloud/CHANGELOG.md
+++ b/google-cloud/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.64.0 / 2019-12-19
+
+* Bigtable 1.0.0 release
+
 ### 0.63.0 / 2019-11-06
 
 #### Documentation

--- a/google-cloud/lib/google/cloud/version.rb
+++ b/google-cloud/lib/google/cloud/version.rb
@@ -15,6 +15,6 @@
 
 module Google
   module Cloud
-    VERSION = "0.63.0".freeze
+    VERSION = "0.64.0".freeze
   end
 end


### PR DESCRIPTION
* Bigtable 1.0.0 release

<details><summary>Commits since previous release</summary><pre><code>commit f161cdec4b84701b0865c80e34ad79b8d9bbd098
Author: Chris Smith <quartzmo@gmail.com>
Date:   Tue Dec 3 15:49:42 2019 -0700

    Release google-cloud-bigtable 1.0.0 (#4473)
    
    #### Documentation
    
    * Update release level to GA
    * Add OVERVIEW.md guide with samples
    * Add sample to README.md
    * Fix samples and copy edit all in-line documentation
    * Correct error in lower-level API Table IAM documentation
    * Update lower-level API documentation to indicate attributes as required
    * Update low-level IAM Policy documentation
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud/google-cloud.gemspec b/google-cloud/google-cloud.gemspec
index 062c06158..a3c007cee 100644
--- a/google-cloud/google-cloud.gemspec
+++ b/google-cloud/google-cloud.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-asset", "~> 0.1"
   gem.add_dependency "google-cloud-bigquery", "~> 1.1"
   gem.add_dependency "google-cloud-bigquery-data_transfer", "~> 0.1"
-  gem.add_dependency "google-cloud-bigtable", "~> 0.1"
+  gem.add_dependency "google-cloud-bigtable", "~> 1.0"
   gem.add_dependency "google-cloud-container", "~> 0.1"
   gem.add_dependency "google-cloud-dataproc", "~> 0.1"
   gem.add_dependency "google-cloud-datastore", "~> 1.4"

```

</details>

This pull request was generated using releasetool.