### PR TITLE
Release google-cloud-errors 0.1.0

### DIFF
--- a/google-cloud-errors/CHANGELOG.md
+++ b/google-cloud-errors/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-01-09
+
+* Initial release, extracted from google-cloud-core.
+

--- a/google-cloud-errors/lib/google/cloud/errors/version.rb
+++ b/google-cloud-errors/lib/google/cloud/errors/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Errors
-      VERSION = "1.0.0".freeze
+      VERSION = "0.1.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Initial release, extracted from google-cloud-core.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-errors/CHANGELOG.md b/google-cloud-errors/CHANGELOG.md
index 996fc1821..f88957a62 100644
--- a/google-cloud-errors/CHANGELOG.md
+++ b/google-cloud-errors/CHANGELOG.md
@@ -1,6 +1,2 @@
 # Release History
 
-### 0.1.0 / 2020-01-09
-
-* Initial release, extracted from google-cloud-core.
-
diff --git a/google-cloud-errors/lib/google/cloud/errors/version.rb b/google-cloud-errors/lib/google/cloud/errors/version.rb
index ef30e1496..f6c0500ff 100644
--- a/google-cloud-errors/lib/google/cloud/errors/version.rb
+++ b/google-cloud-errors/lib/google/cloud/errors/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Errors
-      VERSION = "0.1.0".freeze
+      VERSION = "1.0.0".freeze
     end
   end
 end

```

</details>

This pull request was generated using releasetool.