### PR TITLE
Release google-cloud-core 1.5.0

### DIFF
--- a/google-cloud-core/CHANGELOG.md
+++ b/google-cloud-core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History
 
+### 1.5.0 / 2020-01-09
+
+* Extract error classes into a separate gem, google-cloud-errors.
+* Various fixes for Core Config
+    * Fix warnings on to_s!
+    * Alias to_s! as inspect
+    * Add send to ILLEGAL_KEYS
+    * Add respond_to? as alias of field?
+
 ### 1.4.1 / 2019-10-29
 
 #### Documentation

--- a/google-cloud-core/lib/google/cloud/core/version.rb
+++ b/google-cloud-core/lib/google/cloud/core/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Core
-      VERSION = "1.4.1".freeze
+      VERSION = "1.5.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Extract error classes into a separate gem, google-cloud-errors.
* Various fixes for Core Config
    * Fix warnings on to_s!
    * Alias to_s! as inspect
    * Add send to ILLEGAL_KEYS
    * Add respond_to? as alias of field?

<details><summary>Commits since previous release</summary><pre><code>commit cd14c8892399231c1bf5f13a87c8c98baf0ef65c
Author: Mike Moore <mike@blowmage.com>
Date:   Fri Dec 27 15:45:55 2019 -0700

    Fixes for Core Config (#4541)
    
    * Fix warnings on to_s!
    * Alias to_s! as inspect
    * Add send to ILLEGAL_KEYS
    * Add respond_to? as alias of field?

commit 9f6d3fa8ec882f8ca4e4467abd4bdd61bea9a94c
Author: Daniel Azuma <dazuma@google.com>
Date:   Fri Dec 27 11:44:46 2019 -0800

    chore: Split out google-cloud-errors gem (#4537)

commit f8d2266d4a84c1885fd6b5323c123d95d443a330
Author: Daniel Azuma <dazuma@google.com>
Date:   Thu Oct 31 18:32:19 2019 -0700

    chore: Remove hacks in place for old versions of Ruby
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-core/Gemfile b/google-cloud-core/Gemfile
index 479254515..a3c2e0b21 100644
--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 gem "google-api-client", "~> 0.23"
 gem "google-cloud-env", path: "../google-cloud-env"
+gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "google-gax", "~> 1.0"
 
 gem "rake", "~> 12.3"
diff --git a/google-cloud-core/google-cloud-core.gemspec b/google-cloud-core/google-cloud-core.gemspec
index 55cd442fa..e4bc307a9 100644
--- a/google-cloud-core/google-cloud-core.gemspec
+++ b/google-cloud-core/google-cloud-core.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-env", "~> 1.0"
+  gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "google-style", "~> 1.24.0"
diff --git a/google-cloud-core/lib/google/cloud.rb b/google-cloud-core/lib/google/cloud.rb
index 3d398ff05..d528a8551 100644
--- a/google-cloud-core/lib/google/cloud.rb
+++ b/google-cloud-core/lib/google/cloud.rb
@@ -121,73 +121,6 @@ module Google
       end
     end
 
-    # Update the supported and recommended version thresholds according to the
-    # MRI support schedule: supported means non-EOL, and recommended means in
-    # normal (rather than security) maintenance. Generally, this means updating
-    # these at the end of March each year, if the previous year patterns hold.
-    # See https://www.ruby-lang.org/en/downloads/branches/
-
-    ##
-    # Minimum "supported" Ruby version (non-EOL)
-    # @private
-    #
-    SUPPORTED_VERSION_THRESHOLD = "2.3".freeze
-
-    ##
-    # Minimum "recommended" Ruby version (normal maintenance)
-    # @private
-    #
-    RECOMMENDED_VERSION_THRESHOLD = "2.4".freeze
-
-    ##
-    # Check Ruby version and emit a warning if it is old
-    # @private
-    #
-    def self.warn_on_old_ruby_version \
-        supported_version: SUPPORTED_VERSION_THRESHOLD,
-        recommended_version: RECOMMENDED_VERSION_THRESHOLD
-      return if ENV["GOOGLE_CLOUD_SUPPRESS_RUBY_WARNINGS"]
-      cur_version = Gem::Version.new RUBY_VERSION
-      if cur_version < Gem::Version.new(supported_version)
-        warn_unsupported_ruby cur_version, recommended_version
-      elsif cur_version < Gem::Version.new(recommended_version)
-        warn_nonrecommended_ruby cur_version, recommended_version
-      end
-    rescue ArgumentError
-      warn "Unable to determine current Ruby version."
-    end
-
-    ##
-    # Print a warning for an EOL version of Ruby
-    # @private
-    #
-    def self.warn_unsupported_ruby cur_version, recommended_version
-      warn "WARNING: You are running Ruby #{cur_version}, which has reached" \
-        " end-of-life and is no longer supported by Ruby Core."
-      warn "The Google Cloud API clients work best on supported versions of" \
-        " Ruby. It is strongly recommended that you upgrade to Ruby" \
-        " #{recommended_version} or later."
-      warn "See https://www.ruby-lang.org/en/downloads/branches/ for more" \
-        " info on the Ruby maintenance schedule."
-      warn "To suppress this message, set the" \
-        " GOOGLE_CLOUD_SUPPRESS_RUBY_WARNINGS environment variable."
-    end
-
-    ##
-    # Print a warning for a supported but nearing EOL version of Ruby
-    # @private
-    #
-    def self.warn_nonrecommended_ruby cur_version, recommended_version
-      warn "WARNING: You are running Ruby #{cur_version}, which is nearing" \
-        " end-of-life."
-      warn "The Google Cloud API clients work best on supported versions of" \
-        " Ruby. Consider upgrading to Ruby #{recommended_version} or later."
-      warn "See https://www.ruby-lang.org/en/downloads/branches/ for more" \
-        " info on the Ruby maintenance schedule."
-      warn "To suppress this message, set the" \
-        " GOOGLE_CLOUD_SUPPRESS_RUBY_WARNINGS environment variable."
-    end
-
     ##
     # Safely load all google-cloud-* gems.
     # @private
@@ -233,8 +166,5 @@ end
 # Set the default top-level configuration
 Google::Cloud.init_configuration
 
-# Emit a warning if current Ruby is at or nearing end-of-life
-Google::Cloud.warn_on_old_ruby_version
-
 # Auto-load all Google Cloud service gems.
 Google::Cloud.auto_load_gems
diff --git a/google-cloud-core/lib/google/cloud/config.rb b/google-cloud-core/lib/google/cloud/config.rb
index c7d202e61..14f3d2c5c 100644
--- a/google-cloud-core/lib/google/cloud/config.rb
+++ b/google-cloud-core/lib/google/cloud/config.rb
@@ -336,6 +336,7 @@ module Google
       def field? key
         @validators[key.to_sym].is_a? ::Proc
       end
+      alias respond_to? field?
 
       ##
       # Check if the given key has been explicitly added as a subconfig name.
@@ -395,11 +396,12 @@ module Google
       def to_s!
         elems = @validators.keys.map do |k|
           v = @values[k]
-          vstr = Config.config?(v) ? v.to_s! : value.inspect
+          vstr = Config.config?(v) ? v.to_s! : v.inspect
           " #{k}=#{vstr}"
         end
         "<Config:#{elems.join}>"
       end
+      alias inspect to_s!
 
       ##
       # Returns a nested hash representation of this configuration state,
@@ -495,9 +497,11 @@ module Google
       #
       ILLEGAL_KEYS = [:add_options,
                       :initialize,
+                      :inspect,
                       :instance_eval,
                       :instance_exec,
                       :method_missing,
+                      :send,
                       :singleton_method_added,
                       :singleton_method_removed,
                       :singleton_method_undefined].freeze
diff --git a/google-cloud-core/lib/google/cloud/errors.rb b/google-cloud-core/lib/google/cloud/errors.rb
deleted file mode 100644
index 7b59da0e8..000000000
--- a/google-cloud-core/lib/google/cloud/errors.rb
+++ /dev/null
@@ -1,324 +0,0 @@
-# Copyright 2015 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-
-require "English"
-
-module Google
-  module Cloud
-    ##
-    # Base google-cloud exception class.
-    class Error < StandardError
-      ##
-      # Construct a new Google::Cloud::Error object, optionally passing in a
-      # message.
-      def initialize msg = nil
-        super
-        @cause = $ERROR_INFO
-      end
-
-      # Add Error#cause (introduced in 2.1) to Ruby 2.0.
-      unless respond_to? :cause
-        ##
-        # The previous exception at the time this exception was raised. This is
-        # useful for wrapping exceptions and retaining the original exception
-        # information.
-        define_method :cause do
-          @cause
-        end
-      end
-
-      ##
-      # Returns the value of `status_code` from the underlying cause error
-      # object, if both are present. Otherwise returns `nil`.
-      #
-      # This is typically present on errors originating from calls to an API
-      # over HTTP/REST.
-      #
-      # @return [Object, nil]
-      def status_code
-        return nil unless cause&.respond_to? :status_code
-        cause.status_code
-      end
-
-      ##
-      # Returns the value of `body` from the underlying cause error
-      # object, if both are present. Otherwise returns `nil`.
-      #
-      # This is typically present on errors originating from calls to an API
-      # over HTTP/REST.
-      #
-      # @return [Object, nil]
-      def body
-        return nil unless cause&.respond_to? :body
-        cause.body
-      end
-
-      ##
-      # Returns the value of `header` from the underlying cause error
-      # object, if both are present. Otherwise returns `nil`.
-      #
-      # This is typically present on errors originating from calls to an API
-      # over HTTP/REST.
-      #
-      # @return [Object, nil]
-      def header
-        return nil unless cause&.respond_to? :header
-        cause.header
-      end
-
-      ##
-      # Returns the value of `code` from the underlying cause error
-      # object, if both are present. Otherwise returns `nil`.
-      #
-      # This is typically present on errors originating from calls to an API
-      # over gRPC.
-      #
-      # @return [Object, nil]
-      def code
-        return nil unless cause&.respond_to? :code
-        cause.code
-      end
-
-      ##
-      # Returns the value of `details` from the underlying cause error
-      # object, if both are present. Otherwise returns `nil`.
-      #
-      # This is typically present on errors originating from calls to an API
-      # over gRPC.
-      #
-      # @return [Object, nil]
-      def details
-        return nil unless cause&.respond_to? :details
-        cause.details
-      end
-
-      ##
-      # Returns the value of `metadata` from the underlying cause error
-      # object, if both are present. Otherwise returns `nil`.
-      #
-      # This is typically present on errors originating from calls to an API
-      # over gRPC.
-      #
-      # @return [Object, nil]
-      def metadata
-        return nil unless cause&.respond_to? :metadata
-        cause.metadata
-      end
-
-      ##
-      # Returns the value of `status_details` from the underlying cause error
-      # object, if both are present. Otherwise returns `nil`.
-      #
-      # This is typically present on errors originating from calls to an API
-      # over gRPC.
-      #
-      # @return [Object, nil]
-      def status_details
-        return nil unless cause&.respond_to? :status_details
-        cause.status_details
-      end
-
-      # @private Create a new error object from a client error
-      def self.from_error error
-        klass = if error.respond_to? :code
-                  grpc_error_class_for error.code
-                elsif error.respond_to? :status_code
-                  gapi_error_class_for error.status_code
-                else
-                  self
-                end
-        klass.new error.message
-      end
-
-      # @private Identify the subclass for a gRPC error
-      def self.grpc_error_class_for grpc_error_code
-        # The gRPC status code 0 is for a successful response.
-        # So there is no error subclass for a 0 status code, use current class.
-        [
-          self, CanceledError, UnknownError, InvalidArgumentError,
-          DeadlineExceededError, NotFoundError, AlreadyExistsError,
-          PermissionDeniedError, ResourceExhaustedError,
-          FailedPreconditionError, AbortedError, OutOfRangeError,
-          UnimplementedError, InternalError, UnavailableError, DataLossError,
-          UnauthenticatedError
-        ][grpc_error_code] || self
-      end
-
-      # @private Identify the subclass for a Google API Client error
-      def self.gapi_error_class_for http_status_code
-        # The http status codes mapped to their error classes.
-        {
-          400 => InvalidArgumentError, # FailedPreconditionError/OutOfRangeError
-          401 => UnauthenticatedError,
-          403 => PermissionDeniedError,
-          404 => NotFoundError,
-          409 => AlreadyExistsError, # AbortedError
-          412 => FailedPreconditionError,
-          429 => ResourceExhaustedError,
-          499 => CanceledError,
-          500 => InternalError, # UnknownError/DataLossError
-          501 => UnimplementedError,
-          503 => UnavailableError,
-          504 => DeadlineExceededError
-        }[http_status_code] || self
-      end
-    end
-
-    ##
-    # Canceled indicates the operation was cancelled (typically by the caller).
-    class CanceledError < Error
-    end
-
-    ##
-    # Unknown error.  An example of where this error may be returned is
-    # if a Status value received from another address space belongs to
-    # an error-space that is not known in this address space.  Also
-    # errors raised by APIs that do not return enough error information
-    # may be converted to this error.
-    class UnknownError < Error
-    end
-
-    ##
-    # InvalidArgument indicates client specified an invalid argument.
-    # Note that this differs from FailedPrecondition. It indicates arguments
-    # that are problematic regardless of the state of the system
-    # (e.g., a malformed file name).
-    class InvalidArgumentError < Error
-    end
-
-    ##
-    # DeadlineExceeded means operation expired before completion.
-    # For operations that change the state of the system, this error may be
-    # returned even if the operation has completed successfully. For
-    # example, a successful response from a server could have been delayed
-    # long enough for the deadline to expire.
-    class DeadlineExceededError < Error
-    end
-
-    ##
-    # NotFound means some requested entity (e.g., file or directory) was
-    # not found.
-    class NotFoundError < Error
-    end
-
-    ##
-    # AlreadyExists means an attempt to create an entity failed because one
-    # already exists.
-    class AlreadyExistsError < Error
-    end
-
-    ##
-    # PermissionDenied indicates the caller does not have permission to
-    # execute the specified operation. It must not be used for rejections
-    # caused by exhausting some resource (use ResourceExhausted
-    # instead for those errors).  It must not be
-    # used if the caller cannot be identified (use Unauthenticated
-    # instead for those errors).
-    class PermissionDeniedError < Error
-    end
-
-    ##
-    # Unauthenticated indicates the request does not have valid
-    # authentication credentials for the operation.
-    class UnauthenticatedError < Error
-    end
-
-    ##
-    # ResourceExhausted indicates some resource has been exhausted, perhaps
-    # a per-user quota, or perhaps the entire file system is out of space.
-    class ResourceExhaustedError < Error
-    end
-
-    ##
-    # FailedPrecondition indicates operation was rejected because the
-    # system is not in a state required for the operation's execution.
-    # For example, directory to be deleted may be non-empty, an rmdir
-    # operation is applied to a non-directory, etc.
-    #
-    # A litmus test that may help a service implementor in deciding
-    # between FailedPrecondition, Aborted, and Unavailable:
-    #  (a) Use Unavailable if the client can retry just the failing call.
-    #  (b) Use Aborted if the client should retry at a higher-level
-    #      (e.g., restarting a read-modify-write sequence).
-    #  (c) Use FailedPrecondition if the client should not retry until
-    #      the system state has been explicitly fixed.  E.g., if an "rmdir"
-    #      fails because the directory is non-empty, FailedPrecondition
-    #      should be returned since the client should not retry unless
-    #      they have first fixed up the directory by deleting files from it.
-    #  (d) Use FailedPrecondition if the client performs conditional
-    #      REST Get/Update/Delete on a resource and the resource on the
-    #      server does not match the condition. E.g., conflicting
-    #      read-modify-write on the same resource.
-    class FailedPreconditionError < Error
-    end
-
-    ##
-    # Aborted indicates the operation was aborted, typically due to a
-    # concurrency issue like sequencer check failures, transaction aborts,
-    # etc.
-    #
-    # See litmus test above for deciding between FailedPrecondition,
-    # Aborted, and Unavailable.
-    class AbortedError < Error
-    end
-
-    ##
-    # OutOfRange means operation was attempted past the valid range.
-    # E.g., seeking or reading past end of file.
-    #
-    # Unlike InvalidArgument, this error indicates a problem that may
-    # be fixed if the system state changes. For example, a 32-bit file
-    # system will generate InvalidArgument if asked to read at an
-    # offset that is not in the range [0,2^32-1], but it will generate
-    # OutOfRange if asked to read from an offset past the current
-    # file size.
-    #
-    # There is a fair bit of overlap between FailedPrecondition and
-    # OutOfRange.  We recommend using OutOfRange (the more specific
-    # error) when it applies so that callers who are iterating through
-    # a space can easily look for an OutOfRange error to detect when
-    # they are done.
-    class OutOfRangeError < Error
-    end
-
-    ##
-    # Unimplemented indicates operation is not implemented or not
-    # supported/enabled in this service.
-    class UnimplementedError < Error
-    end
-
-    ##
-    # Internal errors.  Means some invariants expected by underlying
-    # system has been broken.  If you see one of these errors,
-    # something is very broken.
-    class InternalError < Error
-    end
-
-    ##
-    # Unavailable indicates the service is currently unavailable.
-    # This is a most likely a transient condition and may be corrected
-    # by retrying with a backoff.
-    #
-    # See litmus test above for deciding between FailedPrecondition,
-    # Aborted, and Unavailable.
-    class UnavailableError < Error
-    end
-
-    ##
-    # DataLoss indicates unrecoverable data loss or corruption.
-    class DataLossError < Error
-    end
-  end
-end
diff --git a/google-cloud-core/test/google/cloud/config_test.rb b/google-cloud-core/test/google/cloud/config_test.rb
index 77ae20bda..b4f84d878 100644
--- a/google-cloud-core/test/google/cloud/config_test.rb
+++ b/google-cloud-core/test/google/cloud/config_test.rb
@@ -387,6 +387,34 @@ describe Google::Cloud::Config do
     end
   end
 
+  describe "#to_s!" do
+    it "builds without warnings" do
+      -> () {
+        checked_config.to_s!.must_equal "<Config: opt1_int=1 sub1=<Config: opt2_sym=:hi sub2=<Config: opt3_bool=true opt3_bool_nil=true opt3_enum=:one opt3_regex=\"hi\" opt3_class=\"hi\" opt3_default=nil>>>"
+      }.must_be_silent
+    end
+
+    it "is aliased as inspect" do
+      -> () {
+        checked_config.inspect.must_equal "<Config: opt1_int=1 sub1=<Config: opt2_sym=:hi sub2=<Config: opt3_bool=true opt3_bool_nil=true opt3_enum=:one opt3_regex=\"hi\" opt3_class=\"hi\" opt3_default=nil>>>"
+      }.must_be_silent
+    end
+  end
+
+  describe "#respond_to?" do
+    it "is an alias of field" do
+      checked_config.field?(:opt1_int).must_equal true
+      checked_config.respond_to?(:opt1_int).must_equal true
+      checked_config.respond_to?(:opt1_int).must_equal checked_config.field?(:opt1_int)
+
+      checked_config.delete! :opt1_int
+
+      checked_config.field?(:opt1_int).must_equal false
+      checked_config.respond_to?(:opt1_int).must_equal false
+      checked_config.respond_to?(:opt1_int).must_equal checked_config.field?(:opt1_int)
+    end
+  end
+
   describe "shared config" do
     after {
       Google::Cloud.configure.reset!
diff --git a/google-cloud-core/test/google/cloud/errors/error_cause_test.rb b/google-cloud-core/test/google/cloud/errors/error_cause_test.rb
deleted file mode 100644
index 743f3cfda..000000000
--- a/google-cloud-core/test/google/cloud/errors/error_cause_test.rb
+++ /dev/null
@@ -1,71 +0,0 @@
-# Copyright 2017 Google LLC
-#
-# Licensed under the Apache License, Version 2.0  the "License";
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-require "helper"
-require "google/cloud/errors"
-
-describe Google::Cloud::Error, :cause do
-  def wrapped_std_error msg
-    begin
-      raise msg
-    rescue => std_err
-      raise Google::Cloud::Error.from_error std_err
-    end
-  rescue => gcoud_err
-    return gcoud_err
-  end
-
-  # These tests show Google::Cloud::Error#cause is available, even on ruby 2.0
-
-  it "always has a cause" do
-    error = wrapped_std_error "yo"
-
-    error.must_be_kind_of Google::Cloud::Error
-    error.message.must_equal "yo"
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-
-    error.cause.wont_be :nil?
-    error.cause.must_be_kind_of StandardError
-    error.cause.message.must_equal "yo"
-
-    error.instance_variable_get(:@cause).must_be_kind_of StandardError
-    error.instance_variable_get(:@cause).message.must_equal "yo"
-  end
-
-  it "can have a nil cause" do
-    error = Google::Cloud::Error.new "sup"
-
-    error.must_be_kind_of Google::Cloud::Error
-    error.message.must_equal "sup"
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-
-    error.cause.must_be :nil?
-
-    error.instance_variable_get(:@cause).must_be :nil?
-  end
-end
diff --git a/google-cloud-core/test/google/cloud/errors/gapi_errors_test.rb b/google-cloud-core/test/google/cloud/errors/gapi_errors_test.rb
deleted file mode 100644
index fe1b1a32f..000000000
--- a/google-cloud-core/test/google/cloud/errors/gapi_errors_test.rb
+++ /dev/null
@@ -1,124 +0,0 @@
-# Copyright 2016 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-require "helper"
-require "google/cloud/errors"
-require "google/apis/errors"
-
-describe Google::Cloud::Error, :gapi do
-  def gapi_error msg, status, body = nil, header = nil
-    Google::Apis::Error.new msg, status_code: status, body: body, header: header
-  end
-
-  it "identifies InvalidArgumentError" do
-    mapped_error = Google::Cloud::Error.from_error gapi_error("invalid", 400)
-    mapped_error.must_be_kind_of Google::Cloud::InvalidArgumentError
-  end
-
-  it "identifies FailedPreconditionError" do
-    skip "don't know how we differentiate this error yet"
-    mapped_error = Google::Cloud::Error.from_error gapi_error("precondition", 400)
-    mapped_error.must_be_kind_of Google::Cloud::FailedPreconditionError
-  end
-
-  it "identifies OutOfRangeError" do
-    skip "don't know how we differentiate this error yet"
-    mapped_error = Google::Cloud::Error.from_error gapi_error("out of range", 400)
-    mapped_error.must_be_kind_of Google::Cloud::OutOfRangeError
-  end
-
-  it "identifies UnauthenticatedError" do
-    mapped_error = Google::Cloud::Error.from_error gapi_error("unauthenticated", 401)
-    mapped_error.must_be_kind_of Google::Cloud::UnauthenticatedError
-  end
-
-  it "identifies PermissionDeniedError" do
-    mapped_error = Google::Cloud::Error.from_error gapi_error("denied", 403)
-    mapped_error.must_be_kind_of Google::Cloud::PermissionDeniedError
-  end
-
-  it "identifies NotFoundError" do
-    mapped_error = Google::Cloud::Error.from_error gapi_error("notfound", 404)
-    mapped_error.must_be_kind_of Google::Cloud::NotFoundError
-  end
-
-  it "identifies AlreadyExistsError" do
-    mapped_error = Google::Cloud::Error.from_error gapi_error("exists", 409)
-    mapped_error.must_be_kind_of Google::Cloud::AlreadyExistsError
-  end
-
-  it "identifies AbortedError" do
-    skip "don't know how we differentiate this error yet"
-    mapped_error = Google::Cloud::Error.from_error gapi_error("aborted", 409)
-    mapped_error.must_be_kind_of Google::Cloud::AbortedError
-  end
-
-  it "identifies invalid (411) error" do
-    # We don't know what to map this error case to
-    mapped_error = Google::Cloud::Error.from_error gapi_error("invalid", 411)
-    mapped_error.must_be_kind_of Google::Cloud::Error
-  end
-
-  it "identifies FailedPreconditionError" do
-    mapped_error = Google::Cloud::Error.from_error gapi_error("conditionNotMet", 412)
-    mapped_error.must_be_kind_of Google::Cloud::FailedPreconditionError
-  end
-
-  it "identifies ResourceExhaustedError" do
-    mapped_error = Google::Cloud::Error.from_error gapi_error("exhausted", 429)
-    mapped_error.must_be_kind_of Google::Cloud::ResourceExhaustedError
-  end
-
-  it "identifies CanceledError" do
-    mapped_error = Google::Cloud::Error.from_error gapi_error("canceled", 499)
-    mapped_error.must_be_kind_of Google::Cloud::CanceledError
-  end
-
-  it "identifies InternalError" do
-    mapped_error = Google::Cloud::Error.from_error gapi_error("internal", 500)
-    mapped_error.must_be_kind_of Google::Cloud::InternalError
-  end
-
-  it "identifies UnknownError" do
-    skip "don't know how we differentiate this error yet"
-    mapped_error = Google::Cloud::Error.from_error gapi_error("unknown", 500)
-    mapped_error.must_be_kind_of Google::Cloud::UnknownError
-  end
-
-  it "identifies DataLossError" do
-    skip "don't know how we differentiate this error yet"
-    mapped_error = Google::Cloud::Error.from_error gapi_error("data loss", 500)
-    mapped_error.must_be_kind_of Google::Cloud::DataLossError
-  end
-
-  it "identifies UnimplementedError" do
-    mapped_error = Google::Cloud::Error.from_error gapi_error("unimplemented", 501)
-    mapped_error.must_be_kind_of Google::Cloud::UnimplementedError
-  end
-
-  it "identifies UnavailableError" do
-    mapped_error = Google::Cloud::Error.from_error gapi_error("unavailable", 503)
-    mapped_error.must_be_kind_of Google::Cloud::UnavailableError
-  end
-
-  it "identifies DeadlineExceededError" do
-    mapped_error = Google::Cloud::Error.from_error gapi_error("exceeded", 504)
-    mapped_error.must_be_kind_of Google::Cloud::DeadlineExceededError
-  end
-
-  it "identifies unknown error" do
-    mapped_error = Google::Cloud::Error.from_error gapi_error("unknown", 999)
-    mapped_error.must_be_kind_of Google::Cloud::Error
-  end
-end
diff --git a/google-cloud-core/test/google/cloud/errors/grpc_errors_test.rb b/google-cloud-core/test/google/cloud/errors/grpc_errors_test.rb
deleted file mode 100644
index 6a991632f..000000000
--- a/google-cloud-core/test/google/cloud/errors/grpc_errors_test.rb
+++ /dev/null
@@ -1,108 +0,0 @@
-# Copyright 2016 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-require "helper"
-require "google/cloud/errors"
-require "grpc/errors"
-
-describe Google::Cloud::Error, :grpc do
-  it "identifies CanceledError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(1, "cancelled")
-    mapped_error.must_be_kind_of Google::Cloud::CanceledError
-  end
-
-  it "identifies UnknownError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(2, "unknown")
-    mapped_error.must_be_kind_of Google::Cloud::UnknownError
-  end
-
-  it "identifies InvalidArgumentError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(3, "invalid")
-    mapped_error.must_be_kind_of Google::Cloud::InvalidArgumentError
-  end
-
-  it "identifies DeadlineExceededError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(4, "exceeded")
-    mapped_error.must_be_kind_of Google::Cloud::DeadlineExceededError
-  end
-
-  it "identifies NotFoundError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(5, "not found")
-    mapped_error.must_be_kind_of Google::Cloud::NotFoundError
-  end
-
-  it "identifies AlreadyExistsError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(6, "exists")
-    mapped_error.must_be_kind_of Google::Cloud::AlreadyExistsError
-  end
-
-  it "identifies PermissionDeniedError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(7, "denied")
-    mapped_error.must_be_kind_of Google::Cloud::PermissionDeniedError
-  end
-
-  it "identifies ResourceExhaustedError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(8, "exhausted")
-    mapped_error.must_be_kind_of Google::Cloud::ResourceExhaustedError
-  end
-
-  it "identifies FailedPreconditionError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(9, "precondition")
-    mapped_error.must_be_kind_of Google::Cloud::FailedPreconditionError
-  end
-
-  it "identifies AbortedError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(10, "aborted")
-    mapped_error.must_be_kind_of Google::Cloud::AbortedError
-  end
-
-  it "identifies OutOfRangeError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(11, "out of range")
-    mapped_error.must_be_kind_of Google::Cloud::OutOfRangeError
-  end
-
-  it "identifies UnimplementedError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(12, "unimplemented")
-    mapped_error.must_be_kind_of Google::Cloud::UnimplementedError
-  end
-
-  it "identifies InternalError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(13, "internal")
-    mapped_error.must_be_kind_of Google::Cloud::InternalError
-  end
-
-  it "identifies UnavailableError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(14, "unavailable")
-    mapped_error.must_be_kind_of Google::Cloud::UnavailableError
-  end
-
-  it "identifies DataLossError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(15, "data loss")
-    mapped_error.must_be_kind_of Google::Cloud::DataLossError
-  end
-
-  it "identifies UnauthenticatedError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(16, "unauthenticated")
-    mapped_error.must_be_kind_of Google::Cloud::UnauthenticatedError
-  end
-
-  it "identifies unknown error" do
-    # We don't know what to map this error case to
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(0, "unknown")
-    mapped_error.must_be_kind_of Google::Cloud::Error
-
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(17, "unknown")
-    mapped_error.must_be_kind_of Google::Cloud::Error
-  end
-end
diff --git a/google-cloud-core/test/google/cloud/errors/wrapped_gapi_test.rb b/google-cloud-core/test/google/cloud/errors/wrapped_gapi_test.rb
deleted file mode 100644
index 376da2f42..000000000
--- a/google-cloud-core/test/google/cloud/errors/wrapped_gapi_test.rb
+++ /dev/null
@@ -1,332 +0,0 @@
-# Copyright 2017 Google LLC
-#
-# Licensed under the Apache License, Version 2.0  the "License";
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-require "helper"
-require "google/cloud/errors"
-require "google/apis/errors"
-
-describe Google::Cloud::Error, :wrapped_gapi do
-  def wrapped_error msg, status, body = nil, header = nil
-    err = gapi_error msg, status, body, header
-    begin
-      begin
-        raise err
-      rescue => inner_err
-        raise Google::Cloud::Error.from_error inner_err
-      end
-    rescue => e
-      return e
-    end
-  end
-
-  def gapi_error msg, status, body = nil, header = nil
-    Google::Apis::Error.new msg, status_code: status, body: body, header: header
-  end
-
-  it "wraps InvalidArgumentError" do
-    error = wrapped_error "invalid", 400, "invalid body", ["invalid headers"]
-    error.must_be_kind_of Google::Cloud::InvalidArgumentError
-
-    error.message.must_equal "invalid"
-    error.status_code.must_equal 400
-    error.body.must_equal "invalid body"
-    error.header.must_equal ["invalid headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps FailedPreconditionError" do
-    skip "don't know how we differentiate this error yet"
-
-    error = wrapped_error "precondition", 400, "precondition body", ["precondition headers"]
-    error.must_be_kind_of Google::Cloud::FailedPreconditionError
-
-    error.message.must_equal "precondition"
-    error.status_code.must_equal 400
-    error.body.must_equal "precondition body"
-    error.header.must_equal ["precondition headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps OutOfRangeError" do
-    skip "don't know how we differentiate this error yet"
-
-    error = wrapped_error "out of range", 400, "out of range body", ["out of range headers"]
-    error.must_be_kind_of Google::Cloud::OutOfRangeError
-
-    error.message.must_equal "out of range"
-    error.status_code.must_equal 400
-    error.body.must_equal "out of range body"
-    error.header.must_equal ["out of range headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps UnauthenticatedError" do
-    error = wrapped_error "unauthenticated", 401, "unauthenticated body", ["unauthenticated headers"]
-    error.must_be_kind_of Google::Cloud::UnauthenticatedError
-
-    error.message.must_equal "unauthenticated"
-    error.status_code.must_equal 401
-    error.body.must_equal "unauthenticated body"
-    error.header.must_equal ["unauthenticated headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps PermissionDeniedError" do
-    error = wrapped_error "denied", 403, "denied body", ["denied headers"]
-    error.must_be_kind_of Google::Cloud::PermissionDeniedError
-
-    error.message.must_equal "denied"
-    error.status_code.must_equal 403
-    error.body.must_equal "denied body"
-    error.header.must_equal ["denied headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps NotFoundError" do
-    error = wrapped_error "notfound", 404, "notfound body", ["notfound headers"]
-    error.must_be_kind_of Google::Cloud::NotFoundError
-
-    error.message.must_equal "notfound"
-    error.status_code.must_equal 404
-    error.body.must_equal "notfound body"
-    error.header.must_equal ["notfound headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps AlreadyExistsError" do
-    error = wrapped_error "exists", 409, "exists body", ["exists headers"]
-    error.must_be_kind_of Google::Cloud::AlreadyExistsError
-
-    error.message.must_equal "exists"
-    error.status_code.must_equal 409
-    error.body.must_equal "exists body"
-    error.header.must_equal ["exists headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps AbortedError" do
-    skip "don't know how we differentiate this error yet"
-
-    error = wrapped_error "aborted", 409, "aborted body", ["aborted headers"]
-    error.must_be_kind_of Google::Cloud::AbortedError
-
-    error.message.must_equal "aborted"
-    error.status_code.must_equal 409
-    error.body.must_equal "aborted body"
-    error.header.must_equal ["aborted headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps invalid (411) error" do
-    # We don't know what to map this error case to
-    error = wrapped_error "invalid", 411, "invalid body", ["invalid headers"]
-    error.must_be_kind_of Google::Cloud::Error
-
-    error.message.must_equal "invalid"
-    error.status_code.must_equal 411
-    error.body.must_equal "invalid body"
-    error.header.must_equal ["invalid headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps FailedPreconditionError" do
-    error = wrapped_error "conditionNotMet", 412, "conditionNotMet body", ["conditionNotMet headers"]
-    error.must_be_kind_of Google::Cloud::FailedPreconditionError
-
-    error.message.must_equal "conditionNotMet"
-    error.status_code.must_equal 412
-    error.body.must_equal "conditionNotMet body"
-    error.header.must_equal ["conditionNotMet headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps ResourceExhaustedError" do
-    error = wrapped_error "exhausted", 429, "exhausted body", ["exhausted headers"]
-    error.must_be_kind_of Google::Cloud::ResourceExhaustedError
-
-    error.message.must_equal "exhausted"
-    error.status_code.must_equal 429
-    error.body.must_equal "exhausted body"
-    error.header.must_equal ["exhausted headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps CanceledError" do
-    error = wrapped_error "canceled", 499, "canceled body", ["canceled headers"]
-    error.must_be_kind_of Google::Cloud::CanceledError
-
-    error.message.must_equal "canceled"
-    error.status_code.must_equal 499
-    error.body.must_equal "canceled body"
-    error.header.must_equal ["canceled headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps InternalError" do
-    error = wrapped_error "internal", 500, "internal body", ["internal headers"]
-    error.must_be_kind_of Google::Cloud::InternalError
-
-    error.message.must_equal "internal"
-    error.status_code.must_equal 500
-    error.body.must_equal "internal body"
-    error.header.must_equal ["internal headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps UnknownError" do
-    skip "don't know how we differentiate this error yet"
-
-    error = wrapped_error "unknown", 500, "unknown body", ["unknown headers"]
-    error.must_be_kind_of Google::Cloud::UnknownError
-
-    error.message.must_equal "invalid"
-    error.status_code.must_equal 500
-    error.body.must_equal "invalid body"
-    error.header.must_equal ["invalid headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps DataLossError" do
-    skip "don't know how we differentiate this error yet"
-
-    error = wrapped_error "data loss", 500, "data loss body", ["data loss headers"]
-    error.must_be_kind_of Google::Cloud::DataLossError
-
-    error.message.must_equal "data loss"
-    error.status_code.must_equal 500
-    error.body.must_equal "data loss body"
-    error.header.must_equal ["data loss headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps UnimplementedError" do
-    error = wrapped_error "unimplemented", 501, "unimplemented body", ["unimplemented headers"]
-    error.must_be_kind_of Google::Cloud::UnimplementedError
-
-    error.message.must_equal "unimplemented"
-    error.status_code.must_equal 501
-    error.body.must_equal "unimplemented body"
-    error.header.must_equal ["unimplemented headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps UnavailableError" do
-    error = wrapped_error "unavailable", 503, "unavailable body", ["unavailable headers"]
-    error.must_be_kind_of Google::Cloud::UnavailableError
-
-    error.message.must_equal "unavailable"
-    error.status_code.must_equal 503
-    error.body.must_equal "unavailable body"
-    error.header.must_equal ["unavailable headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps DeadlineExceededError" do
-    error = wrapped_error "exceeded", 504, "exceeded body", ["exceeded headers"]
-    error.must_be_kind_of Google::Cloud::DeadlineExceededError
-
-    error.message.must_equal "exceeded"
-    error.status_code.must_equal 504
-    error.body.must_equal "exceeded body"
-    error.header.must_equal ["exceeded headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-
-  it "wraps unknown error" do
-    error = wrapped_error "unknown", 999, "unknown body", ["unknown headers"]
-    error.must_be_kind_of Google::Cloud::Error
-
-    error.message.must_equal "unknown"
-    error.status_code.must_equal 999
-    error.body.must_equal "unknown body"
-    error.header.must_equal ["unknown headers"]
-
-    error.code.must_be :nil?
-    error.details.must_be :nil?
-    error.metadata.must_be :nil?
-    error.status_details.must_be :nil?
-  end
-end
diff --git a/google-cloud-core/test/google/cloud/errors/wrapped_gax_test.rb b/google-cloud-core/test/google/cloud/errors/wrapped_gax_test.rb
deleted file mode 100644
index 02e72b8ba..000000000
--- a/google-cloud-core/test/google/cloud/errors/wrapped_gax_test.rb
+++ /dev/null
@@ -1,325 +0,0 @@
-# Copyright 2017 Google LLC
-#
-# Licensed under the Apache License, Version 2.0  the "License";
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-require "helper"
-require "google/cloud/errors"
-require "grpc/errors"
-require "google/gax/errors"
-require "google/rpc/status_pb"
-
-describe Google::Cloud::Error, :wrapped_gax do
-  def debug_info
-    Google::Rpc::DebugInfo.new detail: "lolz"
-  end
-  def encoded_protobuf
-    any = Google::Protobuf::Any.new
-    any.pack debug_info
-
-    status = Google::Rpc::Status.new details: [any]
-
-    Google::Rpc::Status.encode status
-  end
-
-  def wrapped_error status, msg, metadata = {}
-    err = grpc_error status, msg, metadata
-    begin
-      begin
-        begin
-          raise err
-        rescue => inner_err
-          raise Google::Gax::GaxError.new(inner_err.message)
-        end
-      rescue => gax_err
-        raise Google::Cloud::Error.from_error gax_err.cause
-      end
-    rescue => e
-      return e
-    end
-  end
-
-  def grpc_error status, msg, metadata = {}
-    GRPC::BadStatus.new status, msg, metadata
-  end
-
-  it "wraps CanceledError" do
-    error = wrapped_error 1, "cancelled", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::CanceledError
-
-    error.message.must_equal "1:cancelled"
-    error.code.must_equal 1
-    error.details.must_equal "cancelled"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps UnknownError" do
-    error = wrapped_error 2, "unknown", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::UnknownError
-
-    error.message.must_equal "2:unknown"
-    error.code.must_equal 2
-    error.details.must_equal "unknown"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps InvalidArgumentError" do
-    error = wrapped_error 3, "invalid", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::InvalidArgumentError
-
-    error.message.must_equal "3:invalid"
-    error.code.must_equal 3
-    error.details.must_equal "invalid"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps DeadlineExceededError" do
-    error = wrapped_error 4, "exceeded", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::DeadlineExceededError
-
-    error.message.must_equal "4:exceeded"
-    error.code.must_equal 4
-    error.details.must_equal "exceeded"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps NotFoundError" do
-    error = wrapped_error 5, "not found", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::NotFoundError
-
-    error.message.must_equal "5:not found"
-    error.code.must_equal 5
-    error.details.must_equal "not found"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps AlreadyExistsError" do
-    error = wrapped_error 6, "exists", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::AlreadyExistsError
-
-    error.message.must_equal "6:exists"
-    error.code.must_equal 6
-    error.details.must_equal "exists"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps PermissionDeniedError" do
-    error = wrapped_error 7, "denied", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::PermissionDeniedError
-
-    error.message.must_equal "7:denied"
-    error.code.must_equal 7
-    error.details.must_equal "denied"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps ResourceExhaustedError" do
-    error = wrapped_error 8, "exhausted", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::ResourceExhaustedError
-
-    error.message.must_equal "8:exhausted"
-    error.code.must_equal 8
-    error.details.must_equal "exhausted"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps FailedPreconditionError" do
-    error = wrapped_error 9, "precondition", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::FailedPreconditionError
-
-    error.message.must_equal "9:precondition"
-    error.code.must_equal 9
-    error.details.must_equal "precondition"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps AbortedError" do
-    error = wrapped_error 10, "aborted", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::AbortedError
-
-    error.message.must_equal "10:aborted"
-    error.code.must_equal 10
-    error.details.must_equal "aborted"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps OutOfRangeError" do
-    error = wrapped_error 11, "out of range", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::OutOfRangeError
-
-    error.message.must_equal "11:out of range"
-    error.code.must_equal 11
-    error.details.must_equal "out of range"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps UnimplementedError" do
-    error = wrapped_error 12, "unimplemented", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::UnimplementedError
-
-    error.message.must_equal "12:unimplemented"
-    error.code.must_equal 12
-    error.details.must_equal "unimplemented"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps InternalError" do
-    error = wrapped_error 13, "internal", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::InternalError
-
-    error.message.must_equal "13:internal"
-    error.code.must_equal 13
-    error.details.must_equal "internal"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps UnavailableError" do
-    error = wrapped_error 14, "unavailable", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::UnavailableError
-
-    error.message.must_equal "14:unavailable"
-    error.code.must_equal 14
-    error.details.must_equal "unavailable"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps DataLossError" do
-    error = wrapped_error 15, "data loss", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::DataLossError
-
-    error.message.must_equal "15:data loss"
-    error.code.must_equal 15
-    error.details.must_equal "data loss"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps UnauthenticatedError" do
-    error = wrapped_error 16, "unauthenticated", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::UnauthenticatedError
-
-    error.message.must_equal "16:unauthenticated"
-    error.code.must_equal 16
-    error.details.must_equal "unauthenticated"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps unknown error (0)" do
-    # We don't know what to map this error case to
-    error = wrapped_error 0, "unknown", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::Error
-
-    error.message.must_equal "0:unknown"
-    error.code.must_equal 0
-    error.details.must_equal "unknown"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps unknown error (17)" do
-    error = wrapped_error 17, "unknown", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
-    error.must_be_kind_of Google::Cloud::Error
-
-    error.message.must_equal "17:unknown"
-    error.code.must_equal 17
-    error.details.must_equal "unknown"
-    error.metadata["foo"].must_equal "bar"
-    error.status_details.must_equal [debug_info]
-
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-end
diff --git a/google-cloud-core/test/google/cloud/errors/wrapped_grpc_test.rb b/google-cloud-core/test/google/cloud/errors/wrapped_grpc_test.rb
deleted file mode 100644
index 25b326451..000000000
--- a/google-cloud-core/test/google/cloud/errors/wrapped_grpc_test.rb
+++ /dev/null
@@ -1,307 +0,0 @@
-# Copyright 2017 Google LLC
-#
-# Licensed under the Apache License, Version 2.0  the "License";
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-require "helper"
-require "google/cloud/errors"
-require "grpc/errors"
-
-describe Google::Cloud::Error, :wrapped_grpc do
-  def wrapped_error status, msg, metadata = {}
-    err = grpc_error status, msg, metadata
-    begin
-      begin
-        raise err
-      rescue => inner_err
-        raise Google::Cloud::Error.from_error inner_err
-      end
-    rescue => e
-      return e
-    end
-  end
-
-  def grpc_error status, msg, metadata = {}
-    GRPC::BadStatus.new status, msg, metadata
-  end
-
-  it "wraps CanceledError" do
-    error = wrapped_error 1, "cancelled", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::CanceledError
-
-    error.message.must_equal "1:cancelled"
-    error.code.must_equal 1
-    error.details.must_equal "cancelled"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps UnknownError" do
-    error = wrapped_error 2, "unknown", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::UnknownError
-
-    error.message.must_equal "2:unknown"
-    error.code.must_equal 2
-    error.details.must_equal "unknown"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps InvalidArgumentError" do
-    error = wrapped_error 3, "invalid", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::InvalidArgumentError
-
-    error.message.must_equal "3:invalid"
-    error.code.must_equal 3
-    error.details.must_equal "invalid"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps DeadlineExceededError" do
-    error = wrapped_error 4, "exceeded", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::DeadlineExceededError
-
-    error.message.must_equal "4:exceeded"
-    error.code.must_equal 4
-    error.details.must_equal "exceeded"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps NotFoundError" do
-    error = wrapped_error 5, "not found", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::NotFoundError
-
-    error.message.must_equal "5:not found"
-    error.code.must_equal 5
-    error.details.must_equal "not found"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps AlreadyExistsError" do
-    error = wrapped_error 6, "exists", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::AlreadyExistsError
-
-    error.message.must_equal "6:exists"
-    error.code.must_equal 6
-    error.details.must_equal "exists"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps PermissionDeniedError" do
-    error = wrapped_error 7, "denied", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::PermissionDeniedError
-
-    error.message.must_equal "7:denied"
-    error.code.must_equal 7
-    error.details.must_equal "denied"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps ResourceExhaustedError" do
-    error = wrapped_error 8, "exhausted", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::ResourceExhaustedError
-
-    error.message.must_equal "8:exhausted"
-    error.code.must_equal 8
-    error.details.must_equal "exhausted"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps FailedPreconditionError" do
-    error = wrapped_error 9, "precondition", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::FailedPreconditionError
-
-    error.message.must_equal "9:precondition"
-    error.code.must_equal 9
-    error.details.must_equal "precondition"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps AbortedError" do
-    error = wrapped_error 10, "aborted", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::AbortedError
-
-    error.message.must_equal "10:aborted"
-    error.code.must_equal 10
-    error.details.must_equal "aborted"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps OutOfRangeError" do
-    error = wrapped_error 11, "out of range", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::OutOfRangeError
-
-    error.message.must_equal "11:out of range"
-    error.code.must_equal 11
-    error.details.must_equal "out of range"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps UnimplementedError" do
-    error = wrapped_error 12, "unimplemented", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::UnimplementedError
-
-    error.message.must_equal "12:unimplemented"
-    error.code.must_equal 12
-    error.details.must_equal "unimplemented"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps InternalError" do
-    error = wrapped_error 13, "internal", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::InternalError
-
-    error.message.must_equal "13:internal"
-    error.code.must_equal 13
-    error.details.must_equal "internal"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps UnavailableError" do
-    error = wrapped_error 14, "unavailable", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::UnavailableError
-
-    error.message.must_equal "14:unavailable"
-    error.code.must_equal 14
-    error.details.must_equal "unavailable"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps DataLossError" do
-    error = wrapped_error 15, "data loss", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::DataLossError
-
-    error.message.must_equal "15:data loss"
-    error.code.must_equal 15
-    error.details.must_equal "data loss"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps UnauthenticatedError" do
-    error = wrapped_error 16, "unauthenticated", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::UnauthenticatedError
-
-    error.message.must_equal "16:unauthenticated"
-    error.code.must_equal 16
-    error.details.must_equal "unauthenticated"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps unknown error (0)" do
-    # We don't know what to map this error case to
-    error = wrapped_error 0, "unknown", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::Error
-
-    error.message.must_equal "0:unknown"
-    error.code.must_equal 0
-    error.details.must_equal "unknown"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-
-  it "wraps unknown error (17)" do
-    error = wrapped_error 17, "unknown", { "foo" => "bar" }
-    error.must_be_kind_of Google::Cloud::Error
-
-    error.message.must_equal "17:unknown"
-    error.code.must_equal 17
-    error.details.must_equal "unknown"
-    error.metadata.must_equal({ "foo" => "bar" })
-
-    error.status_details.must_be :nil?
-    error.status_code.must_be :nil?
-    error.body.must_be :nil?
-    error.header.must_be :nil?
-  end
-end

```

</details>

This pull request was generated using releasetool.