### PR TITLE
Release google-cloud-errors 1.0.0

### DIFF
--- a/google-cloud-errors/CHANGELOG.md
+++ b/google-cloud-errors/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 1.0.0 / 2020-01-09
+
+* Initial release, extracted from google-cloud-core.
+


### PR DESCRIPTION
* Initial release, extracted from google-cloud-core.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-errors/CHANGELOG.md b/google-cloud-errors/CHANGELOG.md
index 21e3419ef..f88957a62 100644
--- a/google-cloud-errors/CHANGELOG.md
+++ b/google-cloud-errors/CHANGELOG.md
@@ -1,6 +1,2 @@
 # Release History
 
-### 1.0.0 / 2020-01-09
-
-* Initial release, extracted from google-cloud-core.
-

```

</details>

This pull request was generated using releasetool.