### PR TITLE
Add support for Pub/Sub Dead Letter Queues

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -170,7 +170,7 @@ describe Google::Cloud::PubSub, :pubsub do
       received_messages.count.must_equal 1
       received_message = received_messages.first
       received_message.wont_be :nil?
-      received_message.delivery_attempt.must_equal 0
+      received_message.delivery_attempt.must_be :nil?
       received_message.msg.data.must_equal msg.data
       received_message.msg.published_at.wont_be :nil?
       # Acknowledge the message
@@ -199,7 +199,7 @@ describe Google::Cloud::PubSub, :pubsub do
       received_messages.count.must_equal 1
       received_message = received_messages.first
       received_message.wont_be :nil?
-      received_message.delivery_attempt.must_equal 0
+      received_message.delivery_attempt.must_be :nil?
       received_message.msg.data.must_equal msg.data
       received_message.msg.published_at.wont_be :nil?
       # Acknowledge the message
@@ -217,7 +217,7 @@ describe Google::Cloud::PubSub, :pubsub do
       received_messages.count.must_equal 1
       received_message = received_messages.first
       received_message.wont_be :nil?
-      received_message.delivery_attempt.must_equal 0
+      received_message.delivery_attempt.must_be :nil?
       received_message.msg.data.must_equal msg.data
       # Acknowledge the message
       subscription.ack received_message.ack_id
@@ -237,7 +237,7 @@ describe Google::Cloud::PubSub, :pubsub do
       # Remove the subscription
       subscription.delete
     end
-focus
+
     it "should be able to direct messages to a dead letter topic" do
       dead_letter_topic = retrieve_topic dead_letter_topic_name
       dead_letter_subscription = dead_letter_topic.subscribe "#{$topic_prefix}-dead-letter-sub1"
@@ -248,19 +248,19 @@ focus
       subscription.dead_letter_topic.reload!.name.must_equal dead_letter_topic.name
 
       # update
-      # subscription.dead_letter_max_delivery_attempts = 5
-      # subscription.dead_letter_max_delivery_attempts.must_equal 5
-      # dead_letter_topic_2 = retrieve_topic dead_letter_topic_name_2
-      # dead_letter_subscription_2 = dead_letter_topic_2.subscribe "#{$topic_prefix}-dead-letter-sub1"
-      # subscription.dead_letter_topic = dead_letter_topic_2
-      # subscription.dead_letter_topic.reload!.name.must_equal dead_letter_topic_2.name
+      subscription.dead_letter_max_delivery_attempts = 5
+      subscription.dead_letter_max_delivery_attempts.must_equal 5
+      dead_letter_topic_2 = retrieve_topic dead_letter_topic_name_2
+      dead_letter_subscription_2 = dead_letter_topic_2.subscribe "#{$topic_prefix}-dead-letter-sub2"
+      subscription.dead_letter_topic = dead_letter_topic_2
+      subscription.dead_letter_topic.reload!.name.must_equal dead_letter_topic_2.name
 
       # Publish a new message
       msg = topic.publish "dead-letter-#{rand(1000)}"
       msg.wont_be :nil?
 
       # Check it pulls the message
-      (1..6).each do |i|
+      (1..5).each do |i|
         received_messages = pull_with_retry subscription
         received_messages.count.must_equal 1
         received_message = received_messages.first

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -143,7 +143,7 @@ describe Google::Cloud::PubSub, :pubsub do
       # update
       subscription.labels = {}
       subscription.labels.must_be :empty?
-
+    ensure
       # delete
       subscription.delete
     end
@@ -174,6 +174,7 @@ describe Google::Cloud::PubSub, :pubsub do
       received_message.msg.published_at.wont_be :nil?
       # Acknowledge the message
       subscription.ack received_message.ack_id
+    ensure
       # Remove the subscription
       subscription.delete
     end
@@ -232,7 +233,7 @@ describe Google::Cloud::PubSub, :pubsub do
       snapshot.labels.must_be :frozen?
       snapshot.labels = {}
       snapshot.labels.must_be :empty?
-
+    ensure
       # Remove the subscription
       subscription.delete
     end
@@ -284,7 +285,7 @@ describe Google::Cloud::PubSub, :pubsub do
         received_message.wont_be :nil?
         received_message.msg.data.must_equal msg.data
         received_message.delivery_attempt.must_be :nil?
-
+      ensure
         # Remove the subscription
         subscription.delete
         dead_letter_subscription.delete

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -179,7 +179,7 @@ describe Google::Cloud::PubSub, :pubsub do
       received_messages.count.must_equal 1
       received_message = received_messages.first
       received_message.wont_be :nil?
-      received_message.delivery_attempt.wont_be :nil?
+      received_message.delivery_attempt.must_be :>, 0
       received_message.msg.data.must_equal msg.data
       received_message.msg.published_at.wont_be :nil?
       # Acknowledge the message
@@ -208,7 +208,7 @@ describe Google::Cloud::PubSub, :pubsub do
       received_messages.count.must_equal 1
       received_message = received_messages.first
       received_message.wont_be :nil?
-      received_message.delivery_attempt.wont_be :nil?
+      received_message.delivery_attempt.must_be :>, 0
       received_message.msg.data.must_equal msg.data
       received_message.msg.published_at.wont_be :nil?
       # Acknowledge the message
@@ -227,7 +227,7 @@ describe Google::Cloud::PubSub, :pubsub do
       received_messages.count.must_equal 1
       received_message = received_messages.first
       received_message.wont_be :nil?
-      received_message.delivery_attempt.wont_be :nil?
+      received_message.delivery_attempt.must_be :>, 0
       received_message.msg.data.must_equal msg.data
       # Acknowledge the message
       subscription.ack received_message.ack_id

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -239,19 +239,15 @@ describe Google::Cloud::PubSub, :pubsub do
 
     if $project_number
       it "should be able to direct messages to a dead letter topic" do
-        # Dead Letter Queue (DLQ) testing requires IAM bindings to the Cloud Pub/Sub service account that is automatically
-        # created and managed by the service team in a private project.
-        service_account_email = "serviceAccount:service-#{$project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
-
         dead_letter_topic = retrieve_topic dead_letter_topic_name
-        dead_letter_topic.policy do |p|
-          p.add "roles/pubsub.publisher", service_account_email
-        end
         dead_letter_subscription = dead_letter_topic.subscribe "#{$topic_prefix}-dead-letter-sub1"
 
-        dead_letter_subscription.policy do |p|
-          p.add "roles/pubsub.subscriber", service_account_email
-        end
+        # Dead Letter Queue (DLQ) testing requires IAM bindings to the Cloud Pub/Sub service account that is
+        # automatically created and managed by the service team in a private project.
+        service_account_email = "serviceAccount:service-#{$project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+
+        dead_letter_topic.policy { |p| p.add "roles/pubsub.publisher", service_account_email }
+        dead_letter_subscription.policy { |p| p.add "roles/pubsub.subscriber", service_account_email }
 
         # create
         subscription = topic.subscribe "#{$topic_prefix}-sub6", dead_letter_topic: dead_letter_topic, dead_letter_max_delivery_attempts: 6

--- a/google-cloud-pubsub/acceptance/pubsub_helper.rb
+++ b/google-cloud-pubsub/acceptance/pubsub_helper.rb
@@ -78,9 +78,9 @@ end
 require "time"
 require "securerandom"
 t = Time.now.utc.iso8601.gsub ":", "-"
-$topic_prefix = "gcloud-ruby-acceptance-#{t}-#{SecureRandom.hex(4)}".downcase
-$topic_names = 8.times.map { "#{$topic_prefix}-#{SecureRandom.hex(4)}".downcase }
-$snapshot_prefix = "gcloud-ruby-acceptance-#{t}-snapshot-#{SecureRandom.hex(4)}".downcase
+$topic_prefix = "ruby-topic-#{t}-#{SecureRandom.hex(4)}".downcase
+$topic_names = 10.times.map { "#{$topic_prefix}-#{SecureRandom.hex(4)}".downcase }
+$snapshot_prefix = "ruby-snp-#{t}-snapshot-#{SecureRandom.hex(4)}".downcase
 $snapshot_names = 3.times.map { "#{$snapshot_prefix}-#{SecureRandom.hex(4)}".downcase }
 
 def clean_up_pubsub_topics

--- a/google-cloud-pubsub/acceptance/pubsub_helper.rb
+++ b/google-cloud-pubsub/acceptance/pubsub_helper.rb
@@ -27,6 +27,11 @@ end
 # Create shared pubsub object so we don't create new for each test
 $pubsub = Google::Cloud.new.pubsub
 
+# Dead Letter Queue (DLQ) testing requires IAM bindings to the Cloud Pub/Sub service account that is automatically
+# created and managed by the service team in a private project.
+# Format: `service-${GCLOUD_PROJECT_NUMBER}@gcp-sa-pubsub.iam.gserviceaccount.com`
+$project_number = ENV["GCLOUD_PROJECT_NUMBER"]
+
 module Acceptance
   ##
   # Test class for running against a PubSub instance.
@@ -109,4 +114,9 @@ end
 Minitest.after_run do
   clean_up_pubsub_topics
   clean_up_pubsub_snapshots
+  unless $project_number
+    puts "The Dead Letter Queue (DLQ) tests were not run. To enable, ensure that " \
+         "GCLOUD_PROJECT_NUMBER is present in the environment in order to bind IAM permissions to " \
+         "service-${GCLOUD_PROJECT_NUMBER}@gcp-sa-pubsub.iam.gserviceaccount.com"
+  end
 end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -101,6 +101,7 @@ module Google
         #   end
         #
         def delivery_attempt
+          return nil if @grpc.delivery_attempt && @grpc.delivery_attempt < 1
           @grpc.delivery_attempt
         end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -64,6 +64,49 @@ module Google
         end
 
         ##
+        # Returns the delivery attempt counter for the message. The delivery attempt
+        # counter is `1 + (the sum of number of NACKs and number of
+        # ack_deadline exceeds)` for the message.
+        #
+        # A NACK is any call to `ModifyAckDeadline` with a `0` deadline. An `ack_deadline`
+        # exceeds event is whenever a message is not acknowledged within
+        # `ack_deadline`. Note that `ack_deadline` is initially
+        # `Subscription.ackDeadlineSeconds`, but may get extended automatically by
+        # the client library.
+        #
+        # The first delivery of a given message will have this value as `1`. The value
+        # is calculated at best effort and is approximate.
+        #
+        # If a dead letter policy is not set on the subscription, this will be `0`. See
+        # {Topic#subscribe}, {Subscription#dead_letter_topic=} and
+        # {Subscription#dead_letter_max_delivery_attempts=}.
+        #
+        # EXPERIMENTAL: This feature is part of a closed alpha release. This
+        # API might be changed in backward-incompatible ways and is not recommended
+        # for production use. It is not subject to any SLA or deprecation policy.
+        #
+        # @return [Integer]
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   topic = pubsub.topic "my-topic"
+        #   dead_letter_topic = pubsub.topic "my-dead-letter-topic", skip_lookup: true
+        #   sub = topic.subscribe "my-topic-sub",
+        #                         dead_letter_topic: dead_letter_topic,
+        #                         dead_letter_max_delivery_attempts: 10
+        #
+        #   subscriber = sub.listen do |received_message|
+        #     puts received_message.message.delivery_attempt
+        #   end
+        #
+        def delivery_attempt
+          @grpc.delivery_attempt
+        end
+
+        ##
         # The received message.
         def message
           Message.from_grpc @grpc.message

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -64,28 +64,26 @@ module Google
         end
 
         ##
-        # Returns the delivery attempt counter for the message. The delivery attempt
-        # counter is `1 + (the sum of number of NACKs and number of
-        # ack_deadline exceeds)` for the message.
+        # Returns the delivery attempt counter for the message. If a dead letter policy is not set on the subscription,
+        # this will be `0`. See {Topic#subscribe}, {Subscription#dead_letter_topic=} and
+        # {Subscription#dead_letter_max_delivery_attempts=}.
         #
-        # A NACK is any call to `ModifyAckDeadline` with a `0` deadline. An `ack_deadline`
-        # exceeds event is whenever a message is not acknowledged within
-        # `ack_deadline`. Note that `ack_deadline` is initially
-        # `Subscription.ackDeadlineSeconds`, but may get extended automatically by
-        # the client library.
+        # The delivery attempt counter is `1 + (the sum of number of NACKs and number of ack_deadline exceeds)` for the
+        # message.
+        #
+        # A NACK is any call to `ModifyAckDeadline` with a `0` deadline. An `ack_deadline` exceeds event is whenever a
+        # message is not acknowledged within `ack_deadline`. Note that `ack_deadline` is initially
+        # `Subscription.ackDeadlineSeconds`, but may get extended automatically by the client library.
         #
         # The first delivery of a given message will have this value as `1`. The value
         # is calculated at best effort and is approximate.
         #
-        # If a dead letter policy is not set on the subscription, this will be `0`. See
-        # {Topic#subscribe}, {Subscription#dead_letter_topic=} and
-        # {Subscription#dead_letter_max_delivery_attempts=}.
+        # EXPERIMENTAL: This feature is part of a closed alpha release. This API might be changed in
+        # backward-incompatible ways and is not recommended for production use. It is not subject to any SLA or
+        # deprecation policy.
         #
-        # EXPERIMENTAL: This feature is part of a closed alpha release. This
-        # API might be changed in backward-incompatible ways and is not recommended
-        # for production use. It is not subject to any SLA or deprecation policy.
-        #
-        # @return [Integer]
+        # @return [Integer] A delivery attempt value of `1` or greater, or `0` if a dead letter policy is not set on the
+        #   subscription.
         #
         # @example
         #   require "google/cloud/pubsub"

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -65,7 +65,7 @@ module Google
 
         ##
         # Returns the delivery attempt counter for the message. If a dead letter policy is not set on the subscription,
-        # this will be `0`. See {Topic#subscribe}, {Subscription#dead_letter_topic=} and
+        # this will be `nil`. See {Topic#subscribe}, {Subscription#dead_letter_topic=} and
         # {Subscription#dead_letter_max_delivery_attempts=}.
         #
         # The delivery attempt counter is `1 + (the sum of number of NACKs and number of ack_deadline exceeds)` for the
@@ -75,15 +75,15 @@ module Google
         # message is not acknowledged within `ack_deadline`. Note that `ack_deadline` is initially
         # `Subscription.ackDeadlineSeconds`, but may get extended automatically by the client library.
         #
-        # The first delivery of a given message will have this value as `1`. The value
-        # is calculated at best effort and is approximate.
+        # The first delivery of a given message will have this value as `1`. The value is calculated at best effort and
+        # is approximate.
         #
         # EXPERIMENTAL: This feature is part of a closed alpha release. This API might be changed in
         # backward-incompatible ways and is not recommended for production use. It is not subject to any SLA or
         # deprecation policy.
         #
-        # @return [Integer] A delivery attempt value of `1` or greater, or `0` if a dead letter policy is not set on the
-        #   subscription.
+        # @return [Integer, nil] A delivery attempt value of `1` or greater, or `nil` if a dead letter policy is not set
+        #   on the subscription.
         #
         # @example
         #   require "google/cloud/pubsub"

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -78,9 +78,10 @@ module Google
         # The first delivery of a given message will have this value as `1`. The value is calculated at best effort and
         # is approximate.
         #
-        # EXPERIMENTAL: This feature is part of a closed alpha release. This API might be changed in
-        # backward-incompatible ways and is not recommended for production use. It is not subject to any SLA or
-        # deprecation policy.
+        # EXPERIMENTAL: This feature is part of a closed alpha release and is available only to whitelisted partners.
+        # This method will return `nil` if a dead letter policy is not set on the subscription. This API might be
+        # changed in backward-incompatible ways and is not recommended for production use. It is not subject to any SLA
+        # or deprecation policy.
         #
         # @return [Integer, nil] A delivery attempt value of `1` or greater, or `nil` if a dead letter policy is not set
         #   on the subscription.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -479,10 +479,11 @@ module Google
 
         def dead_letter_policy options
           return nil unless options[:dead_letter_topic_name]
-          Google::Cloud::PubSub::V1::DeadLetterPolicy.new(
-            dead_letter_topic:     options[:dead_letter_topic_name],
-            max_delivery_attempts: options[:dead_letter_max_delivery_attempts]
-          )
+          policy = Google::Cloud::PubSub::V1::DeadLetterPolicy.new dead_letter_topic: options[:dead_letter_topic_name]
+          if options[:dead_letter_max_delivery_attempts]
+            policy.max_delivery_attempts = options[:dead_letter_max_delivery_attempts]
+          end
+          policy
         end
 
         def default_headers

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -238,7 +238,6 @@ module Google
           mrd = Convert.number_to_duration options[:retention]
           labels = options[:labels]
           message_ordering = options[:message_ordering]
-
           execute do
             subscriber.create_subscription \
               name, topic,
@@ -248,6 +247,7 @@ module Google
               message_retention_duration: mrd,
               labels:                     labels,
               enable_message_ordering:    message_ordering,
+              dead_letter_policy:         dead_letter_policy(options),
               options:                    default_options
           end
         end
@@ -475,6 +475,14 @@ module Google
           # Rails' String#to_time returns nil if the string doesn't parse.
           return false if obj.to_time.nil?
           true
+        end
+
+        def dead_letter_policy options
+          return nil unless options[:dead_letter_topic_name]
+          Google::Cloud::PubSub::V1::DeadLetterPolicy.new(
+            dead_letter_topic:     options[:dead_letter_topic_name],
+            max_delivery_attempts: options[:dead_letter_max_delivery_attempts]
+          )
         end
 
         def default_headers

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -369,8 +369,8 @@ module Google
         #   pubsub = Google::Cloud::PubSub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
-        #   dead_letter_topic = pubsub.topic "my-dead-letter-topic", skip_lookup: true
-        #   sub.topic.name #=> "projects/my-project/topics/my-topic"
+        #   sub.dead_letter_topic.name #=> "projects/my-project/topics/my-dead-letter-topic"
+        #   sub.dead_letter_max_delivery_attempts #=> 10
         #
         def dead_letter_topic
           ensure_grpc!
@@ -399,7 +399,7 @@ module Google
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   dead_letter_topic = pubsub.topic "my-dead-letter-topic", skip_lookup: true
-        #   sub.topic.name #=> "projects/my-project/topics/my-topic"
+        #   sub.dead_letter_topic = dead_letter_topic
         #
         def dead_letter_topic= new_dead_letter_topic
           ensure_grpc!
@@ -427,6 +427,15 @@ module Google
         #
         # @return [Integer] A value between 5 and 100. If this value is 0, a default value of 5 is used.
         #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   sub = pubsub.subscription "my-topic-sub"
+        #   sub.dead_letter_topic.name #=> "projects/my-project/topics/my-dead-letter-topic"
+        #   sub.dead_letter_max_delivery_attempts #=> 10
+        #
         def dead_letter_max_delivery_attempts
           ensure_grpc!
           @grpc.dead_letter_policy&.max_delivery_attempts
@@ -447,6 +456,16 @@ module Google
         #
         # @param [Integer] new_dead_letter_max_delivery_attempts A value between 5 and 100. If this parameter is 0, a
         #   default value of 5 is used.
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   sub = pubsub.subscription "my-topic-sub"
+        #   sub.dead_letter_topic.name #=> "projects/my-project/topics/my-dead-letter-topic"
+        #
+        #   sub.dead_letter_max_delivery_attempts = 20
         #
         def dead_letter_max_delivery_attempts= new_dead_letter_max_delivery_attempts
           ensure_grpc!

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -353,15 +353,16 @@ module Google
         end
 
         ##
-        # Returns the {Topic} to which dead letter messages should be published. Dead lettering is done on a best effort
-        # basis. The same message might be dead lettered multiple times.
+        # Returns the {Topic} to which dead letter messages should be published if a dead letter policy is configured,
+        # otherwise `nil`. Dead lettering is done on a best effort basis. The same message might be dead lettered
+        # multiple times.
         #
         # See also {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts=} and
         # {#dead_letter_max_delivery_attempts}.
         #
         # Makes an API call to retrieve the topic name when called on a reference object. See {#reference?}.
         #
-        # @return [Topic]
+        # @return [Topic, nil]
         #
         # @example
         #   require "google/cloud/pubsub"
@@ -382,15 +383,16 @@ module Google
         # Sets the {Topic} to which dead letter messages for the subscription should be published. Dead lettering is
         # done on a best effort basis. The same message might be dead lettered multiple times.
         # The Cloud Pub/Sub service account associated with the enclosing subscription's parent project (i.e.,
-        # service-\\{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com) must have
-        # permission to Publish() to this topic.
+        # `service-\\{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com`) must have permission to Publish() to this
+        # topic.
         #
         # The operation will fail if the topic does not exist. Users should ensure that there is a subscription attached
         # to this topic since messages published to a topic with no subscriptions are lost.
         #
         # See also {#dead_letter_topic}, {#dead_letter_max_delivery_attempts=} and {#dead_letter_max_delivery_attempts}.
         #
-        # @param [Topic] new_dead_letter_topic The bucket to hold the logging output
+        # @param [Topic] new_dead_letter_topic The topic to which dead letter messages for the subscription should be
+        #   published.
         #
         # @example
         #   require "google/cloud/pubsub"
@@ -411,9 +413,9 @@ module Google
         end
 
         ##
-        # Returns the maximum number of delivery attempts for any message in the subscription's dead letter policy.
-        # Dead lettering is done on a best effort basis. The same message might be dead lettered multiple times.
-        # The value must be between 5 and 100.
+        # Returns the maximum number of delivery attempts for any message in the subscription's dead letter policy if a
+        # dead letter policy is configured, otherwise `nil`. Dead lettering is done on a best effort basis. The same
+        # message might be dead lettered multiple times. The value must be between 5 and 100.
         #
         # The number of delivery attempts is defined as 1 + (the sum of number of NACKs and number of times the
         # acknowledgement deadline has been exceeded for the message). A NACK is any call to ModifyAckDeadline with a 0
@@ -425,7 +427,8 @@ module Google
         #
         # Makes an API call to retrieve the value when called on a reference object. See {#reference?}.
         #
-        # @return [Integer] A value between 5 and 100. If this value is 0, a default value of 5 is used.
+        # @return [Integer, nil] A value between 5 and 100, or `nil` if no dead letter policy is configured. If this
+        #   value is 0, a default value of 5 is used.
         #
         # @example
         #   require "google/cloud/pubsub"

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -324,8 +324,18 @@ module Google
         #
         #   pubsub = Google::Cloud::PubSub.new
         #
+        #   # Dead Letter Queue (DLQ) testing requires IAM bindings to the Cloud Pub/Sub service account that is
+        #   # automatically created and managed by the service team in a private project.
+        #   my_project_number = "000000000000"
+        #   service_account_email = "serviceAccount:service-#{my_project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+        #
+        #   dead_letter_topic = pubsub.topic "my-dead-letter-topic"
+        #   dead_letter_subscription = dead_letter_topic.subscribe "my-dead-letter-sub"
+        #
+        #   dead_letter_topic.policy { |p| p.add "roles/pubsub.publisher", service_account_email }
+        #   dead_letter_subscription.policy { |p| p.add "roles/pubsub.subscriber", service_account_email }
+        #
         #   topic = pubsub.topic "my-topic"
-        #   dead_letter_topic = pubsub.topic "my-dead-letter-topic", skip_lookup: true
         #   sub = topic.subscribe "my-topic-sub",
         #                         dead_letter_topic: dead_letter_topic,
         #                         dead_letter_max_delivery_attempts: 10

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -288,8 +288,8 @@ module Google
         # @param [Topic] dead_letter_topic The {Topic} to which dead letter messages for the subscription should be
         #   published. Dead lettering is done on a best effort basis. The same message might be dead lettered multiple
         #   times. The Cloud Pub/Sub service account associated with the enclosing subscription's parent project (i.e.,
-        #   service-\\{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com) must have permission to Publish() to this
-        #   topic.
+        #   `service-\\{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com`) must have permission to Publish() to
+        #   this topic.
         #
         #   The operation will fail if the topic does not exist. Users should ensure that there is a subscription
         #   attached to this topic since messages published to a topic with no subscriptions are lost.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -319,6 +319,17 @@ module Google
         #                         deadline: 120,
         #                         endpoint: "https://example.com/push"
         #
+        # @example Configure a Dead Letter Queues policy:
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   topic = pubsub.topic "my-topic"
+        #   dead_letter_topic = pubsub.topic "my-dead-letter-topic", skip_lookup: true
+        #   sub = topic.subscribe "my-topic-sub",
+        #                         dead_letter_topic: dead_letter_topic,
+        #                         dead_letter_max_delivery_attempts: 10
+        #
         def subscribe subscription_name, deadline: nil, retain_acked: false, retention: nil, endpoint: nil, labels: nil,
                       message_ordering: nil, dead_letter_topic: nil, dead_letter_max_delivery_attempts: nil
           ensure_service!

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -598,6 +598,19 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::PubSub::Topic#subscribe@Configure a Dead Letter Queues policy:" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_publisher.expect :get_topic, topic_resp("my-dead-letter-topic"), ["projects/my-project/topics/my-dead-letter-topic", Hash]
+      mock_subscriber.expect :create_subscription, OpenStruct.new(name: "my-dead-letter-sub"), ["projects/my-project/subscriptions/my-dead-letter-sub", "projects/my-project/topics/my-dead-letter-topic", Hash]
+      mock_publisher.expect :get_iam_policy, policy_resp, ["projects/my-project/topics/my-dead-letter-topic", Hash]
+      mock_subscriber.expect :get_iam_policy, policy_resp, ["projects/my-project/subscriptions/my-dead-letter-sub", Hash]
+      mock_publisher.expect :set_iam_policy, policy_resp, ["projects/my-project/topics/my-dead-letter-topic", Google::Iam::V1::Policy, Hash]
+      mock_subscriber.expect :set_iam_policy, policy_resp, ["projects/my-project/subscriptions/my-dead-letter-sub", Google::Iam::V1::Policy, Hash]
+      mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/my-topic", Hash]
+      mock_subscriber.expect :create_subscription, OpenStruct.new(name: "my-topic-sub"), ["projects/my-project/subscriptions/my-topic-sub", "projects/my-project/topics/my-topic", Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::PubSub::Topic#subscription" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/my-topic", Hash]

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -230,6 +230,13 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::PubSub::ReceivedMessage#delivery_attempt" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/my-topic", Hash]
+      mock_subscriber.expect :create_subscription, OpenStruct.new(name: "my-topic-sub"), ["projects/my-project/subscriptions/my-topic-sub", "projects/my-project/topics/my-topic", Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::PubSub::ReceivedMessage#modify_ack_deadline!" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp, ["projects/my-project/subscriptions/my-topic-sub", Hash]

--- a/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
@@ -69,7 +69,14 @@ describe Google::Cloud::PubSub::ReceivedMessage, :mock_pubsub do
   end
 
   it "knows its delivery_attempt counter" do
-    rec_message.delivery_attempt.must_equal 1
+    rec_message.delivery_attempt.must_equal 10
+  end
+
+  it "returns nil for delivery_attempt when delivery_attempt is 0" do
+    rec_message_data_non_dlq = rec_message_hash rec_message_msg, delivery_attempt: 0
+    rec_message_grpc_non_dlq = Google::Cloud::PubSub::V1::ReceivedMessage.new rec_message_data_non_dlq
+    rec_message_non_dlq = Google::Cloud::PubSub::ReceivedMessage.from_grpc rec_message_grpc_non_dlq, subscription
+    rec_message_non_dlq.delivery_attempt.must_be :nil?
   end
 
   it "can acknowledge" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
@@ -68,6 +68,10 @@ describe Google::Cloud::PubSub::ReceivedMessage, :mock_pubsub do
     rec_message.publish_time.must_equal publish_time
   end
 
+  it "knows its delivery_attempt counter" do
+    rec_message.delivery_attempt.must_equal 1
+  end
+
   it "can acknowledge" do
     ack_res = nil
     mock = Minitest::Mock.new

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
@@ -172,9 +172,9 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
 
     inventory.add rec_msg1_grpc
     inventory.wont_be :full?
-    inventory.total_bytesize.must_equal 56
+    inventory.total_bytesize.must_equal 58
     inventory.add rec_msg2_grpc, rec_msg3_grpc
-    inventory.total_bytesize.must_equal 168
+    inventory.total_bytesize.must_equal 174
     inventory.must_be :full?
   end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
@@ -15,9 +15,11 @@
 require "helper"
 
 describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
+  let(:labels) { { "foo" => "bar" } }
   let(:topic_name) { "topic-name-goes-here" }
+  let(:dead_letter_topic_path) { topic_path("topic-name-dead-letter") }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_hash) { subscription_hash topic_name, sub_name, labels: labels, dead_letter_topic: dead_letter_topic_path, max_delivery_attempts: 6 }
   let(:sub_deadline) { sub_hash[:ack_deadline_seconds] }
   let(:sub_endpoint) { sub_hash[:push_config][:push_endpoint] }
   let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
@@ -72,6 +74,18 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
     subscription.push_config.authentication.email.must_equal "user@example.com"
     subscription.push_config.authentication.audience.must_equal "client-12345"
     subscription.push_config.must_be :oidc_token?
+  end
+
+  it "gets labels from the Google API object" do
+    subscription.labels.must_equal labels
+  end
+
+  it "gets dead_letter_topic from the Google API object" do
+    subscription.dead_letter_topic.name.must_equal dead_letter_topic_path
+  end
+
+  it "gets dead_letter_max_delivery_attempts from the Google API object" do
+    subscription.dead_letter_max_delivery_attempts.must_equal 6
   end
 
   describe "reference subscription object of a subscription that does exist" do
@@ -137,6 +151,40 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       subscription.service.mocked_subscriber = mock
 
       subscription.expires_in.must_equal two_days_seconds
+
+      mock.verify
+    end
+
+    it "makes an HTTP API call to retrieve labels" do
+      get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, sub_name, labels: labels)
+      mock = Minitest::Mock.new
+      mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
+      subscription.service.mocked_subscriber = mock
+
+      subscription.labels.must_equal labels
+
+      mock.verify
+    end
+
+    it "makes an HTTP API call to retrieve dead_letter_topic and dead_letter_max_delivery_attempts" do
+      get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, sub_name, dead_letter_topic: dead_letter_topic_path, max_delivery_attempts: 7)
+      mock = Minitest::Mock.new
+      mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
+      subscription.service.mocked_subscriber = mock
+
+      subscription.dead_letter_topic.name.must_equal dead_letter_topic_path
+      subscription.dead_letter_max_delivery_attempts.must_equal 7
+
+      mock.verify
+    end
+
+    it "makes an HTTP API call to retrieve labels" do
+      get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, sub_name, labels: labels)
+      mock = Minitest::Mock.new
+      mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
+      subscription.service.mocked_subscriber = mock
+
+      subscription.labels.must_equal labels
 
       mock.verify
     end
@@ -210,10 +258,52 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       end.must_raise Google::Cloud::NotFoundError
     end
 
+    it "raises NotFoundError when retrieving labels" do
+      stub = Object.new
+      def stub.get_subscription *args
+        gax_error = Google::Gax::GaxError.new "not found"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        raise gax_error
+      end
+      subscription.service.mocked_subscriber = stub
+
+      expect do
+        subscription.labels
+      end.must_raise Google::Cloud::NotFoundError
+    end
+
     it "does not raise NotFoundError when accessing push_config" do
       subscription.push_config.must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig
       subscription.push_config.endpoint.must_be :empty?
       subscription.push_config.authentication.must_be :nil?
+    end
+
+    it "raises NotFoundError when retrieving dead_letter_topic" do
+      stub = Object.new
+      def stub.get_subscription *args
+        gax_error = Google::Gax::GaxError.new "not found"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        raise gax_error
+      end
+      subscription.service.mocked_subscriber = stub
+
+      expect do
+        subscription.dead_letter_topic
+      end.must_raise Google::Cloud::NotFoundError
+    end
+
+    it "raises NotFoundError when retrieving dead_letter_max_delivery_attempts" do
+      stub = Object.new
+      def stub.get_subscription *args
+        gax_error = Google::Gax::GaxError.new "not found"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        raise gax_error
+      end
+      subscription.service.mocked_subscriber = stub
+
+      expect do
+        subscription.dead_letter_max_delivery_attempts
+      end.must_raise Google::Cloud::NotFoundError
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::PubSub::Topic, :subscribe, :mock_pubsub do
   it "creates a subscription when calling subscribe" do
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name
@@ -37,7 +37,7 @@ describe Google::Cloud::PubSub::Topic, :subscribe, :mock_pubsub do
   it "creates a subscription with labels" do
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name, labels: labels)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: labels, enable_message_ordering: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: labels, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, labels: labels
@@ -56,7 +56,7 @@ describe Google::Cloud::PubSub::Topic, :subscribe, :mock_pubsub do
     it "creates a subscription when calling subscribe" do
       create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
       mock = Minitest::Mock.new
-      mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, options: default_options]
+      mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
       topic.service.mocked_subscriber = mock
 
       sub = topic.subscribe new_sub_name

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -30,6 +30,8 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     response = Google::Cloud::PubSub::V1::ListTopicSubscriptionsResponse.new topic_subscriptions_hash(3, "next_page_token")
     paged_enum_struct response
   end
+  let(:dead_letter_topic_name) { "topic-name-dead-letter" }
+  let(:dead_letter_topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(dead_letter_topic_name)), pubsub.service }
 
   it "knows its name" do
     topic.name.must_equal topic_path(topic_name)
@@ -55,7 +57,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name
@@ -70,7 +72,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.create_subscription new_sub_name
@@ -85,7 +87,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.new_subscription new_sub_name
@@ -101,7 +103,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     deadline = 42
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: 42, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: 42, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, deadline: deadline
@@ -118,7 +120,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     duration = Google::Protobuf::Duration.new seconds: 600, nanos: 0
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: true, message_retention_duration: duration, labels: nil, enable_message_ordering: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: true, message_retention_duration: duration, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, retain_acked: true, retention: 600
@@ -135,7 +137,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     push_config = Google::Cloud::PubSub::V1::PushConfig.new(push_endpoint: endpoint)
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: push_config, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: push_config, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, endpoint: endpoint
@@ -150,7 +152,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name, labels: labels)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: labels, enable_message_ordering: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: labels, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, labels: labels
@@ -161,6 +163,30 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     sub.must_be_kind_of Google::Cloud::PubSub::Subscription
     sub.labels.must_equal labels
     sub.labels.must_be :frozen?
+  end
+
+  it "creates a subscription with dead_letter_topic and dead_letter_max_delivery_attempts" do
+    new_sub_name = "new-sub-#{Time.now.to_i}"
+    create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name, dead_letter_topic: dead_letter_topic_name, max_delivery_attempts: 7)
+    dead_letter_policy = Google::Cloud::PubSub::V1::DeadLetterPolicy.new dead_letter_topic: topic_path(dead_letter_topic_name), max_delivery_attempts: 7
+    mock = Minitest::Mock.new
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: dead_letter_policy, options: default_options]
+    topic.service.mocked_subscriber = mock
+
+    sub = topic.subscribe new_sub_name, dead_letter_topic: dead_letter_topic, dead_letter_max_delivery_attempts: 7
+
+    mock.verify
+
+    sub.wont_be :nil?
+    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
+    sub.dead_letter_topic.name.must_equal topic_path(dead_letter_topic_name)
+    sub.dead_letter_max_delivery_attempts.must_equal 7
+  end
+
+  it "raises when creating a subscription with dead_letter_max_delivery_attempts but no dead_letter_topic" do
+    assert_raises ArgumentError do
+      topic.subscribe "my-new-sub", dead_letter_max_delivery_attempts: 7
+    end
   end
 
   it "raises when creating a subscription that already exists" do

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -218,7 +218,7 @@ class MockPubsub < Minitest::Spec
     }
   end
 
-  def rec_message_hash message, id = rand(1000000), delivery_attempt: 1
+  def rec_message_hash message, id = rand(1000000), delivery_attempt: 10
     {
       ack_id: "ack-id-#{id}",
       delivery_attempt: delivery_attempt,

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -218,13 +218,14 @@ class MockPubsub < Minitest::Spec
     }
   end
 
-  def rec_message_hash message, id = rand(1000000)
+  def rec_message_hash message, id = rand(1000000), delivery_attempt: 1
     {
       ack_id: "ack-id-#{id}",
+      delivery_attempt: delivery_attempt,
       message: {
         data: message,
         attributes: {},
-        message_id: "msg-id-#{id}",
+        message_id: "msg-id-#{id}"
       }
     }
   end

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -169,8 +169,12 @@ class MockPubsub < Minitest::Spec
 
   def subscription_hash topic_name, sub_name,
                         deadline = 60,
-                        endpoint = "http://example.com/callback", labels: nil
-    { name: subscription_path(sub_name),
+                        endpoint = "http://example.com/callback",
+                        labels: nil,
+                        dead_letter_topic: nil,
+                        max_delivery_attempts: nil
+    raise "dead_letter_topic is required" if max_delivery_attempts && !dead_letter_topic
+    hsh = { name: subscription_path(sub_name),
       topic: topic_path(topic_name),
       push_config: {
         push_endpoint: endpoint,
@@ -185,6 +189,11 @@ class MockPubsub < Minitest::Spec
       labels: labels,
       expiration_policy: { ttl: { seconds: 172800, nanos: 0 } }, # 2 days
     }
+    hsh[:dead_letter_policy] = {
+      dead_letter_topic: dead_letter_topic,
+      max_delivery_attempts: max_delivery_attempts
+    } if dead_letter_topic
+    hsh
   end
 
   def snapshots_hash topic_name, num_snapshots, token = nil


### PR DESCRIPTION
* Add `dead_letter_topic` and `dead_letter_max_delivery_attempts` to `Topic#subscribe`
* Add `Subscription#dead_letter_topic` and `Subscription#dead_letter_topic=`
* Add `Subscription#dead_letter_max_delivery_attempts` and `Subscription#dead_letter_max_delivery_attempts=`
* Add `ReceivedMessage#delivery_attempt`