### PR TITLE
test(spanner): fix tests to avoid repeated updates to stubbed method calls.

### DIFF
--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
@@ -66,7 +66,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, sql, transaction: tx_selector, params: nil, param_types: {}, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, sql, transaction: tx_selector, param_types: {}, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql: sql)
@@ -78,7 +78,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL).to_h }, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql: "SELECT * FROM users WHERE active = @active", params: { active: true } )
@@ -90,7 +90,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64).to_h }, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE age = @age", params: { age: 29 } )
@@ -102,7 +102,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64).to_h }, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE score = @score", params: { score: 0.9 } )
@@ -116,7 +116,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP).to_h }, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp } )
@@ -130,7 +130,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE).to_h }, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date } )
@@ -142,7 +142,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING).to_h }, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" } )
@@ -156,7 +156,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES).to_h }, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file } )
@@ -168,7 +168,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)).to_h }, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] } )
@@ -180,7 +180,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)).to_h }, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, param_types: { list: [:INT64] } )
@@ -192,7 +192,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])).to_h }, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } } )
@@ -204,7 +204,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )).to_h }, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } } )
@@ -216,7 +216,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with an Array of Hashes" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))).to_h }, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql: "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] } )
@@ -228,7 +228,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with an Array of STRUCTs" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))).to_h }, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     struct_fields = Google::Cloud::Spanner::Fields.new name: :STRING, email: :STRING
@@ -241,7 +241,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])).to_h }, resume_token: nil, partition_token: partition_token, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE settings = @dict", params: { dict: { } } )

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
@@ -66,8 +66,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, sql, transaction: tx_selector, param_types: {}, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, sql, transaction: tx_selector, param_types: {}, partition_token: partition_token, options: default_options
 
     results = batch_snapshot.execute_partition partition(sql: sql)
 
@@ -78,8 +78,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL).to_h }, partition_token: partition_token, options: default_options
 
     results = batch_snapshot.execute_partition partition(sql: "SELECT * FROM users WHERE active = @active", params: { active: true } )
 
@@ -90,8 +90,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64).to_h }, partition_token: partition_token, options: default_options
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE age = @age", params: { age: 29 } )
 
@@ -102,8 +102,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64).to_h }, partition_token: partition_token, options: default_options
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE score = @score", params: { score: 0.9 } )
 
@@ -116,8 +116,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP).to_h }, partition_token: partition_token, options: default_options
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp } )
 
@@ -130,8 +130,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE).to_h }, partition_token: partition_token, options: default_options
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date } )
 
@@ -142,8 +142,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING).to_h }, partition_token: partition_token, options: default_options
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" } )
 
@@ -156,8 +156,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES).to_h }, partition_token: partition_token, options: default_options
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file } )
 
@@ -168,8 +168,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)).to_h }, partition_token: partition_token, options: default_options
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] } )
 
@@ -180,8 +180,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)).to_h }, partition_token: partition_token, options: default_options
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, param_types: { list: [:INT64] } )
 
@@ -192,8 +192,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])).to_h }, partition_token: partition_token, options: default_options
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } } )
 
@@ -204,8 +204,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )).to_h }, partition_token: partition_token, options: default_options
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } } )
 
@@ -216,8 +216,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with an Array of Hashes" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))).to_h }, partition_token: partition_token, options: default_options
 
     results = batch_snapshot.execute_partition partition(sql: "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] } )
 
@@ -228,8 +228,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with an Array of STRUCTs" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))).to_h }, partition_token: partition_token, options: default_options
 
     struct_fields = Google::Cloud::Spanner::Fields.new name: :STRING, email: :STRING
     results = batch_snapshot.execute_partition partition(sql: "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [struct_fields.data(["mike", "mike@example.net"]), struct_fields.data(["chris","chris@example.net"])] } )
@@ -241,8 +241,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])).to_h }, partition_token: partition_token, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])).to_h }, partition_token: partition_token, options: default_options
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE settings = @dict", params: { dict: { } } )
 

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_query_test.rb
@@ -63,8 +63,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
 
     results = batch_snapshot.execute_query "SELECT * FROM users"
 
@@ -75,8 +75,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query using execute alias" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
 
     results = batch_snapshot.execute "SELECT * FROM users"
 
@@ -87,8 +87,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query using execute_sql alias" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
 
     results = batch_snapshot.execute_sql "SELECT * FROM users"
 
@@ -99,8 +99,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query using query alias" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
 
     results = batch_snapshot.query "SELECT * FROM users"
 
@@ -111,8 +111,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE active = @active", params: { active: true }
 
@@ -123,8 +123,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE age = @age", params: { age: 29 }
 
@@ -135,8 +135,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
 
@@ -149,8 +149,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
 
@@ -163,8 +163,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
 
@@ -175,8 +175,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
 
@@ -189,8 +189,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
 
@@ -201,8 +201,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
 
@@ -213,8 +213,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
 
@@ -225,8 +225,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
 
@@ -237,8 +237,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
 
@@ -249,8 +249,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array of Hashes" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
 
     results = batch_snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] }
 
@@ -261,8 +261,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array of STRUCTs" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
 
     struct_fields = Google::Cloud::Spanner::Fields.new name: :STRING, email: :STRING
     results = batch_snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [struct_fields.data(["mike", "mike@example.net"]), struct_fields.data(["chris","chris@example.net"])] }
@@ -274,8 +274,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_query_test.rb
@@ -63,7 +63,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_query "SELECT * FROM users"
@@ -75,7 +75,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query using execute alias" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute "SELECT * FROM users"
@@ -87,7 +87,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query using execute_sql alias" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_sql "SELECT * FROM users"
@@ -99,7 +99,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query using query alias" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.query "SELECT * FROM users"
@@ -111,7 +111,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE active = @active", params: { active: true }
@@ -123,7 +123,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE age = @age", params: { age: 29 }
@@ -135,7 +135,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
@@ -149,7 +149,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
@@ -163,7 +163,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
@@ -175,7 +175,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
@@ -189,7 +189,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
@@ -201,7 +201,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
@@ -213,7 +213,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
@@ -225,7 +225,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
@@ -237,7 +237,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -249,7 +249,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array of Hashes" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] }
@@ -261,7 +261,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array of STRUCTs" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     struct_fields = Google::Cloud::Spanner::Fields.new name: :STRING, email: :STRING
@@ -274,7 +274,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_partition_update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_partition_update_test.rb
@@ -46,8 +46,8 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, options: default_options
 
     row_count = client.execute_partition_update "UPDATE users SET active = true"
 
@@ -60,8 +60,8 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
 
     row_count = client.execute_partition_update "UPDATE users SET active = @active", params: { active: true }
 
@@ -74,8 +74,8 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
 
     row_count = client.execute_partition_update "UPDATE users SET age = @age", params: { age: 29 }
 
@@ -88,8 +88,8 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
 
     row_count = client.execute_partition_update "UPDATE users SET score = @score", params: { score: 0.9 }
 
@@ -104,8 +104,8 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
 
     row_count = client.execute_partition_update "UPDATE users SET updated_at = @updated_at", params: { updated_at: timestamp }
 
@@ -120,8 +120,8 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
 
     row_count = client.execute_partition_update "UPDATE users SET birthday = @birthday", params: { birthday: date }
 
@@ -134,8 +134,8 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
 
     row_count = client.execute_partition_update "UPDATE users SET name = @name", params: { name: "Charlie" }
 
@@ -150,8 +150,8 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
 
     row_count = client.execute_partition_update "UPDATE users SET avatar = @avatar", params: { avatar: file }
 
@@ -164,8 +164,8 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
 
     row_count = client.execute_partition_update "UPDATE users SET project_ids = @list", params: { list: [1,2,3] }
 
@@ -178,8 +178,8 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
 
     row_count = client.execute_partition_update "UPDATE users SET project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
 
@@ -192,8 +192,8 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
 
     row_count = client.execute_partition_update "UPDATE users SET settings = @dict", params: { dict: { env: :production } }
 
@@ -206,8 +206,8 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
 
     row_count = client.execute_partition_update "UPDATE users SET settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
 
@@ -220,8 +220,8 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
 
     row_count = client.execute_partition_update "UPDATE users SET settings = @dict", params: { dict: { } }
 
@@ -238,8 +238,8 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, no_stats_results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql no_stats_results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, options: default_options
 
     err = expect do
       client.execute_partition_update "UPDATE users SET active = true"

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_partition_update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_partition_update_test.rb
@@ -46,7 +46,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, options: default_options
     spanner.service.mocked_service = mock
 
     row_count = client.execute_partition_update "UPDATE users SET active = true"
@@ -60,7 +60,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
     spanner.service.mocked_service = mock
 
     row_count = client.execute_partition_update "UPDATE users SET active = @active", params: { active: true }
@@ -74,7 +74,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
     spanner.service.mocked_service = mock
 
     row_count = client.execute_partition_update "UPDATE users SET age = @age", params: { age: 29 }
@@ -88,7 +88,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
     spanner.service.mocked_service = mock
 
     row_count = client.execute_partition_update "UPDATE users SET score = @score", params: { score: 0.9 }
@@ -104,7 +104,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
     spanner.service.mocked_service = mock
 
     row_count = client.execute_partition_update "UPDATE users SET updated_at = @updated_at", params: { updated_at: timestamp }
@@ -120,7 +120,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
     spanner.service.mocked_service = mock
 
     row_count = client.execute_partition_update "UPDATE users SET birthday = @birthday", params: { birthday: date }
@@ -134,7 +134,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
     spanner.service.mocked_service = mock
 
     row_count = client.execute_partition_update "UPDATE users SET name = @name", params: { name: "Charlie" }
@@ -150,7 +150,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
     spanner.service.mocked_service = mock
 
     row_count = client.execute_partition_update "UPDATE users SET avatar = @avatar", params: { avatar: file }
@@ -164,7 +164,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     spanner.service.mocked_service = mock
 
     row_count = client.execute_partition_update "UPDATE users SET project_ids = @list", params: { list: [1,2,3] }
@@ -178,7 +178,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     spanner.service.mocked_service = mock
 
     row_count = client.execute_partition_update "UPDATE users SET project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
@@ -192,7 +192,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
     spanner.service.mocked_service = mock
 
     row_count = client.execute_partition_update "UPDATE users SET settings = @dict", params: { dict: { env: :production } }
@@ -206,7 +206,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
     spanner.service.mocked_service = mock
 
     row_count = client.execute_partition_update "UPDATE users SET settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -220,7 +220,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
     spanner.service.mocked_service = mock
 
     row_count = client.execute_partition_update "UPDATE users SET settings = @dict", params: { dict: { } }
@@ -238,7 +238,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, pdml_tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, no_stats_results_enum, [session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, no_stats_results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, options: default_options
     spanner.service.mocked_service = mock
 
     err = expect do

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_resume_test.rb
@@ -106,8 +106,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :resume, :mock_spanner 
   it "resumes broken response streams" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, RaiseableEnumerator.new(results_enum1), [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
-    mock.expect :execute_streaming_sql, RaiseableEnumerator.new(results_enum2), [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: "abc123", partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, RaiseableEnumerator.new(results_enum1), session_grpc.name, "SELECT * FROM users", options: default_options
+    MockSpannerHelper.expect_execute_streaming_sql mock, RaiseableEnumerator.new(results_enum2), session_grpc.name, "SELECT * FROM users", resume_token: "abc123", options: default_options    
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users"

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_resume_test.rb
@@ -106,9 +106,9 @@ describe Google::Cloud::Spanner::Client, :execute_query, :resume, :mock_spanner 
   it "resumes broken response streams" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, RaiseableEnumerator.new(results_enum1), session_grpc.name, "SELECT * FROM users", options: default_options
-    MockSpannerHelper.expect_execute_streaming_sql mock, RaiseableEnumerator.new(results_enum2), session_grpc.name, "SELECT * FROM users", resume_token: "abc123", options: default_options    
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql RaiseableEnumerator.new(results_enum1), session_grpc.name, "SELECT * FROM users", options: default_options
+    expect_execute_streaming_sql RaiseableEnumerator.new(results_enum2), session_grpc.name, "SELECT * FROM users", resume_token: "abc123", options: default_options    
 
     results = client.execute_query "SELECT * FROM users"
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_single_use_test.rb
@@ -71,7 +71,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users", single_use: { strong: true }
@@ -94,7 +94,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users", single_use: { timestamp: time_obj }
@@ -117,7 +117,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users", single_use: { read_timestamp: time_obj }
@@ -140,7 +140,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users", single_use: { staleness: 120 }
@@ -163,7 +163,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users", single_use: { exact_staleness: 120 }
@@ -186,7 +186,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users", single_use: { bounded_timestamp: time_obj }
@@ -209,7 +209,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users", single_use: { min_read_timestamp: time_obj }
@@ -232,7 +232,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users", single_use: { bounded_staleness: 120 }
@@ -255,7 +255,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users", single_use: { max_staleness: 120 }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_single_use_test.rb
@@ -71,8 +71,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
 
     results = client.execute_query "SELECT * FROM users", single_use: { strong: true }
 
@@ -94,8 +94,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
 
     results = client.execute_query "SELECT * FROM users", single_use: { timestamp: time_obj }
 
@@ -117,8 +117,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
 
     results = client.execute_query "SELECT * FROM users", single_use: { read_timestamp: time_obj }
 
@@ -140,8 +140,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
 
     results = client.execute_query "SELECT * FROM users", single_use: { staleness: 120 }
 
@@ -163,8 +163,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
 
     results = client.execute_query "SELECT * FROM users", single_use: { exact_staleness: 120 }
 
@@ -186,8 +186,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
 
     results = client.execute_query "SELECT * FROM users", single_use: { bounded_timestamp: time_obj }
 
@@ -209,8 +209,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
 
     results = client.execute_query "SELECT * FROM users", single_use: { min_read_timestamp: time_obj }
 
@@ -232,8 +232,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
 
     results = client.execute_query "SELECT * FROM users", single_use: { bounded_staleness: 120 }
 
@@ -255,8 +255,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: transaction, options: default_options
 
     results = client.execute_query "SELECT * FROM users", single_use: { max_staleness: 120 }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_test.rb
@@ -60,7 +60,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a simple query" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users"
@@ -75,7 +75,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query using execute alias" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users"
@@ -90,7 +90,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query using execute_sql alias" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_sql "SELECT * FROM users"
@@ -105,7 +105,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query using query alias" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", options: default_options
     spanner.service.mocked_service = mock
 
     results = client.query "SELECT * FROM users"
@@ -120,7 +120,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE active = @active", params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users WHERE active = @active", params: { active: true }
@@ -135,7 +135,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE age = @age", params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users WHERE age = @age", params: { age: 29 }
@@ -150,7 +150,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE score = @score", params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
@@ -167,7 +167,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
@@ -184,7 +184,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
@@ -199,7 +199,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE name = @name", params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
@@ -216,7 +216,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
@@ -231,7 +231,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
@@ -246,7 +246,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
@@ -261,7 +261,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id),  session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
@@ -276,7 +276,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id),  session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -291,7 +291,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with an Array of Hashes" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] }
@@ -304,7 +304,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with an Array of STRUCTs" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
     spanner.service.mocked_service = mock
 
     struct_fields = client.fields name: :STRING, email: :STRING
@@ -318,7 +318,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
     spanner.service.mocked_service = mock
 
     results = client.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_test.rb
@@ -60,8 +60,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a simple query" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", options: default_options
 
     results = client.execute_query "SELECT * FROM users"
 
@@ -75,8 +75,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query using execute alias" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", options: default_options
 
     results = client.execute "SELECT * FROM users"
 
@@ -90,8 +90,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query using execute_sql alias" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", options: default_options
 
     results = client.execute_sql "SELECT * FROM users"
 
@@ -105,8 +105,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query using query alias" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", options: default_options
 
     results = client.query "SELECT * FROM users"
 
@@ -120,8 +120,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE active = @active", params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE active = @active", params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
 
     results = client.execute_query "SELECT * FROM users WHERE active = @active", params: { active: true }
 
@@ -135,8 +135,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE age = @age", params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE age = @age", params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
 
     results = client.execute_query "SELECT * FROM users WHERE age = @age", params: { age: 29 }
 
@@ -150,8 +150,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE score = @score", params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE score = @score", params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
 
     results = client.execute_query "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
 
@@ -167,8 +167,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
 
     results = client.execute_query "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
 
@@ -184,8 +184,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
 
     results = client.execute_query "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
 
@@ -199,8 +199,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE name = @name", params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE name = @name", params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
 
     results = client.execute_query "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
 
@@ -216,8 +216,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
 
     results = client.execute_query "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
 
@@ -231,8 +231,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
 
     results = client.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
 
@@ -246,8 +246,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
 
     results = client.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
 
@@ -261,8 +261,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id),  session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
 
     results = client.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
 
@@ -276,8 +276,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id),  session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
 
     results = client.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
 
@@ -291,8 +291,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with an Array of Hashes" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
 
     results = client.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] }
 
@@ -304,8 +304,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with an Array of STRUCTs" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
 
     struct_fields = client.fields name: :STRING, email: :STRING
     results = client.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [struct_fields.data(["mike", "mike@example.net"]), struct_fields.data(["chris","chris@example.net"])] }
@@ -318,8 +318,8 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
 
     results = client.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
@@ -47,8 +47,8 @@ describe Google::Cloud::Spanner::Client, :fields_for, :mock_spanner do
   it "can get a table's fields" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE 1 = 0", options: default_options
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE 1 = 0", options: default_options
 
     fields = client.fields_for "users"
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
@@ -47,7 +47,7 @@ describe Google::Cloud::Spanner::Client, :fields_for, :mock_spanner do
   it "can get a table's fields" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE 1 = 0", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE 1 = 0", options: default_options
     spanner.service.mocked_service = mock
 
     fields = client.fields_for "users"

--- a/google-cloud-spanner/test/google/cloud/spanner/client/reset_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/reset_test.rb
@@ -56,11 +56,7 @@ describe Google::Cloud::Spanner::Client, :close, :mock_spanner do
     mock.expect :batch_create_sessions, batch_create_sessions_grpc, [
       database_path(instance_id, database_id), 1, session_template: nil, options: default_options
     ]
-    mock.expect :execute_streaming_sql, results_enum, [
-      session.path, "SELECT 1",
-      transaction: nil, params: nil, param_types: nil, resume_token: nil,
-      partition_token: nil, seqno: nil, options: default_options
-    ]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT 1", options: default_options
 
     spanner.service.mocked_service = mock
     client = spanner.client instance_id, database_id, pool: { min: 1, max: 1 }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/reset_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/reset_test.rb
@@ -56,9 +56,9 @@ describe Google::Cloud::Spanner::Client, :close, :mock_spanner do
     mock.expect :batch_create_sessions, batch_create_sessions_grpc, [
       database_path(instance_id, database_id), 1, session_template: nil, options: default_options
     ]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT 1", options: default_options
-
     spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT 1", options: default_options
+    
     client = spanner.client instance_id, database_id, pool: { min: 1, max: 1 }
     client.reset.must_equal true
     client.execute_query("SELECT 1").rows.first.values.must_equal [1]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -68,13 +68,13 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, options: default_options
+    spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, options: default_options
     mock
   end
 
   it "can execute a simple query without any options" do
     mock = mock_builder()
-    spanner.service.mocked_service = mock
 
     results = nil
     client.snapshot do |snp|
@@ -109,7 +109,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     it "can execute a simple query with the strong option" do
       mock = mock_builder()
-      spanner.service.mocked_service = mock
 
       results = nil
       client.snapshot strong: true do |snp|
@@ -133,7 +132,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     it "can execute a simple query with the timestamp option (Time)" do
       mock = mock_builder()
-      spanner.service.mocked_service = mock
 
       results = nil
       client.snapshot timestamp: snapshot_time do |snp|
@@ -150,7 +148,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     it "can execute a simple query with the read_timestamp option (Time)" do
       mock = mock_builder()
-      spanner.service.mocked_service = mock
 
       results = nil
       client.snapshot read_timestamp: snapshot_time do |snp|
@@ -167,7 +164,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     it "can execute a simple query with the timestamp option (DateTime)" do
       mock = mock_builder()
-      spanner.service.mocked_service = mock
 
       results = nil
       client.snapshot timestamp: snapshot_datetime do |snp|
@@ -184,7 +180,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     it "can execute a simple query with the read_timestamp option (DateTime)" do
       mock = mock_builder()
-      spanner.service.mocked_service = mock
 
       results = nil
       client.snapshot read_timestamp: snapshot_datetime do |snp|
@@ -207,7 +202,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     it "can execute a simple query with the staleness option" do
       mock = mock_builder()
-      spanner.service.mocked_service = mock
 
       results = nil
       client.snapshot staleness: snapshot_staleness do |snp|
@@ -224,7 +218,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     it "can execute a simple query with the exact_staleness option" do
       mock = mock_builder()
-      spanner.service.mocked_service = mock
 
       results = nil
       client.snapshot exact_staleness: snapshot_staleness do |snp|
@@ -242,7 +235,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
   it "does not allow nested snapshots" do
     mock = mock_builder()
-    spanner.service.mocked_service = mock
 
     results = nil
     results2 = nil

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -63,12 +63,17 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
   let(:snp_opts) { Google::Spanner::V1::TransactionOptions::ReadOnly.new return_read_timestamp: true }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new read_only: snp_opts }
-
-  it "can execute a simple query without any options" do
+  
+  def mock_builder
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, options: default_options
+    mock
+  end
+
+  it "can execute a simple query without any options" do
+    mock = mock_builder()
     spanner.service.mocked_service = mock
 
     results = nil
@@ -103,10 +108,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
     let(:snp_opts) { Google::Spanner::V1::TransactionOptions::ReadOnly.new strong: true, return_read_timestamp: true }
 
     it "can execute a simple query with the strong option" do
-      mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-      mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+      mock = mock_builder()
       spanner.service.mocked_service = mock
 
       results = nil
@@ -130,10 +132,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
     let(:snp_opts) { Google::Spanner::V1::TransactionOptions::ReadOnly.new read_timestamp: snapshot_timestamp, return_read_timestamp: true }
 
     it "can execute a simple query with the timestamp option (Time)" do
-      mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-      mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+      mock = mock_builder()
       spanner.service.mocked_service = mock
 
       results = nil
@@ -150,10 +149,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
     end
 
     it "can execute a simple query with the read_timestamp option (Time)" do
-      mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-      mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+      mock = mock_builder()
       spanner.service.mocked_service = mock
 
       results = nil
@@ -170,10 +166,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
     end
 
     it "can execute a simple query with the timestamp option (DateTime)" do
-      mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-      mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+      mock = mock_builder()
       spanner.service.mocked_service = mock
 
       results = nil
@@ -190,10 +183,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
     end
 
     it "can execute a simple query with the read_timestamp option (DateTime)" do
-      mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-      mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+      mock = mock_builder()
       spanner.service.mocked_service = mock
 
       results = nil
@@ -216,10 +206,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
     let(:snp_opts) { Google::Spanner::V1::TransactionOptions::ReadOnly.new exact_staleness: duration_staleness, return_read_timestamp: true }
 
     it "can execute a simple query with the staleness option" do
-      mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-      mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+      mock = mock_builder()
       spanner.service.mocked_service = mock
 
       results = nil
@@ -236,10 +223,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
     end
 
     it "can execute a simple query with the exact_staleness option" do
-      mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-      mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+      mock = mock_builder()
       spanner.service.mocked_service = mock
 
       results = nil
@@ -257,10 +241,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
   end
 
   it "does not allow nested snapshots" do
-    mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
-    mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    mock = mock_builder()
     spanner.service.mocked_service = mock
 
     results = nil

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -76,10 +76,10 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
@@ -130,10 +130,10 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
@@ -184,10 +184,10 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
@@ -238,13 +238,13 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
@@ -302,19 +302,19 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -74,12 +74,13 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
+    spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
@@ -96,7 +97,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
       Google::Spanner::V1::CommitResponse.new commit_timestamp: Google::Protobuf::Timestamp.new()
     end
     mock.expect :sleep, nil, [1.3]
-    spanner.service.mocked_service = mock
 
     client.define_singleton_method :sleep do |count|
       # call the mock to satisfy the expectation
@@ -128,12 +128,13 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
+    spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
@@ -150,7 +151,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
       Google::Spanner::V1::CommitResponse.new commit_timestamp: Google::Protobuf::Timestamp.new()
     end
     mock.expect :sleep, nil, [60]
-    spanner.service.mocked_service = mock
 
     client.define_singleton_method :sleep do |count|
       # call the mock to satisfy the expectation
@@ -182,12 +182,13 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
+    spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
@@ -204,7 +205,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
       Google::Spanner::V1::CommitResponse.new commit_timestamp: Google::Protobuf::Timestamp.new()
     end
     mock.expect :sleep, nil, [123.456]
-    spanner.service.mocked_service = mock
 
     client.define_singleton_method :sleep do |count|
       # call the mock to satisfy the expectation
@@ -236,15 +236,16 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
+    spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
@@ -268,7 +269,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     end
     mock.expect :sleep, nil, [1.3]
     mock.expect :sleep, nil, [30]
-    spanner.service.mocked_service = mock
 
     client.define_singleton_method :sleep do |count|
       # call the mock to satisfy the expectation
@@ -300,21 +300,22 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
+    spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
@@ -335,7 +336,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock.expect :current_time, Time.now + 60, []
     mock.expect :current_time, Time.now + 90, []
     mock.expect :current_time, Time.now + 125, []
-    spanner.service.mocked_service = mock
 
     client.define_singleton_method :sleep do |count|
       # call the mock to satisfy the expectation

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
@@ -65,13 +65,13 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
 
   it "will rollback and not pass on the error when using Rollback" do
     mock = Minitest::Mock.new
+    spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
     mock.expect :rollback, nil, [session_grpc.name, transaction_id, options: default_options]
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    spanner.service.mocked_service = mock
 
     results = nil
     timestamp = client.transaction do |tx|
@@ -93,13 +93,13 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
 
   it "will rollback and pass on the error" do
     mock = Minitest::Mock.new
+    spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
     mock.expect :rollback, nil, [session_grpc.name, transaction_id, options: default_options]
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    spanner.service.mocked_service = mock
 
     results = nil
     assert_raises ZeroDivisionError do

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
@@ -67,7 +67,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
     mock.expect :rollback, nil, [session_grpc.name, transaction_id, options: default_options]
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
@@ -95,7 +95,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
     mock.expect :rollback, nil, [session_grpc.name, transaction_id, options: default_options]
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -69,7 +69,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
     mock.expect :commit, commit_resp, [session_grpc.name, [], transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -67,13 +67,13 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
+    spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
     mock.expect :commit, commit_resp, [session_grpc.name, [], transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     # transaction checkin
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
-    spanner.service.mocked_service = mock
 
     results = nil
     timestamp = client.transaction do |tx|

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
@@ -59,7 +59,7 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
     pool.session_queue = [session]
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT 1", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT 1", options: default_options
     session.service.mocked_service = mock
 
     pool.keepalive_or_release!

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
@@ -59,8 +59,8 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
     pool.session_queue = [session]
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT 1", options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT 1", options: default_options
 
     pool.keepalive_or_release!
 

--- a/google-cloud-spanner/test/google/cloud/spanner/session/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/execute_query_test.rb
@@ -59,7 +59,7 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users", options: default_options
     session.service.mocked_service = mock
 
     results = session.execute_query "SELECT * FROM users"
@@ -71,7 +71,7 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE active = @active", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE active = @active", params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
     session.service.mocked_service = mock
 
     params, types = params_types({ active: true })
@@ -84,7 +84,7 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE age = @age", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE age = @age", params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
     session.service.mocked_service = mock
 
     params, types = params_types({ age: 29 })
@@ -97,7 +97,7 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE score = @score", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE score = @score", params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
     session.service.mocked_service = mock
 
     params, types = params_types({ score: 0.9 })
@@ -112,7 +112,7 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE updated_at = @updated_at", params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
     session.service.mocked_service = mock
 
     params, types = params_types({ updated_at: timestamp })
@@ -127,7 +127,7 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE birthday = @birthday", params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
     session.service.mocked_service = mock
 
     params, types = params_types({ birthday: date })
@@ -140,7 +140,7 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE name = @name", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE name = @name", params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
     session.service.mocked_service = mock
 
     params, types = params_types({ name: "Charlie" })
@@ -155,7 +155,7 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE avatar = @avatar", params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
     session.service.mocked_service = mock
 
     params, types = params_types({ avatar: file })
@@ -168,7 +168,7 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     session.service.mocked_service = mock
 
     params, types = params_types({ list: [1,2,3] })
@@ -181,7 +181,7 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     session.service.mocked_service = mock
 
     params, types = params_types({ list: [] }, { list: [:INT64] })
@@ -194,7 +194,7 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
     session.service.mocked_service = mock
 
     params, types = params_types({ dict: { env: :production } })
@@ -207,7 +207,7 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
     session.service.mocked_service = mock
 
     params, types = params_types({ dict: { env: "production", score: 0.9, project_ids: [1,2,3] } })
@@ -220,7 +220,7 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
     session.service.mocked_service = mock
 
     params, types = params_types({ dict: { } })

--- a/google-cloud-spanner/test/google/cloud/spanner/session/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/execute_query_test.rb
@@ -59,8 +59,8 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users", options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users", options: default_options
 
     results = session.execute_query "SELECT * FROM users"
 
@@ -71,8 +71,8 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE active = @active", params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE active = @active", params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
 
     params, types = params_types({ active: true })
     results = session.execute_query "SELECT * FROM users WHERE active = @active", params: params, types: types
@@ -84,8 +84,8 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE age = @age", params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE age = @age", params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
 
     params, types = params_types({ age: 29 })
     results = session.execute_query "SELECT * FROM users WHERE age = @age", params: params, types: types
@@ -97,8 +97,8 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE score = @score", params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE score = @score", params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
 
     params, types = params_types({ score: 0.9 })
     results = session.execute_query "SELECT * FROM users WHERE score = @score", params: params, types: types
@@ -112,8 +112,8 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE updated_at = @updated_at", params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE updated_at = @updated_at", params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
 
     params, types = params_types({ updated_at: timestamp })
     results = session.execute_query "SELECT * FROM users WHERE updated_at = @updated_at", params: params, types: types
@@ -127,8 +127,8 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE birthday = @birthday", params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE birthday = @birthday", params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
 
     params, types = params_types({ birthday: date })
     results = session.execute_query "SELECT * FROM users WHERE birthday = @birthday", params: params, types: types
@@ -140,8 +140,8 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE name = @name", params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE name = @name", params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
 
     params, types = params_types({ name: "Charlie" })
     results = session.execute_query "SELECT * FROM users WHERE name = @name", params: params, types: types
@@ -155,8 +155,8 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE avatar = @avatar", params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE avatar = @avatar", params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
 
     params, types = params_types({ avatar: file })
     results = session.execute_query "SELECT * FROM users WHERE avatar = @avatar", params: params, types: types
@@ -168,8 +168,8 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
 
     params, types = params_types({ list: [1,2,3] })
     results = session.execute_query "SELECT * FROM users WHERE project_ids = @list", params: params, types: types
@@ -181,8 +181,8 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
 
     params, types = params_types({ list: [] }, { list: [:INT64] })
     results = session.execute_query "SELECT * FROM users WHERE project_ids = @list", params: params, types: types
@@ -194,8 +194,8 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
 
     params, types = params_types({ dict: { env: :production } })
     results = session.execute_query "SELECT * FROM users WHERE settings = @dict", params: params, types: types
@@ -207,8 +207,8 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
 
     params, types = params_types({ dict: { env: "production", score: 0.9, project_ids: [1,2,3] } })
     results = session.execute_query "SELECT * FROM users WHERE settings = @dict", params: params, types: types
@@ -220,8 +220,8 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
 
     params, types = params_types({ dict: { } })
     results = session.execute_query "SELECT * FROM users WHERE settings = @dict", params: params, types: types

--- a/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
@@ -44,7 +44,7 @@ describe Google::Cloud::Spanner::Session, :keepalive, :mock_spanner do
 
   it "can call keepalive" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT 1", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT 1", options: default_options
     session.service.mocked_service = mock
 
     session.keepalive!
@@ -57,7 +57,7 @@ describe Google::Cloud::Spanner::Session, :keepalive, :mock_spanner do
     def results_enum.peek
       raise GRPC::NotFound.new 5, "not found"
     end
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT 1", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT 1", options: default_options
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     session.service.mocked_service = mock
 
@@ -71,7 +71,7 @@ describe Google::Cloud::Spanner::Session, :keepalive, :mock_spanner do
     def results_enum.peek
       raise GRPC::NotFound.new 5, "not found"
     end
-    mock.expect :execute_streaming_sql, results_enum, [session_labels.path, "SELECT 1", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_labels.path, "SELECT 1", options: default_options
     mock.expect :create_session, session_grpc_labels, [database_path(instance_id, database_id), session: Google::Spanner::V1::Session.new(labels: labels), options: default_options]
     session_labels.service.mocked_service = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
@@ -44,8 +44,8 @@ describe Google::Cloud::Spanner::Session, :keepalive, :mock_spanner do
 
   it "can call keepalive" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT 1", options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT 1", options: default_options
 
     session.keepalive!
 
@@ -57,9 +57,9 @@ describe Google::Cloud::Spanner::Session, :keepalive, :mock_spanner do
     def results_enum.peek
       raise GRPC::NotFound.new 5, "not found"
     end
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT 1", options: default_options
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT 1", options: default_options
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
 
     result = session.keepalive!
     result.must_equal false
@@ -71,9 +71,9 @@ describe Google::Cloud::Spanner::Session, :keepalive, :mock_spanner do
     def results_enum.peek
       raise GRPC::NotFound.new 5, "not found"
     end
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_labels.path, "SELECT 1", options: default_options
-    mock.expect :create_session, session_grpc_labels, [database_path(instance_id, database_id), session: Google::Spanner::V1::Session.new(labels: labels), options: default_options]
     session_labels.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_labels.path, "SELECT 1", options: default_options
+    mock.expect :create_session, session_grpc_labels, [database_path(instance_id, database_id), session: Google::Spanner::V1::Session.new(labels: labels), options: default_options]
 
     result = session_labels.keepalive!
     result.must_equal false

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_query_test.rb
@@ -63,8 +63,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
 
     results = snapshot.execute_query "SELECT * FROM users"
 
@@ -75,8 +75,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
 
     results = snapshot.execute_query "SELECT * FROM users WHERE active = @active", params: { active: true }
 
@@ -87,8 +87,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
 
     results = snapshot.execute_query "SELECT * FROM users WHERE age = @age", params: { age: 29 }
 
@@ -99,8 +99,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
 
     results = snapshot.execute_query "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
 
@@ -113,8 +113,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
 
     results = snapshot.execute_query "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
 
@@ -127,8 +127,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
 
     results = snapshot.execute_query "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
 
@@ -139,8 +139,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
 
     results = snapshot.execute_query "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
 
@@ -153,8 +153,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
 
     results = snapshot.execute_query "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
 
@@ -165,8 +165,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
 
     results = snapshot.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
 
@@ -177,8 +177,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
 
     results = snapshot.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
 
@@ -189,8 +189,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
 
     results = snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
 
@@ -201,8 +201,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
 
     results = snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
 
@@ -213,8 +213,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array of Hashes" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
 
     results = snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] }
 
@@ -225,8 +225,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array of STRUCTs" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
 
     struct_fields = snapshot.fields name: :STRING, email: :STRING
     results = snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [struct_fields.data(["mike", "mike@example.net"]), struct_fields.data(["chris","chris@example.net"])] }
@@ -238,8 +238,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
 
     results = snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_query_test.rb
@@ -63,7 +63,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users", transaction: tx_selector, options: default_options
     session.service.mocked_service = mock
 
     results = snapshot.execute_query "SELECT * FROM users"
@@ -75,7 +75,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options
     session.service.mocked_service = mock
 
     results = snapshot.execute_query "SELECT * FROM users WHERE active = @active", params: { active: true }
@@ -87,7 +87,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options
     session.service.mocked_service = mock
 
     results = snapshot.execute_query "SELECT * FROM users WHERE age = @age", params: { age: 29 }
@@ -99,7 +99,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options
     session.service.mocked_service = mock
 
     results = snapshot.execute_query "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
@@ -113,7 +113,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options
     session.service.mocked_service = mock
 
     results = snapshot.execute_query "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
@@ -127,7 +127,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options
     session.service.mocked_service = mock
 
     results = snapshot.execute_query "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
@@ -139,7 +139,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options
     session.service.mocked_service = mock
 
     results = snapshot.execute_query "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
@@ -153,7 +153,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options
     session.service.mocked_service = mock
 
     results = snapshot.execute_query "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
@@ -165,7 +165,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     session.service.mocked_service = mock
 
     results = snapshot.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
@@ -177,7 +177,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options
     session.service.mocked_service = mock
 
     results = snapshot.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
@@ -189,7 +189,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options
     session.service.mocked_service = mock
 
     results = snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
@@ -201,7 +201,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options
     session.service.mocked_service = mock
 
     results = snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -213,7 +213,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array of Hashes" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
     session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] }
@@ -225,7 +225,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array of STRUCTs" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, options: default_options
     session.service.mocked_service = mock
 
     struct_fields = snapshot.fields name: :STRING, email: :STRING
@@ -238,7 +238,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, seqno: nil, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options
     session.service.mocked_service = mock
 
     results = snapshot.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/batch_update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/batch_update_test.rb
@@ -106,10 +106,10 @@ describe Google::Cloud::Spanner::Transaction, :batch_update, :mock_spanner do
 
     it "increases seqno for each request" do
       mock = Minitest::Mock.new
-      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+      MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, seqno: 1, options: default_options
       statement = statement_grpc("UPDATE users SET age = @age", params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) })
       mock.expect :execute_batch_dml, batch_response_grpc, [session_grpc.name, tx_selector, [statement], 2, options: default_options]
-      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET active = false", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 3, options: default_options]
+      MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET active = false", transaction: tx_selector, seqno: 3, options: default_options
       session.service.mocked_service = mock
 
       transaction.execute_update "UPDATE users SET active = true"

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/batch_update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/batch_update_test.rb
@@ -106,11 +106,11 @@ describe Google::Cloud::Spanner::Transaction, :batch_update, :mock_spanner do
 
     it "increases seqno for each request" do
       mock = Minitest::Mock.new
-      MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, seqno: 1, options: default_options
+      session.service.mocked_service = mock
+      expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, seqno: 1, options: default_options
       statement = statement_grpc("UPDATE users SET age = @age", params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) })
       mock.expect :execute_batch_dml, batch_response_grpc, [session_grpc.name, tx_selector, [statement], 2, options: default_options]
-      MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET active = false", transaction: tx_selector, seqno: 3, options: default_options
-      session.service.mocked_service = mock
+      expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET active = false", transaction: tx_selector, seqno: 3, options: default_options
 
       transaction.execute_update "UPDATE users SET active = true"
       transaction.batch_update do |b|

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_query_test.rb
@@ -63,7 +63,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     results = transaction.execute_query "SELECT * FROM users"
@@ -75,7 +75,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     results = transaction.execute_query "SELECT * FROM users WHERE active = @active", params: { active: true }
@@ -87,7 +87,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     results = transaction.execute_query "SELECT * FROM users WHERE age = @age", params: { age: 29 }
@@ -99,7 +99,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     results = transaction.execute_query "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
@@ -113,7 +113,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     results = transaction.execute_query "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
@@ -127,7 +127,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     results = transaction.execute_query "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
@@ -139,7 +139,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     results = transaction.execute_query "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
@@ -153,7 +153,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     results = transaction.execute_query "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
@@ -165,7 +165,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     results = transaction.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
@@ -177,7 +177,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     results = transaction.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
@@ -189,7 +189,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     results = transaction.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
@@ -201,7 +201,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     results = transaction.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -213,7 +213,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array of Hashes" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, seqno: 1, options: default_options
 
     session.service.mocked_service = mock
 
@@ -226,7 +226,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array of STRUCTs" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, seqno: 1, options: default_options
 
     session.service.mocked_service = mock
 
@@ -240,7 +240,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     results = transaction.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_query_test.rb
@@ -63,8 +63,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     results = transaction.execute_query "SELECT * FROM users"
 
@@ -75,8 +75,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, seqno: 1, options: default_options
 
     results = transaction.execute_query "SELECT * FROM users WHERE active = @active", params: { active: true }
 
@@ -87,8 +87,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, seqno: 1, options: default_options
 
     results = transaction.execute_query "SELECT * FROM users WHERE age = @age", params: { age: 29 }
 
@@ -99,8 +99,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, seqno: 1, options: default_options
 
     results = transaction.execute_query "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
 
@@ -113,8 +113,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, seqno: 1, options: default_options
 
     results = transaction.execute_query "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
 
@@ -127,8 +127,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, seqno: 1, options: default_options
 
     results = transaction.execute_query "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
 
@@ -139,8 +139,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, seqno: 1, options: default_options
 
     results = transaction.execute_query "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
 
@@ -153,8 +153,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, seqno: 1, options: default_options
 
     results = transaction.execute_query "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
 
@@ -165,8 +165,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, seqno: 1, options: default_options
 
     results = transaction.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
 
@@ -177,8 +177,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, seqno: 1, options: default_options
 
     results = transaction.execute_query "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
 
@@ -189,8 +189,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, seqno: 1, options: default_options
 
     results = transaction.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
 
@@ -201,8 +201,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, seqno: 1, options: default_options
 
     results = transaction.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
 
@@ -213,9 +213,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array of Hashes" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, seqno: 1, options: default_options
-
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, seqno: 1, options: default_options
 
     results = transaction.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] }
 
@@ -226,9 +225,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with an Array of STRUCTs" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, seqno: 1, options: default_options
-
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, seqno: 1, options: default_options
 
     struct_fields = transaction.fields name: :STRING, email: :STRING
     results = transaction.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [struct_fields.data(["mike", "mike@example.net"]), struct_fields.data(["chris","chris@example.net"])] }
@@ -240,8 +238,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
 
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, seqno: 1, options: default_options
 
     results = transaction.execute_query "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_update_test.rb
@@ -42,8 +42,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, seqno: 1, options: default_options
 
     row_count = transaction.execute_update "UPDATE users SET active = true"
 
@@ -54,8 +54,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with bool param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, seqno: 1, options: default_options
 
     row_count = transaction.execute_update "UPDATE users SET active = @active", params: { active: true }
 
@@ -66,8 +66,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with int param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, seqno: 1, options: default_options
 
     row_count = transaction.execute_update "UPDATE users SET age = @age", params: { age: 29 }
 
@@ -78,8 +78,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with float param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, seqno: 1, options: default_options
 
     row_count = transaction.execute_update "UPDATE users SET score = @score", params: { score: 0.9 }
 
@@ -92,8 +92,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, seqno: 1, options: default_options
 
     row_count = transaction.execute_update "UPDATE users SET updated_at = @updated_at", params: { updated_at: timestamp }
 
@@ -106,8 +106,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, seqno: 1, options: default_options
 
     row_count = transaction.execute_update "UPDATE users SET birthday = @birthday", params: { birthday: date }
 
@@ -118,8 +118,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with String param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, seqno: 1, options: default_options
 
     row_count = transaction.execute_update "UPDATE users SET name = @name", params: { name: "Charlie" }
 
@@ -132,8 +132,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, seqno: 1, options: default_options
 
     row_count = transaction.execute_update "UPDATE users SET avatar = @avatar", params: { avatar: file }
 
@@ -144,8 +144,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with an Array param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, seqno: 1, options: default_options
 
     row_count = transaction.execute_update "UPDATE users SET project_ids = @list", params: { list: [1,2,3] }
 
@@ -156,8 +156,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with an empty Array param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, seqno: 1, options: default_options
 
     row_count = transaction.execute_update "UPDATE users SET project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
 
@@ -168,8 +168,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with a simple Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, seqno: 1, options: default_options
 
     row_count = transaction.execute_update "UPDATE users SET settings = @dict", params: { dict: { env: :production } }
 
@@ -180,8 +180,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with a complex Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session.path, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, seqno: 1, options: default_options
 
     row_count = transaction.execute_update "UPDATE users SET settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
 
@@ -192,8 +192,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with an empty Hash param" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, seqno: 1, options: default_options
 
     row_count = transaction.execute_update "UPDATE users SET settings = @dict", params: { dict: { } }
 
@@ -208,8 +208,8 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
     no_stats_results_enum = Array(no_stats_results_grpc).to_enum
 
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, no_stats_results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql no_stats_results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, seqno: 1, options: default_options
 
     err = expect do
       transaction.execute_update "UPDATE users SET active = true"

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_update_test.rb
@@ -42,7 +42,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     row_count = transaction.execute_update "UPDATE users SET active = true"
@@ -54,7 +54,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with bool param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     row_count = transaction.execute_update "UPDATE users SET active = @active", params: { active: true }
@@ -66,7 +66,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with int param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     row_count = transaction.execute_update "UPDATE users SET age = @age", params: { age: 29 }
@@ -78,7 +78,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with float param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     row_count = transaction.execute_update "UPDATE users SET score = @score", params: { score: 0.9 }
@@ -92,7 +92,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     row_count = transaction.execute_update "UPDATE users SET updated_at = @updated_at", params: { updated_at: timestamp }
@@ -106,7 +106,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     row_count = transaction.execute_update "UPDATE users SET birthday = @birthday", params: { birthday: date }
@@ -118,7 +118,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with String param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     row_count = transaction.execute_update "UPDATE users SET name = @name", params: { name: "Charlie" }
@@ -132,7 +132,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     row_count = transaction.execute_update "UPDATE users SET avatar = @avatar", params: { avatar: file }
@@ -144,7 +144,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with an Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     row_count = transaction.execute_update "UPDATE users SET project_ids = @list", params: { list: [1,2,3] }
@@ -156,7 +156,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with an empty Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     row_count = transaction.execute_update "UPDATE users SET project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
@@ -168,7 +168,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with a simple Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     row_count = transaction.execute_update "UPDATE users SET settings = @dict", params: { dict: { env: :production } }
@@ -180,7 +180,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with a complex Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session.path, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     row_count = transaction.execute_update "UPDATE users SET settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -192,7 +192,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
   it "can execute a DML query with an empty Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "UPDATE users SET settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     row_count = transaction.execute_update "UPDATE users SET settings = @dict", params: { dict: { } }
@@ -208,7 +208,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
     no_stats_results_enum = Array(no_stats_results_grpc).to_enum
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, no_stats_results_enum, [session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, no_stats_results_enum, session_grpc.name, "UPDATE users SET active = true", transaction: tx_selector, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     err = expect do

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/fields_for_test.rb
@@ -50,7 +50,7 @@ describe Google::Cloud::Spanner::Transaction, :fields_for, :mock_spanner do
 
   it "can get a table's fields" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE 1 = 0", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, seqno: 1, options: default_options]
+    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE 1 = 0", transaction: tx_selector, seqno: 1, options: default_options
     session.service.mocked_service = mock
 
     fields = transaction.fields_for "users"

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/fields_for_test.rb
@@ -50,8 +50,8 @@ describe Google::Cloud::Spanner::Transaction, :fields_for, :mock_spanner do
 
   it "can get a table's fields" do
     mock = Minitest::Mock.new
-    MockSpannerHelper.expect_execute_streaming_sql mock, results_enum, session_grpc.name, "SELECT * FROM users WHERE 1 = 0", transaction: tx_selector, seqno: 1, options: default_options
     session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users WHERE 1 = 0", transaction: tx_selector, seqno: 1, options: default_options
 
     fields = transaction.fields_for "users"
 

--- a/google-cloud-spanner/test/google/cloud/spanner_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner_test.rb
@@ -99,7 +99,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "spanner-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
         project.must_equal "project-id"
         credentials.must_equal "spanner-credentials"
         timeout.must_be :nil?
@@ -157,7 +157,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "spanner-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
         project.must_equal "project-id"
         credentials.must_equal "spanner-credentials"
         timeout.must_be :nil?
@@ -185,7 +185,7 @@ describe Google::Cloud do
 
     it "uses provided endpoint" do
       endpoint = "spanner-endpoint2.example.com"
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
         project.must_equal "project-id"
         credentials.must_equal default_credentials
         timeout.must_be :nil?
@@ -211,7 +211,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "spanner-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
         project.must_equal "project-id"
         credentials.must_equal "spanner-credentials"
         timeout.must_be :nil?
@@ -243,7 +243,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         OpenStruct.new project_id: "project-id"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
         project.must_equal "project-id"
         credentials.must_be_kind_of OpenStruct
         credentials.project_id.must_equal "project-id"
@@ -327,7 +327,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "spanner-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
         project.must_equal "project-id"
         credentials.must_equal "spanner-credentials"
         timeout.must_be :nil?
@@ -365,7 +365,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "spanner-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
         project.must_equal "project-id"
         credentials.must_equal "spanner-credentials"
         timeout.must_be :nil?
@@ -403,7 +403,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "spanner-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
         project.must_equal "project-id"
         credentials.must_equal "spanner-credentials"
         timeout.must_equal 42
@@ -443,7 +443,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "spanner-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
         project.must_equal "project-id"
         credentials.must_equal "spanner-credentials"
         timeout.must_equal 42
@@ -484,7 +484,7 @@ describe Google::Cloud do
         scope.must_be :nil?
         "spanner-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
         project.must_equal "project-id"
         credentials.must_equal "spanner-credentials"
         timeout.must_be :nil?

--- a/google-cloud-spanner/test/helper.rb
+++ b/google-cloud-spanner/test/helper.rb
@@ -147,14 +147,12 @@ class MockSpanner < Minitest::Spec
   def paged_enum_struct response
     OpenStruct.new page: OpenStruct.new(response: response)
   end
-end
 
-class MockSpannerHelper
-  def self.expect_execute_streaming_sql mock, results_enum, session_name, sql,
+  def expect_execute_streaming_sql results_enum, session_name, sql,
                                    transaction: nil, params: nil, param_types: nil, 
                                    resume_token: nil, partition_token: nil, seqno: nil,
                                    options: nil
-    mock.expect :execute_streaming_sql, results_enum do |session, sql_query, **kargs|
+    spanner.service.mocked_service.expect :execute_streaming_sql, results_enum do |session, sql_query, **kargs|
       session == session_name &&
         sql_query == sql_query &&
         kargs[:transaction] == transaction &&

--- a/google-cloud-spanner/test/helper.rb
+++ b/google-cloud-spanner/test/helper.rb
@@ -149,6 +149,25 @@ class MockSpanner < Minitest::Spec
   end
 end
 
+class MockSpannerHelper
+  def self.expect_execute_streaming_sql mock, results_enum, session_name, sql,
+                                   transaction: nil, params: nil, param_types: nil, 
+                                   resume_token: nil, partition_token: nil, seqno: nil,
+                                   options: nil
+    mock.expect :execute_streaming_sql, results_enum do |session, sql_query, **kargs|
+      session == session_name &&
+        sql_query == sql_query &&
+        kargs[:transaction] == transaction &&
+        kargs[:params] == params &&
+        kargs[:param_types] == param_types &&
+        kargs[:resume_token] == resume_token &&
+        kargs[:partition_token] == partition_token &&
+        kargs[:seqno] == seqno &&
+        kargs[:options] == options
+    end
+  end
+end
+
 # This is used to raise errors in an enumerator
 class RaiseableEnumerator
   def initialize enum


### PR DESCRIPTION
## Problem

I am working on a feature that needs to add a parameter to `execute_streaming_sql` method. However, this is really annoying because it causes around 250 errors. I need to add this parameter in each single place. 

## Changes

1) Add a helper function `MockSpanner.expect_execute_streaming_sql`, which takes expected results and expected parameters. If parameters are not given, the default values will be expected. 

With this change, I only need to add new parameter in this function (only one place) instead of hundreds of places. 

2) 

Before: 
```ruby
      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
        project.must_equal "project-id"
        credentials.must_equal "spanner-credentials"
        timeout.must_be :nil?
        host.must_be :nil?
        client_config.must_be :nil?
        OpenStruct.new project: project
      }
```

After: 
```ruby
      stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
        project.must_equal "project-id"
        credentials.must_equal "spanner-credentials"
        timeout.must_be :nil?
        host.must_be :nil?
        client_config.must_be :nil?
        OpenStruct.new project: project
      }
```

With adding `**keyword_args`, when we add new parameter for the stubbed service, we do not need to change hundreds of places. We only need to add a single test to see whether the stubbed service respects the new parameters or not. 