### PR TITLE
feat(spanner): allow custom lib name and version for telemetry purpose

### DIFF
--- a/google-cloud-spanner/lib/google-cloud-spanner.rb
+++ b/google-cloud-spanner/lib/google-cloud-spanner.rb
@@ -45,6 +45,12 @@ module Google
     # @param [Integer] timeout Default timeout to use in requests. Optional.
     # @param [Hash] client_config A hash of values to override the default
     #   behavior of the API client. Optional.
+    # @param [String] lib_name Library name. This will override the default
+    #   name of the library in the api call request header
+    #   for telemetry. Optional.
+    # @param [String] lib_version Library version. This will override the
+    #   default version of the library in the api call request header
+    #   for telemetry. Optional.
     #
     # @return [Google::Cloud::Spanner::Project]
     #
@@ -61,10 +67,13 @@ module Google
     #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
     #   spanner = gcloud.spanner scope: platform_scope
     #
-    def spanner scope: nil, timeout: nil, client_config: nil
+    def spanner scope: nil, timeout: nil, client_config: nil, lib_name: nil,
+                lib_version: nil
       Google::Cloud.spanner @project, @keyfile, scope: scope,
                                                 timeout: (timeout || @timeout),
-                                                client_config: client_config
+                                                client_config: client_config,
+                                                lib_name: lib_name,
+                                                lib_version: lib_version
     end
 
     ##
@@ -92,7 +101,12 @@ module Google
     # @param [Integer] timeout Default timeout to use in requests. Optional.
     # @param [Hash] client_config A hash of values to override the default
     #   behavior of the API client. Optional.
-    #
+    # @param [String] lib_name Library name. This will override the default
+    #   name of the library in the api call request header
+    #   for telemetry. Optional.
+    # @param [String] lib_version Library version. This will override the
+    #   default version of the library in the api call request header
+    #   for telemetry. Optional.
     # @return [Google::Cloud::Spanner::Project]
     #
     # @example
@@ -101,12 +115,14 @@ module Google
     #   spanner = Google::Cloud.spanner
     #
     def self.spanner project_id = nil, credentials = nil, scope: nil,
-                     timeout: nil, client_config: nil
+                     timeout: nil, client_config: nil, lib_name: nil,
+                     lib_version: nil
       require "google/cloud/spanner"
       Google::Cloud::Spanner.new project_id: project_id,
                                  credentials: credentials,
                                  scope: scope, timeout: timeout,
-                                 client_config: client_config
+                                 client_config: client_config,
+                                 lib_name: lib_name, lib_version: lib_version
     end
   end
 end
@@ -137,4 +153,6 @@ Google::Cloud.configure.add_config! :spanner do |config|
   config.add_field! :client_config, nil, match: Hash
   config.add_field! :endpoint, nil, match: String
   config.add_field! :emulator_host, default_emulator, match: String, allow_nil: true
+  config.add_field! :lib_name, nil, match: String, allow_nil: true
+  config.add_field! :lib_version, nil, match: String, allow_nil: true
 end

--- a/google-cloud-spanner/lib/google-cloud-spanner.rb
+++ b/google-cloud-spanner/lib/google-cloud-spanner.rb
@@ -46,8 +46,8 @@ module Google
     # @param [Hash] client_config A hash of values to override the default
     #   behavior of the API client. Optional.
     # @param [String] lib_name Library name. This will override the default
-    #   name of the library in the api call request header
-    #   for telemetry. Optional.
+    #   name of the library in the api call request header for telemetry.
+    #   Optional.
     # @param [String] lib_version Library version. This will override the
     #   default version of the library in the api call request header
     #   for telemetry. Optional.

--- a/google-cloud-spanner/lib/google-cloud-spanner.rb
+++ b/google-cloud-spanner/lib/google-cloud-spanner.rb
@@ -45,12 +45,20 @@ module Google
     # @param [Integer] timeout Default timeout to use in requests. Optional.
     # @param [Hash] client_config A hash of values to override the default
     #   behavior of the API client. Optional.
-    # @param [String] lib_name Library name. This will override the default
-    #   name of the library in the api call request header for telemetry.
-    #   Optional.
-    # @param [String] lib_version Library version. This will override the
-    #   default version of the library in the api call request header
-    #   for telemetry. Optional.
+    # @param [String] lib_name Library name. This will be added as a prefix
+    #   to the API call tracking header `x-goog-api-client` with provided
+    #   lib version for telemetry. Optional. For example prefix looks like
+    #   `spanner-activerecord/0.0.1 gccl/1.13.1`. Here,
+    #   `spanner-activerecord/0.0.1` is provided custom library name and
+    #   version and `gccl/1.13.1` represents the Cloud Spanner Ruby library
+    #   with version.
+    # @param [String] lib_version Library version. This will be added as a
+    #   prefix to the API call tracking header `x-goog-api-client` with
+    #   provided lib name for telemetry. Optional. For example prefix look like
+    #   `spanner-activerecord/0.0.1 gccl/1.13.1`. Here,
+    #   `spanner-activerecord/0.0.1` is provided custom library name and
+    #   version and `gccl/1.13.1` represents the Cloud Spanner Ruby library
+    #   with version.
     #
     # @return [Google::Cloud::Spanner::Project]
     #
@@ -101,12 +109,21 @@ module Google
     # @param [Integer] timeout Default timeout to use in requests. Optional.
     # @param [Hash] client_config A hash of values to override the default
     #   behavior of the API client. Optional.
-    # @param [String] lib_name Library name. This will override the default
-    #   name of the library in the api call request header
-    #   for telemetry. Optional.
-    # @param [String] lib_version Library version. This will override the
-    #   default version of the library in the api call request header
-    #   for telemetry. Optional.
+    # @param [String] lib_name Library name. This will be added as a prefix
+    #   to the API call tracking header `x-goog-api-client` with provided
+    #   lib version for telemetry. Optional. For example prefix looks like
+    #   `spanner-activerecord/0.0.1 gccl/1.13.1`. Here,
+    #   `spanner-activerecord/0.0.1` is provided custom library name and
+    #   version and `gccl/1.13.1` represents the Cloud Spanner Ruby library
+    #   with version.
+    # @param [String] lib_version Library version. This will be added as a
+    #   prefix to the API call tracking header `x-goog-api-client` with
+    #   provided lib name for telemetry. Optional. For example prefix look like
+    #   `spanner-activerecord/0.0.1 gccl/1.13.1`. Here,
+    #   `spanner-activerecord/0.0.1` is provided custom library name and
+    #   version and `gccl/1.13.1` represents the Cloud Spanner Ruby library
+    #   with version.
+    #
     # @return [Google::Cloud::Spanner::Project]
     #
     # @example

--- a/google-cloud-spanner/lib/google/cloud/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner.rb
@@ -34,7 +34,7 @@ module Google
     # See {file:OVERVIEW.md Spanner Overview}.
     #
     module Spanner
-      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
 
       ##
       # Creates a new object for connecting to the Spanner service.
@@ -68,6 +68,12 @@ module Google
       #   Deprecated.
       # @param [String] emulator_host Spanner emulator host. Optional.
       #   If the param is nil, uses the value of the `emulator_host` config.
+      # @param [String] lib_name Library name. This will override the default
+      #   name of the library in the api call request header
+      #   for telemetry. Optional.
+      # @param [String] lib_version Library version. This will override the
+      #   default version of the library in the api call request header
+      #   for telemetry. Optional.
       #
       # @return [Google::Cloud::Spanner::Project]
       #
@@ -78,7 +84,7 @@ module Google
       #
       def self.new project_id: nil, credentials: nil, scope: nil, timeout: nil,
                    client_config: nil, endpoint: nil, project: nil, keyfile: nil,
-                   emulator_host: nil
+                   emulator_host: nil, lib_name: nil, lib_version: nil
         project_id    ||= (project || default_project_id)
         scope         ||= configure.scope
         timeout       ||= configure.timeout
@@ -86,6 +92,8 @@ module Google
         endpoint      ||= configure.endpoint
         credentials   ||= (keyfile || default_credentials(scope: scope))
         emulator_host ||= configure.emulator_host
+        lib_name      ||= configure.lib_name
+        lib_version   ||= configure.lib_version
 
         if emulator_host
           credentials = :this_channel_is_insecure
@@ -106,12 +114,13 @@ module Google
         Spanner::Project.new(
           Spanner::Service.new(
             project_id, credentials,
-            host: endpoint, timeout: timeout, client_config: client_config
+            host: endpoint, timeout: timeout, client_config: client_config,
+            lib_name: lib_name, lib_version: lib_version
           )
         )
       end
 
-      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/MethodLength,Metrics/AbcSize
 
       ##
       # Configure the Google Cloud Spanner library.
@@ -133,6 +142,10 @@ module Google
       #   to use the default endpoint.
       # * `emulator_host` - (String) Host name of the emulator. Defaults to
       #   `ENV["SPANNER_EMULATOR_HOST"]`.
+      # * `lib_name` - (String) Override the lib name , or `nil`
+      #   to use the default lib name.
+      # * `lib_version` - (String) Override the lib version , or `nil`
+      #   to use the default version.
       #
       # @return [Google::Cloud::Config] The configuration object the
       #   Google::Cloud::Spanner library uses.

--- a/google-cloud-spanner/lib/google/cloud/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner.rb
@@ -69,8 +69,8 @@ module Google
       # @param [String] emulator_host Spanner emulator host. Optional.
       #   If the param is nil, uses the value of the `emulator_host` config.
       # @param [String] lib_name Library name. This will override the default
-      #   name of the library in the api call request header
-      #   for telemetry. Optional.
+      #   name of the library in the api call request header for telemetry.
+      #   Optional.
       # @param [String] lib_version Library version. This will override the
       #   default version of the library in the api call request header
       #   for telemetry. Optional.

--- a/google-cloud-spanner/lib/google/cloud/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner.rb
@@ -68,12 +68,20 @@ module Google
       #   Deprecated.
       # @param [String] emulator_host Spanner emulator host. Optional.
       #   If the param is nil, uses the value of the `emulator_host` config.
-      # @param [String] lib_name Library name. This will override the default
-      #   name of the library in the api call request header for telemetry.
-      #   Optional.
-      # @param [String] lib_version Library version. This will override the
-      #   default version of the library in the api call request header
-      #   for telemetry. Optional.
+      # @param [String] lib_name Library name. This will be added as a prefix
+      #   to the API call tracking header `x-goog-api-client` with provided
+      #   lib version for telemetry. Optional. For example prefix looks like
+      #   `spanner-activerecord/0.0.1 gccl/1.13.1`. Here,
+      #   `spanner-activerecord/0.0.1` is provided custom library name and
+      #   version and `gccl/1.13.1` represents the Cloud Spanner Ruby library
+      #   with version.
+      # @param [String] lib_version Library version. This will be added as a
+      #   prefix to the API call tracking header `x-goog-api-client` with
+      #   provided lib name for telemetry. Optional. For example prefix look like
+      #   `spanner-activerecord/0.0.1 gccl/1.13.1`. Here,
+      #   `spanner-activerecord/0.0.1` is provided custom library name and
+      #   version and `gccl/1.13.1` represents the Cloud Spanner Ruby library
+      #   with version.
       #
       # @return [Google::Cloud::Spanner::Project]
       #
@@ -143,9 +151,11 @@ module Google
       # * `emulator_host` - (String) Host name of the emulator. Defaults to
       #   `ENV["SPANNER_EMULATOR_HOST"]`.
       # * `lib_name` - (String) Override the lib name , or `nil`
-      #   to use the default lib name.
+      #   to use the default lib name without prefix in agent tracking
+      #   header.
       # * `lib_version` - (String) Override the lib version , or `nil`
-      #   to use the default version.
+      #   to use the default version lib name without prefix in agent
+      #   tracking header.
       #
       # @return [Google::Cloud::Config] The configuration object the
       #   Google::Cloud::Spanner library uses.

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -29,17 +29,20 @@ module Google
       # @private Represents the gRPC Spanner service, including all the API
       # methods.
       class Service
-        attr_accessor :project, :credentials, :timeout, :client_config, :host
+        attr_accessor :project, :credentials, :timeout, :client_config, :host,
+                      :lib_name, :lib_version
 
         ##
         # Creates a new Service instance.
         def initialize project, credentials, host: nil, timeout: nil,
-                       client_config: nil
+                       client_config: nil, lib_name: nil, lib_version: nil
           @project = project
           @credentials = credentials
           @host = host || V1::SpannerClient::SERVICE_ADDRESS
           @timeout = timeout
           @client_config = client_config || {}
+          @lib_name = lib_name || "gccl"
+          @lib_version = lib_version || Google::Cloud::Spanner::VERSION
         end
 
         def channel
@@ -67,8 +70,8 @@ module Google
               client_config: client_config,
               service_address: service_address,
               service_port: service_port,
-              lib_name: "gccl",
-              lib_version: Google::Cloud::Spanner::VERSION
+              lib_name: lib_name,
+              lib_version: lib_version
             )
         end
         attr_accessor :mocked_service
@@ -82,8 +85,8 @@ module Google
               client_config: client_config,
               service_address: service_address,
               service_port: service_port,
-              lib_name: "gccl",
-              lib_version: Google::Cloud::Spanner::VERSION
+              lib_name: lib_name,
+              lib_version: lib_version
             )
         end
         attr_accessor :mocked_instances
@@ -97,8 +100,8 @@ module Google
               client_config: client_config,
               service_address: service_address,
               service_port: service_port,
-              lib_name: "gccl",
-              lib_version: Google::Cloud::Spanner::VERSION
+              lib_name: lib_name,
+              lib_version: lib_version
             )
         end
         attr_accessor :mocked_databases

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -41,8 +41,8 @@ module Google
           @host = host || V1::SpannerClient::SERVICE_ADDRESS
           @timeout = timeout
           @client_config = client_config || {}
-          @lib_name = lib_name || "gccl"
-          @lib_version = lib_version || Google::Cloud::Spanner::VERSION
+          @lib_name = lib_name
+          @lib_version = lib_version
         end
 
         def channel
@@ -70,8 +70,8 @@ module Google
               client_config: client_config,
               service_address: service_address,
               service_port: service_port,
-              lib_name: lib_name,
-              lib_version: lib_version
+              lib_name: lib_name_with_prefix,
+              lib_version: Google::Cloud::Spanner::VERSION
             )
         end
         attr_accessor :mocked_service
@@ -85,8 +85,8 @@ module Google
               client_config: client_config,
               service_address: service_address,
               service_port: service_port,
-              lib_name: lib_name,
-              lib_version: lib_version
+              lib_name: lib_name_with_prefix,
+              lib_version: Google::Cloud::Spanner::VERSION
             )
         end
         attr_accessor :mocked_instances
@@ -100,8 +100,8 @@ module Google
               client_config: client_config,
               service_address: service_address,
               service_port: service_port,
-              lib_name: lib_name,
-              lib_version: lib_version
+              lib_name: lib_name_with_prefix,
+              lib_version: Google::Cloud::Spanner::VERSION
             )
         end
         attr_accessor :mocked_databases
@@ -460,6 +460,14 @@ module Google
         def service_port
           return nil if host.nil?
           URI.parse("//#{host}").port
+        end
+
+        def lib_name_with_prefix
+          return "gccl" if [nil, "gccl"].include? lib_name
+
+          value = lib_name.dup
+          value << "/#{lib_version}" if lib_version
+          value << " gccl"
         end
 
         def default_options_from_session session_name

--- a/google-cloud-spanner/test/google/cloud/spanner_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner_test.rb
@@ -173,8 +173,9 @@ describe Google::Cloud do
             spanner.must_be_kind_of Google::Cloud::Spanner::Project
             spanner.project.must_equal "project-id"
             spanner.service.credentials.must_equal default_credentials
-            spanner.service.lib_name.must_equal "gccl"
-            spanner.service.lib_version.must_equal Google::Cloud::Spanner::VERSION
+            spanner.service.lib_name.must_be :nil?
+            spanner.service.lib_version.must_be :nil?
+            spanner.service.send(:lib_name_with_prefix).must_equal "gccl"
           end
         end
       end
@@ -359,6 +360,26 @@ describe Google::Cloud do
             spanner.project.must_equal "project-id"
             spanner.service.lib_name.must_equal lib_name
             spanner.service.lib_version.must_equal lib_version
+            spanner.service.send(:lib_name_with_prefix).must_equal "#{lib_name}/#{lib_version} gccl"
+          end
+        end
+      end
+    end
+
+    it "uses provided lib name only" do
+      lib_name = "spanner-ruby"
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Get project_id from Google Compute Engine
+        Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
+          Google::Cloud::Spanner::Credentials.stub :default, default_credentials do
+            spanner = Google::Cloud::Spanner.new lib_name: lib_name
+            spanner.must_be_kind_of Google::Cloud::Spanner::Project
+            spanner.project.must_equal "project-id"
+            spanner.service.lib_name.must_equal lib_name
+            spanner.service.lib_version.must_be :nil?
+            spanner.service.send(:lib_name_with_prefix).must_equal "#{lib_name} gccl"
           end
         end
       end

--- a/google-cloud-spanner/test/google/cloud/spanner_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner_test.rb
@@ -125,13 +125,16 @@ describe Google::Cloud do
         "spanner-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
+
         project.must_equal "project-id"
         credentials.must_equal "spanner-credentials"
         timeout.must_be :nil?
         host.must_be :nil?
         client_config.must_be :nil?
-        lib_name.must_be :nil?
-        lib_version.must_be :nil?
+        keyword_args.key?(:lib_name).must_equal true
+        keyword_args.key?(:lib_version).must_equal true
+        keyword_args[:lib_name].must_be :nil?
+        keyword_args[:lib_version].must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -193,8 +196,10 @@ describe Google::Cloud do
         timeout.must_be :nil?
         host.must_be :nil?
         client_config.must_be :nil?
-        lib_name.must_be :nil?
-        lib_version.must_be :nil?
+        keyword_args.key?(:lib_name).must_equal true
+        keyword_args.key?(:lib_version).must_equal true
+        keyword_args[:lib_name].must_be :nil?
+        keyword_args[:lib_version].must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -223,8 +228,10 @@ describe Google::Cloud do
         timeout.must_be :nil?
         host.must_equal endpoint
         client_config.must_be :nil?
-        lib_name.must_be :nil?
-        lib_version.must_be :nil?
+        keyword_args.key?(:lib_name).must_equal true
+        keyword_args.key?(:lib_version).must_equal true
+        keyword_args[:lib_name].must_be :nil?
+        keyword_args[:lib_version].must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -251,8 +258,10 @@ describe Google::Cloud do
         timeout.must_be :nil?
         host.must_be :nil?
         client_config.must_be :nil?
-        lib_name.must_be :nil?
-        lib_version.must_be :nil?
+        keyword_args.key?(:lib_name).must_equal true
+        keyword_args.key?(:lib_version).must_equal true
+        keyword_args[:lib_name].must_be :nil?
+        keyword_args[:lib_version].must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -286,8 +295,10 @@ describe Google::Cloud do
         timeout.must_be :nil?
         host.must_be :nil?
         client_config.must_be :nil?
-        lib_name.must_be :nil?
-        lib_version.must_be :nil?
+        keyword_args.key?(:lib_name).must_equal true
+        keyword_args.key?(:lib_version).must_equal true
+        keyword_args[:lib_name].must_be :nil?
+        keyword_args[:lib_version].must_be :nil?
         OpenStruct.new project: project
       }
       empty_env = OpenStruct.new
@@ -410,8 +421,10 @@ describe Google::Cloud do
         timeout.must_be :nil?
         host.must_be :nil?
         client_config.must_be :nil?
-        lib_name.must_be :nil?
-        lib_version.must_be :nil?
+        keyword_args.key?(:lib_name).must_equal true
+        keyword_args.key?(:lib_version).must_equal true
+        keyword_args[:lib_name].must_be :nil?
+        keyword_args[:lib_version].must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -450,8 +463,10 @@ describe Google::Cloud do
         timeout.must_be :nil?
         host.must_be :nil?
         client_config.must_be :nil?
-        lib_name.must_be :nil?
-        lib_version.must_be :nil?
+        keyword_args.key?(:lib_name).must_equal true
+        keyword_args.key?(:lib_version).must_equal true
+        keyword_args[:lib_name].must_be :nil?
+        keyword_args[:lib_version].must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -490,8 +505,10 @@ describe Google::Cloud do
         timeout.must_equal 42
         host.must_be :nil?
         client_config.must_equal spanner_client_config
-        lib_name.must_be :nil?
-        lib_version.must_be :nil?
+        keyword_args.key?(:lib_name).must_equal true
+        keyword_args.key?(:lib_version).must_equal true
+        keyword_args[:lib_name].must_be :nil?
+        keyword_args[:lib_version].must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -532,8 +549,10 @@ describe Google::Cloud do
         timeout.must_equal 42
         host.must_be :nil?
         client_config.must_equal spanner_client_config
-        lib_name.must_be :nil?
-        lib_version.must_be :nil?
+        keyword_args.key?(:lib_name).must_equal true
+        keyword_args.key?(:lib_version).must_equal true
+        keyword_args[:lib_name].must_be :nil?
+        keyword_args[:lib_version].must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -575,8 +594,10 @@ describe Google::Cloud do
         timeout.must_be :nil?
         host.must_equal endpoint
         client_config.must_be :nil?
-        lib_name.must_be :nil?
-        lib_version.must_be :nil?
+        keyword_args.key?(:lib_name).must_equal true
+        keyword_args.key?(:lib_version).must_equal true
+        keyword_args[:lib_name].must_be :nil?
+        keyword_args[:lib_version].must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -630,15 +651,15 @@ describe Google::Cloud do
         scope.must_be :nil?
         "spanner-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, lib_name: nil, lib_version: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
         project.must_equal "project-id"
         credentials.must_equal "spanner-credentials"
         timeout.must_be :nil?
         host.must_be :nil?
         client_config.must_be :nil?
-        lib_name.must_equal custom_lib_name
-        lib_version.must_equal custom_lib_version
-        OpenStruct.new project: project, lib_name: lib_name, lib_version: lib_version
+        keyword_args[:lib_name].must_equal custom_lib_name
+        keyword_args[:lib_version].must_equal custom_lib_version
+        OpenStruct.new project: project, lib_name: keyword_args[:lib_name], lib_version: keyword_args[:lib_version]
       }
 
       # Clear all environment variables


### PR DESCRIPTION
Towards: #4761 

Allow user-agent to be passed in and not a hardcoded version. This will helpful for database connector i.e ActiveRecord connector.
