### PR TITLE
Release google-cloud-monitoring 0.34.1

### DIFF
--- a/google-cloud-monitoring/CHANGELOG.md
+++ b/google-cloud-monitoring/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.34.1 / 2019-12-20
+
+#### Documentation
+
+* Update description of MetricDescriptor#unit in lower-level API
+
 ### 0.34.0 / 2019-12-18
 
 #### Features

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/version.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Monitoring
-      VERSION = "0.34.0".freeze
+      VERSION = "0.34.1".freeze
     end
   end
 end


### PR DESCRIPTION
#### Documentation

* Update description of MetricDescriptor#unit in lower-level API

<details><summary>Commits since previous release</summary><pre><code>commit 0af6b096b3ab53024540468d369625e7a4238347
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Fri Dec 20 10:39:57 2019 -0800

    docs(monitoring): Update description of MetricDescriptor#unit in lower-level API
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb
index 6672b948e..a25d3b314 100644
--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb
@@ -49,6 +49,58 @@ module Google
     #     Some combinations of `metric_kind` and `value_type` might not be supported.
     # @!attribute [rw] unit
     #   @return [String]
+    #     The units in which the metric value is reported. It is only applicable
+    #     if the `value_type` is `INT64`, `DOUBLE`, or `DISTRIBUTION`. The `unit`
+    #     defines the representation of the stored metric values.
+    #
+    #     Different systems may scale the values to be more easily displayed (so a
+    #     value of `0.02KBy` _might_ be displayed as `20By`, and a value of
+    #     `3523KBy` _might_ be displayed as `3.5MBy`). However, if the `unit` is
+    #     `KBy`, then the value of the metric is always in thousands of bytes, no
+    #     matter how it may be displayed..
+    #
+    #     If you want a custom metric to record the exact number of CPU-seconds used
+    #     by a job, you can create an `INT64 CUMULATIVE` metric whose `unit` is
+    #     `s{CPU}` (or equivalently `1s{CPU}` or just `s`). If the job uses 12,005
+    #     CPU-seconds, then the value is written as `12005`.
+    #
+    #     Alternatively, if you want a custome metric to record data in a more
+    #     granular way, you can create a `DOUBLE CUMULATIVE` metric whose `unit` is
+    #     `ks{CPU}`, and then write the value `12.005` (which is `12005/1000`),
+    #     or use `Kis{CPU}` and write `11.723` (which is `12005/1024`).
+    #
+    #     The supported units are a subset of [The Unified Code for Units of
+    #     Measure](http://unitsofmeasure.org/ucum.html) standard:
+    #
+    #     **Basic units (UNIT)**
+    #
+    #     * `bit`   bit
+    #     * `By`    byte
+    #     * `s`     second
+    #     * `min`   minute
+    #     * `h`     hour
+    #     * `d`     day
+    #
+    #     **Prefixes (PREFIX)**
+    #
+    #     * `k`     kilo    (10^3)
+    #     * `M`     mega    (10^6)
+    #     * `G`     giga    (10^9)
+    #     * `T`     tera    (10^12)
+    #     * `P`     peta    (10^15)
+    #     * `E`     exa     (10^18)
+    #     * `Z`     zetta   (10^21)
+    #     * `Y`     yotta   (10^24)
+    #
+    #     * `m`     milli   (10^-3)
+    #     * `u`     micro   (10^-6)
+    #     * `n`     nano    (10^-9)
+    #     * `p`     pico    (10^-12)
+    #     * `f`     femto   (10^-15)
+    #     * `a`     atto    (10^-18)
+    #     * `z`     zepto   (10^-21)
+    #     * `y`     yocto   (10^-24)
+    #
     #     * `Ki`    kibi    (2^10)
     #     * `Mi`    mebi    (2^20)
     #     * `Gi`    gibi    (2^30)
diff --git a/google-cloud-monitoring/synth.metadata b/google-cloud-monitoring/synth.metadata
index 54c4c4234..cb1e31cd0 100644
--- a/google-cloud-monitoring/synth.metadata
+++ b/google-cloud-monitoring/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-12-17T02:35:26.194367Z",
+  "updateTime": "2019-12-20T11:40:49.297032Z",
   "sources": [
     {
       "generator": {
@@ -12,8 +12,8 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "41fc1403738b61427f3a798ca9750ef47eb9c0f2",
-        "internalRef": "285824386"
+        "sha": "50af0530730348f1e3697bf3c70261f7daaf2981",
+        "internalRef": "286491002"
       }
     },
     {
@@ -45,5 +45,352 @@
         "config": "google/monitoring/dashboard/v1/artman_monitoring.yaml"
       }
     }
+  ],
+  "newFiles": [
+    {
+      "path": "Gemfile"
+    },
+    {
+      "path": ".gitignore"
+    },
+    {
+      "path": "synth.py"
+    },
+    {
+      "path": "LICENSE"
+    },
+    {
+      "path": "Rakefile"
+    },
+    {
+      "path": "CHANGELOG.md"
+    },
+    {
+      "path": ".yardopts"
+    },
+    {
+      "path": "AUTHENTICATION.md"
+    },
+    {
+      "path": "README.md"
+    },
+    {
+      "path": "synth.metadata"
+    },
+    {
+      "path": ".rubocop.yml"
+    },
+    {
+      "path": "google-cloud-monitoring.gemspec"
+    },
+    {
+      "path": ".repo-metadata.json"
+    },
+    {
+      "path": "acceptance/google/cloud/monitoring/v3/metric_service_smoke_test.rb"
+    },
+    {
+      "path": "test/google/cloud/monitoring/v3/alert_policy_service_client_test.rb"
+    },
+    {
+      "path": "test/google/cloud/monitoring/v3/notification_channel_service_client_test.rb"
+    },
+    {
+      "path": "test/google/cloud/monitoring/v3/uptime_check_service_client_test.rb"
+    },
+    {
+      "path": "test/google/cloud/monitoring/v3/group_service_client_test.rb"
+    },
+    {
+      "path": "test/google/cloud/monitoring/v3/service_monitoring_service_client_test.rb"
+    },
+    {
+      "path": "test/google/cloud/monitoring/v3/metric_service_client_test.rb"
+    },
+    {
+      "path": "test/google/cloud/monitoring/dashboard/v1/dashboards_service_client_test.rb"
+    },
+    {
+      "path": "__pycache__/synth.cpython-36.pyc"
+    },
+    {
+      "path": "lib/google-cloud-monitoring.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/version.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/group_service_client.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/notification_channel_service_client_config.json"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/notification_channel_service_client.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/uptime_check_service_client.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/alert_policy_service_client.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/metric_service_client_config.json"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/group_service_client_config.json"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/metric_service_client.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/uptime_check_service_client_config.json"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/service_monitoring_service_client_config.json"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/credentials.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/service_monitoring_service_client.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/alert_policy_service_client_config.json"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/api/monitored_resource.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/api/distribution.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/api/label.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/api/metric.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/protobuf/struct.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/protobuf/duration.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/protobuf/wrappers.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/protobuf/empty.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/protobuf/timestamp.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/protobuf/field_mask.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/protobuf/any.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/rpc/status.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/metric_service.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/uptime_service.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/alert.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/mutation_record.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/alert_service.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/notification_service.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/common.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/notification.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/uptime.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/service_service.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/group_service.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/metric.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/service.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/group.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1/credentials.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1/dashboards_service_client.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1/dashboards_service_client_config.json"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1/doc/google/protobuf/duration.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1/doc/google/protobuf/empty.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1/doc/google/monitoring/dashboard/v1/layouts.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1/doc/google/monitoring/dashboard/v1/scorecard.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1/doc/google/monitoring/dashboard/v1/widget.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1/doc/google/monitoring/dashboard/v1/metrics.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1/doc/google/monitoring/dashboard/v1/text.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1/doc/google/monitoring/dashboard/v1/xychart.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1/doc/google/monitoring/dashboard/v1/dashboards_service.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1/doc/google/monitoring/dashboard/v1/common.rb"
+    },
+    {
+      "path": "lib/google/cloud/monitoring/dashboard/v1/doc/google/monitoring/dashboard/v1/dashboard.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/common_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/notification_service_services_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/group_service_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/mutation_record_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/service_service_services_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/notification_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/notification_service_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/metric_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/alert_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/group_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/uptime_service_services_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/service_service_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/service_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/metric_service_services_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/alert_service_services_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/metric_service_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/uptime_service_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/alert_service_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/group_service_services_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/span_context_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/dropped_labels_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/v3/uptime_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/dashboard/v1/common_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/dashboard/v1/dashboards_service_services_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/dashboard/v1/dashboards_service_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/dashboard/v1/xychart_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/dashboard/v1/drilldowns_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/dashboard/v1/service_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/dashboard/v1/metrics_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/dashboard/v1/text_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/dashboard/v1/dashboard_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/dashboard/v1/layouts_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/dashboard/v1/scorecard_pb.rb"
+    },
+    {
+      "path": "lib/google/monitoring/dashboard/v1/widget_pb.rb"
+    }
   ]
 }
\ No newline at end of file

```

</details>

This pull request was generated using releasetool.