### PR TITLE
Release google-cloud-bigquery-data_transfer 0.5.0

### DIFF
--- a/google-cloud-bigquery-data_transfer/CHANGELOG.md
+++ b/google-cloud-bigquery-data_transfer/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+### 0.5.0 / 2019-12-19
+
+#### Features
+
+* Update TransferConfig attributes
+  * Add TransferConfig#notification_pubsub_topic
+  * Add TransferConfig#email_preferences (EmailPreferences)
+  * Add TransferRun#notification_pubsub_topic
+  * Add TransferRun#email_preferences (EmailPreferences)
+  * Add CreateTransferConfigRequest#service_account_name
+  * Add UpdateTransferConfigRequest#service_account_name
+
 ### 0.4.1 / 2019-11-06
 
 #### Bug Fixes

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/version.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/version.rb
@@ -17,7 +17,7 @@ module Google
   module Cloud
     module Bigquery
       module DataTransfer
-        VERSION = "0.4.1".freeze
+        VERSION = "0.5.0".freeze
       end
     end
   end


### PR DESCRIPTION
#### Features

* Update TransferConfig attributes
  * Add TransferConfig#notification_pubsub_topic
  * Add TransferConfig#email_preferences (EmailPreferences)
  * Add TransferRun#notification_pubsub_topic
  * Add TransferRun#email_preferences (EmailPreferences)
  * Add CreateTransferConfigRequest#service_account_name
  * Add UpdateTransferConfigRequest#service_account_name

<details><summary>Commits since previous release</summary><pre><code>commit a47fa3aece9e75ab53e66ff62c6bb7aa9e458d19
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Thu Dec 19 08:44:28 2019 -0800

    feat(bigquery-data_transfer): Update TransferConfig attributes
    
    * Add TransferConfig#notification_pubsub_topic
    * Add TransferConfig#email_preferences (EmailPreferences)
    * Add TransferRun#notification_pubsub_topic
    * Add TransferRun#email_preferences (EmailPreferences)
    * Add CreateTransferConfigRequest#service_account_name
    * Add UpdateTransferConfigRequest#service_account_name
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb
index 68698b5df..e70034bad 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb
@@ -458,7 +458,8 @@ module Google
             #
             # @param name [String]
             #   Required. The field will contain name of the resource requested, for example:
-            #   `projects/{project_id}/dataSources/{data_source_id}`
+            #   `projects/{project_id}/dataSources/{data_source_id}` or
+            #   `projects/{project_id}/locations/{location_id}/dataSources/{data_source_id}`
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -490,7 +491,8 @@ module Google
             #
             # @param parent [String]
             #   Required. The BigQuery project id for which data sources should be returned.
-            #   Must be in the form: `projects/{project_id}`
+            #   Must be in the form: `projects/{project_id}` or
+            #   `projects/{project_id}/locations/{location_id}
             # @param page_size [Integer]
             #   The maximum number of resources contained in the underlying API
             #   response. If page streaming is performed per-resource, this
@@ -545,9 +547,9 @@ module Google
             #
             # @param parent [String]
             #   Required. The BigQuery project id where the transfer configuration should be created.
-            #   Must be in the format projects/\\{project_id}/locations/\\{location_id}
-            #   If specified location and location of the destination bigquery dataset
-            #   do not match - the request will fail.
+            #   Must be in the format projects/\\{project_id}/locations/\\{location_id} or
+            #   projects/\\{project_id}. If specified location and location of the
+            #   destination bigquery dataset do not match - the request will fail.
             # @param transfer_config [Google::Cloud::Bigquery::Datatransfer::V1::TransferConfig | Hash]
             #   Required. Data transfer configuration to create.
             #   A hash of the same form as `Google::Cloud::Bigquery::Datatransfer::V1::TransferConfig`
@@ -576,6 +578,11 @@ module Google
             #   must use the "none+gsession" response type. which be return a
             #   version_info back in the authorization response which be be put in a JWT
             #   claim in the token request.
+            # @param service_account_name [String]
+            #   Optional service account name. If this field is set, transfer config will
+            #   be created with this service account credentials. It requires that
+            #   requesting user calling this API has permissions to act as this service
+            #   account.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -599,13 +606,15 @@ module Google
                 transfer_config,
                 authorization_code: nil,
                 version_info: nil,
+                service_account_name: nil,
                 options: nil,
                 &block
               req = {
                 parent: parent,
                 transfer_config: transfer_config,
                 authorization_code: authorization_code,
-                version_info: version_info
+                version_info: version_info,
+                service_account_name: service_account_name
               }.delete_if { |_, v| v.nil? }
               req = Google::Gax::to_proto(req, Google::Cloud::Bigquery::Datatransfer::V1::CreateTransferConfigRequest)
               @create_transfer_config.call(req, options, &block)
@@ -646,6 +655,12 @@ module Google
             #   must use the "none+gsession" response type. which be return a
             #   version_info back in the authorization response which be be put in a JWT
             #   claim in the token request.
+            # @param service_account_name [String]
+            #   Optional service account name. If this field is set and
+            #   "service_account_name" is set in update_mask, transfer config will be
+            #   updated to use this service account credentials. It requires that
+            #   requesting user calling this API has permissions to act as this service
+            #   account.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -671,13 +686,15 @@ module Google
                 update_mask,
                 authorization_code: nil,
                 version_info: nil,
+                service_account_name: nil,
                 options: nil,
                 &block
               req = {
                 transfer_config: transfer_config,
                 update_mask: update_mask,
                 authorization_code: authorization_code,
-                version_info: version_info
+                version_info: version_info,
+                service_account_name: service_account_name
               }.delete_if { |_, v| v.nil? }
               req = Google::Gax::to_proto(req, Google::Cloud::Bigquery::Datatransfer::V1::UpdateTransferConfigRequest)
               @update_transfer_config.call(req, options, &block)
@@ -688,7 +705,8 @@ module Google
             #
             # @param name [String]
             #   Required. The field will contain name of the resource requested, for example:
-            #   `projects/{project_id}/transferConfigs/{config_id}`
+            #   `projects/{project_id}/transferConfigs/{config_id}` or
+            #   `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}`
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -719,7 +737,8 @@ module Google
             #
             # @param name [String]
             #   Required. The field will contain name of the resource requested, for example:
-            #   `projects/{project_id}/transferConfigs/{config_id}`
+            #   `projects/{project_id}/transferConfigs/{config_id}` or
+            #   `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}`
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -750,7 +769,8 @@ module Google
             #
             # @param parent [String]
             #   Required. The BigQuery project id for which data sources
-            #   should be returned: `projects/{project_id}`.
+            #   should be returned: `projects/{project_id}` or
+            #   `projects/{project_id}/locations/{location_id}`
             # @param data_source_ids [Array<String>]
             #   When specified, only configurations of requested data sources are returned.
             # @param page_size [Integer]
@@ -813,7 +833,8 @@ module Google
             #
             # @param parent [String]
             #   Required. Transfer configuration name in the form:
-            #   `projects/{project_id}/transferConfigs/{config_id}`.
+            #   `projects/{project_id}/transferConfigs/{config_id}` or
+            #   `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}`.
             # @param start_time [Google::Protobuf::Timestamp | Hash]
             #   Required. Start time of the range of transfer runs. For example,
             #   `"2017-05-25T00:00:00+00:00"`.
@@ -864,7 +885,8 @@ module Google
             #
             # @param name [String]
             #   Required. The field will contain name of the resource requested, for example:
-            #   `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}`
+            #   `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}` or
+            #   `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}/runs/{run_id}`
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -895,7 +917,8 @@ module Google
             #
             # @param name [String]
             #   Required. The field will contain name of the resource requested, for example:
-            #   `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}`
+            #   `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}` or
+            #   `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}/runs/{run_id}`
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -927,7 +950,8 @@ module Google
             # @param parent [String]
             #   Required. Name of transfer configuration for which transfer runs should be retrieved.
             #   Format of transfer configuration resource name is:
-            #   `projects/{project_id}/transferConfigs/{config_id}`.
+            #   `projects/{project_id}/transferConfigs/{config_id}` or
+            #   `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}`.
             # @param states [Array<Google::Cloud::Bigquery::Datatransfer::V1::TransferState>]
             #   When specified, only transfer runs with requested states are returned.
             # @param page_size [Integer]
@@ -990,7 +1014,8 @@ module Google
             #
             # @param parent [String]
             #   Required. Transfer run name in the form:
-            #   `projects/{project_id}/transferConfigs/{config_Id}/runs/{run_id}`.
+            #   `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}` or
+            #   `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}/runs/{run_id}`
             # @param page_size [Integer]
             #   The maximum number of resources contained in the underlying API
             #   response. If page streaming is performed per-resource, this
@@ -1055,7 +1080,8 @@ module Google
             #
             # @param name [String]
             #   Required. The data source in the form:
-            #   `projects/{project_id}/dataSources/{data_source_id}`
+            #   `projects/{project_id}/dataSources/{data_source_id}` or
+            #   `projects/{project_id}/locations/{location_id}/dataSources/{data_source_id}`.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -1089,7 +1115,8 @@ module Google
             #
             # @param parent [String]
             #   Transfer configuration name in the form:
-            #   `projects/{project_id}/transferConfigs/{config_id}`.
+            #   `projects/{project_id}/transferConfigs/{config_id}` or
+            #   `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}`.
             # @param requested_time_range [Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsRequest::TimeRange | Hash]
             #   Time range for the transfer runs that should be started.
             #   A hash of the same form as `Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsRequest::TimeRange`
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb
index 583079e6d..fe6f1ea27 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb
@@ -207,14 +207,16 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     Required. The field will contain name of the resource requested, for example:
-          #     `projects/{project_id}/dataSources/{data_source_id}`
+          #     `projects/{project_id}/dataSources/{data_source_id}` or
+          #     `projects/{project_id}/locations/{location_id}/dataSources/{data_source_id}`
           class GetDataSourceRequest; end
 
           # Request to list supported data sources and their data transfer settings.
           # @!attribute [rw] parent
           #   @return [String]
           #     Required. The BigQuery project id for which data sources should be returned.
-          #     Must be in the form: `projects/{project_id}`
+          #     Must be in the form: `projects/{project_id}` or
+          #     `projects/{project_id}/locations/{location_id}
           # @!attribute [rw] page_token
           #   @return [String]
           #     Pagination token, which can be used to request a specific page
@@ -248,9 +250,9 @@ module Google
           # @!attribute [rw] parent
           #   @return [String]
           #     Required. The BigQuery project id where the transfer configuration should be created.
-          #     Must be in the format projects/\\{project_id}/locations/\\{location_id}
-          #     If specified location and location of the destination bigquery dataset
-          #     do not match - the request will fail.
+          #     Must be in the format projects/\\{project_id}/locations/\\{location_id} or
+          #     projects/\\{project_id}. If specified location and location of the
+          #     destination bigquery dataset do not match - the request will fail.
           # @!attribute [rw] transfer_config
           #   @return [Google::Cloud::Bigquery::Datatransfer::V1::TransferConfig]
           #     Required. Data transfer configuration to create.
@@ -280,6 +282,12 @@ module Google
           #     must use the "none+gsession" response type. which be return a
           #     version_info back in the authorization response which be be put in a JWT
           #     claim in the token request.
+          # @!attribute [rw] service_account_name
+          #   @return [String]
+          #     Optional service account name. If this field is set, transfer config will
+          #     be created with this service account credentials. It requires that
+          #     requesting user calling this API has permissions to act as this service
+          #     account.
           class CreateTransferConfigRequest; end
 
           # A request to update a transfer configuration. To update the user id of the
@@ -316,13 +324,21 @@ module Google
           #     must use the "none+gsession" response type. which be return a
           #     version_info back in the authorization response which be be put in a JWT
           #     claim in the token request.
+          # @!attribute [rw] service_account_name
+          #   @return [String]
+          #     Optional service account name. If this field is set and
+          #     "service_account_name" is set in update_mask, transfer config will be
+          #     updated to use this service account credentials. It requires that
+          #     requesting user calling this API has permissions to act as this service
+          #     account.
           class UpdateTransferConfigRequest; end
 
           # A request to get data transfer information.
           # @!attribute [rw] name
           #   @return [String]
           #     Required. The field will contain name of the resource requested, for example:
-          #     `projects/{project_id}/transferConfigs/{config_id}`
+          #     `projects/{project_id}/transferConfigs/{config_id}` or
+          #     `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}`
           class GetTransferConfigRequest; end
 
           # A request to delete data transfer information. All associated transfer runs
@@ -330,28 +346,32 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     Required. The field will contain name of the resource requested, for example:
-          #     `projects/{project_id}/transferConfigs/{config_id}`
+          #     `projects/{project_id}/transferConfigs/{config_id}` or
+          #     `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}`
           class DeleteTransferConfigRequest; end
 
           # A request to get data transfer run information.
           # @!attribute [rw] name
           #   @return [String]
           #     Required. The field will contain name of the resource requested, for example:
-          #     `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}`
+          #     `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}` or
+          #     `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}/runs/{run_id}`
           class GetTransferRunRequest; end
 
           # A request to delete data transfer run information.
           # @!attribute [rw] name
           #   @return [String]
           #     Required. The field will contain name of the resource requested, for example:
-          #     `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}`
+          #     `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}` or
+          #     `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}/runs/{run_id}`
           class DeleteTransferRunRequest; end
 
           # A request to list data transfers configured for a BigQuery project.
           # @!attribute [rw] parent
           #   @return [String]
           #     Required. The BigQuery project id for which data sources
-          #     should be returned: `projects/{project_id}`.
+          #     should be returned: `projects/{project_id}` or
+          #     `projects/{project_id}/locations/{location_id}`
           # @!attribute [rw] data_source_ids
           #   @return [Array<String>]
           #     When specified, only configurations of requested data sources are returned.
@@ -386,7 +406,8 @@ module Google
           #   @return [String]
           #     Required. Name of transfer configuration for which transfer runs should be retrieved.
           #     Format of transfer configuration resource name is:
-          #     `projects/{project_id}/transferConfigs/{config_id}`.
+          #     `projects/{project_id}/transferConfigs/{config_id}` or
+          #     `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}`.
           # @!attribute [rw] states
           #   @return [Array<Google::Cloud::Bigquery::Datatransfer::V1::TransferState>]
           #     When specified, only transfer runs with requested states are returned.
@@ -430,7 +451,8 @@ module Google
           # @!attribute [rw] parent
           #   @return [String]
           #     Required. Transfer run name in the form:
-          #     `projects/{project_id}/transferConfigs/{config_Id}/runs/{run_id}`.
+          #     `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}` or
+          #     `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}/runs/{run_id}`
           # @!attribute [rw] page_token
           #   @return [String]
           #     Pagination token, which can be used to request a specific page
@@ -468,7 +490,8 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     Required. The data source in the form:
-          #     `projects/{project_id}/dataSources/{data_source_id}`
+          #     `projects/{project_id}/dataSources/{data_source_id}` or
+          #     `projects/{project_id}/locations/{location_id}/dataSources/{data_source_id}`.
           class CheckValidCredsRequest; end
 
           # A response indicating whether the credentials exist and are valid.
@@ -481,7 +504,8 @@ module Google
           # @!attribute [rw] parent
           #   @return [String]
           #     Required. Transfer configuration name in the form:
-          #     `projects/{project_id}/transferConfigs/{config_id}`.
+          #     `projects/{project_id}/transferConfigs/{config_id}` or
+          #     `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}`.
           # @!attribute [rw] start_time
           #   @return [Google::Protobuf::Timestamp]
           #     Required. Start time of the range of transfer runs. For example,
@@ -502,7 +526,8 @@ module Google
           # @!attribute [rw] parent
           #   @return [String]
           #     Transfer configuration name in the form:
-          #     `projects/{project_id}/transferConfigs/{config_id}`.
+          #     `projects/{project_id}/transferConfigs/{config_id}` or
+          #     `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}`.
           # @!attribute [rw] requested_time_range
           #   @return [Google::Cloud::Bigquery::Datatransfer::V1::StartManualTransferRunsRequest::TimeRange]
           #     Time range for the transfer runs that should be started.
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb
index 8440232f9..1d054688f 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb
@@ -18,6 +18,13 @@ module Google
     module Bigquery
       module Datatransfer
         module V1
+          # Represents preferences for sending email notifications for transfer run
+          # events.
+          # @!attribute [rw] enable_failure_email
+          #   @return [true, false]
+          #     If true, email notifications will be sent on transfer run failures.
+          class EmailPreferences; end
+
           # Options customizing the data transfer schedule.
           # @!attribute [rw] disable_auto_scheduling
           #   @return [true, false]
@@ -111,6 +118,14 @@ module Google
           # @!attribute [rw] dataset_region
           #   @return [String]
           #     Output only. Region in which BigQuery dataset is located.
+          # @!attribute [rw] notification_pubsub_topic
+          #   @return [String]
+          #     Pub/Sub topic where notifications will be sent after transfer runs
+          #     associated with this transfer config finish.
+          # @!attribute [rw] email_preferences
+          #   @return [Google::Cloud::Bigquery::Datatransfer::V1::EmailPreferences]
+          #     Email notifications will be sent according to these preferences
+          #     to the email address of the user who owns this transfer config.
           class TransferConfig; end
 
           # Represents a data transfer run.
@@ -163,6 +178,15 @@ module Google
           #     scheduled manually, this is empty.
           #     NOTE: the system might choose to delay the schedule depending on the
           #     current load, so `schedule_time` doesn't always match this.
+          # @!attribute [rw] notification_pubsub_topic
+          #   @return [String]
+          #     Output only. Pub/Sub topic where a notification will be sent after this
+          #     transfer run finishes
+          # @!attribute [rw] email_preferences
+          #   @return [Google::Cloud::Bigquery::Datatransfer::V1::EmailPreferences]
+          #     Output only. Email notifications will be sent according to these
+          #     preferences to the email address of the user who owns the transfer config
+          #     this run was derived from.
           class TransferRun; end
 
           # Represents a user facing message for a particular data transfer run.
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_pb.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_pb.rb
index 2626994a3..edab53455 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_pb.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/datatransfer_pb.rb
@@ -89,12 +89,14 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :transfer_config, :message, 2, "google.cloud.bigquery.datatransfer.v1.TransferConfig"
     optional :authorization_code, :string, 3
     optional :version_info, :string, 5
+    optional :service_account_name, :string, 6
   end
   add_message "google.cloud.bigquery.datatransfer.v1.UpdateTransferConfigRequest" do
     optional :transfer_config, :message, 1, "google.cloud.bigquery.datatransfer.v1.TransferConfig"
     optional :authorization_code, :string, 3
     optional :update_mask, :message, 4, "google.protobuf.FieldMask"
     optional :version_info, :string, 5
+    optional :service_account_name, :string, 6
   end
   add_message "google.cloud.bigquery.datatransfer.v1.GetTransferConfigRequest" do
     optional :name, :string, 1
diff --git a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/transfer_pb.rb b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/transfer_pb.rb
index 608f644b2..3be27f233 100644
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/transfer_pb.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/datatransfer/v1/transfer_pb.rb
@@ -10,6 +10,9 @@ require 'google/protobuf/struct_pb'
 require 'google/protobuf/timestamp_pb'
 require 'google/rpc/status_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
+  add_message "google.cloud.bigquery.datatransfer.v1.EmailPreferences" do
+    optional :enable_failure_email, :bool, 1
+  end
   add_message "google.cloud.bigquery.datatransfer.v1.ScheduleOptions" do
     optional :disable_auto_scheduling, :bool, 3
     optional :start_time, :message, 1, "google.protobuf.Timestamp"
@@ -29,6 +32,8 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :state, :enum, 10, "google.cloud.bigquery.datatransfer.v1.TransferState"
     optional :user_id, :int64, 11
     optional :dataset_region, :string, 14
+    optional :notification_pubsub_topic, :string, 15
+    optional :email_preferences, :message, 18, "google.cloud.bigquery.datatransfer.v1.EmailPreferences"
     oneof :destination do
       optional :destination_dataset_id, :string, 2
     end
@@ -46,6 +51,8 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :state, :enum, 8, "google.cloud.bigquery.datatransfer.v1.TransferState"
     optional :user_id, :int64, 11
     optional :schedule, :string, 12
+    optional :notification_pubsub_topic, :string, 23
+    optional :email_preferences, :message, 25, "google.cloud.bigquery.datatransfer.v1.EmailPreferences"
     oneof :destination do
       optional :destination_dataset_id, :string, 2
     end
@@ -81,6 +88,7 @@ module Google
     module Bigquery
       module Datatransfer
         module V1
+          EmailPreferences = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.EmailPreferences").msgclass
           ScheduleOptions = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.ScheduleOptions").msgclass
           TransferConfig = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.TransferConfig").msgclass
           TransferRun = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.bigquery.datatransfer.v1.TransferRun").msgclass
diff --git a/google-cloud-bigquery-data_transfer/synth.metadata b/google-cloud-bigquery-data_transfer/synth.metadata
index 02f2d2760..c3c2633fa 100644
--- a/google-cloud-bigquery-data_transfer/synth.metadata
+++ b/google-cloud-bigquery-data_transfer/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-29T10:37:40.249514Z",
+  "updateTime": "2019-12-07T11:38:02.115803Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.40.3",
-        "dockerImage": "googleapis/artman@sha256:c805f50525f5f557886c94ab76f56eaa09cb1da58c3ee95111fd34259376621a"
+        "version": "0.42.1",
+        "dockerImage": "googleapis/artman@sha256:c773192618c608a7a0415dd95282f841f8e6bcdef7dd760a988c93b77a64bd57"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "532773acbed8d09451dafb3d403ab1823e6a6e1e",
-        "internalRef": "277177415"
+        "sha": "a4adac3a12aca6e3a792c9c35ee850435fe7cf7e",
+        "internalRef": "284277770"
       }
     },
     {
diff --git a/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb b/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb
index cfbeb01ac..d4610f579 100644
--- a/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb
+++ b/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb
@@ -255,6 +255,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       disabled = true
       user_id = 147132913
       dataset_region = "datasetRegion959248539"
+      notification_pubsub_topic = "notificationPubsubTopic1794281191"
       expected_response = {
         name: name,
         destination_dataset_id: destination_dataset_id,
@@ -264,7 +265,8 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
         data_refresh_window_days: data_refresh_window_days,
         disabled: disabled,
         user_id: user_id,
-        dataset_region: dataset_region
+        dataset_region: dataset_region,
+        notification_pubsub_topic: notification_pubsub_topic
       }
       expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Bigquery::Datatransfer::V1::TransferConfig)
 
@@ -351,6 +353,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       disabled = true
       user_id = 147132913
       dataset_region = "datasetRegion959248539"
+      notification_pubsub_topic = "notificationPubsubTopic1794281191"
       expected_response = {
         name: name,
         destination_dataset_id: destination_dataset_id,
@@ -360,7 +363,8 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
         data_refresh_window_days: data_refresh_window_days,
         disabled: disabled,
         user_id: user_id,
-        dataset_region: dataset_region
+        dataset_region: dataset_region,
+        notification_pubsub_topic: notification_pubsub_topic
       }
       expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Bigquery::Datatransfer::V1::TransferConfig)
 
@@ -515,6 +519,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       disabled = true
       user_id = 147132913
       dataset_region = "datasetRegion959248539"
+      notification_pubsub_topic = "notificationPubsubTopic1794281191"
       expected_response = {
         name: name_2,
         destination_dataset_id: destination_dataset_id,
@@ -524,7 +529,8 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
         data_refresh_window_days: data_refresh_window_days,
         disabled: disabled,
         user_id: user_id,
-        dataset_region: dataset_region
+        dataset_region: dataset_region,
+        notification_pubsub_topic: notification_pubsub_topic
       }
       expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Bigquery::Datatransfer::V1::TransferConfig)
 
@@ -768,12 +774,14 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       data_source_id = "dataSourceId-1015796374"
       user_id = 147132913
       schedule = "schedule-697920873"
+      notification_pubsub_topic = "notificationPubsubTopic1794281191"
       expected_response = {
         name: name_2,
         destination_dataset_id: destination_dataset_id,
         data_source_id: data_source_id,
         user_id: user_id,
-        schedule: schedule
+        schedule: schedule,
+        notification_pubsub_topic: notification_pubsub_topic
       }
       expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Bigquery::Datatransfer::V1::TransferRun)
 

```

</details>

This pull request was generated using releasetool.