### PR TITLE
chore(asset): move orgpolicy docs to the correct location

### DIFF
--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -18,6 +18,7 @@ import synthtool as s
 import synthtool.gcp as gcp
 import synthtool.languages.ruby as ruby
 import logging
+import os
 import re
 import shutil
 from subprocess import call
@@ -58,7 +59,11 @@ orgpolicy_library = gapic2.ruby_library(
 
 s.copy(orgpolicy_library / 'lib/google/cloud/orgpolicy')
 s.copy(orgpolicy_library / 'proto_docs/google/cloud/orgpolicy')
-shutil.move('proto_docs', 'lib/google/cloud/orgpolicy/v1/doc')
+os.makedirs('lib/google/cloud/orgpolicy/v1/doc/google/cloud/orgpolicy/v1', exist_ok=True)
+shutil.move(
+    'proto_docs/google/cloud/orgpolicy/v1/orgpolicy.rb',
+    'lib/google/cloud/orgpolicy/v1/doc/google/cloud/orgpolicy/v1/orgpolicy.rb'
+)
 
 # Copy common templates
 templates = gcp.CommonTemplates().ruby_library()


### PR DESCRIPTION
The synth script code that moved the orgpolicy proto docs from the microgenerator-generated location (in `proto_docs`) to the legacy location (under `lib/**/doc/`) would work only the _first_ time it ran. Subsequent times, the `doc` directory already exists, so it would move `proto_docs` under `doc`, which is not what we want. (And indeed, if we allowed it to run a third time, it would fail outright because `doc/proto_docs` would already exist.) Changed the code to move the file directly, avoiding all the cases around directory moves.

Should prevent recurrence of #4790 