### PR TITLE
feat(bigtable): Add Table-level IAM Policy support

### DIFF
--- a/google-cloud-bigtable/acceptance/bigtable/instance_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/instance_test.rb
@@ -50,11 +50,12 @@ describe "Instances", :bigtable do
   describe "IAM policies and permissions" do
     let(:service_account) { bigtable.service.credentials.client.issuer }
 
-    it "test permissions" do
+    it "tests permissions" do
       instance = bigtable_instance
 
       roles = ["bigtable.instances.get", "bigtable.tables.get"]
       permissions = instance.test_iam_permissions(roles)
+      permissions.must_be_kind_of Array
       permissions.must_equal roles
     end
 

--- a/google-cloud-bigtable/acceptance/bigtable/project_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/project_test.rb
@@ -46,6 +46,6 @@ describe Google::Cloud::Bigtable::Project, :bigtable do
     instance.must_be_kind_of Google::Cloud::Bigtable::Instance
     instance.development?.must_equal true
     instance.clusters.count.must_equal 1
-    instance.clusters.first.nodes.must_equal 0
+    instance.clusters.first.nodes.must_equal 1
   end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/table_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table_test.rb
@@ -125,9 +125,10 @@ describe "Instance Tables", :bigtable do
     let(:service_account) { bigtable.service.credentials.client.issuer }
     let(:table) { bigtable_read_table }
 
-    it "test permissions" do
+    it "tests permissions" do
       roles = ["bigtable.tables.delete", "bigtable.tables.get"]
       permissions = table.test_iam_permissions(roles)
+      permissions.must_be_kind_of Array
       permissions.must_equal roles
     end
 

--- a/google-cloud-bigtable/acceptance/bigtable/table_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table_test.rb
@@ -120,4 +120,33 @@ describe "Instance Tables", :bigtable do
       [true, false].must_include result
     end
   end
+
+  describe "IAM policies and permissions" do
+    let(:service_account) { bigtable.service.credentials.client.issuer }
+    let(:table) { bigtable_read_table }
+
+    it "test permissions" do
+      roles = ["bigtable.tables.delete", "bigtable.tables.get"]
+      permissions = table.test_iam_permissions(roles)
+      permissions.must_equal roles
+    end
+
+    it "allows policy to be updated on a table" do
+      table.policy.must_be_kind_of Google::Cloud::Bigtable::Policy
+
+      service_account.wont_be :nil?
+
+      role = "roles/bigtable.user"
+      member = "serviceAccount:#{service_account}"
+
+      policy = table.policy
+      policy.add(role, member)
+      updated_policy = table.update_policy(policy)
+
+      updated_policy.role(role).wont_be :nil?
+
+      role_member = table.policy.role(role).select { |m| m == member }
+      role_member.size.must_equal 1
+    end
+  end
 end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
@@ -854,7 +854,7 @@ module Google
         #   policy.add("roles/owner", "user:owner@example.com")
         #   updated_policy = instance.update_policy(policy)
         #
-        #   puts update_policy.roles
+        #   puts updated_policy.roles
         #
         def update_policy new_policy
           ensure_service!

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
@@ -884,7 +884,7 @@ module Google
         #   * bigtable.tables.get
         #   * bigtable.tables.list
         #
-        # @return [Array<Strings>] The permissions that have access.
+        # @return [Array<String>] The permissions that are configured for the policy.
         #
         # @example
         #   require "google/cloud/bigtable"
@@ -902,11 +902,8 @@ module Google
         #
         def test_iam_permissions *permissions
           ensure_service!
-          grpc = service.test_instance_permissions(
-            instance_id,
-            Array(permissions).flatten
-          )
-          grpc.permissions
+          grpc = service.test_instance_permissions instance_id, permissions.flatten
+          grpc.permissions.to_a
         end
 
         # @private

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/policy.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/policy.rb
@@ -19,7 +19,7 @@ module Google
       ##
       # # Policy
       #
-      # Represents a Cloud IAM Policy for Bigtable instance resources.
+      # Represents a Cloud IAM Policy for Bigtable resources.
       #
       # A common pattern for updating a resource's metadata, such as its policy,
       # is to read the current data from the service, update the data locally,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
@@ -640,6 +640,58 @@ module Google
           end
         end
 
+        ##
+        # Gets the access control policy for an table resource. Returns an empty
+        # policy if an table exists but does not have a policy set.
+        #
+        # @param table_id [String]
+        #   Unique ID of the table for which the policy is being requested.
+        # @return [Google::Iam::V1::Policy]
+        #
+        def get_table_policy instance_id, table_id
+          execute do
+            tables.get_iam_policy table_path(instance_id, table_id)
+          end
+        end
+
+        ##
+        # Sets the access control policy on an table resource. Replaces any
+        # existing policy.
+        #
+        # @param table_id [String]
+        #   Unique ID of the table the policy is for.
+        # @param policy [Google::Iam::V1::Policy | Hash]
+        #   REQUIRED: The complete policy to be applied to the +resource+. The size of
+        #   the policy is limited to a few 10s of KB. An empty policy is valid
+        #   for Cloud Bigtable, but certain Cloud Platform services (such as Projects)
+        #   might reject an empty policy.
+        #   Alternatively, provide a hash similar to `Google::Iam::V1::Policy`.
+        # @return [Google::Iam::V1::Policy]
+        #
+        def set_table_policy instance_id, table_id, policy
+          execute do
+            tables.set_iam_policy table_path(instance_id, table_id), policy
+          end
+        end
+
+        ##
+        # Returns permissions that the caller has for the specified table resource.
+        #
+        # @param table_id [String]
+        #   The table ID that the policy detail is being requested for.
+        # @param permissions [Array<String>]
+        #   The set of permissions to check for the +resource+. Permissions with
+        #   wildcards (such as '*' or 'storage.*') are not allowed. For more
+        #   information see
+        #   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        # @return [Google::Iam::V1::TestIamPermissionsResponse]
+        #
+        def test_table_permissions instance_id, table_id, permissions
+          execute do
+            tables.test_iam_permissions table_path(instance_id, table_id), permissions
+          end
+        end
+
         def read_rows instance_id, table_id, app_profile_id: nil, rows: nil, filter: nil, rows_limit: nil
           # execute is not used because error handling is in ReadOperations#read_rows
           client.read_rows table_path(instance_id, table_id),

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
@@ -329,7 +329,7 @@ module Google
         #   `bigtable.*`) are not allowed.
         #   See [Access Control](https://cloud.google.com/bigtable/docs/access-control).
         #
-        # @return [Array<Strings>] The permissions that have access.
+        # @return [Array<String>] The permissions that are configured for the policy.
         #
         # @example
         #   require "google/cloud/bigtable"
@@ -347,8 +347,8 @@ module Google
         #
         def test_iam_permissions *permissions
           ensure_service!
-          grpc = service.test_table_permissions instance_id, name, Array(permissions).flatten
-          grpc.permissions
+          grpc = service.test_table_permissions instance_id, name, permissions.flatten
+          grpc.permissions.to_a
         end
 
         ##

--- a/google-cloud-bigtable/support/doctest_helper.rb
+++ b/google-cloud-bigtable/support/doctest_helper.rb
@@ -378,7 +378,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigtable::Instance#test_iam_permissions" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
       mocked_instances.expect :get_instance, instance_resp, ["projects/my-project/instances/my-instance"]
-      mocked_instances.expect :test_iam_permissions, iam_permissions_resp, ["projects/my-project/instances/my-instance", ["bigtable.instances.get", "bigtable.instances.update"]]
+      mocked_instances.expect :test_iam_permissions, instance_iam_permissions_resp, ["projects/my-project/instances/my-instance", ["bigtable.instances.get", "bigtable.instances.update"]]
     end
   end
 
@@ -652,6 +652,29 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigtable::Table#policy" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_tables.expect :get_table, table_resp, ["projects/my-project/instances/my-instance/tables/my-table", Hash]
+      mocked_tables.expect :get_iam_policy, policy_resp, ["projects/my-project/instances/my-instance/tables/my-table"]
+      mocked_tables.expect :set_iam_policy, policy_resp, ["projects/my-project/instances/my-instance/tables/my-table", Google::Iam::V1::Policy]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigtable::Table#test_iam_permissions" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_tables.expect :get_table, table_resp, ["projects/my-project/instances/my-instance/tables/my-table", Hash]
+      mocked_tables.expect :test_iam_permissions, table_iam_permissions_resp, ["projects/my-project/instances/my-instance/tables/my-table", ["bigtable.tables.delete", "bigtable.tables.get"]]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigtable::Table#update_policy" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_tables.expect :get_table, table_resp, ["projects/my-project/instances/my-instance/tables/my-table", Hash]
+      mocked_tables.expect :get_iam_policy, policy_resp, ["projects/my-project/instances/my-instance/tables/my-table"]
+      mocked_tables.expect :set_iam_policy, policy_resp, ["projects/my-project/instances/my-instance/tables/my-table", Google::Iam::V1::Policy]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigtable::Table#wait_for_replication" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
       mocked_tables.expect :get_table, table_resp, ["projects/my-project/instances/my-instance/tables/my-table", Hash]
@@ -842,9 +865,15 @@ def column_families_grpc num: 3
   end
 end
 
-def iam_permissions_resp
+def instance_iam_permissions_resp
   OpenStruct.new(
     permissions: ["bigtable.instances.get"]
+  )
+end
+
+def table_iam_permissions_resp
+  OpenStruct.new(
+    permissions: ["bigtable.tables.get"]
   )
 end
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/iam_policy_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/iam_policy_test.rb
@@ -149,6 +149,7 @@ describe Google::Cloud::Bigtable::Instance, :iam_policy, :mock_bigtable do
 
    mock.verify
 
+   permissions.must_be_kind_of Array
    permissions.must_equal ["bigtable.tables.list"]
  end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/iam_policy_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/iam_policy_test.rb
@@ -1,0 +1,162 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud::Bigtable::Table, :iam_policy, :mock_bigtable do
+  let(:instance_id) { "test-instance" }
+  let(:table_id) { "test-table" }
+  let(:column_families) { column_families_grpc }
+  let(:table_grpc){
+    Google::Bigtable::Admin::V2::Table.new(
+      table_hash(
+        name: table_path(instance_id, table_id),
+        column_families: column_families,
+        granularity: :MILLIS
+      )
+    )
+  }
+  let(:table) do
+    Google::Cloud::Bigtable::Table.from_grpc(table_grpc, bigtable.service)
+  end
+  let(:viewer_policy_json) do
+    {
+      etag: "YWJj",
+      bindings: [{
+        role: "roles/viewer",
+        members: [
+          "user:viewer@example.com",
+          "serviceAccount:1234567890@developer.gserviceaccount.com"
+         ]
+      }]
+    }.to_json
+  end
+  let(:owner_policy_json) do
+    {
+      etag: "YWJj",
+      bindings: [{
+        role: "roles/owner",
+        members: [
+          "user:owner@example.com",
+          "serviceAccount:0987654321@developer.gserviceaccount.com"
+         ]
+      }]
+    }.to_json
+  end
+
+  it "gets the IAM Policy" do
+    get_res = Google::Iam::V1::Policy.decode_json(viewer_policy_json)
+    mock = Minitest::Mock.new
+    mock.expect :get_iam_policy, get_res, [table.path]
+    table.service.mocked_tables = mock
+
+    policy = table.policy
+
+    mock.verify
+
+    policy.must_be_kind_of Google::Cloud::Bigtable::Policy
+    policy.etag.must_equal "abc"
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/viewer"].must_be_kind_of Array
+    policy.roles["roles/viewer"].count.must_equal 2
+    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "update the iam policy" do
+    get_res = Google::Iam::V1::Policy.decode_json(owner_policy_json)
+    mock = Minitest::Mock.new
+    mock.expect :get_iam_policy, get_res, [table.path]
+
+    updated_policy_hash = JSON.parse(owner_policy_json)
+    updated_policy_hash["bindings"].first["members"].shift
+    updated_policy_hash["bindings"].first["members"] << "user:newowner@example.com"
+
+    set_req = Google::Iam::V1::Policy.decode_json(updated_policy_hash.to_json)
+    set_res = Google::Iam::V1::Policy.decode_json(updated_policy_hash.merge(etag: "eHl6").to_json)
+    mock.expect :set_iam_policy, set_res, [table.path, set_req]
+    table.service.mocked_tables = mock
+
+    policy = table.policy
+
+    policy.add("roles/owner", "user:newowner@example.com")
+    policy.remove("roles/owner", "user:owner@example.com")
+
+    policy = table.update_policy(policy)
+
+    mock.verify
+
+    policy.must_be_kind_of Google::Cloud::Bigtable::Policy
+    policy.etag.must_equal "xyz"
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/viewer"].must_be :nil?
+    policy.roles["roles/owner"].must_be_kind_of Array
+    policy.roles["roles/owner"].count.must_equal 2
+    policy.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    policy.roles["roles/owner"].last.must_equal  "user:newowner@example.com"
+  end
+
+  it "get and set policy using block" do
+    get_res = Google::Iam::V1::Policy.decode_json(owner_policy_json)
+    mock = Minitest::Mock.new
+    mock.expect :get_iam_policy, get_res, [table.path]
+
+    updated_policy_hash = JSON.parse(owner_policy_json)
+    updated_policy_hash["bindings"].first["members"].shift
+    updated_policy_hash["bindings"].first["members"] << "user:newowner@example.com"
+
+    set_req = Google::Iam::V1::Policy.decode_json(updated_policy_hash.to_json)
+    set_res = Google::Iam::V1::Policy.decode_json(updated_policy_hash.merge(etag: "eHl6").to_json)
+    mock.expect :set_iam_policy, set_res, [table.path, set_req]
+    table.service.mocked_tables = mock
+
+    policy = table.policy do |v|
+      v.add("roles/owner", "user:newowner@example.com")
+      v.remove("roles/owner", "user:owner@example.com")
+    end
+
+    mock.verify
+
+    policy.must_be_kind_of Google::Cloud::Bigtable::Policy
+    policy.etag.must_equal "xyz"
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/viewer"].must_be :nil?
+    policy.roles["roles/owner"].must_be_kind_of Array
+    policy.roles["roles/owner"].count.must_equal 2
+    policy.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    policy.roles["roles/owner"].last.must_equal  "user:newowner@example.com"
+  end
+
+  it "tests the available permissions" do
+   permissions = ["bigtable.tables.create", "bigtable.tables.list"]
+   test_res = Google::Iam::V1::TestIamPermissionsResponse.new(
+     permissions: ["bigtable.tables.list"]
+   )
+   mock = Minitest::Mock.new
+   mock.expect :test_iam_permissions, test_res, [table.path, permissions]
+   table.service.mocked_tables = mock
+
+   permissions = table.test_iam_permissions(
+     "bigtable.tables.create", "bigtable.tables.list"
+   )
+
+   mock.verify
+
+   permissions.must_equal ["bigtable.tables.list"]
+ end
+end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/iam_policy_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/iam_policy_test.rb
@@ -157,6 +157,7 @@ describe Google::Cloud::Bigtable::Table, :iam_policy, :mock_bigtable do
 
    mock.verify
 
+   permissions.must_be_kind_of Array
    permissions.must_equal ["bigtable.tables.list"]
  end
 end


### PR DESCRIPTION
This PR also fixes an acceptance test that was recently broken by a service change to the nodes count for a development instance.

closes: #4437