### PR TITLE
Release google-cloud-secret_manager-v1beta1 0.1.0

### DIFF
--- a/google-cloud-secret_manager-v1beta1/CHANGELOG.md
+++ b/google-cloud-secret_manager-v1beta1/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-01-09
+
+* Initial release.
+

--- a/google-cloud-secret_manager-v1beta1/lib/google/cloud/secret_manager/v1beta1/version.rb
+++ b/google-cloud-secret_manager-v1beta1/lib/google/cloud/secret_manager/v1beta1/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module SecretManager
       module V1beta1
-        VERSION = "0.0.1"
+        VERSION = "0.1.0"
       end
     end
   end

--- a/google-cloud-secret_manager/google-cloud-secret_manager.gemspec
+++ b/google-cloud-secret_manager/google-cloud-secret_manager.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
-  gem.add_dependency "google-cloud-secret_manager-v1beta1", "~> 0.0"
+  gem.add_dependency "google-cloud-secret_manager-v1beta1", "~> 0.1"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/google-cloud-secret_manager/lib/google/cloud/secret_manager/version.rb
+++ b/google-cloud-secret_manager/lib/google/cloud/secret_manager/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module SecretManager
-      VERSION = "0.1.0".freeze
+      VERSION = "0.0.1".freeze
     end
   end
 end


### PR DESCRIPTION
* Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff

```

</details>

This pull request was generated using releasetool.