### PR TITLE
Remove AUTHENTICATION.md from google-cloud-errors gemspec

### DIFF
--- a/google-cloud-errors/google-cloud-errors.gemspec
+++ b/google-cloud-errors/google-cloud-errors.gemspec
@@ -12,8 +12,7 @@ Gem::Specification.new do |gem|
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +
-                      ["README.md", "AUTHENTICATION.md", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "LICENSE",
-                       ".yardopts"]
+                      ["README.md", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
   gem.required_ruby_version = ">= 2.4"


### PR DESCRIPTION
This gem doesn't include `AUTHENTICATION.md`