### PR TITLE
Pubsub async fix

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
@@ -83,12 +83,12 @@ module Google
           @published_at = nil
           @publish_thread_pool = Concurrent::ThreadPoolExecutor.new max_threads: @publish_threads
           @callback_thread_pool = Concurrent::ThreadPoolExecutor.new max_threads: @callback_threads
-          @thread = Thread.new { run_background }
 
           @ordered = false
           @batches = {}
-          sleep 1
           @cond = new_cond
+
+          @thread = Thread.new { run_background }
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
@@ -87,7 +87,7 @@ module Google
 
           @ordered = false
           @batches = {}
-
+          sleep 1
           @cond = new_cond
         end
 


### PR DESCRIPTION
There is no change to testing included with this PR, since a test is already failing (see issue below). There is a race condition and the test only fails very occasionally, so to verify the change the first commit adds a `sleep 1` to ensure that the test always fails. The second commit then removes the `sleep` call and moves `Thread.new` to the end of `AsyncPublisher#initialize` to fix the bug.

fixes: #4280