### PR TITLE
GCS SigV4 updates

### DIFF
--- a/google-cloud-storage/.rubocop.yml
+++ b/google-cloud-storage/.rubocop.yml
@@ -19,6 +19,8 @@ Layout/SpaceAroundOperators:
   Enabled: false
 Metrics/ClassLength:
   Enabled: false
+Metrics/MethodLength:
+  Max: 40
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-storage.rb"

--- a/google-cloud-storage/conformance/v1/proto/google/cloud/conformance/storage/v1/tests.proto
+++ b/google-cloud-storage/conformance/v1/proto/google/cloud/conformance/storage/v1/tests.proto
@@ -19,9 +19,12 @@ package google.cloud.conformance.storage.v1;
 import "google/protobuf/timestamp.proto";
 
 option csharp_namespace = "Google.Cloud.Storage.V1.Tests.Conformance";
+option java_package = "com.google.cloud.conformance.storage.v1";
+option java_multiple_files = true;
 
 message TestFile {
   repeated SigningV4Test signing_v4_tests = 1;
+  repeated PostPolicyV4Test post_policy_v4_tests = 2;
 }
 
 message SigningV4Test {
@@ -34,4 +37,48 @@ message SigningV4Test {
   google.protobuf.Timestamp timestamp = 7;
   string expectedUrl = 8;
   map<string, string> headers = 9;
+  map<string, string> query_parameters = 10;
+  string scheme = 11;
+  enum UrlStyle {
+    PATH_STYLE = 0;
+    VIRTUAL_HOSTED_STYLE = 1;
+    BUCKET_BOUND_DOMAIN = 2;
+  }
+  UrlStyle urlStyle = 12;
+  string bucketBoundDomain = 13;
+  string expectedCanonicalRequest = 14;
+  string expectedStringToSign = 15;
+}
+
+message ConditionalMatches {
+  repeated string expression = 1;
+}
+
+message PolicyConditions {
+  string successActionStatus = 1;
+  string successActionRedirect = 2;
+  repeated ConditionalMatches matches = 3;
+}
+
+message PolicyInput {
+  string scheme = 1;
+  string bucket = 2;
+  string object = 3;
+  int64 expiration = 4;
+  google.protobuf.Timestamp timestamp = 5;
+  map<string, string> headers = 6;
+  PolicyConditions conditions = 7;
+}
+
+message PolicyOutput {
+  string url = 1;
+  string key = 2;
+  map<string, string> fields = 3;
+  string expectedDecodedPolicy = 4;
+}
+
+message PostPolicyV4Test {
+  string description = 1;
+  PolicyInput policyInput = 2;
+  PolicyOutput policyOutput = 3;
 }

--- a/google-cloud-storage/conformance/v1/proto/google/cloud/conformance/storage/v1/tests_pb.rb
+++ b/google-cloud-storage/conformance/v1/proto/google/cloud/conformance/storage/v1/tests_pb.rb
@@ -7,6 +7,7 @@ require 'google/protobuf/timestamp_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "google.cloud.conformance.storage.v1.TestFile" do
     repeated :signing_v4_tests, :message, 1, "google.cloud.conformance.storage.v1.SigningV4Test"
+    repeated :post_policy_v4_tests, :message, 2, "google.cloud.conformance.storage.v1.PostPolicyV4Test"
   end
   add_message "google.cloud.conformance.storage.v1.SigningV4Test" do
     optional :fileName, :string, 1
@@ -18,6 +19,45 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :timestamp, :message, 7, "google.protobuf.Timestamp"
     optional :expectedUrl, :string, 8
     map :headers, :string, :string, 9
+    map :query_parameters, :string, :string, 10
+    optional :scheme, :string, 11
+    optional :urlStyle, :enum, 12, "google.cloud.conformance.storage.v1.SigningV4Test.UrlStyle"
+    optional :bucketBoundDomain, :string, 13
+    optional :expectedCanonicalRequest, :string, 14
+    optional :expectedStringToSign, :string, 15
+  end
+  add_enum "google.cloud.conformance.storage.v1.SigningV4Test.UrlStyle" do
+    value :PATH_STYLE, 0
+    value :VIRTUAL_HOSTED_STYLE, 1
+    value :BUCKET_BOUND_DOMAIN, 2
+  end
+  add_message "google.cloud.conformance.storage.v1.ConditionalMatches" do
+    repeated :expression, :string, 1
+  end
+  add_message "google.cloud.conformance.storage.v1.PolicyConditions" do
+    optional :successActionStatus, :string, 1
+    optional :successActionRedirect, :string, 2
+    repeated :matches, :message, 3, "google.cloud.conformance.storage.v1.ConditionalMatches"
+  end
+  add_message "google.cloud.conformance.storage.v1.PolicyInput" do
+    optional :scheme, :string, 1
+    optional :bucket, :string, 2
+    optional :object, :string, 3
+    optional :expiration, :int64, 4
+    optional :timestamp, :message, 5, "google.protobuf.Timestamp"
+    map :headers, :string, :string, 6
+    optional :conditions, :message, 7, "google.cloud.conformance.storage.v1.PolicyConditions"
+  end
+  add_message "google.cloud.conformance.storage.v1.PolicyOutput" do
+    optional :url, :string, 1
+    optional :key, :string, 2
+    map :fields, :string, :string, 3
+    optional :expectedDecodedPolicy, :string, 4
+  end
+  add_message "google.cloud.conformance.storage.v1.PostPolicyV4Test" do
+    optional :description, :string, 1
+    optional :policyInput, :message, 2, "google.cloud.conformance.storage.v1.PolicyInput"
+    optional :policyOutput, :message, 3, "google.cloud.conformance.storage.v1.PolicyOutput"
   end
 end
 
@@ -28,6 +68,12 @@ module Google
         module V1
           TestFile = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.conformance.storage.v1.TestFile").msgclass
           SigningV4Test = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.conformance.storage.v1.SigningV4Test").msgclass
+          SigningV4Test::UrlStyle = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.conformance.storage.v1.SigningV4Test.UrlStyle").enummodule
+          ConditionalMatches = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.conformance.storage.v1.ConditionalMatches").msgclass
+          PolicyConditions = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.conformance.storage.v1.PolicyConditions").msgclass
+          PolicyInput = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.conformance.storage.v1.PolicyInput").msgclass
+          PolicyOutput = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.conformance.storage.v1.PolicyOutput").msgclass
+          PostPolicyV4Test = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.cloud.conformance.storage.v1.PostPolicyV4Test").msgclass
         end
       end
     end

--- a/google-cloud-storage/conformance/v1/v4_signatures.json
+++ b/google-cloud-storage/conformance/v1/v4_signatures.json
@@ -7,7 +7,10 @@
       "method": "GET",
       "expiration": "10",
       "timestamp": "2019-02-01T09:00:00Z",
-      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256\u0026X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request\u0026X-Goog-Date=20190201T090000Z\u0026X-Goog-Expires=10\u0026X-Goog-SignedHeaders=host\u0026X-Goog-Signature=95e6a13d43a1d1962e667f17397f2b80ac9bdd1669210d5e08e0135df9dff4e56113485dbe429ca2266487b9d1796ebdee2d7cf682a6ef3bb9fbb4c351686fba90d7b621cf1c4eb1fdf126460dd25fa0837dfdde0a9fd98662ce60844c458448fb2b352c203d9969cb74efa4bdb742287744a4f2308afa4af0e0773f55e32e92973619249214b97283b2daa14195244444e33f938138d1e5f561088ce8011f4986dda33a556412594db7c12fc40e1ff3f1bedeb7a42f5bcda0b9567f17f65855f65071fabb88ea12371877f3f77f10e1466fff6ff6973b74a933322ff0949ce357e20abe96c3dd5cfab42c9c83e740a4d32b9e11e146f0eb3404d2e975896f74"
+      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&X-Goog-Signature=95e6a13d43a1d1962e667f17397f2b80ac9bdd1669210d5e08e0135df9dff4e56113485dbe429ca2266487b9d1796ebdee2d7cf682a6ef3bb9fbb4c351686fba90d7b621cf1c4eb1fdf126460dd25fa0837dfdde0a9fd98662ce60844c458448fb2b352c203d9969cb74efa4bdb742287744a4f2308afa4af0e0773f55e32e92973619249214b97283b2daa14195244444e33f938138d1e5f561088ce8011f4986dda33a556412594db7c12fc40e1ff3f1bedeb7a42f5bcda0b9567f17f65855f65071fabb88ea12371877f3f77f10e1466fff6ff6973b74a933322ff0949ce357e20abe96c3dd5cfab42c9c83e740a4d32b9e11e146f0eb3404d2e975896f74",
+      "scheme": "https",
+      "expectedCanonicalRequest": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\n00e2fb794ea93d7adb703edaebdd509821fcc7d4f1a79ac5c8d2b394df109320",
+      "expectedStringToSign": "GET\n/test-bucket/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host\nhost:storage.googleapis.com\n\nhost\nUNSIGNED-PAYLOAD"
     },
     {
       "description": "Simple PUT",
@@ -16,7 +19,10 @@
       "method": "PUT",
       "expiration": "10",
       "timestamp": "2019-02-01T09:00:00Z",
-      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256\u0026X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request\u0026X-Goog-Date=20190201T090000Z\u0026X-Goog-Expires=10\u0026X-Goog-SignedHeaders=host\u0026X-Goog-Signature=8adff1d4285739e31aa68e73767a46bc5511fde377497dbe08481bf5ceb34e29cc9a59921748d8ec3dd4085b7e9b7772a952afedfcdaecb3ae8352275b8b7c867f204e3db85076220a3127a8a9589302fc1181eae13b9b7fe41109ec8cdc93c1e8bac2d7a0cc32a109ca02d06957211326563ab3d3e678a0ba296e298b5fc5e14593c99d444c94724cc4be97015dbff1dca377b508fa0cb7169195de98d0e4ac96c42b918d28c8d92d33e1bd125ce0fb3cd7ad2c45dae65c22628378f6584971b8bf3945b26f2611eb651e9b6a8648970c1ecf386bb71327b082e7296c4e1ee2fc0bdd8983da80af375c817fb1ad491d0bc22c0f51dba0d66e2cffbc90803e47"
+      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&X-Goog-Signature=8adff1d4285739e31aa68e73767a46bc5511fde377497dbe08481bf5ceb34e29cc9a59921748d8ec3dd4085b7e9b7772a952afedfcdaecb3ae8352275b8b7c867f204e3db85076220a3127a8a9589302fc1181eae13b9b7fe41109ec8cdc93c1e8bac2d7a0cc32a109ca02d06957211326563ab3d3e678a0ba296e298b5fc5e14593c99d444c94724cc4be97015dbff1dca377b508fa0cb7169195de98d0e4ac96c42b918d28c8d92d33e1bd125ce0fb3cd7ad2c45dae65c22628378f6584971b8bf3945b26f2611eb651e9b6a8648970c1ecf386bb71327b082e7296c4e1ee2fc0bdd8983da80af375c817fb1ad491d0bc22c0f51dba0d66e2cffbc90803e47",
+      "scheme": "https",
+      "expectedCanonicalRequest": "PUT\n/test-bucket/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host\nhost:storage.googleapis.com\n\nhost\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\n78742860705da91404222d5d66ff89850292471199c3c2808d116ad12e6177b4"
     },
     {
       "description": "POST for resumable uploads",
@@ -25,10 +31,13 @@
       "method": "POST",
       "expiration": "10",
       "timestamp": "2019-02-01T09:00:00Z",
-      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256\u0026X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request\u0026X-Goog-Date=20190201T090000Z\u0026X-Goog-Expires=10\u0026X-Goog-SignedHeaders=host%3Bx-goog-resumable\u0026X-Goog-Signature=4a6d39b23343cedf4c30782aed4b384001828c79ffa3a080a481ea01a640dea0a0ceb58d67a12cef3b243c3f036bb3799c6ee88e8db3eaf7d0bdd4b70a228d0736e07eaa1ee076aff5c6ce09dff1f1f03a0d8ead0d2893408dd3604fdabff553aa6d7af2da67cdba6790006a70240f96717b98f1a6ccb24f00940749599be7ef72aaa5358db63ddd54b2de9e2d6d6a586eac4fe25f36d86fc6ab150418e9c6fa01b732cded226c6d62fc95b72473a4cc55a8257482583fe66d9ab6ede909eb41516a8690946c3e87b0f2052eb0e97e012a14b2f721c42e6e19b8a1cd5658ea36264f10b9b1ada66b8ed5bf7ed7d1708377ac6e5fe608ae361fb594d2e5b24c54",
+      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host%3Bx-goog-resumable&X-Goog-Signature=4a6d39b23343cedf4c30782aed4b384001828c79ffa3a080a481ea01a640dea0a0ceb58d67a12cef3b243c3f036bb3799c6ee88e8db3eaf7d0bdd4b70a228d0736e07eaa1ee076aff5c6ce09dff1f1f03a0d8ead0d2893408dd3604fdabff553aa6d7af2da67cdba6790006a70240f96717b98f1a6ccb24f00940749599be7ef72aaa5358db63ddd54b2de9e2d6d6a586eac4fe25f36d86fc6ab150418e9c6fa01b732cded226c6d62fc95b72473a4cc55a8257482583fe66d9ab6ede909eb41516a8690946c3e87b0f2052eb0e97e012a14b2f721c42e6e19b8a1cd5658ea36264f10b9b1ada66b8ed5bf7ed7d1708377ac6e5fe608ae361fb594d2e5b24c54",
       "headers": {
-        "X-goog-resumable": "start"
-      }
+        "X-Goog-Resumable": "start"
+      },
+      "scheme": "https",
+      "expectedCanonicalRequest": "POST\n/test-bucket/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host%3Bx-goog-resumable\nhost:storage.googleapis.com\nx-goog-resumable:start\n\nhost;x-goog-resumable\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\n877f8b40179d2753296f2fd6de815ab40503c7a3c446a7b44aa4e74422ff4daf"
     },
     {
       "description": "Vary expiration and timestamp",
@@ -37,7 +46,10 @@
       "method": "GET",
       "expiration": "20",
       "timestamp": "2019-03-01T09:00:00Z",
-      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256\u0026X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190301%2Fauto%2Fstorage%2Fgoog4_request\u0026X-Goog-Date=20190301T090000Z\u0026X-Goog-Expires=20\u0026X-Goog-SignedHeaders=host\u0026X-Goog-Signature=9669ed5b10664dc594c758296580662912cf4bcc5a4ba0b6bf055bcbf6f34eed7bdad664f534962174a924741a0c273a4f67bc1847cef20192a6beab44223bd9d4fbbd749c407b79997598c30f82ddc269ff47ec09fa3afe74e00616d438df0d96a7d8ad0adacfad1dc3286f864d924fe919fb0dce45d3d975c5afe8e13af2db9cc37ba77835f92f7669b61e94c6d562196c1274529e76cfff1564cc2cad7d5387dc8e12f7a5dfd925685fe92c30b43709eee29fa2f66067472cee5423d1a3a4182fe8cea75c9329d181dc6acad7c393cd04f8bf5bc0515127d8ebd65d80c08e19ad03316053ea60033fd1b1fd85a69c576415da3bf0a3718d9ea6d03e0d66f0"
+      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190301%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190301T090000Z&X-Goog-Expires=20&X-Goog-SignedHeaders=host&X-Goog-Signature=9669ed5b10664dc594c758296580662912cf4bcc5a4ba0b6bf055bcbf6f34eed7bdad664f534962174a924741a0c273a4f67bc1847cef20192a6beab44223bd9d4fbbd749c407b79997598c30f82ddc269ff47ec09fa3afe74e00616d438df0d96a7d8ad0adacfad1dc3286f864d924fe919fb0dce45d3d975c5afe8e13af2db9cc37ba77835f92f7669b61e94c6d562196c1274529e76cfff1564cc2cad7d5387dc8e12f7a5dfd925685fe92c30b43709eee29fa2f66067472cee5423d1a3a4182fe8cea75c9329d181dc6acad7c393cd04f8bf5bc0515127d8ebd65d80c08e19ad03316053ea60033fd1b1fd85a69c576415da3bf0a3718d9ea6d03e0d66f0",
+      "scheme": "https",
+      "expectedCanonicalRequest": "GET\n/test-bucket/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190301%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190301T090000Z&X-Goog-Expires=20&X-Goog-SignedHeaders=host\nhost:storage.googleapis.com\nhost\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190301T090000Z\n20190301/auto/storage/goog4_request\n779f19fdb6fd381390e2d5af04947cf21750277ee3c20e0c97b7e46a1dff8907"
     },
     {
       "description": "Vary bucket and object",
@@ -46,7 +58,37 @@
       "method": "GET",
       "expiration": "10",
       "timestamp": "2019-02-01T09:00:00Z",
-      "expectedUrl": "https://storage.googleapis.com/test-bucket2/test-object2?X-Goog-Algorithm=GOOG4-RSA-SHA256\u0026X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request\u0026X-Goog-Date=20190201T090000Z\u0026X-Goog-Expires=10\u0026X-Goog-SignedHeaders=host\u0026X-Goog-Signature=36e3d58dfd3ec1d2dd2f24b5ee372a71e811ffaa2162a2b871d26728d0354270bc116face87127532969c4a3967ed05b7309af741e19c7202f3167aa8c2ac420b61417d6451442bb91d7c822cd17be8783f01e05372769c88913561d27e6660dd8259f0081a71f831be6c50283626cbf04494ac10c394b29bb3bce74ab91548f58a37118a452693cf0483d77561fc9cac8f1765d2c724994cca46a83517a10157ee0347a233a2aaeae6e6ab5e204ff8fc5f54f90a3efdb8301d9fff5475d58cd05b181affd657f48203f4fb133c3a3d355b8eefbd10d5a0a5fd70d06e9515460ad74e22334b2cba4b29cae4f6f285cdb92d8f3126d7a1479ca3bdb69c207d860"
+      "expectedUrl": "https://storage.googleapis.com/test-bucket2/test-object2?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&X-Goog-Signature=36e3d58dfd3ec1d2dd2f24b5ee372a71e811ffaa2162a2b871d26728d0354270bc116face87127532969c4a3967ed05b7309af741e19c7202f3167aa8c2ac420b61417d6451442bb91d7c822cd17be8783f01e05372769c88913561d27e6660dd8259f0081a71f831be6c50283626cbf04494ac10c394b29bb3bce74ab91548f58a37118a452693cf0483d77561fc9cac8f1765d2c724994cca46a83517a10157ee0347a233a2aaeae6e6ab5e204ff8fc5f54f90a3efdb8301d9fff5475d58cd05b181affd657f48203f4fb133c3a3d355b8eefbd10d5a0a5fd70d06e9515460ad74e22334b2cba4b29cae4f6f285cdb92d8f3126d7a1479ca3bdb69c207d860",
+      "scheme": "https",
+      "expectedCanonicalRequest": "GET\n/test-bucket2/test-object2\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host\nhost:storage.googleapis.com\n\nhost\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\na139afbf35ac30e9864f63197f79609731ab1b0ca166e2a456dba156fcd3f9ce"
+    },
+    {
+      "description": "Slashes in object name should not be URL encoded",
+      "bucket": "test-bucket",
+      "object": "path/with/slashes/under_score/amper&sand/file.ext",
+      "headers": {
+        "header/name/with/slash": "should-be-encoded"
+      },
+      "method": "GET",
+      "expiration": "10",
+      "timestamp": "2019-02-01T09:00:00Z",
+      "expectedUrl": "https://storage.googleapis.com/test-bucket/path/with/slashes/under_score/amper%26sand/file.ext?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=header%2Fname%2Fwith%2Fslash%3Bhost&X-Goog-Signature=2a9a82e84e39f5d2c0d980514db17f8c3dece473c9a5743d54e8453f9811927b1b99ce548c534cababd8fa339183e75b410e12e32a4c72f5ff176e95651fabed0072e59e7e236eb7e26f52c0ce599db1c47ae07af1a98d20872b6fde23432c0a5fcf4fb2dda735169198c80cd5cc51be9904f7e5eef2cc489ff44ac5697c529e4b34ac08709a7d2e425619377212c64561ed8b4d2fcb70a26e4f9236f995ab4658d240ac85c7a353bae6b2d39d5fc0716afa435a1f6e100db5504612b5e610db370623ab4b8eba3c03c98f23dcb4b9ffd518f2212abb2f93649d25385d71603d470cff0b7631adb9d0849d38609dedb3097761c8f47ec0d57777bb063611c05b",
+      "scheme": "https",
+      "expectedCanonicalRequest": "GET\n/test-bucket/path/with/slashes/under_score/amper%26sand/file.ext\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=header%2Fname%2Fwith%2Fslash%3Bhost\nheader/name/with/slash:should-be-encoded\nhost:storage.googleapis.com\n\nheader/name/with/slash;host\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\nf1d206dd8cbe1b892d4081ccddae0927d9f5fee5653fb2a2f43e7c20ed455cad"
+    },
+    {
+      "description": "Forward Slashes should not be stripped",
+      "bucket": "test-bucket",
+      "object": "/path/with/slashes/under_score/amper&sand/file.ext",
+      "method": "GET",
+      "expiration": "10",
+      "timestamp": "2019-02-01T09:00:00Z",
+      "expectedUrl": "https://storage.googleapis.com/test-bucket//path/with/slashes/under_score/amper%26sand/file.ext?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&X-Goog-Signature=2db8b70e3f85b39be7824f6d02be31af2e6a2eb63f6bb41254851f7ef51bdad8963a9d2b254f8379c1780c8e6898be002d4100a0abd3d45f1437687fed65d15dd237c3a6f3c399c64ffd4e4cea7ef1c2f0391d35ecbeeaf3e3148d23c6f24c839cfcd92c1496332f5bfbbf1ed1e957eb45fad57df24828c96cf243eec23fba014d277c22a572708beb355888c5a8c0047cb3015d7f62cc90285676e7e34626fd0ce9ba5e0da39fc3de0035cc3ad120c46cb73db87246ae123f7a342c235e9480bd7d7e00c13b1e1bb7be5e2bce74d59a53505172463b48aefeedb48281d90874aa4177c881d3596ed1067f02eaac13d810a7aed234c41978b1394d0ce3662f76",
+      "scheme": "https",
+      "expectedCanonicalRequest": "GET\n/test-bucket//path/with/slashes/under_score/amper%26sand/file.ext\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host\nhost:storage.googleapis.com\n\nhost\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\n63c601ecd6ccfec84f1113fc906609cbdf7651395f4300cecd96ddd2c35164f8"
     },
     {
       "description": "Simple headers",
@@ -55,11 +97,14 @@
       "method": "GET",
       "expiration": "10",
       "timestamp": "2019-02-01T09:00:00Z",
-      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256\u0026X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request\u0026X-Goog-Date=20190201T090000Z\u0026X-Goog-Expires=10\u0026X-Goog-SignedHeaders=bar%3Bfoo%3Bhost\u0026X-Goog-Signature=68ecd3b008328ed30d91e2fe37444ed7b9b03f28ed4424555b5161980531ef87db1c3a5bc0265aad5640af30f96014c94fb2dba7479c41bfe1c020eb90c0c6d387d4dd09d4a5df8b60ea50eb6b01cdd786a1e37020f5f95eb8f9b6cd3f65a1f8a8a65c9fcb61ea662959efd9cd73b683f8d8804ef4d6d9b2852419b013368842731359d7f9e6d1139032ceca75d5e67cee5fd0192ea2125e5f2955d38d3d50cf116f3a52e6a62de77f6207f5b95aaa1d7d0f8a46de89ea72e7ea30f21286318d7eba0142232b0deb3a1dc9e1e812a981c66b5ffda3c6b01a8a9d113155792309fd53a3acfd054ca7776e8eec28c26480cd1e3c812f67f91d14217f39a606669d",
+      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=bar%3Bfoo%3Bhost&X-Goog-Signature=68ecd3b008328ed30d91e2fe37444ed7b9b03f28ed4424555b5161980531ef87db1c3a5bc0265aad5640af30f96014c94fb2dba7479c41bfe1c020eb90c0c6d387d4dd09d4a5df8b60ea50eb6b01cdd786a1e37020f5f95eb8f9b6cd3f65a1f8a8a65c9fcb61ea662959efd9cd73b683f8d8804ef4d6d9b2852419b013368842731359d7f9e6d1139032ceca75d5e67cee5fd0192ea2125e5f2955d38d3d50cf116f3a52e6a62de77f6207f5b95aaa1d7d0f8a46de89ea72e7ea30f21286318d7eba0142232b0deb3a1dc9e1e812a981c66b5ffda3c6b01a8a9d113155792309fd53a3acfd054ca7776e8eec28c26480cd1e3c812f67f91d14217f39a606669d",
       "headers": {
         "BAR": "BAR-value",
         "foo": "foo-value"
-      }
+      },
+      "scheme": "https",
+      "expectedCanonicalRequest": "GET\n/test-bucket/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=bar%3Bfoo%3Bhost\nbar:BAR-value\nfoo:foo-value\nhost:storage.googleapis.com\n\nbar;foo;host\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\n59c1ac1a6ee7d773d5c4487ecc861d60b71c4871dd18fc7d8485fac09df1d296"
     },
     {
       "description": "Headers should be trimmed",
@@ -68,13 +113,16 @@
       "method": "GET",
       "expiration": "10",
       "timestamp": "2019-02-01T09:00:00Z",
-      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=collapsed%3Bhost%3Bleading%3Btabs%3Btrailing&X-Goog-Signature=52fa1d70bcd527ee9c1241f87c56bc481526e8a63d440948595ff776faacb0caa6e8a3060b113546cb27ed29d80c88d402947d83948758d4e5c49e47d9482751d46b2a99c2dae5bc8f7baffab03dec05b28b5d605610686c48e867d6a4239a2a61a785df7d6099d155bba57d0d331d66d667b5df8e165e8277e2675678fc28499abd34053a2bc4e4fa21d032c4278fd29897e8307f142506a3d8d07149cded15f7defa77028fb88ff45132cee5f6232feb8e7f899fe361f1f8ceed0795aff860084f35e27475447dc6e64e4baa09e96a725eee6fa3c408d6bb51c2bd5f649afb8339f46997d9ef22496a79cf0846e52ac941c08dc4b9d63639d0ff2ce8637412",
+      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=collapsed%3Bhost%3Bleading%3Btabs%3Btrailing&X-Goog-Signature=75d77a3ed2d9b74ff7e1e23b2fd7cc714ad4cc32518c65f3a8197827cd87d302623bab990cf2ff3a633bfaae69b6c2d897add78c105aa68411229610421c4239579add4aff6bdbd5067a0fd61c3aa0029d7de0f8ae88fa3458fa70f875e841d6df9598597d9012b9f848c6857e08f2704ca2f332c71738490ffdda2ed928f9340549d7295745725062d28dc1696eab7cb3b88ac4fd445e951423f645d680a60dd8033d65b65f4c10286f59f4258dbb2bcf36a76ffdd40574104cbbf0b76901c24df5854f24c42e9192fcedc386d85704fec6a6bad3a5201e1fb6c491a4c43371b0913420743580daf3504e99204c6ec894b4d70cd27bc60c3fe2850e8bf3ed22",
       "headers": {
         "collapsed": "abc    def",
         "leading": "    xyz",
         "trailing": "abc    ",
         "tabs": "\tabc\t\t\t\tdef\t"
-      }
+      },
+      "scheme": "https",
+      "expectedCanonicalRequest": "GET\n/test-bucket/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=collapsed%3Bhost%3Bleading%3Btabs%3Btrailing\ncollapsed:abc def\nhost:storage.googleapis.com\nleading:xyz\ntabs:abc def\ntrailing:abc\n\ncollapsed;host;leading;tabs;trailing\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\n19153e83555808dbfeb8969043cc8ce8d5db0cce91dc11fb9df58b8130f09d42"
     },
     {
       "description": "Header value with multiple inline values",
@@ -86,7 +134,10 @@
       "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host%3Bmultiple&X-Goog-Signature=5cc113735625341f59c7203f0c2c9febc95ba6af6b9c38814f8e523214712087dc0996e4960d273ae1889f248ac1e58d4d19cb3a69ad7670e9a8ca1b434e878f59339dc7006cf32dfd715337e9f593e0504371839174962a08294586e0c78160a7aa303397888c8350637c6af3b32ac310886cc4590bfda9ca561ee58fb5b8ec56bc606d2ada6e7df31f4276e9dcb96bcaea39dc2cd096f3fad774f9c4b30e317ad43736c05f76831437f44e8726c1e90d3f6c9827dc273f211f32fc85658dfc5d357eb606743a6b00a29e519eef1bebaf9db3e8f4b1f5f9afb648ad06e60bc42fa8b57025056697c874c9ea76f5a73201c9717ea43e54713ff3502ff3fc626b",
       "headers": {
           "multiple": " xyz ,  abc, def  , xyz   "
-      }
+      },
+      "scheme": "https",
+      "expectedCanonicalRequest": "GET\n/test-bucket/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host%3Bmultiple\nhost:storage.googleapis.com\nmultiple:xyz , abc, def , xyz\n\nhost;multiple\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\n4df8e486146c31f1c8cd4e4c730554cde4326791ba48ec11fa969a3de064cd7f"
     },
     {
       "description": "Customer-supplied encryption key",
@@ -100,7 +151,10 @@
         "X-Goog-Encryption-Algorithm": "AES256",
         "X-Goog-Encryption-Key": "key",
         "X-Goog-Encryption-Key-Sha256": "key-hash"
-      }
+      },
+      "scheme": "https",
+      "expectedCanonicalRequest": "GET\n/test-bucket/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host%3Bx-goog-encryption-algorithm%3Bx-goog-encryption-key%3Bx-goog-encryption-key-sha256\nhost:storage.googleapis.com\nx-goog-encryption-algorithm:AES256\nx-goog-encryption-key:key\nx-goog-encryption-key-sha256:key-hash\n\nhost;x-goog-encryption-algorithm;x-goog-encryption-key;x-goog-encryption-key-sha256\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\n66a45104eba8bdd9748723b45cbd54c3f0f6dba337a5deb9fb6a66334223dc06"
     },
     {
       "description": "List Objects",
@@ -108,7 +162,271 @@
       "method": "GET",
       "expiration": "10",
       "timestamp": "2019-02-01T09:00:00Z",
-      "expectedUrl": "https://storage.googleapis.com/test-bucket?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&X-Goog-Signature=6dbe94f8e52b2b8a9a476b1c857efa474e09944e2b52b925800316e094a7169d8dbe0df9c0ac08dabb22ac7e827470ceccd65f5a3eadba2a4fb9beebfe37f0d9bb1e552b851fa31a25045bdf019e507f5feb44f061551ef1aeb18dcec0e38ba2e2f77d560a46eaace9c56ed9aa642281301a9d848b0eb30749e34bc7f73a3d596240533466ff9b5f289cd0d4c845c7d96b82a35a5abd0c3aff83e4440ee6873e796087f43545544dc8c01afe1d79c726696b6f555371e491980e7ec145cca0803cf562c38f3fa1d724242f5dea25aac91d74ec9ddd739ff65523627763eaef25cd1f95ad985aaf0079b7c74eb5bcb2870a9b137a7b2c8e41fbe838c95872f75b"
+      "expectedUrl": "https://storage.googleapis.com/test-bucket?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&X-Goog-Signature=6dbe94f8e52b2b8a9a476b1c857efa474e09944e2b52b925800316e094a7169d8dbe0df9c0ac08dabb22ac7e827470ceccd65f5a3eadba2a4fb9beebfe37f0d9bb1e552b851fa31a25045bdf019e507f5feb44f061551ef1aeb18dcec0e38ba2e2f77d560a46eaace9c56ed9aa642281301a9d848b0eb30749e34bc7f73a3d596240533466ff9b5f289cd0d4c845c7d96b82a35a5abd0c3aff83e4440ee6873e796087f43545544dc8c01afe1d79c726696b6f555371e491980e7ec145cca0803cf562c38f3fa1d724242f5dea25aac91d74ec9ddd739ff65523627763eaef25cd1f95ad985aaf0079b7c74eb5bcb2870a9b137a7b2c8e41fbe838c95872f75b",
+      "scheme": "https",
+      "expectedCanonicalRequest": "GET\n/test-bucket\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host\nhost:storage.googleapis.com\n\nhost\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\n51a7426c2a6c6ab80f336855fc629461ff182fb1d2cb552ac68e5ce8e25db487"
+    },
+    {
+      "description": "Query Parameter Encoding",
+      "bucket": "test-bucket",
+      "object": "test-object",
+      "method": "GET",
+      "expiration": "10",
+      "timestamp": "2019-02-01T09:00:00Z",
+      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&aA0%C3%A9%2F%3D%25-_.~=~._-%25%3D%2F%C3%A90Aa&X-Goog-Signature=221f1905382ce560042b0441e678b6589f4a661fd319f079bde1f7d7ab07e8515334dbabd901c95d3f16a03f389f661ef7de897fdc7cea8914d93ac8638ad56a9dca62ec8983478a9513a702e12dd57182b5b5ee58d7e94dd685f6c2bbaec1ad168294eaf8300cafec7565e1ad99f55b324caa48720d541e1b2be39b10baa7ff39d2cb77efdad91d63fa0c80625234430027077f68f8ad8c258ef8aba93e2a15fb3f74111e9ffab46f481899d1e83db7d84d9b2645975086ba67ce2d9284d50bb2725871d05621a791ee1c9db7db8a52d579191c5f59da6063128effbe0bbc1ae9a573e298e63aa29bbe9bb8dba76a6c98154a9f03f5ce0cb8f176e0ad14acae",
+      "queryParameters": {
+        "aA0é/=%-_.~": "~._-%=/é0Aa"
+      },
+      "scheme": "https",
+      "expectedCanonicalRequest": "GET\n/test-bucket/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&aA0%C3%A9%2F%3D%25-_.~=~._-%25%3D%2F%C3%A90Aa\nhost:storage.googleapis.com\n\nhost\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\na4815f31e2df44febcde5f15614a38dfaab1d2dbc2488c92e0dfaef06351448a"
+    },
+    {
+      "description": "Query Parameter Ordering",
+      "bucket": "test-bucket",
+      "object": "test-object",
+      "method": "GET",
+      "expiration": "10",
+      "timestamp": "2019-02-01T09:00:00Z",
+      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-Meta-Foo=bar&X-Goog-SignedHeaders=host&prefix=%2Ffoo&X-Goog-Signature=a07745e1b3d59b85cbe11aa766df72c22468959e7217615dccb7f030234f66b60b37e480f30725ed51f29816362ca8286c619ebb66448ff1d370be2a4a48aacf20d3d2d6200ed17341a5791baf2ee5cd9c2823adacc6264f66c8a54fa887e1bce3c55cf78fb2f6a52618cf09d6f945f63d148052a7b66a75e075ff5065828a806b84bdc49a42399be7483225c720d5e18a6160f79d815f433e7921694fe1d041099851793c2581db0e5ca503cfb566e414f900ceede5f9b22030edd32ab20b6f7f9fb2afba89098b9364e03397c03a94eac3a140c99979b8786844fb4f6c62c1985378939dd1bbaea8e41b9100dda85a27733171cc78d96ee362ea2c3432f4d8",
+      "queryParameters": {
+        "prefix": "/foo",
+        "X-Goog-Meta-Foo": "bar"
+      },
+      "scheme": "https",
+      "expectedCanonicalRequest": "GET\n/test-bucket/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-Meta-Foo=bar&X-Goog-SignedHeaders=host&prefix=%2Ffoo\nhost:storage.googleapis.com\n\nhost\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\n4dafe74ad142f32b7c25fc4e6b38fd3b8a6339d7f112247573fb0066f637db6c"
+    },
+    {
+      "description": "Header Ordering",
+      "bucket": "test-bucket",
+      "object": "test-object",
+      "method": "GET",
+      "expiration": "10",
+      "timestamp": "2019-02-01T09:00:00Z",
+      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host%3Bx-goog-date&X-Goog-Signature=55a28435997457f1498291e878fd39c5f321973057d2541886020fdfd212b1467d9eeffdc70951ea952d634cb4193e657ed5b7860c46d37f7d904774680a16e518aa9dff273e8441d6893de615eb592e3113d682ad64a87eb0e0c48df17c30f899e7f940ba230530b30f725ab9ec38789682413752de6a026ae69dd858843100645f3ec986aed618d229f8844d378e0e66e907ede6dff7aac56723f51eb830e8877a56100c86a876173424602abefe6c22b6540a2b36634860b2e89137f297cca8f080bdf3433a9d614c5ab2ec84f65412b45516b30500886a2300f23c3423ae0e91546e3471ee08d06894bddc76203a418d46f35bf0b4574f7b24a693fb046c",
+      "headers": {
+        "X-Goog-Date": "20190201T090000Z"
+      },
+      "scheme": "https",
+      "expectedCanonicalRequest": "GET\n/test-bucket/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host%3Bx-goog-date\nhost:storage.googleapis.com\nx-goog-date:20190201T090000Z\n\nhost;x-goog-date\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\n4052143280d90d5f4a8c878ff7418be6fee5d34e50b1da28d8081a094b88fa61"
+    },
+    {
+      "description": "Signed Payload Instead of UNSIGNED-PAYLOAD",
+      "bucket": "test-bucket",
+      "object": "test-object",
+      "method": "PUT",
+      "expiration": "10",
+      "timestamp": "2019-02-01T09:00:00Z",
+      "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host%3Bx-goog-content-sha256%3Bx-testcasemetadata-payload-value&X-Goog-Signature=3e5a9669e9aa162888dff1553d24c159bad4f16d444987f6a1b26d8ad0cb7927f15bfaf79c205324d2138fd1f62edb255430c77a03c0d6e9601399e2519014f9e1a7051d9be735cde530022c84602b1c4c25c86cb1e1584489e49d511c9a618a1a8443af31626ca5b2ad105eda1e4499f52b4043f3c1a3bd40c06c0cae36bb19a50ed8671e5d2cdbb148a196ce5a8c14d6970c08225da293e1ef400c92e7a3d5ba0a29ad0893827c96b203a04b04ebd51929bf99b323beba93097dfee700ee2c1bd97013779e5c8f156e56175d4d07e453b2eb0d616086f9f4753dde63507efe88b0dec29c872d25d9465f07778b16b532814148c578ee7e64ed8437006fa551",
+      "headers": {
+        "X-Goog-Content-SHA256": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b982",
+        "X-TestCaseMetadata-Payload-Value": "hello"
+      },
+      "scheme": "https",
+      "expectedCanonicalRequest": "PUT\n/test-bucket/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host%3Bx-goog-content-sha256%3Bx-testcasemetadata-payload-value\nhost:storage.googleapis.com\nx-goog-content-sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b982\nx-testcasemetadata-payload-value:hello\n\nhost;x-goog-content-sha256;x-testcasemetadata-payload-value\n2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b982",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\nbe21a0841a897930ff5cf72e6e74ec5274efd76c3fe4cde6678f24a0a3d6dbec"
+    },
+    {
+      "description": "Virtual Hosted Style",
+      "bucket": "test-bucket",
+      "object": "test-object",
+      "method": "GET",
+      "expiration": "10",
+      "timestamp": "2019-02-01T09:00:00Z",
+      "expectedUrl": "https://test-bucket.storage.googleapis.com/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&X-Goog-Signature=06c633ea060b0eda81ee58dd3337b01b0d243a44f18cb03ec948861f533a129e579c7fd4c856d187f1c7b86e5715ea0abf6a1c6ba32b69274d22b1b0406df6847dc87f0d289fe8dc0682351574849b8b13e4b66922f39441af96becb73ea4c56cd5e3eeb30bc91fe84e8bd205adca8639253bdb65b2fcaf2598a230c6d8f6d8177c9e58a61b6e826767f594056b490184d676897c4bbedc15d6fbf08c3fa82a406c62e74db661e6c5d7d3ced29e0619ee719dce4b8136360345b8dce120b9f1debd511c8dac3e6d874ee05bfda8c8f1c4fedd0c07fc6d98f5f18a349bb204d8ff401402a025194e2792df8a09282141157e4ca51d26a8d0d142a01c805321911",
+      "scheme": "https",
+      "urlStyle": "VIRTUAL_HOSTED_STYLE",
+      "expectedCanonicalRequest": "GET\n/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host\nhost:test-bucket.storage.googleapis.com\n\nhost\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\n89eeae48258eccdcb1f592fb908008e3f5d36a949c002c1e614c94356dc18fc6"
+    },
+    {
+      "description": "HTTP Bucket Bound Domain Support",
+      "bucket": "test-bucket",
+      "object": "test-object",
+      "method": "GET",
+      "expiration": "10",
+      "timestamp": "2019-02-01T09:00:00Z",
+      "expectedUrl": "http://mydomain.tld/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&X-Goog-Signature=7115a77f8c7ed1a8b74bca8b520904fca7f3bab90d69ea052687a94efd9b3a4e2a7fb7135d40e295e0a21958194c55da7e106227957c22ed6edc9d8b3d2a8133bc8af84fc9695dda8081d53f0db5ea9f28e5bfc225d78f873e9f571fd287bb7a95330e726aebd8eb4623cdb0b1a7ceb210b2ce1351b6be0191c2ad7b38f7ceb6c5ce2f98dbfb5a5a649050585e46e97f72f1f5407de657a56e34a3fdc80cdaa0598bd47f3e8af5ff22d0916b19b106890bff8c3f6587f1d3b076b16cd0ba0508607a672be33b9c75d537e15258450b43d22a21c4d528090acbb8e5bae7b31fc394e61394106ef1d6a8ed43074ab05bcec65674cd8113fb3de388da4d97e62f56",
+      "scheme": "http",
+      "urlStyle": "BUCKET_BOUND_DOMAIN",
+      "bucketBoundDomain": "mydomain.tld",
+      "expectedCanonicalRequest": "GET\n/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host\nhost:mydomain.tld\n\nhost\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\nd6c309924b51a5abbe4d6356f7bf29c2120c6b14649b1e97b3bc9309adca7d4b"
+    },
+    {
+      "description": "HTTPS Bucket Bound Domain Support",
+      "bucket": "test-bucket",
+      "object": "test-object",
+      "method": "GET",
+      "expiration": "10",
+      "timestamp": "2019-02-01T09:00:00Z",
+      "expectedUrl": "https://mydomain.tld/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&X-Goog-Signature=7115a77f8c7ed1a8b74bca8b520904fca7f3bab90d69ea052687a94efd9b3a4e2a7fb7135d40e295e0a21958194c55da7e106227957c22ed6edc9d8b3d2a8133bc8af84fc9695dda8081d53f0db5ea9f28e5bfc225d78f873e9f571fd287bb7a95330e726aebd8eb4623cdb0b1a7ceb210b2ce1351b6be0191c2ad7b38f7ceb6c5ce2f98dbfb5a5a649050585e46e97f72f1f5407de657a56e34a3fdc80cdaa0598bd47f3e8af5ff22d0916b19b106890bff8c3f6587f1d3b076b16cd0ba0508607a672be33b9c75d537e15258450b43d22a21c4d528090acbb8e5bae7b31fc394e61394106ef1d6a8ed43074ab05bcec65674cd8113fb3de388da4d97e62f56",
+      "scheme": "https",
+      "urlStyle": "BUCKET_BOUND_DOMAIN",
+      "bucketBoundDomain": "mydomain.tld",
+      "expectedCanonicalRequest": "GET\n/test-object\nX-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host\nhost:mydomain.tld\n\nhost\nUNSIGNED-PAYLOAD",
+      "expectedStringToSign": "GOOG4-RSA-SHA256\n20190201T090000Z\n20190201/auto/storage/goog4_request\nd6c309924b51a5abbe4d6356f7bf29c2120c6b14649b1e97b3bc9309adca7d4b"
+    }
+  ],
+  "postPolicyV4Tests": [
+    {
+      "description": "POST Policy Simple",
+      "policyInput": {
+        "scheme": "https",
+        "bucket": "rsaposttest-1579902670-h3q7wvodjor6bc7y",
+        "object": "test-object",
+        "expiration": 10,
+        "timestamp": "2020-01-23T04:35:30Z"
+      },
+      "policyOutput": {
+        "url": "https://storage.googleapis.com/rsaposttest-1579902670-h3q7wvodjor6bc7y/",
+        "fields" : {
+          "key": "test-object",
+          "x-goog-algorithm": "GOOG4-RSA-SHA256",
+          "x-goog-credential": "test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request",
+          "x-goog-date": "20200123T043530Z",
+          "x-goog-signature": "925766caea79216580bff38d89b14f7f5b45719f54a87224b39b21592f60cad3aa1ec42b3e39b01c8a14420133a029fe5f32b4e925b1acd9c5e24aadaea70f9dddeb75dd14cf5ca7464e5bcffac576d2645f558f086e0c9b6ba67bdc0cc3e7543b1aa08aa491549a6f6d7b303b39751cab7edb5222f5f9a11a961442030475fc1485df631a97c81958b252c37dbcf2bb2bfb6ecd589d46a0fe4298f4f1f0c5b23b1b8ae57c0f522a786d508c5311270552f27b8940917ba3f1b8004e1f4c80340de3de859ebd795ee7ca5bf382c29c5fa9e47f2de915fdc0dcfdb764dca33943062316bb3fe4c13615c10cfb107daa92fa49187552c918c6fd6aa3a272f0d9fb",
+          "policy": "eyJjb25kaXRpb25zIjogW3sia2V5IjogInRlc3Qtb2JqZWN0In0sIHsieC1nb29nLWRhdGUiOiAiMjAyMDAxMjNUMDQzNTMwWiJ9LCB7IngtZ29vZy1jcmVkZW50aWFsIjogInRlc3QtaWFtLWNyZWRlbnRpYWxzQGR1bW15LXByb2plY3QtaWQuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20vMjAyMDAxMjMvYXV0by9zdG9yYWdlL2dvb2c0X3JlcXVlc3QifSwgeyJ4LWdvb2ctYWxnb3JpdGhtIjogIkdPT0c0LVJTQS1TSEEyNTYifV0sICJleHBpcmF0aW9uIjogIjIwMjAtMDEtMjNUMDQ6MzU6NDBaIn0="
+        },
+        "expectedDecodedPolicy": "{\"conditions\": [{\"key\": \"test-object\"}, {\"x-goog-date\": \"20200123T043530Z\"}, {\"x-goog-credential\": \"test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request\"}, {\"x-goog-algorithm\": \"GOOG4-RSA-SHA256\"}], \"expiration\": \"2020-01-23T04:35:40Z\"}"
+      }
+    },
+    {
+      "description": "POST Policy ACL matching",
+      "policyInput": {
+        "scheme": "https",
+        "bucket": "rsaposttest-1579902662-x2kd7kjwh2w5izcw",
+        "object": "test-object",
+        "expiration": 10,
+        "timestamp": "2020-01-23T04:35:30Z",
+        "conditions": {
+          "matches": [{
+            "expression": ["startsWith", "$acl", "public"]
+          }]
+        }
+      },
+      "policyOutput": {
+        "url": "https://storage.googleapis.com/rsaposttest-1579894185-x2kd7kjwh2w5izcw/",
+        "fields" : {
+          "key": "test-object",
+          "x-goog-algorithm": "GOOG4-RSA-SHA256",
+          "x-goog-credential": "test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request",
+          "x-goog-date": "20200123T043530Z",
+          "x-goog-signature": "18a7d82b377ff1a09849824eb6d4666f4face04f5b9e557811173a954c87b573f24c58cc0e06f8f6d964a1fc63a62ce2137d1e08de98401070c0742d388c6079814d728e3e3ccff81e748c24f109736781b32d1e6da2457348d37bad61609f1cb4206274c5901f59db408821d9e27b44a977c0bd21f66e5b79de9991d354e4c1c49e2dd8a0b8535e320bf45dc1b4f3b7ca30638091e62fb70b5bbedd14c4d56ba0486650d35f454aa89654310f238f55d4834c9c1db2e48ca1ac2b353d6a4324d5bd54093d6f7b09fa372cf68923ab0dd13caff04c53d1d31140bf4842cc87529b984f67215423c05a1036baa3226b472902d67373cbc359794e6b98dd2e5ad7",
+          "policy": "eyJjb25kaXRpb25zIjogW3sia2V5IjogInRlc3Qtb2JqZWN0In0sIHsieC1nb29nLWRhdGUiOiAiMjAyMDAxMjNUMDQzNTMwWiJ9LCB7IngtZ29vZy1jcmVkZW50aWFsIjogInRlc3QtaWFtLWNyZWRlbnRpYWxzQGR1bW15LXByb2plY3QtaWQuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20vMjAyMDAxMjMvYXV0by9nY3MvZ29vZzRfcmVxdWVzdCJ9LCB7IngtZ29vZy1hbGdvcml0aG0iOiAiR09PRzQtUlNBLVNIQTI1NiJ9XSwgImV4cGlyYXRpb24iOiAiMjAyMC0wMS0yM1QwNDozNTo0MFoifQ=="
+        },
+        "expectedDecodedPolicy": "{\"conditions\": [{\"key\": \"test-object\"}, {\"x-goog-date\": \"20200123T043530Z\"}, {\"x-goog-credential\": \"test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/gcs/goog4_request\"}, {\"x-goog-algorithm\": \"GOOG4-RSA-SHA256\"}], \"expiration\": \"2020-01-23T04:35:40Z\"}"
+      }
+    },
+    {
+      "description": "POST Policy Within Content-Range",
+      "policyInput": {
+        "scheme": "https",
+        "bucket": "rsaposttest-1579902672-lpd47iogn6hx4sle",
+        "object": "test-object",
+        "expiration": 10,
+        "timestamp": "2020-01-23T04:35:30Z",
+        "conditions": {
+          "matches": [{
+            "expression": ["content-length-range", "246", "266"]
+          }]
+        }
+      },
+      "policyOutput": {
+        "url": "https://storage.googleapis.com/rsaposttest-1579902672-lpd47iogn6hx4sle/",
+        "fields" : {
+          "key": "test-object",
+          "x-goog-algorithm": "GOOG4-RSA-SHA256",
+          "x-goog-credential": "test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request",
+          "x-goog-date": "20200123T043530Z",
+          "x-goog-signature": "8cfa9dc9a8d35f597f6f7bbf749322b3883cb221e907d1b3fc511333421c8f666649a35add399547faa327da07a13025987f64194ede8ee8687ace756d72e8841ed7b08a7335afad12252b1aafe9a84cd72932a76074781264d645886e28b7095e70d5a6814e4fcaa2192080d50c361057b0127a9c1f072c55636d030f1d3ecc5273f5d70a84981ec81499dc4cd07e516b6739811ac578b1cc2de459598c42ba640089bd0ec68d498674757f8e044ecc902eb522b60af5b4999ff028800905c0a7b4e35e7552027ac1f059c50c492b2633908010c95d24cf5f5354073d36c7b2fb74d1b961605e7aa011f07a3f48b680f9c3a3fb7034c3c02034f4a1bbbc7433",
+          "policy": "eyJjb25kaXRpb25zIjogW1siY29udGVudC1sZW5ndGgtcmFuZ2UiLCAyNDYsIDI2Nl0sIHsia2V5IjogInRlc3Qtb2JqZWN0In0sIHsieC1nb29nLWRhdGUiOiAiMjAyMDAxMjNUMDQzNTMwWiJ9LCB7IngtZ29vZy1jcmVkZW50aWFsIjogInRlc3QtaWFtLWNyZWRlbnRpYWxzQGR1bW15LXByb2plY3QtaWQuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20vMjAyMDAxMjMvYXV0by9zdG9yYWdlL2dvb2c0X3JlcXVlc3QifSwgeyJ4LWdvb2ctYWxnb3JpdGhtIjogIkdPT0c0LVJTQS1TSEEyNTYifV0sICJleHBpcmF0aW9uIjogIjIwMjAtMDEtMjNUMDQ6MzU6NDBaIn0="
+        },
+        "expectedDecodedPolicy": "{\"conditions\": [[\"content-length-range\", 246, 266], {\"key\": \"test-object\"}, {\"x-goog-date\": \"20200123T043530Z\"}, {\"x-goog-credential\": \"test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request\"}, {\"x-goog-algorithm\": \"GOOG4-RSA-SHA256\"}], \"expiration\": \"2020-01-23T04:35:40Z\"}"
+      }
+    },
+    {
+      "description": "POST Policy Cache-Control File Header",
+      "policyInput": {
+        "scheme": "https",
+        "bucket": "rsaposttest-1579902669-nwk5s7vvfjgdjs62",
+        "object": "test-object",
+        "expiration": 10,
+        "timestamp": "2020-01-23T04:35:30Z",
+        "headers": {
+          "acl": "public-read",
+          "cache-control": "public,max-age=86400"
+        }
+      },
+      "policyOutput": {
+        "url": "https://storage.googleapis.com/rsaposttest-1579902669-nwk5s7vvfjgdjs62/",
+        "fields": {
+          "key": "test-object",
+          "acl": "public-read",
+          "cache-control": "public,max-age=86400",
+          "x-goog-algorithm": "GOOG4-RSA-SHA256",
+          "x-goog-credential": "test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request",
+          "x-goog-date": "20200123T043530Z",
+          "x-goog-signature": "0b427e08c1f5688354b60b82679fec4f7eaf9f13cc06afcb8d4231fd46e96f2090d219e196acf8564d10ee89adc77572a26b4ade961894587972cb1c364aaac00748675a010be9245fb92c11ce6aead8b4fdb3d93f18d6886489f086735863978c6405d945ec6ae8986863a77dd6c4d0d7840bed0f108f3965d3dc18102e65995276f71bcb5c6b1590f488226cce62fa47de0cd7cbf8ce09efb58b052ce6f02e92c86a942cab37435eab6560ce5f870ecaf7045401167e884999e268a97a5d0a700df97a1d986d28db47ab1f926198df82bdec6d2bd54f41fe162c91f606f0c628ae8e8425622e4147b8b04582e6b0e0cf5fad501644540b57e283a692a8441f",
+          "policy": "eyJjb25kaXRpb25zIjogW3siYWNsIjogInB1YmxpYy1yZWFkIn0sIHsiY2FjaGUtY29udHJvbCI6ICJwdWJsaWMsbWF4LWFnZT04NjQwMCJ9LCB7ImtleSI6ICJ0ZXN0LW9iamVjdCJ9LCB7IngtZ29vZy1kYXRlIjogIjIwMjAwMTIzVDA0MzUzMFoifSwgeyJ4LWdvb2ctY3JlZGVudGlhbCI6ICJ0ZXN0LWlhbS1jcmVkZW50aWFsc0BkdW1teS1wcm9qZWN0LWlkLmlhbS5nc2VydmljZWFjY291bnQuY29tLzIwMjAwMTIzL2F1dG8vc3RvcmFnZS9nb29nNF9yZXF1ZXN0In0sIHsieC1nb29nLWFsZ29yaXRobSI6ICJHT09HNC1SU0EtU0hBMjU2In1dLCAiZXhwaXJhdGlvbiI6ICIyMDIwLTAxLTIzVDA0OjM1OjQwWiJ9="
+        },
+        "expectedDecodedPolicy": "{\"conditions\": [{\"acl\": \"public-read\"}, {\"cache-control\": \"public,max-age=86400\"}, {\"key\": \"test-object\"}, {\"x-goog-date\": \"20200123T043530Z\"}, {\"x-goog-credential\": \"test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request\"}, {\"x-goog-algorithm\": \"GOOG4-RSA-SHA256\"}], \"expiration\": \"2020-01-23T04:35:40Z\"}"
+      }
+    },
+    {
+      "description": "POST Policy Success With Status",
+      "policyInput": {
+        "scheme": "https",
+        "bucket": "rsaposttest-1579902678-pt5yms55j47r6qy4",
+        "object": "test-object",
+        "expiration": 10,
+        "timestamp": "2020-01-23T04:35:30Z",
+        "conditions": {
+          "successActionStatus": "200"
+        }
+      },
+      "policyOutput": {
+        "url": "https://storage.googleapis.com/rsaposttest-1579902678-pt5yms55j47r6qy4/",
+        "fields": {
+          "key": "test-object",
+          "success_action_status": "200",
+          "x-goog-algorithm": "GOOG4-RSA-SHA256",
+          "x-goog-credential": "test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request",
+          "x-goog-date": "20200123T043530Z",
+          "x-goog-signature": "64d92b33d9c44664ed7a16c8505f807d54cab46203e595b9885e298c44e598aa03d60a0a13b63746f064d29f803d2c6852856822dae04f20a645257c9445b98af03d73621d7d18097d7c64e0c37142546a5aa2754432118b7d1d5f1dbd9ca4407a0b991c2a0874bc4b8e0ac2a2c92d3ad1679f47af1c211ca73219047598e95a87e95dacb2ef8c3c33a3de61b23e34c76623844f688ad862cb8639f4213817baf35acb4f8a7b687d687721c356522e4c4995db07c571f6605d2aaea02722f5c38ef6e130f87b9790d3117374a8aa205592d5dda5ab676bab4b83191f81eb24d86e8d147080040dcaa46f9e1a9385cae58bda2e70abd6d82bfc24ff5589633436",
+          "policy": "eyJjb25kaXRpb25zIjogW3sic3VjY2Vzc19hY3Rpb25fc3RhdHVzIjogIjIwMCJ9LCB7ImtleSI6ICJ0ZXN0LW9iamVjdCJ9LCB7IngtZ29vZy1kYXRlIjogIjIwMjAwMTIzVDA0MzUzMFoifSwgeyJ4LWdvb2ctY3JlZGVudGlhbCI6ICJ0ZXN0LWlhbS1jcmVkZW50aWFsc0BkdW1teS1wcm9qZWN0LWlkLmlhbS5nc2VydmljZWFjY291bnQuY29tLzIwMjAwMTIzL2F1dG8vc3RvcmFnZS9nb29nNF9yZXF1ZXN0In0sIHsieC1nb29nLWFsZ29yaXRobSI6ICJHT09HNC1SU0EtU0hBMjU2In1dLCAiZXhwaXJhdGlvbiI6ICIyMDIwLTAxLTIzVDA0OjM1OjQwWiJ9"
+        },
+        "expectedDecodedPolicy": "{\"conditions\": [{\"success_action_status\": \"200\"}, {\"key\": \"test-object\"}, {\"x-goog-date\": \"20200123T043530Z\"}, {\"x-goog-credential\": \"test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request\"}, {\"x-goog-algorithm\": \"GOOG4-RSA-SHA256\"}], \"expiration\": \"2020-01-23T04:35:40Z\"}"
+      }
+    },
+    {
+      "description": "POST Policy Success With Redirect",
+      "policyInput": {
+        "scheme": "https",
+        "bucket": "rsaposttest-1579902671-6ldm6caw4se52vrx",
+        "object": "test-object",
+        "expiration": 10,
+        "timestamp": "2020-01-23T04:35:30Z",
+        "conditions": {
+          "successActionRedirect": "http://www.google.com/"
+        }
+      },
+      "policyOutput": {
+        "url": "https://storage.googleapis.com/rsaposttest-1579902671-6ldm6caw4se52vrx/",
+        "fields" : {
+          "key": "test-object",
+          "success_action_redirect": "http://www.google.com/",
+          "x-goog-algorithm": "GOOG4-RSA-SHA256",
+          "x-goog-credential": "test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request",
+          "x-goog-date": "20200123T043530Z",
+          "x-goog-signature": "88cac749907f9d8e8a8d8a3d09acc349663f12c59ddec7294fe8bbff8437cd2632856f2ff1479fb0f2ce92484a15dc5bd20a2c19d142ecf0641814d96f12ebb4ba4b0d1f1f7e8881bcf2fb5d7823c0fc3a132f4e7793ce27316ed75a985e1b6183a087b887970214abfd5b6d6ea1f6fc1ccf86bb376cb0f8b5053a0962b528ec018115195b9b5e054cf6773ee72113cf41daa258f2a3a16c2d3b49e256a5655c1ea07ed0a358d167f31be41db476fe51483dbbc1fc188aca718a791a7bb8ee4177ddbee3a213d093e4ae088db335caace173c504ffd4e0bea23b1cfeeb1c5181b9b74115b63fd290cce40735ee05f20ad2c799ce94fd4458429d57a2654be1e9",
+          "policy": "eyJjb25kaXRpb25zIjogW3sic3VjY2Vzc19hY3Rpb25fcmVkaXJlY3QiOiAiaHR0cDovL3d3dy5nb29nbGUuY29tLyJ9LCB7ImtleSI6ICJ0ZXN0LW9iamVjdCJ9LCB7IngtZ29vZy1kYXRlIjogIjIwMjAwMTIzVDA0MzUzMFoifSwgeyJ4LWdvb2ctY3JlZGVudGlhbCI6ICJ0ZXN0LWlhbS1jcmVkZW50aWFsc0BkdW1teS1wcm9qZWN0LWlkLmlhbS5nc2VydmljZWFjY291bnQuY29tLzIwMjAwMTIzL2F1dG8vc3RvcmFnZS9nb29nNF9yZXF1ZXN0In0sIHsieC1nb29nLWFsZ29yaXRobSI6ICJHT09HNC1SU0EtU0hBMjU2In1dLCAiZXhwaXJhdGlvbiI6ICIyMDIwLTAxLTIzVDA0OjM1OjQwWiJ9"
+        },
+        "expectedDecodedPolicy": "{\"conditions\": [{\"success_action_redirect\": \"http://www.google.com/\"}, {\"key\": \"test-object\"}, {\"x-goog-date\": \"20200123T043530Z\"}, {\"x-goog-credential\": \"test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request\"}, {\"x-goog-algorithm\": \"GOOG4-RSA-SHA256\"}], \"expiration\": \"2020-01-23T04:35:40Z\"}"
+      }
     }
   ]
 }

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1443,6 +1443,12 @@ module Google
         # @param [Symbol, String] version The version of the signed credential
         #   to create. Must be one of `:v2` or `:v4`. The default value is
         #   `:v2`.
+        # @param [Boolean] virtual_hosted_style Whether to use a virtual hosted-style
+        #   hostname, which adds the bucket into the host portion of the URI rather
+        #   than the path, e.g. `https://mybucket.storage.googleapis.com/...`.
+        #   For V4 signing, this also sets the `host` header in the canonicalized
+        #   extension headers to the virtual hosted-style host, unless that header is
+        #   supplied via the `headers` param. The default value is `false`.
         #
         # @return [String]
         #
@@ -1513,7 +1519,7 @@ module Google
         def signed_url path = nil, method: nil, expires: nil, content_type: nil,
                        content_md5: nil, headers: nil, issuer: nil,
                        client_email: nil, signing_key: nil, private_key: nil,
-                       query: nil, version: nil
+                       query: nil, version: nil, virtual_hosted_style: nil
           ensure_service!
           version ||= :v2
           case version.to_sym
@@ -1531,7 +1537,8 @@ module Google
                               headers: headers, issuer: issuer,
                               client_email: client_email,
                               signing_key: signing_key,
-                              private_key: private_key, query: query
+                              private_key: private_key, query: query,
+                              virtual_hosted_style: virtual_hosted_style
           else
             raise ArgumentError, "version '#{version}' not supported"
           end

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1523,28 +1523,49 @@ module Google
         #   bucket = storage.bucket "my-todo-app"
         #   list_files_url = bucket.signed_url version: :v4
         #
-        def signed_url path = nil, method: "GET", expires: nil, content_type: nil, content_md5: nil, headers: nil,
-                       issuer: nil, client_email: nil, signing_key: nil, private_key: nil, query: nil, scheme: "HTTPS",
-                       virtual_hosted_style: nil, bucket_bound_hostname: nil, version: nil
+        def signed_url path = nil,
+                       method: "GET",
+                       expires: nil,
+                       content_type: nil,
+                       content_md5: nil,
+                       headers: nil,
+                       issuer: nil,
+                       client_email: nil,
+                       signing_key: nil,
+                       private_key: nil,
+                       query: nil,
+                       scheme: "HTTPS",
+                       virtual_hosted_style: nil,
+                       bucket_bound_hostname: nil,
+                       version: nil
           ensure_service!
           version ||= :v2
           case version.to_sym
           when :v2
             signer = File::SignerV2.from_bucket self, path
-            signer.signed_url method: method, expires: expires,
-                              headers: headers, content_type: content_type,
-                              content_md5: content_md5, issuer: issuer,
+            signer.signed_url method: method,
+                              expires: expires,
+                              headers: headers,
+                              content_type: content_type,
+                              content_md5: content_md5,
+                              issuer: issuer,
                               client_email: client_email,
                               signing_key: signing_key,
-                              private_key: private_key, query: query
+                              private_key: private_key,
+                              query: query
           when :v4
             signer = File::SignerV4.from_bucket self, path
-            signer.signed_url method: method, expires: expires,
-                              headers: headers, issuer: issuer,
+            signer.signed_url method: method,
+                              expires: expires,
+                              headers: headers,
+                              issuer: issuer,
                               client_email: client_email,
                               signing_key: signing_key,
-                              private_key: private_key, query: query, scheme: scheme,
-                              virtual_hosted_style: virtual_hosted_style, bucket_bound_hostname: bucket_bound_hostname
+                              private_key: private_key,
+                              query: query,
+                              scheme: scheme,
+                              virtual_hosted_style: virtual_hosted_style,
+                              bucket_bound_hostname: bucket_bound_hostname
           else
             raise ArgumentError, "version '#{version}' not supported"
           end

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1446,9 +1446,13 @@ module Google
         #   than the path, e.g. `https://mybucket.storage.googleapis.com/...`.
         #   For V4 signing, this also sets the `host` header in the canonicalized
         #   extension headers to the virtual hosted-style host, unless that header is
-        #   supplied via the `headers` param. The default value is `false`.
-        # @param [String] bucket_bound_hostname An alternate hostname which is bound
-        #   in some way to a specific bucket.
+        #   supplied via the `headers` param. The default value of `false` uses the
+        #   form of `https://storage.googleapis.com/mybucket`.
+        # @param [String] bucket_bound_hostname Use a bucket-bound hostname, which
+        #   replaces the `storage.googleapis.com` host with the name of a `CNAME`
+        #   bucket, e.g. a bucket named `gcs-subdomain.my.domain.tld`, or a Google
+        #   Cloud Load Balancer which routes to a bucket you own, e.g.
+        #   `my-load-balancer-domain.tld`.
         # @param [Symbol, String] version The version of the signed credential
         #   to create. Must be one of `:v2` or `:v4`. The default value is
         #   `:v2`.

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1440,15 +1440,18 @@ module Google
         #   using the URL, but only when the file resource is missing the
         #   corresponding values. (These values can be permanently set using
         #   {File#content_disposition=} and {File#content_type=}.)
-        # @param [Symbol, String] version The version of the signed credential
-        #   to create. Must be one of `:v2` or `:v4`. The default value is
-        #   `:v2`.
+        # @param [String] scheme The URL scheme. The default value is `HTTPS`.
         # @param [Boolean] virtual_hosted_style Whether to use a virtual hosted-style
         #   hostname, which adds the bucket into the host portion of the URI rather
         #   than the path, e.g. `https://mybucket.storage.googleapis.com/...`.
         #   For V4 signing, this also sets the `host` header in the canonicalized
         #   extension headers to the virtual hosted-style host, unless that header is
         #   supplied via the `headers` param. The default value is `false`.
+        # @param [String] bucket_bound_hostname An alternate hostname which is bound
+        #   in some way to a specific bucket.
+        # @param [Symbol, String] version The version of the signed credential
+        #   to create. Must be one of `:v2` or `:v4`. The default value is
+        #   `:v2`.
         #
         # @return [String]
         #
@@ -1516,10 +1519,9 @@ module Google
         #   bucket = storage.bucket "my-todo-app"
         #   list_files_url = bucket.signed_url version: :v4
         #
-        def signed_url path = nil, method: nil, expires: nil, content_type: nil,
-                       content_md5: nil, headers: nil, issuer: nil,
-                       client_email: nil, signing_key: nil, private_key: nil,
-                       query: nil, version: nil, virtual_hosted_style: nil
+        def signed_url path = nil, method: "GET", expires: nil, content_type: nil, content_md5: nil, headers: nil,
+                       issuer: nil, client_email: nil, signing_key: nil, private_key: nil, query: nil, scheme: "HTTPS",
+                       virtual_hosted_style: nil, bucket_bound_hostname: nil, version: nil
           ensure_service!
           version ||= :v2
           case version.to_sym
@@ -1537,8 +1539,8 @@ module Google
                               headers: headers, issuer: issuer,
                               client_email: client_email,
                               signing_key: signing_key,
-                              private_key: private_key, query: query,
-                              virtual_hosted_style: virtual_hosted_style
+                              private_key: private_key, query: query, scheme: scheme,
+                              virtual_hosted_style: virtual_hosted_style, bucket_bound_hostname: bucket_bound_hostname
           else
             raise ArgumentError, "version '#{version}' not supported"
           end

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -1485,9 +1485,13 @@ module Google
         #   than the path, e.g. `https://mybucket.storage.googleapis.com/...`.
         #   For V4 signing, this also sets the `host` header in the canonicalized
         #   extension headers to the virtual hosted-style host, unless that header is
-        #   supplied via the `headers` param. The default value is `false`.
-        # @param [String] bucket_bound_hostname An alternate hostname which is bound
-        #   in some way to a specific bucket.
+        #   supplied via the `headers` param. The default value of `false` uses the
+        #   form of `https://storage.googleapis.com/mybucket`.
+        # @param [String] bucket_bound_hostname Use a bucket-bound hostname, which
+        #   replaces the `storage.googleapis.com` host with the name of a `CNAME`
+        #   bucket, e.g. a bucket named `gcs-subdomain.my.domain.tld`, or a Google
+        #   Cloud Load Balancer which routes to a bucket you own, e.g.
+        #   `my-load-balancer-domain.tld`.
         # @param [Symbol, String] version The version of the signed credential
         #   to create. Must be one of `:v2` or `:v4`. The default value is
         #   `:v2`.

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -1482,6 +1482,12 @@ module Google
         # @param [Symbol, String] version The version of the signed credential
         #   to create. Must be one of `:v2` or `:v4`. The default value is
         #   `:v2`.
+        # @param [Boolean] virtual_hosted_style Whether to use a virtual hosted-style
+        #   hostname, which adds the bucket into the host portion of the URI rather
+        #   than the path, e.g. `https://mybucket.storage.googleapis.com/...`.
+        #   For V4 signing, this also sets the `host` header in the canonicalized
+        #   extension headers to the virtual hosted-style host, unless that header is
+        #   supplied via the `headers` param. The default value is `false`.
         #
         # @return [String]
         #
@@ -1546,7 +1552,7 @@ module Google
         def signed_url method: nil, expires: nil, content_type: nil,
                        content_md5: nil, headers: nil, issuer: nil,
                        client_email: nil, signing_key: nil, private_key: nil,
-                       query: nil, version: nil
+                       query: nil, version: nil, virtual_hosted_style: nil
           ensure_service!
           version ||= :v2
           case version.to_sym
@@ -1564,7 +1570,8 @@ module Google
                               headers: headers, issuer: issuer,
                               client_email: client_email,
                               signing_key: signing_key,
-                              private_key: private_key, query: query
+                              private_key: private_key, query: query,
+                              virtual_hosted_style: virtual_hosted_style
           else
             raise ArgumentError, "version '#{version}' not supported"
           end

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -1479,15 +1479,18 @@ module Google
         #   using the URL, but only when the file resource is missing the
         #   corresponding values. (These values can be permanently set using
         #   {#content_disposition=} and {#content_type=}.)
-        # @param [Symbol, String] version The version of the signed credential
-        #   to create. Must be one of `:v2` or `:v4`. The default value is
-        #   `:v2`.
+        # @param [String] scheme The URL scheme. The default value is `HTTPS`.
         # @param [Boolean] virtual_hosted_style Whether to use a virtual hosted-style
         #   hostname, which adds the bucket into the host portion of the URI rather
         #   than the path, e.g. `https://mybucket.storage.googleapis.com/...`.
         #   For V4 signing, this also sets the `host` header in the canonicalized
         #   extension headers to the virtual hosted-style host, unless that header is
         #   supplied via the `headers` param. The default value is `false`.
+        # @param [String] bucket_bound_hostname An alternate hostname which is bound
+        #   in some way to a specific bucket.
+        # @param [Symbol, String] version The version of the signed credential
+        #   to create. Must be one of `:v2` or `:v4`. The default value is
+        #   `:v2`.
         #
         # @return [String]
         #
@@ -1549,10 +1552,9 @@ module Google
         #   # Send the `x-goog-resumable:start` header and the content type
         #   # with the resumable upload POST request.
         #
-        def signed_url method: nil, expires: nil, content_type: nil,
-                       content_md5: nil, headers: nil, issuer: nil,
-                       client_email: nil, signing_key: nil, private_key: nil,
-                       query: nil, version: nil, virtual_hosted_style: nil
+        def signed_url method: "GET", expires: nil, content_type: nil, content_md5: nil, headers: nil, issuer: nil,
+                       client_email: nil, signing_key: nil, private_key: nil, query: nil, scheme: "HTTPS",
+                       virtual_hosted_style: nil, bucket_bound_hostname: nil, version: nil
           ensure_service!
           version ||= :v2
           case version.to_sym
@@ -1570,8 +1572,8 @@ module Google
                               headers: headers, issuer: issuer,
                               client_email: client_email,
                               signing_key: signing_key,
-                              private_key: private_key, query: query,
-                              virtual_hosted_style: virtual_hosted_style
+                              private_key: private_key, query: query, scheme: scheme,
+                              virtual_hosted_style: virtual_hosted_style, bucket_bound_hostname: bucket_bound_hostname
           else
             raise ArgumentError, "version '#{version}' not supported"
           end

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -1516,7 +1516,7 @@ module Google
         #   file = bucket.file "avatars/heidi/400x400.png"
         #   shared_url = file.signed_url expires: 300, # 5 minutes from now
         #                                version: :v4
-
+        #
         # @example Using the `issuer` and `signing_key` options:
         #   require "google/cloud/storage"
         #
@@ -1556,28 +1556,48 @@ module Google
         #   # Send the `x-goog-resumable:start` header and the content type
         #   # with the resumable upload POST request.
         #
-        def signed_url method: "GET", expires: nil, content_type: nil, content_md5: nil, headers: nil, issuer: nil,
-                       client_email: nil, signing_key: nil, private_key: nil, query: nil, scheme: "HTTPS",
-                       virtual_hosted_style: nil, bucket_bound_hostname: nil, version: nil
+        def signed_url method: "GET",
+                       expires: nil,
+                       content_type: nil,
+                       content_md5: nil,
+                       headers: nil,
+                       issuer: nil,
+                       client_email: nil,
+                       signing_key: nil,
+                       private_key: nil,
+                       query: nil,
+                       scheme: "HTTPS",
+                       virtual_hosted_style: nil,
+                       bucket_bound_hostname: nil,
+                       version: nil
           ensure_service!
           version ||= :v2
           case version.to_sym
           when :v2
             signer = File::SignerV2.from_file self
-            signer.signed_url method: method, expires: expires,
-                              headers: headers, content_type: content_type,
-                              content_md5: content_md5, issuer: issuer,
+            signer.signed_url method: method,
+                              expires: expires,
+                              headers: headers,
+                              content_type: content_type,
+                              content_md5: content_md5,
+                              issuer: issuer,
                               client_email: client_email,
                               signing_key: signing_key,
-                              private_key: private_key, query: query
+                              private_key: private_key,
+                              query: query
           when :v4
             signer = File::SignerV4.from_file self
-            signer.signed_url method: method, expires: expires,
-                              headers: headers, issuer: issuer,
+            signer.signed_url method: method,
+                              expires: expires,
+                              headers: headers,
+                              issuer: issuer,
                               client_email: client_email,
                               signing_key: signing_key,
-                              private_key: private_key, query: query, scheme: scheme,
-                              virtual_hosted_style: virtual_hosted_style, bucket_bound_hostname: bucket_bound_hostname
+                              private_key: private_key,
+                              query: query,
+                              scheme: scheme,
+                              virtual_hosted_style: virtual_hosted_style,
+                              bucket_bound_hostname: bucket_bound_hostname
           else
             raise ArgumentError, "version '#{version}' not supported"
           end

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
@@ -64,12 +64,14 @@ module Google
             # Request, because when you create a presigned URL, you don't know
             # the payload content because the URL is used to upload an arbitrary
             # payload. Instead, you use a constant string UNSIGNED-PAYLOAD.
+            payload = headers.key?("X-Goog-Content-SHA256") ? headers["X-Goog-Content-SHA256"] : "UNSIGNED-PAYLOAD"
+            # TODO: Also support X-Amz-Content-SHA256 payload?
             canonical_request = [method,
                                  ext_path,
                                  canonical_query_str,
                                  canonical_headers_str,
                                  signed_headers_str,
-                                 "UNSIGNED-PAYLOAD"].join("\n")
+                                 payload].join("\n")
             puts "\n\nactual:\n\n#{canonical_request}\n\n"
             # Construct string to sign
             req_sha = Digest::SHA256.hexdigest canonical_request

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
@@ -168,7 +168,7 @@ module Google
           def ext_path
             path = "/#{@bucket_name}"
             path += "/#{String(@file_name)}" if @file_name && !@file_name.empty?
-            Addressable::URI.escape path
+            CGI.escape(path).gsub "%2F", "/"
           end
 
           ##

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
@@ -153,11 +153,18 @@ module Google
             query["X-Goog-Date"] = goog_date
             query["X-Goog-Expires"] = expires
             query["X-Goog-SignedHeaders"] = signed_headers_str
-            query = query.map { |k, v| [CGI.escape(k.to_s), CGI.escape(v.to_s)] }.to_h
+            query = query.map { |k, v| [escape_query_param(k), escape_query_param(v)] }.to_h
             query = query.sort.to_h
             canonical_query_str = ""
             query.each { |k, v| canonical_query_str += "#{k}=#{v}&" }
             canonical_query_str.chomp "&"
+          end
+
+          ##
+          # Only the characters in the regex set [A-Za-z0-9.~_-] must be left un-escaped; all others must be
+          # percent-encoded using %XX UTF-8 style.
+          def escape_query_param str
+            CGI.escape(str.to_s).gsub("%7E", "~")
           end
 
           def host_name virtual_hosted_style, bucket_bound_hostname

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
@@ -124,16 +124,14 @@ module Google
             # Headers needs to be in alpha order.
             canonical_headers = headers || {}
             headers_arr = canonical_headers.map do |k, v|
-              [k.downcase, v.strip.gsub(/[^\S\t]+/, " ").gsub(/\t+/, "\t")]
+              [k.downcase, v.strip.gsub(/[^\S\t]+/, " ").gsub(/\t+/, " ")]
             end
             canonical_headers = Hash[headers_arr]
             canonical_headers["host"] = "storage.googleapis.com"
 
             canonical_headers = canonical_headers.sort_by { |k, _| k.to_s }.to_h # TODO: replace with default sort?
             canonical_headers_str = ""
-            canonical_headers.each do |k, v|
-              canonical_headers_str += "#{k}:#{v}\n"
-            end
+            canonical_headers.each { |k, v| canonical_headers_str += "#{k}:#{v}\n" }
             signed_headers_str = ""
             canonical_headers.each_key { |k| signed_headers_str += "#{k};" }
             signed_headers_str = signed_headers_str.chomp ";"

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
@@ -137,7 +137,7 @@ module Google
 
             canonical_headers = canonical_headers.sort_by(&:first).to_h
             canonical_headers_str = canonical_headers.map { |k, v| "#{k}:#{v}\n" }.join
-            signed_headers_str = canonical_headers.keys.map { |k| "#{k};" }.join.chomp ";"
+            signed_headers_str = canonical_headers.keys.join ";"
             [canonical_headers_str, signed_headers_str]
           end
 
@@ -157,7 +157,7 @@ module Google
             query["X-Goog-Expires"] = expires
             query["X-Goog-SignedHeaders"] = signed_headers_str
             query = query.map { |k, v| [escape_query_param(k), escape_query_param(v)] }.sort_by(&:first).to_h
-            query.map { |k, v| "#{k}=#{v}&" }.join.chomp "&"
+            query.map { |k, v| "#{k}=#{v}" }.join "&"
           end
 
           ##

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -522,15 +522,18 @@ module Google
         #   using the URL, but only when the file resource is missing the
         #   corresponding values. (These values can be permanently set using
         #   {File#content_disposition=} and {File#content_type=}.)
-        # @param [Symbol, String] version The version of the signed credential
-        #   to create. Must be one of `:v2` or `:v4`. The default value is
-        #   `:v2`.
+        # @param [String] scheme The URL scheme. The default value is `HTTPS`.
         # @param [Boolean] virtual_hosted_style Whether to use a virtual hosted-style
         #   hostname, which adds the bucket into the host portion of the URI rather
         #   than the path, e.g. `https://mybucket.storage.googleapis.com/...`.
         #   For V4 signing, this also sets the `host` header in the canonicalized
         #   extension headers to the virtual hosted-style host, unless that header is
         #   supplied via the `headers` param. The default value is `false`.
+        # @param [String] bucket_bound_hostname An alternate hostname which is bound
+        #   in some way to a specific bucket.
+        # @param [Symbol, String] version The version of the signed credential
+        #   to create. Must be one of `:v2` or `:v4`. The default value is
+        #   `:v2`.
         #
         # @return [String]
         #
@@ -597,10 +600,9 @@ module Google
         #   # Send the `x-goog-resumable:start` header and the content type
         #   # with the resumable upload POST request.
         #
-        def signed_url bucket, path, method: nil, expires: nil,
-                       content_type: nil, content_md5: nil, headers: nil,
-                       issuer: nil, client_email: nil, signing_key: nil,
-                       private_key: nil, query: nil, version: nil, virtual_hosted_style: nil
+        def signed_url bucket, path, method: "GET", expires: nil, content_type: nil, content_md5: nil, headers: nil,
+                       issuer: nil, client_email: nil, signing_key: nil, private_key: nil, query: nil, scheme: "HTTPS",
+                       virtual_hosted_style: nil, bucket_bound_hostname: nil, version: nil
           version ||= :v2
           case version.to_sym
           when :v2
@@ -618,8 +620,8 @@ module Google
                               headers: headers, issuer: issuer,
                               client_email: client_email,
                               signing_key: signing_key,
-                              private_key: private_key, query: query,
-                              virtual_hosted_style: virtual_hosted_style
+                              private_key: private_key, query: query, scheme: scheme,
+                              virtual_hosted_style: virtual_hosted_style, bucket_bound_hostname: bucket_bound_hostname
           else
             raise ArgumentError, "version '#{version}' not supported"
           end

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -528,9 +528,13 @@ module Google
         #   than the path, e.g. `https://mybucket.storage.googleapis.com/...`.
         #   For V4 signing, this also sets the `host` header in the canonicalized
         #   extension headers to the virtual hosted-style host, unless that header is
-        #   supplied via the `headers` param. The default value is `false`.
-        # @param [String] bucket_bound_hostname An alternate hostname which is bound
-        #   in some way to a specific bucket.
+        #   supplied via the `headers` param. The default value of `false` uses the
+        #   form of `https://storage.googleapis.com/mybucket`.
+        # @param [String] bucket_bound_hostname Use a bucket-bound hostname, which
+        #   replaces the `storage.googleapis.com` host with the name of a `CNAME`
+        #   bucket, e.g. a bucket named `gcs-subdomain.my.domain.tld`, or a Google
+        #   Cloud Load Balancer which routes to a bucket you own, e.g.
+        #   `my-load-balancer-domain.tld`.
         # @param [Symbol, String] version The version of the signed credential
         #   to create. Must be one of `:v2` or `:v4`. The default value is
         #   `:v2`.

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -604,28 +604,50 @@ module Google
         #   # Send the `x-goog-resumable:start` header and the content type
         #   # with the resumable upload POST request.
         #
-        def signed_url bucket, path, method: "GET", expires: nil, content_type: nil, content_md5: nil, headers: nil,
-                       issuer: nil, client_email: nil, signing_key: nil, private_key: nil, query: nil, scheme: "HTTPS",
-                       virtual_hosted_style: nil, bucket_bound_hostname: nil, version: nil
+        def signed_url bucket,
+                       path,
+                       method: "GET",
+                       expires: nil,
+                       content_type: nil,
+                       content_md5: nil,
+                       headers: nil,
+                       issuer: nil,
+                       client_email: nil,
+                       signing_key: nil,
+                       private_key: nil,
+                       query: nil,
+                       scheme: "HTTPS",
+                       virtual_hosted_style: nil,
+                       bucket_bound_hostname: nil,
+                       version: nil
           version ||= :v2
           case version.to_sym
           when :v2
             signer = File::SignerV2.new bucket, path, service
 
-            signer.signed_url method: method, expires: expires,
-                              headers: headers, content_type: content_type,
-                              content_md5: content_md5, issuer: issuer,
+            signer.signed_url method: method,
+                              expires: expires,
+                              headers: headers,
+                              content_type: content_type,
+                              content_md5: content_md5,
+                              issuer: issuer,
                               client_email: client_email,
                               signing_key: signing_key,
-                              private_key: private_key, query: query
+                              private_key: private_key,
+                              query: query
           when :v4
             signer = File::SignerV4.new bucket, path, service
-            signer.signed_url method: method, expires: expires,
-                              headers: headers, issuer: issuer,
+            signer.signed_url method: method,
+                              expires: expires,
+                              headers: headers,
+                              issuer: issuer,
                               client_email: client_email,
                               signing_key: signing_key,
-                              private_key: private_key, query: query, scheme: scheme,
-                              virtual_hosted_style: virtual_hosted_style, bucket_bound_hostname: bucket_bound_hostname
+                              private_key: private_key,
+                              query: query,
+                              scheme: scheme,
+                              virtual_hosted_style: virtual_hosted_style,
+                              bucket_bound_hostname: bucket_bound_hostname
           else
             raise ArgumentError, "version '#{version}' not supported"
           end

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -525,6 +525,12 @@ module Google
         # @param [Symbol, String] version The version of the signed credential
         #   to create. Must be one of `:v2` or `:v4`. The default value is
         #   `:v2`.
+        # @param [Boolean] virtual_hosted_style Whether to use a virtual hosted-style
+        #   hostname, which adds the bucket into the host portion of the URI rather
+        #   than the path, e.g. `https://mybucket.storage.googleapis.com/...`.
+        #   For V4 signing, this also sets the `host` header in the canonicalized
+        #   extension headers to the virtual hosted-style host, unless that header is
+        #   supplied via the `headers` param. The default value is `false`.
         #
         # @return [String]
         #
@@ -594,7 +600,7 @@ module Google
         def signed_url bucket, path, method: nil, expires: nil,
                        content_type: nil, content_md5: nil, headers: nil,
                        issuer: nil, client_email: nil, signing_key: nil,
-                       private_key: nil, query: nil, version: nil
+                       private_key: nil, query: nil, version: nil, virtual_hosted_style: nil
           version ||= :v2
           case version.to_sym
           when :v2
@@ -612,7 +618,8 @@ module Google
                               headers: headers, issuer: issuer,
                               client_email: client_email,
                               signing_key: signing_key,
-                              private_key: private_key, query: query
+                              private_key: private_key, query: query,
+                              virtual_hosted_style: virtual_hosted_style
           else
             raise ArgumentError, "version '#{version}' not supported"
           end

--- a/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v4_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
   it "accepts missing path argument to return URL for listing objects in bucket" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nf087e8d0ad6fca774e1a291a807a2a118c0d31d1b5980b4b8e0424d719b5ec09"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nc709544abd06ec8c09e9825c9a786a8759cd089bf7c64534ccef6058c0b0f88a"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -47,7 +47,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
   it "uses the credentials' issuer and signing_key to generate signed_url" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\ndbaaff5efcb05bbb97a173421f9e365b70b6be90d9a2090a71264daabc22f988"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\ndefeee4e2131c1e8e39d4bd739b856297e93b20265a427c5a70a2fd65c4cfd0a"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -71,7 +71,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
       credentials.signing_key = PoisonSigningKey.new
 
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nef7980d38d1a4f86ce3e40e92c71ef5e73a4891d69a36e7ef3e7fcf4feb0eb97"]
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n743e0f302812fbc80545275f54593e9186adee22752444edeeaf50cafe2c02d3"]
 
       signed_url = bucket.signed_url file_path,
                                      issuer: "option_issuer",
@@ -95,7 +95,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
       credentials.signing_key = PoisonSigningKey.new
 
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\na64d70ac9d1dfa8353eebf2424294e26d20f0b540fd71f08ecd221a116b4fe53"]
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nf02f56367165cb2745d426eabaf709f7c3d015ac9cd75158017a0f4fa72ca3d2"]
 
       OpenSSL::PKey::RSA.stub :new, signing_key_mock do
 
@@ -120,7 +120,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
   it "allows headers to be passed in as options" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n4b561c5261aeea6e75a6718f8e672827c356b09a272bfe93bd8ab3dcec39906c"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nbf06932c7e0573d8ee8c4b7638a4043f7265c4e019694156a68773ad4d7ee25c"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -161,7 +161,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
   it "allows query params to be passed in" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nce1d02ef4024da92a69e4f84100a41775c1dcc61d55729ca3054068f8b5ff01f"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n0a72e261a6f1877de0d1708ca26aba6f3116a12e569f564346b96dd96d2c9bd6"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -182,7 +182,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
   it "allows query params to be passed in as symbols" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nc504c40bab3dedc378faeccd57b46ab697e6aebc1bbcba14f4b01c7871e1f37b"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\na7f06df47c14c9806213f0580c0490c862476820cd668f322850edb89d14484d"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v4_test.rb
@@ -161,7 +161,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
   it "allows query params to be passed in" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nf2f6b29f677af847b40cd43a5b2b09c171a1c3b0ffd021adf6f15ece0e77e607"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nce1d02ef4024da92a69e4f84100a41775c1dcc61d55729ca3054068f8b5ff01f"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -182,7 +182,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
   it "allows query params to be passed in as symbols" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nade7c049b7cddfac8f7a4509c85f8012913b300e9afe5ab498eeb77fae7e5c70"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nc504c40bab3dedc378faeccd57b46ab697e6aebc1bbcba14f4b01c7871e1f37b"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 

--- a/google-cloud-storage/test/google/cloud/storage/file/signer_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file/signer_v4_test.rb
@@ -44,7 +44,7 @@ class SignerV4Test < MockStorage
       method = test["method"] unless test["method"]&.empty?
       headers = test.headers.to_h if test.headers # convert from protobuf map
       query = test.query_parameters.to_h if test.query_parameters # convert from protobuf map
-      bucket_bound_domain = test.bucketBoundDomain unless test.bucketBoundDomain&.empty?
+      bucket_bound_hostname = test.bucketBoundDomain unless test.bucketBoundDomain&.empty?
       Time.stub :now, SignerV4Test.timestamp_to_time(test.timestamp) do
         # method under test
         signed_url = signer.signed_url method: method,
@@ -53,7 +53,7 @@ class SignerV4Test < MockStorage
                                        query: query,
                                        scheme: test.scheme,
                                        virtual_hosted_style: (test.urlStyle == :VIRTUAL_HOSTED_STYLE),
-                                       bucket_bound_domain: bucket_bound_domain
+                                       bucket_bound_hostname: bucket_bound_hostname
        
         signed_url.must_equal test.expectedUrl
       end

--- a/google-cloud-storage/test/google/cloud/storage/file/signer_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file/signer_v4_test.rb
@@ -36,17 +36,18 @@ class SignerV4Test < MockStorage
 
   def self.build_test_for test, index
     define_method("test_#{index}: #{test.description}") do
-
       @test = [test, index]
       # start: test method body
       signer = Google::Cloud::Storage::File::SignerV4.new test.bucket,
                                                           test.object,
                                                           storage.service
+      query = test.query_parameters.to_h if test.query_parameters # convert from protobuf map
       Time.stub :now, SignerV4Test.timestamp_to_time(test.timestamp) do
         # method under test
         signed_url = signer.signed_url method: test["method"],
                                        expires: test.expiration,
-                                       headers: test.headers
+                                       headers: test.headers,
+                                       query: query
        
         signed_url.must_equal test.expectedUrl
       end

--- a/google-cloud-storage/test/google/cloud/storage/file/signer_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file/signer_v4_test.rb
@@ -22,43 +22,91 @@ class SignerV4Test < MockStorage
     account = JSON.parse File.read(account_file_path)
     credentials.issuer = account["client_email"]
     credentials.signing_key = OpenSSL::PKey::RSA.new account["private_key"]
-    @test = nil
+    @test_data = nil # not thread safe
   end
 
   def teardown
-    if !passed? && @test
-      test = @test.first
-      puts "\ntest_#{@test.last}: #{test.description}:\n"
+    if !passed? && @test_data
+      test = @test_data[0]
+      puts "\ntest_#{@test_data[1]}_#{@test_data[2]}: #{test.description}:\n"
       puts "CanonicalRequest\n\nexpected:\n\n#{test.expectedCanonicalRequest}\n\n"
       puts "StringToSign\n\nexpected:\n\n#{test.expectedStringToSign}\n\n"
     end
-  end  
+  end
 
-  def self.build_test_for test, index
-    define_method("test_#{index}: #{test.description}") do
-      @test = [test, index]
-      # start: test method body
+  def self.signer_v4_test_for test, index
+    define_method("test_signer_v4_#{index}: #{test.description}") do
+      @test_data = [test, "signer_v4", index]
       signer = Google::Cloud::Storage::File::SignerV4.new test.bucket,
                                                           test.object,
                                                           storage.service
-      method = test["method"] unless test["method"]&.empty?
-      headers = test.headers.to_h if test.headers # convert from protobuf map
-      query = test.query_parameters.to_h if test.query_parameters # convert from protobuf map
-      bucket_bound_hostname = test.bucketBoundDomain unless test.bucketBoundDomain&.empty?
       Time.stub :now, SignerV4Test.timestamp_to_time(test.timestamp) do
-        # method under test
-        signed_url = signer.signed_url method: method,
-                                       expires: test.expiration,
-                                       headers: headers,
-                                       query: query,
-                                       scheme: test.scheme,
-                                       virtual_hosted_style: (test.urlStyle == :VIRTUAL_HOSTED_STYLE),
-                                       bucket_bound_hostname: bucket_bound_hostname
-       
+        # sut
+        signed_url = signer.signed_url **SignerV4Test.kwargs(test)
+
         signed_url.must_equal test.expectedUrl
       end
-      # end: test method body
     end
+  end
+
+  def self.project_test_for test, index
+    define_method("test_project_#{index}: #{test.description}") do
+      @test_data = [test, "project", index]
+      Time.stub :now, SignerV4Test.timestamp_to_time(test.timestamp) do
+        # sut
+        signed_url = storage.signed_url test.bucket, test.object, **SignerV4Test.kwargs(test).merge({version: :v4})
+
+        signed_url.must_equal test.expectedUrl
+      end
+    end
+  end
+
+  def self.bucket_test_for test, index
+    define_method("test_bucket_#{index}: #{test.description}") do
+      @test_data = [test, "bucket", index]
+      bucket_gapi = Google::Apis::StorageV1::Bucket.from_json random_bucket_hash(test.bucket).to_json
+      bucket = Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service
+      Time.stub :now, SignerV4Test.timestamp_to_time(test.timestamp) do
+        # sut
+        signed_url = bucket.signed_url test.object, **SignerV4Test.kwargs(test).merge({version: :v4})
+
+        signed_url.must_equal test.expectedUrl
+      end
+    end
+  end
+
+  def self.file_test_for test, index
+    define_method("test_file_#{index}: #{test.description}") do
+      @test_data = [test, "file", index]
+      bucket_gapi = Google::Apis::StorageV1::Bucket.from_json random_bucket_hash(test.bucket).to_json
+      bucket = Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service
+      file_gapi = Google::Apis::StorageV1::Object.from_json random_file_hash(test.bucket, test.object).to_json
+      file = Google::Cloud::Storage::File.from_gapi file_gapi, storage.service
+      Time.stub :now, SignerV4Test.timestamp_to_time(test.timestamp) do
+        # sut
+        signed_url = file.signed_url **SignerV4Test.kwargs(test).merge({version: :v4})
+
+        signed_url.must_equal test.expectedUrl
+      end
+    end
+  end
+
+  # Build kwargs hash from test fixtures.
+  # Convert some arguments from protobuf maps and default "" strings.
+  def self.kwargs test
+    method = test["method"] unless test["method"]&.empty?
+    headers = test.headers.to_h if test.headers
+    query = test.query_parameters.to_h if test.query_parameters
+    bucket_bound_hostname = test.bucketBoundDomain unless test.bucketBoundDomain&.empty?
+    {
+      method: method,
+      expires: test.expiration,
+      headers: headers,
+      query: query,
+      scheme: test.scheme,
+      virtual_hosted_style: (test.urlStyle == :VIRTUAL_HOSTED_STYLE),
+      bucket_bound_hostname: bucket_bound_hostname
+    }
   end
 
   def self.timestamp_to_time timestamp
@@ -69,5 +117,8 @@ end
 file_path = File.expand_path "../../../../../conformance/v1/v4_signatures.json", __dir__
 test_file = Google::Cloud::Conformance::Storage::V1::TestFile.decode_json File.read(file_path)
 test_file.signing_v4_tests.each_with_index do |test, index|
-  SignerV4Test.build_test_for test, index
+  SignerV4Test.signer_v4_test_for test, index
+  SignerV4Test.project_test_for test, index
+  SignerV4Test.bucket_test_for test, index
+  SignerV4Test.file_test_for test, index
 end

--- a/google-cloud-storage/test/google/cloud/storage/file_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_signed_url_v4_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
   it "uses the credentials' issuer and signing_key to generate signed_url" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\ndbaaff5efcb05bbb97a173421f9e365b70b6be90d9a2090a71264daabc22f988"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\ndefeee4e2131c1e8e39d4bd739b856297e93b20265a427c5a70a2fd65c4cfd0a"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -50,8 +50,7 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
       credentials.signing_key = PoisonSigningKey.new
 
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nef7980d38d1a4f86ce3e40e92c71ef5e73a4891d69a36e7ef3e7fcf4feb0eb97"]
-
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n743e0f302812fbc80545275f54593e9186adee22752444edeeaf50cafe2c02d3"]
       signed_url = file.signed_url issuer: "option_issuer",
                                    signing_key: signing_key_mock, version: :v4
 
@@ -73,7 +72,7 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
       credentials.signing_key = PoisonSigningKey.new
 
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\na64d70ac9d1dfa8353eebf2424294e26d20f0b540fd71f08ecd221a116b4fe53"]
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nf02f56367165cb2745d426eabaf709f7c3d015ac9cd75158017a0f4fa72ca3d2"]
 
       OpenSSL::PKey::RSA.stub :new, signing_key_mock do
 
@@ -97,7 +96,7 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
   it "allows headers to be passed in as options" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n4b561c5261aeea6e75a6718f8e672827c356b09a272bfe93bd8ab3dcec39906c"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nbf06932c7e0573d8ee8c4b7638a4043f7265c4e019694156a68773ad4d7ee25c"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -137,7 +136,7 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
   it "allows query params to be passed in" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nce1d02ef4024da92a69e4f84100a41775c1dcc61d55729ca3054068f8b5ff01f"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n0a72e261a6f1877de0d1708ca26aba6f3116a12e569f564346b96dd96d2c9bd6"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -157,7 +156,7 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
   it "allows query params to be passed in as symbols" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nc504c40bab3dedc378faeccd57b46ab697e6aebc1bbcba14f4b01c7871e1f37b"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\na7f06df47c14c9806213f0580c0490c862476820cd668f322850edb89d14484d"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 

--- a/google-cloud-storage/test/google/cloud/storage/file_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_signed_url_v4_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
+describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
   let(:bucket_name) { "bucket" }
   let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash(bucket_name).to_json }
   let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
@@ -137,7 +137,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
   it "allows query params to be passed in" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nf2f6b29f677af847b40cd43a5b2b09c171a1c3b0ffd021adf6f15ece0e77e607"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nce1d02ef4024da92a69e4f84100a41775c1dcc61d55729ca3054068f8b5ff01f"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -157,7 +157,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
   it "allows query params to be passed in as symbols" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nade7c049b7cddfac8f7a4509c85f8012913b300e9afe5ab498eeb77fae7e5c70"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nc504c40bab3dedc378faeccd57b46ab697e6aebc1bbcba14f4b01c7871e1f37b"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v4_test.rb
@@ -137,7 +137,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
   it "allows query params to be passed in" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nf2f6b29f677af847b40cd43a5b2b09c171a1c3b0ffd021adf6f15ece0e77e607"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nce1d02ef4024da92a69e4f84100a41775c1dcc61d55729ca3054068f8b5ff01f"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -158,7 +158,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
   it "allows query params to be passed in as symbols" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nade7c049b7cddfac8f7a4509c85f8012913b300e9afe5ab498eeb77fae7e5c70"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nc504c40bab3dedc378faeccd57b46ab697e6aebc1bbcba14f4b01c7871e1f37b"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v4_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
   it "uses the credentials' issuer and signing_key to generate signed_url" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\ndbaaff5efcb05bbb97a173421f9e365b70b6be90d9a2090a71264daabc22f988"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\ndefeee4e2131c1e8e39d4bd739b856297e93b20265a427c5a70a2fd65c4cfd0a"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -47,7 +47,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
       credentials.signing_key = PoisonSigningKey.new
 
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nef7980d38d1a4f86ce3e40e92c71ef5e73a4891d69a36e7ef3e7fcf4feb0eb97"]
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n743e0f302812fbc80545275f54593e9186adee22752444edeeaf50cafe2c02d3"]
 
       signed_url = bucket.signed_url file_path,
                                      issuer: "option_issuer",
@@ -71,7 +71,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
       credentials.signing_key = PoisonSigningKey.new
 
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\na64d70ac9d1dfa8353eebf2424294e26d20f0b540fd71f08ecd221a116b4fe53"]
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nf02f56367165cb2745d426eabaf709f7c3d015ac9cd75158017a0f4fa72ca3d2"]
 
       OpenSSL::PKey::RSA.stub :new, signing_key_mock do
 
@@ -96,7 +96,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
   it "allows headers to be passed in as options" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n4b561c5261aeea6e75a6718f8e672827c356b09a272bfe93bd8ab3dcec39906c"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nbf06932c7e0573d8ee8c4b7638a4043f7265c4e019694156a68773ad4d7ee25c"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -137,7 +137,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
   it "allows query params to be passed in" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nce1d02ef4024da92a69e4f84100a41775c1dcc61d55729ca3054068f8b5ff01f"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n0a72e261a6f1877de0d1708ca26aba6f3116a12e569f564346b96dd96d2c9bd6"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -158,7 +158,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
   it "allows query params to be passed in as symbols" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nc504c40bab3dedc378faeccd57b46ab697e6aebc1bbcba14f4b01c7871e1f37b"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\na7f06df47c14c9806213f0580c0490c862476820cd668f322850edb89d14484d"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v4_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
   it "uses the credentials' issuer and signing_key to generate signed_url" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\ndbaaff5efcb05bbb97a173421f9e365b70b6be90d9a2090a71264daabc22f988"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\ndefeee4e2131c1e8e39d4bd739b856297e93b20265a427c5a70a2fd65c4cfd0a"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -49,7 +49,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
       credentials.signing_key = PoisonSigningKey.new
 
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nef7980d38d1a4f86ce3e40e92c71ef5e73a4891d69a36e7ef3e7fcf4feb0eb97"]
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n743e0f302812fbc80545275f54593e9186adee22752444edeeaf50cafe2c02d3"]
 
       signed_url = file.signed_url issuer: "option_issuer",
                                    signing_key: signing_key_mock, version: :v4
@@ -72,7 +72,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
       credentials.signing_key = PoisonSigningKey.new
 
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\na64d70ac9d1dfa8353eebf2424294e26d20f0b540fd71f08ecd221a116b4fe53"]
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nf02f56367165cb2745d426eabaf709f7c3d015ac9cd75158017a0f4fa72ca3d2"]
 
       OpenSSL::PKey::RSA.stub :new, signing_key_mock do
 
@@ -96,7 +96,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
   it "allows headers to be passed in as options" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n4b561c5261aeea6e75a6718f8e672827c356b09a272bfe93bd8ab3dcec39906c"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nbf06932c7e0573d8ee8c4b7638a4043f7265c4e019694156a68773ad4d7ee25c"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -136,7 +136,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
   it "allows query params to be passed in" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nce1d02ef4024da92a69e4f84100a41775c1dcc61d55729ca3054068f8b5ff01f"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n0a72e261a6f1877de0d1708ca26aba6f3116a12e569f564346b96dd96d2c9bd6"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -156,7 +156,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
   it "allows query params to be passed in as symbols" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nc504c40bab3dedc378faeccd57b46ab697e6aebc1bbcba14f4b01c7871e1f37b"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\na7f06df47c14c9806213f0580c0490c862476820cd668f322850edb89d14484d"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v4_test.rb
@@ -136,7 +136,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
   it "allows query params to be passed in" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nf2f6b29f677af847b40cd43a5b2b09c171a1c3b0ffd021adf6f15ece0e77e607"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nce1d02ef4024da92a69e4f84100a41775c1dcc61d55729ca3054068f8b5ff01f"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -156,7 +156,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
   it "allows query params to be passed in as symbols" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nade7c049b7cddfac8f7a4509c85f8012913b300e9afe5ab498eeb77fae7e5c70"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nc504c40bab3dedc378faeccd57b46ab697e6aebc1bbcba14f4b01c7871e1f37b"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 

--- a/google-cloud-storage/test/google/cloud/storage/project_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_signed_url_v4_test.rb
@@ -21,7 +21,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
   it "uses the credentials' issuer and signing_key to generate signed_url" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\ndbaaff5efcb05bbb97a173421f9e365b70b6be90d9a2090a71264daabc22f988"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\ndefeee4e2131c1e8e39d4bd739b856297e93b20265a427c5a70a2fd65c4cfd0a"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -45,7 +45,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
       credentials.signing_key = PoisonSigningKey.new
 
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nef7980d38d1a4f86ce3e40e92c71ef5e73a4891d69a36e7ef3e7fcf4feb0eb97"]
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n743e0f302812fbc80545275f54593e9186adee22752444edeeaf50cafe2c02d3"]
 
       signed_url = storage.signed_url bucket_name, file_path,
                                       issuer: "option_issuer",
@@ -69,7 +69,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
       credentials.signing_key = PoisonSigningKey.new
 
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\na64d70ac9d1dfa8353eebf2424294e26d20f0b540fd71f08ecd221a116b4fe53"]
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nf02f56367165cb2745d426eabaf709f7c3d015ac9cd75158017a0f4fa72ca3d2"]
 
       OpenSSL::PKey::RSA.stub :new, signing_key_mock do
 
@@ -94,7 +94,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
   it "allows headers to be passed in as options" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n4b561c5261aeea6e75a6718f8e672827c356b09a272bfe93bd8ab3dcec39906c"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nbf06932c7e0573d8ee8c4b7638a4043f7265c4e019694156a68773ad4d7ee25c"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -135,7 +135,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
   it "allows query params to be passed in" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nce1d02ef4024da92a69e4f84100a41775c1dcc61d55729ca3054068f8b5ff01f"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n0a72e261a6f1877de0d1708ca26aba6f3116a12e569f564346b96dd96d2c9bd6"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -156,7 +156,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
   it "allows query params to be passed in as symbols" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nc504c40bab3dedc378faeccd57b46ab697e6aebc1bbcba14f4b01c7871e1f37b"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\na7f06df47c14c9806213f0580c0490c862476820cd668f322850edb89d14484d"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 

--- a/google-cloud-storage/test/google/cloud/storage/project_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_signed_url_v4_test.rb
@@ -135,7 +135,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
   it "allows query params to be passed in" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nf2f6b29f677af847b40cd43a5b2b09c171a1c3b0ffd021adf6f15ece0e77e607"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nce1d02ef4024da92a69e4f84100a41775c1dcc61d55729ca3054068f8b5ff01f"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 
@@ -156,7 +156,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
   it "allows query params to be passed in as symbols" do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nade7c049b7cddfac8f7a4509c85f8012913b300e9afe5ab498eeb77fae7e5c70"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\nc504c40bab3dedc378faeccd57b46ab697e6aebc1bbcba14f4b01c7871e1f37b"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 


### PR DESCRIPTION
`ci` currently passing, including all conformance tests.

closes: #4735
closes: #4736
closes: #4737
closes: #4738