### PR TITLE
fix(firestore): Use client instead of service in DocumentReference::List

### DIFF
--- a/google-cloud-firestore/acceptance/firestore/collection_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/collection_test.rb
@@ -57,5 +57,8 @@ describe "Collection", :firestore_acceptance do
 
     docs_max_1 = rand_col.list_documents max: 1
     docs_max_1.size.must_equal 1
+
+    rand_col.list_documents.map(&:delete)
+    rand_col.list_documents.must_be :empty?
   end
 end

--- a/google-cloud-firestore/acceptance/firestore/collection_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/collection_test.rb
@@ -27,6 +27,7 @@ describe "Collection", :firestore_acceptance do
     doc_ref = root_col.doc # no id, will create random id instead
 
     doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    doc_ref.client.must_be_kind_of Google::Cloud::Firestore::Client
     doc_ref.document_id.length.must_equal 20 # random doc id
 
     doc_ref.parent.collection_path.must_equal root_col.collection_path
@@ -35,6 +36,7 @@ describe "Collection", :firestore_acceptance do
   it "has add method" do
     doc_ref = root_col.add({ foo: "hello world" })
     doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    doc_ref.client.must_be_kind_of Google::Cloud::Firestore::Client
 
     doc_snp = doc_ref.get
     doc_snp.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
@@ -51,6 +53,7 @@ describe "Collection", :firestore_acceptance do
     docs.must_be_kind_of Array
     docs.size.must_be :>, 1
     docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    docs.first.client.must_be_kind_of Google::Cloud::Firestore::Client
 
     docs_max_1 = rand_col.list_documents max: 1
     docs_max_1.size.must_equal 1

--- a/google-cloud-firestore/lib/google/cloud/firestore/client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/client.rb
@@ -672,7 +672,7 @@ module Google
           ensure_service!
           grpc = service.list_documents \
             parent, collection_id, token: token, max: max
-          DocumentReference::List.from_grpc grpc, service, parent, collection_id
+          DocumentReference::List.from_grpc grpc, self, parent, collection_id
         end
 
         protected

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_reference/list.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_reference/list.rb
@@ -85,10 +85,10 @@ module Google
           #   end
           def next
             return nil unless next?
-            ensure_service!
+            ensure_client!
             options = { token: token, max: @max }
-            grpc = @service.list_documents @parent, @collection_id, options
-            self.class.from_grpc grpc, @service, @parent, @collection_id, @max
+            grpc = @client.service.list_documents @parent, @collection_id, options
+            self.class.from_grpc grpc, @client, @parent, @collection_id, @max
           end
 
           ##
@@ -163,16 +163,16 @@ module Google
           ##
           # @private New DocumentReference::List from a
           # Google::Firestore::V1::ListDocumentsResponse object.
-          def self.from_grpc grpc, service, parent, collection_id, max = nil
+          def self.from_grpc grpc, client, parent, collection_id, max = nil
             documents = List.new(Array(grpc.documents).map do |document|
-              DocumentReference.from_path document.name, service
+              DocumentReference.from_path document.name, client
             end)
             documents.instance_variable_set :@parent, parent
             documents.instance_variable_set :@collection_id, collection_id
             token = grpc.next_page_token
             token = nil if token == "".freeze
             documents.instance_variable_set :@token, token
-            documents.instance_variable_set :@service, service
+            documents.instance_variable_set :@client, client
             documents.instance_variable_set :@max, max
             documents
           end
@@ -180,9 +180,9 @@ module Google
           protected
 
           ##
-          # Raise an error unless an active service is available.
-          def ensure_service!
-            raise "Must have active connection" unless @service
+          # Raise an error unless an active client is available.
+          def ensure_client!
+            raise "Must have active connection" unless @client
           end
         end
       end


### PR DESCRIPTION
fixes: #4511