### PR TITLE
docs(secret_manager): Clarify library status and provide some additional links

### DIFF
--- a/google-cloud-secret_manager/README.md
+++ b/google-cloud-secret_manager/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Secret Manager API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Secret Manager API
 
 [Secret Manager API][Product Documentation]:
 Secret Manager provides a secure and convenient tool for storing API keys, passwords, certificates, and other sensitive data.
@@ -20,14 +20,15 @@ $ gem install google-cloud-secret_manager
 ```
 
 ### Next Steps
-- Read the [Client Library Documentation][] for Secret Manager API
-  to see other available methods on the client.
+- Read the [Client Library Documentation][] for the Secret Manager API, and the underlying
+  [V1beta1 Client Documentation][] to see other available methods on the client.
 - Read the [Secret Manager API Product documentation][Product Documentation]
   to learn more about the product and see How-to Guides.
 - View this [repository's main README](https://github.com/googleapis/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
 [Client Library Documentation]: https://googleapis.dev/ruby/google-cloud-secret_manager/latest
+[V1beta1 Client Documentation]: https://googleapis.dev/ruby/google-cloud-secret_manager-v1beta1/latest
 [Product Documentation]: https://cloud.google.com/natural-language
 
 ## Enabling Logging

--- a/google-cloud-secret_manager/lib/google/cloud/secret_manager.rb
+++ b/google-cloud-secret_manager/lib/google/cloud/secret_manager.rb
@@ -25,7 +25,8 @@ module Google
       # Create a new `SecretManagerService::Client` object.
       #
       # @param version [String, Symbol] The API version to create the client instance. Optional. If not provided
-      #   defaults to `:v1beta1`.
+      #   defaults to `:v1beta1`, which will return an instance of
+      #   [Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client](https://googleapis.dev/ruby/google-cloud-secret_manager-v1beta1/latest/Google/Cloud/SecretManager/V1beta1/SecretManagerService/Client.html).
       #
       # @return [SecretManagerService::Client] A client object for the specified version.
       #


### PR DESCRIPTION
Two requests from @sethvargo

* Remove "alpha" designation from the library. We're likely to be removing this designation altogether in the future.
* Provide links to the v1beta1 client class documentation