### PR TITLE
Release google-cloud-logging 1.9.3

### DIFF
--- a/google-cloud-logging/CHANGELOG.md
+++ b/google-cloud-logging/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 1.9.3 / 2019-12-20
+
+#### Documentation
+
+* Update description of MetricDescriptor#unit in lower-level API
+
 ### 1.9.2 / 2019-12-18
 
 #### Bug Fixes

--- a/google-cloud-logging/lib/google/cloud/logging/version.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Logging
-      VERSION = "1.9.2".freeze
+      VERSION = "1.9.3".freeze
     end
   end
 end


### PR DESCRIPTION
#### Documentation

* Update description of MetricDescriptor#unit in lower-level API

<details><summary>Commits since previous release</summary><pre><code>commit 8fa2bea2b02f766da7d4465fc0a5dd4d46c1502f
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Fri Dec 20 10:33:34 2019 -0800

    docs(logging): Update description of MetricDescriptor#unit in lower-level API
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb
index f2ac95480..3b82982b3 100644
--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb
@@ -49,6 +49,58 @@ module Google
     #     Some combinations of `metric_kind` and `value_type` might not be supported.
     # @!attribute [rw] unit
     #   @return [String]
+    #     The units in which the metric value is reported. It is only applicable
+    #     if the `value_type` is `INT64`, `DOUBLE`, or `DISTRIBUTION`. The `unit`
+    #     defines the representation of the stored metric values.
+    #
+    #     Different systems may scale the values to be more easily displayed (so a
+    #     value of `0.02KBy` _might_ be displayed as `20By`, and a value of
+    #     `3523KBy` _might_ be displayed as `3.5MBy`). However, if the `unit` is
+    #     `KBy`, then the value of the metric is always in thousands of bytes, no
+    #     matter how it may be displayed..
+    #
+    #     If you want a custom metric to record the exact number of CPU-seconds used
+    #     by a job, you can create an `INT64 CUMULATIVE` metric whose `unit` is
+    #     `s{CPU}` (or equivalently `1s{CPU}` or just `s`). If the job uses 12,005
+    #     CPU-seconds, then the value is written as `12005`.
+    #
+    #     Alternatively, if you want a custome metric to record data in a more
+    #     granular way, you can create a `DOUBLE CUMULATIVE` metric whose `unit` is
+    #     `ks{CPU}`, and then write the value `12.005` (which is `12005/1000`),
+    #     or use `Kis{CPU}` and write `11.723` (which is `12005/1024`).
+    #
+    #     The supported units are a subset of [The Unified Code for Units of
+    #     Measure](http://unitsofmeasure.org/ucum.html) standard:
+    #
+    #     **Basic units (UNIT)**
+    #
+    #     * `bit`   bit
+    #     * `By`    byte
+    #     * `s`     second
+    #     * `min`   minute
+    #     * `h`     hour
+    #     * `d`     day
+    #
+    #     **Prefixes (PREFIX)**
+    #
+    #     * `k`     kilo    (10^3)
+    #     * `M`     mega    (10^6)
+    #     * `G`     giga    (10^9)
+    #     * `T`     tera    (10^12)
+    #     * `P`     peta    (10^15)
+    #     * `E`     exa     (10^18)
+    #     * `Z`     zetta   (10^21)
+    #     * `Y`     yotta   (10^24)
+    #
+    #     * `m`     milli   (10^-3)
+    #     * `u`     micro   (10^-6)
+    #     * `n`     nano    (10^-9)
+    #     * `p`     pico    (10^-12)
+    #     * `f`     femto   (10^-15)
+    #     * `a`     atto    (10^-18)
+    #     * `z`     zepto   (10^-21)
+    #     * `y`     yocto   (10^-24)
+    #
     #     * `Ki`    kibi    (2^10)
     #     * `Mi`    mebi    (2^20)
     #     * `Gi`    gibi    (2^30)
diff --git a/google-cloud-logging/synth.metadata b/google-cloud-logging/synth.metadata
index 93a9d17df..69e6e19c9 100644
--- a/google-cloud-logging/synth.metadata
+++ b/google-cloud-logging/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-11-28T11:40:34.621850Z",
+  "updateTime": "2019-12-20T11:40:29.869422Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.42.1",
-        "dockerImage": "googleapis/artman@sha256:c773192618c608a7a0415dd95282f841f8e6bcdef7dd760a988c93b77a64bd57"
+        "version": "0.42.3",
+        "dockerImage": "googleapis/artman@sha256:feed210b5723c6f524b52ef6d7740a030f2d1a8f7c29a71c5e5b4481ceaad7f5"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "3ddad085965896ffb205d44cb0c0616fe3def10b",
-        "internalRef": "282857635"
+        "sha": "50af0530730348f1e3697bf3c70261f7daaf2981",
+        "internalRef": "286491002"
       }
     }
   ],
@@ -28,5 +28,361 @@
         "config": "google/logging/artman_logging.yaml"
       }
     }
+  ],
+  "newFiles": [
+    {
+      "path": "Gemfile"
+    },
+    {
+      "path": "CONTRIBUTING.md"
+    },
+    {
+      "path": ".gitignore"
+    },
+    {
+      "path": "synth.py"
+    },
+    {
+      "path": "google-cloud-logging.gemspec"
+    },
+    {
+      "path": "LICENSE"
+    },
+    {
+      "path": "Rakefile"
+    },
+    {
+      "path": "CODE_OF_CONDUCT.md"
+    },
+    {
+      "path": "TROUBLESHOOTING.md"
+    },
+    {
+      "path": "CHANGELOG.md"
+    },
+    {
+      "path": ".yardopts"
+    },
+    {
+      "path": "AUTHENTICATION.md"
+    },
+    {
+      "path": ".autotest"
+    },
+    {
+      "path": "README.md"
+    },
+    {
+      "path": "INSTRUMENTATION.md"
+    },
+    {
+      "path": "OVERVIEW.md"
+    },
+    {
+      "path": "LOGGING.md"
+    },
+    {
+      "path": "synth.metadata"
+    },
+    {
+      "path": ".rubocop.yml"
+    },
+    {
+      "path": ".repo-metadata.json"
+    },
+    {
+      "path": "acceptance/logging_helper.rb"
+    },
+    {
+      "path": "acceptance/logging/logging_test.rb"
+    },
+    {
+      "path": "test/helper.rb"
+    },
+    {
+      "path": "test/google/cloud/logging_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/logger_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/resource_descriptor_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/async_writer_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/project_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/sink_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/rails_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/metric_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/resource_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/middleware_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/entry_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/project/logger_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/project/shared_async_writer_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/project/sinks_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/project/async_writer_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/project/resource_descriptors_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/project/metrics_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/project/write_entries_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/project/list_logs_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/project/list_entries_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/convert/object_to_value_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/convert/hash_to_struct_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/logger/fatal_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/logger/info_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/logger/error_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/logger/add_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/logger/debug_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/logger/warn_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/logger/unknown_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/async_writer/logger_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/entry/severity_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/entry/to_grpc_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/entry/http_request_test.rb"
+    },
+    {
+      "path": "test/google/cloud/logging/entry/operation_test.rb"
+    },
+    {
+      "path": "__pycache__/synth.cpython-36.pyc"
+    },
+    {
+      "path": "support/doctest_helper.rb"
+    },
+    {
+      "path": "lib/google-cloud-logging.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/convert.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/errors.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/logger.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/resource_descriptor.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/project.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/version.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/sink.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/async_writer.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/middleware.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/resource.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/credentials.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/rails.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/metric.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/service.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/entry.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/resource_descriptor/list.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/logging_service_v2_client.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/credentials.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/config_service_v2_client_config.json"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/config_service_v2_client.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/metrics_service_v2_client.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/logging_service_v2_client_config.json"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/metrics_service_v2_client_config.json"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/api/monitored_resource.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/api/distribution.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/api/label.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/api/metric.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/protobuf/struct.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/protobuf/duration.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/protobuf/empty.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/protobuf/timestamp.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/protobuf/field_mask.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/protobuf/any.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/logging/v2/log_entry.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/logging/v2/logging_config.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/logging/v2/logging.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/logging/v2/logging_metrics.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/logging/type/http_request.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/metric/list.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/sink/list.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/entry/list.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/entry/source_location.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/entry/operation.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/entry/http_request.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/log/list.rb"
+    },
+    {
+      "path": "lib/google/logging/v2/log_entry_pb.rb"
+    },
+    {
+      "path": "lib/google/logging/v2/logging_services_pb.rb"
+    },
+    {
+      "path": "lib/google/logging/v2/logging_pb.rb"
+    },
+    {
+      "path": "lib/google/logging/v2/logging_config_pb.rb"
+    },
+    {
+      "path": "lib/google/logging/v2/logging_metrics_services_pb.rb"
+    },
+    {
+      "path": "lib/google/logging/v2/logging_metrics_pb.rb"
+    },
+    {
+      "path": "lib/google/logging/v2/logging_config_services_pb.rb"
+    },
+    {
+      "path": "integration/logging_helper.rb"
+    },
+    {
+      "path": "integration/common_logging_test.rb"
+    },
+    {
+      "path": "integration/gke/logging_test.rb"
+    },
+    {
+      "path": "integration/gae/logging_test.rb"
+    }
   ]
 }
\ No newline at end of file

```

</details>

This pull request was generated using releasetool.