### PR TITLE
fix(billing): default to the correct billing service version

### DIFF
--- a/google-cloud-billing/lib/google/cloud/billing.rb
+++ b/google-cloud-billing/lib/google/cloud/billing.rb
@@ -29,7 +29,7 @@ module Google
       #
       # @return [CloudBilling::Client] A client object for the specified version.
       #
-      def self.cloud_billing_service version: :v1beta1, &block
+      def self.cloud_billing_service version: :v1, &block
         require "google/cloud/billing/#{version.to_s.downcase}"
 
         package_name = Google::Cloud::Billing
@@ -49,7 +49,7 @@ module Google
       #
       # @return [CloudCatalog::Client] A client object for the specified version.
       #
-      def self.cloud_catalog_service version: :v1beta1, &block
+      def self.cloud_catalog_service version: :v1, &block
         require "google/cloud/billing/#{version.to_s.downcase}"
 
         package_name = Google::Cloud::Billing

--- a/google-cloud-billing/lib/google/cloud/billing/version.rb
+++ b/google-cloud-billing/lib/google/cloud/billing/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Billing
-      VERSION = "0.1.0".freeze
+      VERSION = "0.0.1".freeze
     end
   end
 end

--- a/google-cloud-billing/test/google/cloud/billing/client_test.rb
+++ b/google-cloud-billing/test/google/cloud/billing/client_test.rb
@@ -1,0 +1,40 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "google/cloud/billing"
+require "gapic/common"
+require "gapic/grpc"
+
+describe Google::Cloud::Billing do
+  let(:grpc_channel) { GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure }
+
+  it "constructs a billing service client with the default version" do
+    Gapic::ServiceStub.stub :new, :stub do
+      client = Google::Cloud::Billing.cloud_billing_service do |config|
+        config.credentials = grpc_channel
+      end
+      client.must_be_kind_of Google::Cloud::Billing::V1::CloudBilling::Client
+    end
+  end
+
+  it "constructs a catalog service client with the default version" do
+    Gapic::ServiceStub.stub :new, :stub do
+      client = Google::Cloud::Billing.cloud_catalog_service do |config|
+        config.credentials = grpc_channel
+      end
+      client.must_be_kind_of Google::Cloud::Billing::V1::CloudCatalog::Client
+    end
+  end
+end


### PR DESCRIPTION
The billing veneer wasn't defaulting to the correct API version. Fixed. Also added basic tests to ensure that the factory methods will actually return the right thing. And set the gem version to 0.0.1 so the first releasetool run will bump it to 0.1.0 like we want.