### PR TITLE
docs(logging): Fix doc links to Cmek methods in lower-level client

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
@@ -1062,7 +1062,7 @@ module Google
           # organizations. Once configured, it applies to all projects and folders in
           # the GCP organization.
           #
-          # {Google::Logging::V2::ConfigServiceV2::UpdateCmekSettings UpdateCmekSettings}
+          # {Google::Cloud::Logging::V2::ConfigServiceV2Client#update_cmek_settings}
           # will fail if 1) `kms_key_name` is invalid, or 2) the associated service
           # account does not have the required
           # `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging_config.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging_config.rb
@@ -428,7 +428,7 @@ module Google
       class DeleteExclusionRequest; end
 
       # The parameters to
-      # {Google::Logging::V2::ConfigServiceV2::GetCmekSettings GetCmekSettings}.
+      # {Google::Cloud::Logging::V2::ConfigServiceV2Client#get_cmek_settings}.
       #
       # See [Enabling CMEK for Logs Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
       # for more information.
@@ -449,7 +449,7 @@ module Google
       class GetCmekSettingsRequest; end
 
       # The parameters to
-      # {Google::Logging::V2::ConfigServiceV2::UpdateCmekSettings UpdateCmekSettings}.
+      # {Google::Cloud::Logging::V2::ConfigServiceV2Client#update_cmek_settings}.
       #
       # See [Enabling CMEK for Logs Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
       # for more information.
@@ -530,7 +530,7 @@ module Google
       #     Before enabling CMEK for Logs Router, you must first assign the role
       #     `roles/cloudkms.cryptoKeyEncrypterDecrypter` to the service account that
       #     the Logs Router will use to access your Cloud KMS key. Use
-      #     {Google::Logging::V2::ConfigServiceV2::GetCmekSettings GetCmekSettings} to
+      #     {Google::Cloud::Logging::V2::ConfigServiceV2Client#get_cmek_settings} to
       #     obtain the service account ID.
       #
       #     See [Enabling CMEK for Logs

--- a/google-cloud-logging/synth.metadata
+++ b/google-cloud-logging/synth.metadata
@@ -1,20 +1,6 @@
 {
-  "updateTime": "2020-02-12T11:41:21.824851Z",
+  "updateTime": "2020-02-13T20:11:56.959473Z",
   "sources": [
-    {
-      "git": {
-        "name": ".",
-        "remote": "https://github.com/googleapis/google-cloud-ruby.git",
-        "sha": "9fbc94c17cae022cdef367798e0325732f91189c"
-      }
-    },
-    {
-      "git": {
-        "name": "synthtool",
-        "remote": "rpc://devrel/cloud/libraries/tools/autosynth",
-        "sha": "dd7cd93888cbeb1d4c56a1ca814491c7813160e8"
-      }
-    },
     {
       "generator": {
         "name": "artman",
@@ -26,9 +12,8 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "8a36b928873ff9c05b43859b9d4ea14cd205df57",
-        "internalRef": "294459768",
-        "log": "8a36b928873ff9c05b43859b9d4ea14cd205df57\nFix: Define the \"bigquery.googleapis.com/Table\" resource in the BigQuery Storage API (v1beta2).\n\nPiperOrigin-RevId: 294459768\n\nc7a3caa2c40c49f034a3c11079dd90eb24987047\nFix: Define the \"bigquery.googleapis.com/Table\" resource in the BigQuery Storage API (v1).\n\nPiperOrigin-RevId: 294456889\n\n5006247aa157e59118833658084345ee59af7c09\nFix: Make deprecated fields optional\nFix: Deprecate SetLoggingServiceRequest.zone in line with the comments\nFeature: Add resource name method signatures where appropriate\n\nPiperOrigin-RevId: 294383128\n\neabba40dac05c5cbe0fca3a35761b17e372036c4\nFix: C# and PHP package/namespace capitalization for BigQuery Storage v1.\n\nPiperOrigin-RevId: 294382444\n\nf8d9a858a7a55eba8009a23aa3f5cc5fe5e88dde\nfix: artman configuration file for bigtable-admin\n\nPiperOrigin-RevId: 294322616\n\n0f29555d1cfcf96add5c0b16b089235afbe9b1a9\nAPI definition for (not-yet-launched) GCS gRPC.\n\nPiperOrigin-RevId: 294321472\n\nfcc86bee0e84dc11e9abbff8d7c3529c0626f390\nfix: Bigtable Admin v2\n\nChange LRO metadata from PartialUpdateInstanceMetadata\nto UpdateInstanceMetadata. (Otherwise, it will not build.)\n\nPiperOrigin-RevId: 294264582\n\n6d9361eae2ebb3f42d8c7ce5baf4bab966fee7c0\nrefactor: Add annotations to Bigtable Admin v2.\n\nPiperOrigin-RevId: 294243406\n\nad7616f3fc8e123451c8b3a7987bc91cea9e6913\nFix: Resource type in CreateLogMetricRequest should use logging.googleapis.com.\nFix: ListLogEntries should have a method signature for convenience of calling it.\n\nPiperOrigin-RevId: 294222165\n\n63796fcbb08712676069e20a3e455c9f7aa21026\nFix: Remove extraneous resource definition for cloudkms.googleapis.com/CryptoKey.\n\nPiperOrigin-RevId: 294176658\n\n"
+        "sha": "56b55aa8818cd0a532a7d779f6ef337ba809ccbd",
+        "internalRef": "294931650"
       }
     }
   ],
@@ -42,6 +27,95 @@
         "generator": "gapic",
         "config": "google/logging/artman_logging.yaml"
       }
+    }
+  ],
+  "newFiles": [
+    {
+      "path": "lib/google/cloud/logging/v2/config_service_v2_client.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/config_service_v2_client_config.json"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/credentials.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/api/distribution.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/api/label.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/api/metric.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/api/monitored_resource.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/logging/type/http_request.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/logging/v2/log_entry.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/logging/v2/logging.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/logging/v2/logging_config.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/logging/v2/logging_metrics.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/protobuf/any.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/protobuf/duration.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/protobuf/empty.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/protobuf/field_mask.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/protobuf/struct.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/doc/google/protobuf/timestamp.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/logging_service_v2_client.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/logging_service_v2_client_config.json"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/metrics_service_v2_client.rb"
+    },
+    {
+      "path": "lib/google/cloud/logging/v2/metrics_service_v2_client_config.json"
+    },
+    {
+      "path": "lib/google/logging/v2/log_entry_pb.rb"
+    },
+    {
+      "path": "lib/google/logging/v2/logging_config_pb.rb"
+    },
+    {
+      "path": "lib/google/logging/v2/logging_config_services_pb.rb"
+    },
+    {
+      "path": "lib/google/logging/v2/logging_metrics_pb.rb"
+    },
+    {
+      "path": "lib/google/logging/v2/logging_metrics_services_pb.rb"
+    },
+    {
+      "path": "lib/google/logging/v2/logging_pb.rb"
+    },
+    {
+      "path": "lib/google/logging/v2/logging_services_pb.rb"
     }
   ]
 }

--- a/google-cloud-logging/synth.py
+++ b/google-cloud-logging/synth.py
@@ -143,3 +143,16 @@ s.replace(
     '\{Google::Logging::V2::ConfigServiceV2::UpdateSink sinks::update\}',
     '{Google::Logging::V2::ConfigServiceV2#update_sink}'
 )
+s.replace(
+    [
+        'lib/google/cloud/logging/v2/config_service_v2_client.rb',
+        'lib/google/cloud/logging/v2/doc/google/logging/v2/logging_config.rb'
+    ],
+    '\{Google::Logging::V2::ConfigServiceV2::UpdateCmekSettings UpdateCmekSettings\}',
+    '{Google::Cloud::Logging::V2::ConfigServiceV2Client#update_cmek_settings}'
+)
+s.replace(
+    'lib/google/cloud/logging/v2/doc/google/logging/v2/logging_config.rb',
+    '\{Google::Logging::V2::ConfigServiceV2::GetCmekSettings GetCmekSettings\}',
+    '{Google::Cloud::Logging::V2::ConfigServiceV2Client#get_cmek_settings}'
+)


### PR DESCRIPTION
This PR updates `synth.py` to fix docs links that are breaking the google-cloud-logging `yard` task in the `ci` build. (Currently broken in master.)