### PR TITLE
chore: remove release level string from readmes and yardocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,53 +10,49 @@ services.
 * [API documentation](https://googleapis.github.io/google-cloud-ruby/docs)
 * [google-cloud on RubyGems](https://rubygems.org/gems/google-cloud)
 
-This client supports the following Google Cloud Platform services at a [General
-Availability (GA)](#versioning) quality level:
+This client supports the following Google Cloud Platform services:
 
-* [BigQuery](#bigquery-ga) (GA)
-* [Cloud Bigtable](#cloud-bigtable-ga) (GA)
-* [Cloud Datastore](#cloud-datastore-ga) (GA)
-* [Cloud Firestore](#cloud-firestore-ga) (GA)
-* [Cloud Key Management Service](#cloud-key-management-service-ga) (GA)
-* [Stackdriver Logging](#stackdriver-logging-ga) (GA)
-* [Cloud Pub/Sub](#cloud-pubsub-ga) (GA)
-* [Cloud Spanner API](#cloud-spanner-api-ga) (GA)
-* [Cloud Storage](#cloud-storage-ga) (GA)
-* [Cloud Translation API](#cloud-translation-api-ga) (GA)
-* [Cloud Video Intelligence API](#cloud-video-intelligence-api-ga) (GA)
-
-This client supports the following Google Cloud Platform services at a
-[Beta](#versioning) quality level:
-
-* [Cloud Asset](#cloud-asset-beta) (Beta)
-* [BigQuery Data Transfer](#bigquery-data-transfer-api-beta) (Beta)
-* [Stackdriver Debugger](#stackdriver-debugger-beta) (Beta)
-* [Stackdriver Error Reporting](#stackdriver-error-reporting-beta) (Beta)
-* [Stackdriver Monitoring API](#stackdriver-monitoring-api-beta) (Beta)
-* [Stackdriver Trace](#stackdriver-trace-beta) (Beta)
-
-This client supports the following Google Cloud Platform services at an
-[Alpha](#versioning) quality level:
-
-* [Container Analysis](#container-analysis-alpha) (Alpha)
-* [Container Engine](#container-engine-alpha) (Alpha)
-* [Cloud Dataproc](#cloud-dataproc-alpha) (Alpha)
-* [Data Loss Prevention](#data-loss-prevention-alpha) (Alpha)
-* [Dialogflow API](#dialogflow-api-alpha) (Alpha)
-* [Cloud DNS](#cloud-dns-alpha) (Alpha)
-* [Cloud Natural Language API](#cloud-natural-language-api-alpha) (Alpha)
-* [Cloud OS Login](#cloud-os-login-alpha) (Alpha)
-* [Phishing Protection](#phishing-protection-alpha) (Alpha)
-* [Recaptcha Enterprise](#recaptcha-enterprise-alpha) (Alpha)
-* [Cloud Redis](#cloud-redis-api-alpha) (Alpha)
-* [Cloud Resource Manager](#cloud-resource-manager-alpha) (Alpha)
-* [Cloud Scheduler](#cloud-scheduler-alpha) (Alpha)
-* [Cloud Security Center](#cloud-security-center-alpha) (Alpha)
-* [Cloud Speech API](#cloud-speech-api-alpha) (Alpha)
-* [Cloud Talent Solutions API](#cloud-talent-solutions-api-alpha) (Alpha)
-* [Cloud Tasks API](#cloud-tasks-api-alpha) (Alpha)
-* [Cloud Text-To-Speech API](#cloud-text-to-speech-api-alpha) (Alpha)
-* [Cloud Vision API](#cloud-vision-api-alpha) (Alpha)
+* [Cloud Asset](#cloud-asset)
+* [Cloud AutoML API](#cloud-automl-api)
+* [BigQuery](#bigquery)
+* [BigQuery Data Transfer](#bigquery-data-transfer-api)
+* [Cloud Bigtable](#cloud-bigtable)
+* [Cloud Billing API](#cloud-billing-api)
+* [Container Analysis](#container-analysis)
+* [Container Engine](#container-engine)
+* [Cloud Dataproc](#cloud-dataproc)
+* [Cloud Datastore](#cloud-datastore)
+* [Stackdriver Debugger](#stackdriver-debugger)
+* [Dialogflow API](#dialogflow-api)
+* [Data Loss Prevention](#data-loss-prevention)
+* [Cloud DNS](#cloud-dns)
+* [Stackdriver Error Reporting](#stackdriver-error-reporting)
+* [Cloud Firestore](#cloud-firestore)
+* [Cloud Key Management Service](#cloud-key-management-service)
+* [Cloud Natural Language API](#cloud-natural-language-api)
+* [Stackdriver Logging](#stackdriver-logging)
+* [Stackdriver Monitoring API](#stackdriver-monitoring-api)
+* [Cloud OS Login](#cloud-os-login)
+* [Phishing Protection](#phishing-protection)
+* [Cloud Pub/Sub](#cloud-pubsub)
+* [Recaptcha Enterprise](#recaptcha-enterprise)
+* [Cloud Recommender API](#cloud-recommender-api)
+* [Cloud Redis](#cloud-redis-api)
+* [Cloud Resource Manager](#cloud-resource-manager)
+* [Cloud Scheduler](#cloud-scheduler)
+* [Secret Manager API](#secret-manager-api)
+* [Cloud Security Center](#cloud-security-center)
+* [Cloud Spanner API](#cloud-spanner-api)
+* [Cloud Speech API](#cloud-speech-api)
+* [Cloud Storage](#cloud-storage)
+* [Cloud Talent Solutions API](#cloud-talent-solutions-api)
+* [Cloud Tasks API](#cloud-tasks-api)
+* [Cloud Text-To-Speech API](#cloud-text-to-speech-api)
+* [Stackdriver Trace](#stackdriver-trace)
+* [Cloud Translation API](#cloud-translation-api)
+* [Cloud Video Intelligence API](#cloud-video-intelligence-api)
+* [Cloud Vision API](#cloud-vision-api)
+* [Web Risk API](#web-risk-api)
 
 The support for each service is distributed as a separate gem. However, for your
 convenience, the `google-cloud` gem lets you install the entire collection.
@@ -100,7 +96,7 @@ listed below for each service.
 The preview examples below demonstrate how to provide the **Project ID** and
 **Credentials JSON file path** directly in code.
 
-### Cloud Asset API (Beta)
+### Cloud Asset API
 
 - [google-cloud-asset README](google-cloud-asset/README.md)
 - [google-cloud-asset API documentation](https://googleapis.dev/ruby/google-cloud-asset/latest)
@@ -112,7 +108,19 @@ The preview examples below demonstrate how to provide the **Project ID** and
 $ gem install google-cloud-asset
 ```
 
-### BigQuery (GA)
+### Cloud AutoML API
+
+- [google-cloud-automl README](google-cloud-automl/README.md)
+- [google-cloud-automl API documentation](https://googleapis.dev/ruby/google-cloud-automl/latest)
+- [google-cloud-automl on RubyGems](https://rubygems.org/gems/google-cloud-automl/)
+
+#### Quick Start
+
+```sh
+$ gem install google-cloud-automl
+```
+
+### BigQuery
 
 - [google-cloud-bigquery README](google-cloud-bigquery/README.md)
 - [google-cloud-bigquery API documentation](https://googleapis.dev/ruby/google-cloud-bigquery/latest)
@@ -154,7 +162,7 @@ data.each do |row|
 end
 ```
 
-### BigQuery Data Transfer API (Beta)
+### BigQuery Data Transfer API
 
 - [google-bigquery-data_transfer README](google-cloud-bigquery-data_transfer/README.md)
 - [google-bigquery-data_transfer API documentation](https://googleapis.dev/ruby/google-cloud-bigquery-data_transfer/latest)
@@ -189,7 +197,7 @@ data_transfer_service_client.list_data_sources(formatted_parent).each_page do |p
 end
 ```
 
-### Cloud Bigtable (GA)
+### Cloud Bigtable
 
 - [google-cloud-bigtable README](google-cloud-bigtable/README.md)
 - [google-cloud-bigtable API documentation](https://googleapis.dev/ruby/google-cloud-bigtable/latest)
@@ -222,7 +230,19 @@ entry.set_cell(
 table.mutate_row(entry)
 ```
 
-### Cloud Datastore (GA)
+### Cloud Billing API
+
+- [google-cloud-billing README](google-cloud-billing/README.md)
+- [google-cloud-billing API documentation](https://googleapis.dev/ruby/google-cloud-billing/latest)
+- [google-cloud-billing on RubyGems](https://rubygems.org/gems/google-cloud-billing/)
+
+#### Quick Start
+
+```sh
+$ gem install google-cloud-billing
+```
+
+### Cloud Datastore
 
 - [google-cloud-datastore README](google-cloud-datastore/README.md)
 - [google-cloud-datastore API documentation](https://googleapis.dev/ruby/google-cloud-datastore/latest)
@@ -264,7 +284,7 @@ query = datastore.query("Task").
 tasks = datastore.run query
 ```
 
-### Stackdriver Debugger (Beta)
+### Stackdriver Debugger
 
 - [google-cloud-debugger README](google-cloud-debugger/README.md)
 - [google-cloud-debugger instrumentation documentation](./google-cloud-debugger/INSTRUMENTATION.md)
@@ -286,7 +306,7 @@ debugger = Google::Cloud::Debugger.new
 debugger.start
 ```
 
-### Cloud DNS (Alpha)
+### Cloud DNS
 
 - [google-cloud-dns README](google-cloud-dns/README.md)
 - [google-cloud-dns API documentation](https://googleapis.dev/ruby/google-cloud-dns/latest)
@@ -322,7 +342,7 @@ end
 
 ```
 
-### Container Analysis (Alpha)
+### Container Analysis
 
 - [google-cloud-container_analysis README](google-cloud-container_analysis/README.md)
 - [google-cloud-container_analysis API documentation](https://googleapis.dev/ruby/google-cloud-container_analysis/latest)
@@ -348,7 +368,7 @@ results = grafeas_client.list_occurrences(parent).each do |occurrence|
 end
 ```
 
-### Container Engine (Alpha)
+### Container Engine
 
 - [google-cloud-container README](google-cloud-container/README.md)
 - [google-cloud-container API documentation](https://googleapis.dev/ruby/google-cloud-container/latest)
@@ -372,7 +392,7 @@ zone = "us-central1-a"
 response = cluster_manager_client.list_clusters(project_id_2, zone)
 ```
 
-### Cloud Dataproc (Alpha)
+### Cloud Dataproc
 
 - [google-cloud-dataproc README](google-cloud-dataproc/README.md)
 - [google-cloud-dataproc API documentation](https://googleapis.dev/ruby/google-cloud-dataproc/latest)
@@ -408,7 +428,7 @@ cluster_controller_client.list_clusters(project_id_2, region).each_page do |page
 end
 ```
 
-### Data Loss Prevention (Alpha)
+### Data Loss Prevention
 
 - [google-cloud-dlp README](google-cloud-dlp/README.md)
 - [google-cloud-dlp API documentation](https://googleapis.dev/ruby/google-cloud-dlp/latest)
@@ -436,7 +456,7 @@ items = [items_element]
 response = dlp_service_client.inspect_content(inspect_config, items)
 ```
 
-### Dialogflow API (Alpha)
+### Dialogflow API
 
 - [google-cloud-dialogflow README](google-cloud-dialogflow/README.md)
 - [google-cloud-dialogflow API documentation](https://googleapis.dev/ruby/google-cloud-dialogflow/latest)
@@ -449,7 +469,7 @@ response = dlp_service_client.inspect_content(inspect_config, items)
 $ gem install google-cloud-dialogflow
 ```
 
-### Stackdriver Error Reporting (Beta)
+### Stackdriver Error Reporting
 
 - [google-cloud-error_reporting README](google-cloud-error_reporting/README.md)
 - [google-cloud-error_reporting instrumentation documentation](./google-cloud-error_reporting/INSTRUMENTATION.md)
@@ -475,7 +495,7 @@ rescue => exception
 end
 ```
 
-### Cloud Firestore (GA)
+### Cloud Firestore
 
 - [google-cloud-firestore README](google-cloud-firestore/README.md)
 - [google-cloud-firestore API documentation](https://googleapis.dev/ruby/google-cloud-firestore/latest)
@@ -511,7 +531,7 @@ firestore.transaction do |tx|
 end
 ```
 
-### Cloud Key Management Service (GA)
+### Cloud Key Management Service
 
 - [google-cloud-kms README](google-cloud-kms/README.md)
 - [google-cloud-kms API documentation](https://googleapis.dev/ruby/google-cloud-kms/latest)
@@ -545,7 +565,7 @@ kms.list_key_rings(key_ring_parent).each do |key_ring|
 end
 ```
 
-### Stackdriver Logging (GA)
+### Stackdriver Logging
 
 - [google-cloud-logging README](google-cloud-logging/README.md)
 - [google-cloud-logging API documentation](https://googleapis.dev/ruby/google-cloud-logging/latest)
@@ -584,7 +604,7 @@ entry.resource.labels[:version_id] = "20150925t173233"
 logging.write_entries entry
 ```
 
-### Cloud Natural Language API (Alpha)
+### Cloud Natural Language API
 
 - [google-cloud-language README](google-cloud-language/README.md)
 - [google-cloud-language API documentation](https://googleapis.dev/ruby/google-cloud-language/latest)
@@ -618,7 +638,7 @@ annotation.sentences.count #=> 2
 annotation.tokens.count #=> 13
 ```
 
-### Cloud OS Login (Alpha)
+### Cloud OS Login
 
 - [google-cloud-os_login README](google-cloud-os_login/README.md)
 - [google-cloud-os_login API documentation](https://googleapis.dev/ruby/google-cloud-os_login/latest)
@@ -631,7 +651,7 @@ annotation.tokens.count #=> 13
 $ gem install google-cloud-os_login
 ```
 
-### Phishing Protection (Alpha)
+### Phishing Protection
 
 - [google-cloud-phishing_protection README](google-cloud-phishing_protection/README.md)
 - [google-cloud-phishing_protection API documentation](https://googleapis.dev/ruby/google-cloud-phishing_protection/latest)
@@ -644,7 +664,7 @@ $ gem install google-cloud-os_login
 $ gem install google-cloud-phishing_protection
 ```
 
-### Cloud Pub/Sub (GA)
+### Cloud Pub/Sub
 
 - [google-cloud-pubsub README](google-cloud-pubsub/README.md)
 - [google-cloud-pubsub API documentation](https://googleapis.dev/ruby/google-cloud-pubsub/latest)
@@ -689,7 +709,7 @@ subscriber.start
 subscriber.stop.wait!
 ```
 
-### Recaptcha Enterprise (Alpha)
+### Recaptcha Enterprise
 
 - [google-cloud-recaptcha_enterprise README](google-cloud-recaptcha_enterprise/README.md)
 - [google-cloud-recaptcha_enterprise API documentation](https://googleapis.dev/ruby/google-cloud-recaptcha_enterprise/latest)
@@ -702,7 +722,19 @@ subscriber.stop.wait!
 $ gem install google-cloud-recaptcha_enterprise
 ```
 
-### Cloud Redis API (Alpha)
+### Cloud Recommender API
+
+- [google-cloud-recommender README](google-cloud-recommender/README.md)
+- [google-cloud-automl API documentation](https://googleapis.dev/ruby/google-cloud-recommender/latest)
+- [google-cloud-recommender on RubyGems](https://rubygems.org/gems/google-cloud-recommender/)
+
+#### Quick Start
+
+```sh
+$ gem install google-cloud-recommender
+```
+
+### Cloud Redis API
 
 - [google-cloud-redis README](google-cloud-redis/README.md)
 - [google-cloud-redis API documentation](https://googleapis.dev/ruby/google-cloud-redis/latest)
@@ -716,7 +748,7 @@ $ gem install google-cloud-redis
 ```
 
 
-### Cloud Resource Manager (Alpha)
+### Cloud Resource Manager
 
 - [google-cloud-resource_manager README](google-cloud-resource_manager/README.md)
 - [google-cloud-resource_manager API documentation](https://googleapis.dev/ruby/google-cloud-resource_manager/latest)
@@ -751,7 +783,7 @@ end
 projects = resource_manager.projects filter: "labels.env:production"
 ```
 
-### Stackdriver Trace (Beta)
+### Stackdriver Trace
 
 - [google-cloud-trace README](google-cloud-trace/README.md)
 - [google-cloud-trace instrumentation documentation](./google-cloud-trace/INSTRUMENTATION.md)
@@ -777,7 +809,7 @@ result_set.each do |trace_record|
 end
 ```
 
-### Cloud Spanner API (GA)
+### Cloud Spanner API
 
 - [google-cloud-spanner README](google-cloud-spanner/README.md)
 - [google-cloud-spanner API documentation](https://googleapis.dev/ruby/google-cloud-spanner/latest)
@@ -808,7 +840,7 @@ db.transaction do |tx|
 end
 ```
 
-### Cloud Speech API (Alpha)
+### Cloud Speech API
 
 - [google-cloud-speech README](google-cloud-speech/README.md)
 - [google-cloud-speech API documentation](https://googleapis.dev/ruby/google-cloud-speech/latest)
@@ -837,7 +869,7 @@ result.transcript #=> "how old is the Brooklyn Bridge"
 result.confidence #=> 0.9826789498329163
 ```
 
-### Cloud Scheduler (Alpha)
+### Cloud Scheduler
 
 - [Client Library Documentation][]
 - [Product Documentation][]
@@ -893,7 +925,19 @@ module GRPC
 end
 ```
 
-### Cloud Security Center API (Alpha)
+### Secret Manager API
+
+- [google-cloud-secret_manager README](google-cloud-secret_manager/README.md)
+- [google-cloud-automl API documentation](https://googleapis.dev/ruby/google-cloud-secret_manager/latest)
+- [google-cloud-secret_manager on RubyGems](https://rubygems.org/gems/google-cloud-secret_manager/)
+
+#### Quick Start
+
+```sh
+$ gem install google-cloud-secret_manager
+```
+
+### Cloud Security Center API
 
 - [google-cloud-security_center README](google-cloud-security_center/README.md)
 - [google-cloud-security_center API documentation](https://googleapis.dev/ruby/google-cloud-security_center/latest)
@@ -906,7 +950,7 @@ end
 $ gem install google-cloud-security_center
 ```
 
-### Cloud Storage (GA)
+### Cloud Storage
 
 - [google-cloud-storage README](google-cloud-storage/README.md)
 - [google-cloud-storage API documentation](https://googleapis.dev/ruby/google-cloud-storage/latest)
@@ -941,7 +985,7 @@ backup = storage.bucket "task-attachment-backups"
 file.copy backup, file.name
 ```
 
-### Cloud Talent Solutions API (Alpha)
+### Cloud Talent Solutions API
 
 - [google-cloud-talent README](google-cloud-talent/README.md)
 - [google-cloud-talent API documentation](https://googleapis.dev/ruby/google-cloud-talent/latest)
@@ -979,7 +1023,7 @@ $ gem install google-cloud-talent
  end
 ```
 
-### Cloud Tasks API (Alpha)
+### Cloud Tasks API
 
 - [google-cloud-tasks README](google-cloud-tasks/README.md)
 - [google-cloud-tasks API documentation](https://googleapis.dev/ruby/google-cloud-tasks/latest)
@@ -1013,7 +1057,7 @@ $ gem install google-cloud-tasks
  end
 ```
 
-### Cloud Text To Speech API (Alpha)
+### Cloud Text To Speech API
 
 #### Quick Start
 
@@ -1037,7 +1081,7 @@ response = text_to_speech_client.synthesize_speech(input, voice, audio_config)
 File.write("example.mp3", response.audio_content, mode: "wb")
 ```
 
-### Cloud Translation API (GA)
+### Cloud Translation API
 
 - [google-cloud-translate README](google-cloud-translate/README.md)
 - [google-cloud-translate API documentation](https://googleapis.dev/ruby/google-cloud-translate/latest)
@@ -1067,7 +1111,7 @@ translation.to #=> "la"
 translation.text #=> "Salve mundi!"
 ```
 
-### Cloud Vision API (Alpha)
+### Cloud Vision API
 
 - [google-cloud-vision README](google-cloud-vision/README.md)
 - [google-cloud-vision API documentation](https://googleapis.dev/ruby/google-cloud-vision/latest)
@@ -1097,7 +1141,7 @@ requests = [requests_element]
 response = image_annotator_client.batch_annotate_images(requests)
 ```
 
-### Stackdriver Monitoring API (Beta)
+### Stackdriver Monitoring API
 
 - [google-cloud-monitoring README](google-cloud-monitoring/README.md)
 - [google-cloud-monitoring API documentation](https://googleapis.dev/ruby/google-cloud-monitoring/latest)
@@ -1133,7 +1177,7 @@ $ gem install google-cloud-monitoring
  end
 ```
 
-### Cloud Video Intelligence API (GA)
+### Cloud Video Intelligence API
 
 - [google-cloud-video_intelligence README](google-cloud-video_intelligence/README.md)
 - [google-cloud-video_intelligence API documentation](https://googleapis.dev/ruby/google-cloud-video_intelligence/latest)
@@ -1184,6 +1228,18 @@ $ gem install google-cloud-video_intelligence
  operation.wait_until_done!
 ```
 
+### Web Risk API
+
+- [google-cloud-webrisk README](google-cloud-webrisk/README.md)
+- [google-cloud-automl API documentation](https://googleapis.dev/ruby/google-cloud-webrisk/latest)
+- [google-cloud-webrisk on RubyGems](https://rubygems.org/gems/google-cloud-webrisk/)
+
+#### Quick Start
+
+```sh
+$ gem install google-cloud-webrisk
+```
+
 
 ## Supported Ruby Versions
 
@@ -1196,19 +1252,16 @@ and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.
 
-## Versioning
+## Library Versioning
 
-This library follows [Semantic Versioning](http://semver.org/).
+The libraries in this repository follow [Semantic Versioning](http://semver.org/).
 
-Please note it is currently under active development. Any release versioned 0.x.y is subject to backwards incompatible changes at any time.
+Note that different libraries may be released at different support quality
+levels:
 
-**GA**: Libraries defined at the GA (general availability) quality level are stable. The code surface will not change in backwards-incompatible ways unless absolutely necessary (e.g. because of critical security issues) or with an extensive deprecation period. Issues and requests against GA libraries are addressed with the highest priority.
+**GA**: Libraries defined at the GA (general availability) quality level, indicated by a version number greater than or equal to 1.0, are stable. The code surface will not change in backwards-incompatible ways unless absolutely necessary (e.g. because of critical security issues), or unless accompanying a semver-major version update (such as version 1.x to 2.x.) Issues and requests against GA libraries are addressed with the highest priority.
 
-Please note that the auto-generated portions of the GA libraries (the ones in modules such as `v1` or `v2`) are considered to be of **Beta** quality, even if the libraries that wrap them are GA.
-
-**Beta**: Libraries defined at a Beta quality level are expected to be mostly stable and we're working towards their release candidate. We will address issues and requests with a higher priority.
-
-**Alpha**: Libraries defined at an Alpha quality level are still a work-in-progress and are more likely to get backwards-incompatible updates.
+**Beta**: Libraries defined at a Beta quality level, indicated by a version number less than 1.0, are expected to be mostly stable and we're working towards their release candidate. However, these libraries may get backwards-incompatible updates from time to time. We will still address issues and requests with a high priority.
 
 ## Contributing
 

--- a/google-cloud-asset/README.md
+++ b/google-cloud-asset/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud Asset API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud Asset API
 
 [Cloud Asset API][Product Documentation]:
 The cloud asset API manages the history and inventory of cloud resources.

--- a/google-cloud-asset/lib/google/cloud/asset.rb
+++ b/google-cloud-asset/lib/google/cloud/asset.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud Asset API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud Asset API
     #
     # [Cloud Asset API][Product Documentation]:
     # The cloud asset API manages the history and inventory of cloud resources.

--- a/google-cloud-asset/lib/google/cloud/asset/v1.rb
+++ b/google-cloud-asset/lib/google/cloud/asset/v1.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Asset API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Asset API
       #
       # [Cloud Asset API][Product Documentation]:
       # The cloud asset API manages the history and inventory of cloud resources.

--- a/google-cloud-asset/lib/google/cloud/asset/v1beta1.rb
+++ b/google-cloud-asset/lib/google/cloud/asset/v1beta1.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Asset API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Asset API
       #
       # [Cloud Asset API][Product Documentation]:
       # The cloud asset API manages the history and inventory of cloud resources.

--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -120,6 +120,16 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-asset.gemspec',
@@ -183,11 +193,6 @@ s.replace(
     ],
     'https://googlecloudplatform\\.github\\.io/google-cloud-ruby',
     'https://googleapis.github.io/google-cloud-ruby'
-)
-s.replace(
-    'README.md',
-    '# Ruby Client for Cloud Asset API \(\[Alpha\]\(https:\/\/github\.com\/googleapis\/google-cloud-ruby#versioning\)\)',
-    '# Ruby Client for Cloud Asset API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))'
 )
 
 for version in ['v1', 'v1beta1']:

--- a/google-cloud-automl/README.md
+++ b/google-cloud-automl/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud AutoML API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud AutoML API
 
 [Cloud AutoML API][Product Documentation]:
 Train high-quality custom machine learning models with minimum effort and

--- a/google-cloud-automl/lib/google/cloud/automl.rb
+++ b/google-cloud-automl/lib/google/cloud/automl.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud AutoML API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud AutoML API
     #
     # [Cloud AutoML API][Product Documentation]:
     # Train high-quality custom machine learning models with minimum effort and

--- a/google-cloud-automl/lib/google/cloud/automl/v1beta1.rb
+++ b/google-cloud-automl/lib/google/cloud/automl/v1beta1.rb
@@ -24,7 +24,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud AutoML API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud AutoML API
       #
       # [Cloud AutoML API][Product Documentation]:
       # Train high-quality custom machine learning models with minimum effort and

--- a/google-cloud-automl/synth.py
+++ b/google-cloud-automl/synth.py
@@ -160,6 +160,16 @@ s.replace(
     ])
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-bigquery-data_transfer/README.md
+++ b/google-cloud-bigquery-data_transfer/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for BigQuery Data Transfer API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for BigQuery Data Transfer API
 
 [BigQuery Data Transfer API][Product Documentation]:
 Schedule queries or transfer external data from SaaS applications to Google

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for BigQuery Data Transfer API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for BigQuery Data Transfer API
       #
       # [BigQuery Data Transfer API][Product Documentation]:
       # Schedule queries or transfer external data from SaaS applications to Google

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1.rb
@@ -22,7 +22,7 @@ module Google
         # rubocop:disable LineLength
 
         ##
-        # # Ruby Client for BigQuery Data Transfer API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+        # # Ruby Client for BigQuery Data Transfer API
         #
         # [BigQuery Data Transfer API][Product Documentation]:
         # Schedule queries or transfer external data from SaaS applications to Google

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -102,6 +102,16 @@ s.replace(
     ])
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # PERMANENT: Use custom credentials env variable names
 s.replace(
     'lib/google/cloud/bigquery/data_transfer/v1/credentials.rb',

--- a/google-cloud-bigtable/README.md
+++ b/google-cloud-bigtable/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud Bigtable API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud Bigtable API
 
 [Cloud Bigtable API][Product Documentation]:
 API for reading and writing the contents of Bigtables associated with a

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Bigtable Admin API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Bigtable Admin API
       #
       # [Cloud Bigtable Admin API][Product Documentation]:
       # Administer your Cloud Bigtable tables and instances.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2.rb
@@ -25,7 +25,7 @@ module Google
         # rubocop:disable LineLength
 
         ##
-        # # Ruby Client for Cloud Bigtable Admin API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+        # # Ruby Client for Cloud Bigtable Admin API
         #
         # [Cloud Bigtable Admin API][Product Documentation]:
         # Administer your Cloud Bigtable tables and instances.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Bigtable API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Bigtable API
       #
       # [Cloud Bigtable API][Product Documentation]:
       # API for reading and writing the contents of Bigtables associated with a

--- a/google-cloud-container/README.md
+++ b/google-cloud-container/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Kubernetes Engine API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Kubernetes Engine API
 
 [Kubernetes Engine API][Product Documentation]:
 Builds and manages container-based applications, powered by the open source

--- a/google-cloud-container/lib/google/cloud/container.rb
+++ b/google-cloud-container/lib/google/cloud/container.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Kubernetes Engine API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Kubernetes Engine API
     #
     # [Kubernetes Engine API][Product Documentation]:
     # Builds and manages container-based applications, powered by the open source

--- a/google-cloud-container/lib/google/cloud/container/v1.rb
+++ b/google-cloud-container/lib/google/cloud/container/v1.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Kubernetes Engine API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Kubernetes Engine API
       #
       # [Kubernetes Engine API][Product Documentation]:
       # Builds and manages container-based applications, powered by the open source

--- a/google-cloud-container/lib/google/cloud/container/v1beta1.rb
+++ b/google-cloud-container/lib/google/cloud/container/v1beta1.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Kubernetes Engine API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Kubernetes Engine API
       #
       # [Kubernetes Engine API][Product Documentation]:
       # Builds and manages container-based applications, powered by the open source

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -112,6 +112,16 @@ s.replace(
     ])
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # Fix for tests that assume protos implement to_hash
 s.replace(
     'test/google/cloud/container/v1*/cluster_manager_client_test.rb',

--- a/google-cloud-container_analysis/README.md
+++ b/google-cloud-container_analysis/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Container Analysis API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Container Analysis API
 
 [Container Analysis API][Product Documentation]:
 An implementation of the Grafeas API, which stores, and enables querying

--- a/google-cloud-container_analysis/lib/google/cloud/container_analysis.rb
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis.rb
@@ -22,7 +22,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Container Analysis API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Container Analysis API
     #
     # [Container Analysis API][Product Documentation]:
     # An implementation of the Grafeas API, which stores, and enables querying

--- a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1.rb
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Container Analysis API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Container Analysis API
       #
       # [Container Analysis API][Product Documentation]:
       # An implementation of the Grafeas API, which stores, and enables querying

--- a/google-cloud-container_analysis/synth.py
+++ b/google-cloud-container_analysis/synth.py
@@ -136,6 +136,13 @@ s.replace(
     'CONTAINER_ANALYSIS_'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    'lib/google/cloud/**/*.rb',
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [

--- a/google-cloud-dataproc/README.md
+++ b/google-cloud-dataproc/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Google Cloud Dataproc API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Google Cloud Dataproc API
 
 [Google Cloud Dataproc API][Product Documentation]:
 Manages Hadoop-based clusters and jobs on Google Cloud Platform.

--- a/google-cloud-dataproc/lib/google/cloud/dataproc.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Google Cloud Dataproc API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Google Cloud Dataproc API
     #
     # [Google Cloud Dataproc API][Product Documentation]:
     # Manages Hadoop-based clusters and jobs on Google Cloud Platform.

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1.rb
@@ -27,7 +27,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Google Cloud Dataproc API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Google Cloud Dataproc API
       #
       # [Google Cloud Dataproc API][Product Documentation]:
       # Manages Hadoop-based clusters and jobs on Google Cloud Platform.

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1beta2.rb
@@ -27,7 +27,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Google Cloud Dataproc API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Google Cloud Dataproc API
       #
       # [Google Cloud Dataproc API][Product Documentation]:
       # Manages Hadoop-based clusters and jobs on Google Cloud Platform.

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -126,6 +126,16 @@ s.replace(
     ])
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Stackdriver Debugger API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Stackdriver Debugger API
       #
       # [Stackdriver Debugger API][Product Documentation]:
       # Examines the call stack and variables of a running application without

--- a/google-cloud-debugger/synth.py
+++ b/google-cloud-debugger/synth.py
@@ -105,6 +105,13 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    'lib/google/cloud/**/*.rb',
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-dialogflow/README.md
+++ b/google-cloud-dialogflow/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Dialogflow API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Dialogflow API
 
 [Dialogflow API][Product Documentation]:
 Builds conversational interfaces (for example, chatbots, and voice-powered

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Dialogflow API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Dialogflow API
     #
     # [Dialogflow API][Product Documentation]:
     # Builds conversational interfaces (for example, chatbots, and voice-powered

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2.rb
@@ -30,7 +30,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Dialogflow API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Dialogflow API
       #
       # [Dialogflow API][Product Documentation]:
       # Builds conversational interfaces (for example, chatbots, and voice-powered

--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -99,6 +99,16 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2232
 s.replace(
     [

--- a/google-cloud-dlp/README.md
+++ b/google-cloud-dlp/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud Data Loss Prevention (DLP) API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud Data Loss Prevention (DLP) API
 
 [Cloud Data Loss Prevention (DLP) API][Product Documentation]:
 Provides methods for detection, risk analysis, and de-identification of

--- a/google-cloud-dlp/lib/google/cloud/dlp.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud Data Loss Prevention (DLP) API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud Data Loss Prevention (DLP) API
     #
     # [Cloud Data Loss Prevention (DLP) API][Product Documentation]:
     # Provides methods for detection, risk analysis, and de-identification of

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Data Loss Prevention (DLP) API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Data Loss Prevention (DLP) API
       #
       # [Cloud Data Loss Prevention (DLP) API][Product Documentation]:
       # Provides methods for detection, risk analysis, and de-identification of

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -91,6 +91,16 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-firestore/README.md
+++ b/google-cloud-firestore/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Google Cloud Firestore API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Google Cloud Firestore API
 
 [Google Cloud Firestore API][Product Documentation]:
 

--- a/google-cloud-firestore/lib/google/cloud/firestore/admin.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/admin.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Google Cloud Firestore Admin API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Google Cloud Firestore Admin API
       #
       # [Google Cloud Firestore Admin API][Product Documentation]:
       # Accesses the NoSQL document database built for automatic scaling, high

--- a/google-cloud-firestore/lib/google/cloud/firestore/admin/v1.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/admin/v1.rb
@@ -24,7 +24,7 @@ module Google
         # rubocop:disable LineLength
 
         ##
-        # # Ruby Client for Google Cloud Firestore Admin API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+        # # Ruby Client for Google Cloud Firestore Admin API
         #
         # [Google Cloud Firestore Admin API][Product Documentation]:
         # Accesses the NoSQL document database built for automatic scaling, high

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Google Cloud Firestore API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Google Cloud Firestore API
       #
       # [Google Cloud Firestore API][Product Documentation]:
       #

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Google Cloud Firestore API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Google Cloud Firestore API
       #
       # [Google Cloud Firestore API][Product Documentation]:
       #

--- a/google-cloud-firestore/synth.py
+++ b/google-cloud-firestore/synth.py
@@ -152,6 +152,13 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    'lib/google/cloud/**/*.rb',
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-irm/README.md
+++ b/google-cloud-irm/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Stackdriver Incident Response & Management API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Stackdriver Incident Response & Management API
 
 [Stackdriver Incident Response & Management API][Product Documentation]:
 

--- a/google-cloud-irm/lib/google/cloud/irm.rb
+++ b/google-cloud-irm/lib/google/cloud/irm.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Stackdriver Incident Response & Management API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Stackdriver Incident Response & Management API
     #
     # [Stackdriver Incident Response & Management API][Product Documentation]:
     #

--- a/google-cloud-irm/lib/google/cloud/irm/v1alpha2.rb
+++ b/google-cloud-irm/lib/google/cloud/irm/v1alpha2.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Stackdriver Incident Response & Management API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Stackdriver Incident Response & Management API
       #
       # [Stackdriver Incident Response & Management API][Product Documentation]:
       #

--- a/google-cloud-kms/README.md
+++ b/google-cloud-kms/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud Key Management Service (KMS) API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud Key Management Service (KMS) API
 
 [Cloud Key Management Service (KMS) API][Product Documentation]:
 Manages keys and performs cryptographic operations in a central cloud

--- a/google-cloud-kms/lib/google/cloud/kms.rb
+++ b/google-cloud-kms/lib/google/cloud/kms.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud Key Management Service (KMS) API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud Key Management Service (KMS) API
     #
     # [Cloud Key Management Service (KMS) API][Product Documentation]:
     # Manages keys and performs cryptographic operations in a central cloud

--- a/google-cloud-kms/lib/google/cloud/kms/v1.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1.rb
@@ -23,7 +23,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Key Management Service (KMS) API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Key Management Service (KMS) API
       #
       # [Cloud Key Management Service (KMS) API][Product Documentation]:
       # Manages keys and performs cryptographic operations in a central cloud

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -140,6 +140,16 @@ s.replace(
     ])
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-language/README.md
+++ b/google-cloud-language/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud Natural Language API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud Natural Language API
 
 [Cloud Natural Language API][Product Documentation]:
 Provides natural language understanding technologies, such as sentiment

--- a/google-cloud-language/lib/google/cloud/language.rb
+++ b/google-cloud-language/lib/google/cloud/language.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud Natural Language API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud Natural Language API
     #
     # [Cloud Natural Language API][Product Documentation]:
     # Provides natural language understanding technologies, such as sentiment

--- a/google-cloud-language/lib/google/cloud/language/v1.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Natural Language API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Natural Language API
       #
       # [Cloud Natural Language API][Product Documentation]:
       # Provides natural language understanding technologies, such as sentiment

--- a/google-cloud-language/lib/google/cloud/language/v1beta2.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Google Cloud Natural Language API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Google Cloud Natural Language API
       #
       # [Google Cloud Natural Language API][Product Documentation]:
       # Google Cloud Natural Language API provides natural language understanding

--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -105,6 +105,16 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [

--- a/google-cloud-monitoring/README.md
+++ b/google-cloud-monitoring/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Stackdriver Monitoring API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Stackdriver Monitoring API
 
 [Stackdriver Monitoring API][Product Documentation]:
 Manages your Stackdriver Monitoring data and configurations. Most projects

--- a/google-cloud-monitoring/lib/google/cloud/monitoring.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Stackdriver Monitoring API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Stackdriver Monitoring API
     #
     # [Stackdriver Monitoring API][Product Documentation]:
     # Manages your Stackdriver Monitoring data and configurations. Most projects

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/dashboard.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/dashboard.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Stackdriver Monitoring Dashboards API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Stackdriver Monitoring Dashboards API
       #
       # [Stackdriver Monitoring Dashboards API][Product Documentation]:
       # Manages dashboard configurations used in the Stackdriver UI.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/dashboard/v1.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/dashboard/v1.rb
@@ -22,7 +22,7 @@ module Google
         # rubocop:disable LineLength
 
         ##
-        # # Ruby Client for Stackdriver Monitoring Dashboards API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+        # # Ruby Client for Stackdriver Monitoring Dashboards API
         #
         # [Stackdriver Monitoring Dashboards API][Product Documentation]:
         # Manages dashboard configurations used in the Stackdriver UI.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3.rb
@@ -28,7 +28,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Stackdriver Monitoring API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Stackdriver Monitoring API
       #
       # [Stackdriver Monitoring API][Product Documentation]:
       # Manages your Stackdriver Monitoring data and configurations. Most projects

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -146,6 +146,16 @@ s.replace(
     ])
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-os_login/README.md
+++ b/google-cloud-os_login/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud OS Login API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud OS Login API
 
 [Cloud OS Login API][Product Documentation]:
 You can use OS Login to manage access to your VM instances using IAM roles.

--- a/google-cloud-os_login/lib/google/cloud/os_login.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud OS Login API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud OS Login API
     #
     # [Cloud OS Login API][Product Documentation]:
     # You can use OS Login to manage access to your VM instances using IAM roles.

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud OS Login API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud OS Login API
       #
       # [Cloud OS Login API][Product Documentation]:
       # You can use OS Login to manage access to your VM instances using IAM roles.

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1beta.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1beta.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Google Cloud OS Login API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Google Cloud OS Login API
       #
       # [Google Cloud OS Login API][Product Documentation]:
       # Manages OS login configuration for Google account users.

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -126,6 +126,16 @@ s.replace(
     ])
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [

--- a/google-cloud-phishing_protection/README.md
+++ b/google-cloud-phishing_protection/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Phishing Protection API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Phishing Protection API
 
 [Phishing Protection API][Product Documentation]:
 

--- a/google-cloud-phishing_protection/lib/google/cloud/phishing_protection.rb
+++ b/google-cloud-phishing_protection/lib/google/cloud/phishing_protection.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Phishing Protection API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Phishing Protection API
     #
     # [Phishing Protection API][Product Documentation]:
     #

--- a/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/v1beta1.rb
+++ b/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/v1beta1.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Phishing Protection API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Phishing Protection API
       #
       # [Phishing Protection API][Product Documentation]:
       #

--- a/google-cloud-phishing_protection/synth.py
+++ b/google-cloud-phishing_protection/synth.py
@@ -95,6 +95,16 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-recaptcha_enterprise/README.md
+++ b/google-cloud-recaptcha_enterprise/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for reCAPTCHA Enterprise API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for reCAPTCHA Enterprise API
 
 [reCAPTCHA Enterprise API][Product Documentation]:
 

--- a/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise.rb
+++ b/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for reCAPTCHA Enterprise API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for reCAPTCHA Enterprise API
     #
     # [reCAPTCHA Enterprise API][Product Documentation]:
     #

--- a/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise/v1beta1.rb
+++ b/google-cloud-recaptcha_enterprise/lib/google/cloud/recaptcha_enterprise/v1beta1.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for reCAPTCHA Enterprise API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for reCAPTCHA Enterprise API
       #
       # [reCAPTCHA Enterprise API][Product Documentation]:
       #

--- a/google-cloud-recaptcha_enterprise/synth.py
+++ b/google-cloud-recaptcha_enterprise/synth.py
@@ -94,6 +94,16 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(
     'google-cloud-recaptcha_enterprise.gemspec',

--- a/google-cloud-redis/README.md
+++ b/google-cloud-redis/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Google Cloud Memorystore for Redis API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Google Cloud Memorystore for Redis API
 
 [Google Cloud Memorystore for Redis API][Product Documentation]:
 Creates and manages Redis instances on the Google Cloud Platform.

--- a/google-cloud-redis/lib/google/cloud/redis.rb
+++ b/google-cloud-redis/lib/google/cloud/redis.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Google Cloud Memorystore for Redis API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Google Cloud Memorystore for Redis API
     #
     # [Google Cloud Memorystore for Redis API][Product Documentation]:
     # Creates and manages Redis instances on the Google Cloud Platform.

--- a/google-cloud-redis/lib/google/cloud/redis/v1.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Google Cloud Memorystore for Redis API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Google Cloud Memorystore for Redis API
       #
       # [Google Cloud Memorystore for Redis API][Product Documentation]:
       # Creates and manages Redis instances on the Google Cloud Platform.

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Google Cloud Memorystore for Redis API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Google Cloud Memorystore for Redis API
       #
       # [Google Cloud Memorystore for Redis API][Product Documentation]:
       # Creates and manages Redis instances on the Google Cloud Platform.

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -102,6 +102,16 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [

--- a/google-cloud-scheduler/README.md
+++ b/google-cloud-scheduler/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud Scheduler API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud Scheduler API
 
 [Cloud Scheduler API][Product Documentation]:
 Creates and manages jobs run on a regular recurring schedule.

--- a/google-cloud-scheduler/lib/google/cloud/scheduler.rb
+++ b/google-cloud-scheduler/lib/google/cloud/scheduler.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud Scheduler API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud Scheduler API
     #
     # [Cloud Scheduler API][Product Documentation]:
     # Creates and manages jobs run on a regular recurring schedule.

--- a/google-cloud-scheduler/lib/google/cloud/scheduler/v1.rb
+++ b/google-cloud-scheduler/lib/google/cloud/scheduler/v1.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Scheduler API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Scheduler API
       #
       # [Cloud Scheduler API][Product Documentation]:
       # Creates and manages jobs run on a regular recurring schedule.

--- a/google-cloud-scheduler/lib/google/cloud/scheduler/v1beta1.rb
+++ b/google-cloud-scheduler/lib/google/cloud/scheduler/v1beta1.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Scheduler API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Scheduler API
       #
       # [Cloud Scheduler API][Product Documentation]:
       # Creates and manages jobs run on a regular recurring schedule.

--- a/google-cloud-scheduler/synth.py
+++ b/google-cloud-scheduler/synth.py
@@ -110,6 +110,16 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # TEMP: Re-add project_path helper which was earlier mistakenly generated but
 # is no longer. This helper method is likely unused, and we will remove it
 # when switching to the microgenerator.

--- a/google-cloud-security_center/README.md
+++ b/google-cloud-security_center/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud Security Command Center API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud Security Command Center API
 
 [Cloud Security Command Center API][Product Documentation]:
 Cloud Security Command Center API provides access to temporal views of

--- a/google-cloud-security_center/lib/google/cloud/security_center.rb
+++ b/google-cloud-security_center/lib/google/cloud/security_center.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud Security Command Center API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud Security Command Center API
     #
     # [Cloud Security Command Center API][Product Documentation]:
     # Cloud Security Command Center API provides access to temporal views of

--- a/google-cloud-security_center/lib/google/cloud/security_center/v1.rb
+++ b/google-cloud-security_center/lib/google/cloud/security_center/v1.rb
@@ -23,7 +23,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Security Command Center API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Security Command Center API
       #
       # [Cloud Security Command Center API][Product Documentation]:
       # Cloud Security Command Center API provides access to temporal views of

--- a/google-cloud-security_center/lib/google/cloud/security_center/v1p1beta1.rb
+++ b/google-cloud-security_center/lib/google/cloud/security_center/v1p1beta1.rb
@@ -24,7 +24,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Security Command Center API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Security Command Center API
       #
       # [Cloud Security Command Center API][Product Documentation]:
       # Cloud Security Command Center API provides access to temporal views of

--- a/google-cloud-security_center/synth.py
+++ b/google-cloud-security_center/synth.py
@@ -143,6 +143,16 @@ s.replace(
     ])
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database.rb
@@ -23,7 +23,7 @@ module Google
         # rubocop:disable LineLength
 
         ##
-        # # Ruby Client for Cloud Spanner Database Admin API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+        # # Ruby Client for Cloud Spanner Database Admin API
         #
         # [Cloud Spanner Database Admin API][Product Documentation]:
         #

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1.rb
@@ -24,7 +24,7 @@ module Google
           # rubocop:disable LineLength
 
           ##
-          # # Ruby Client for Cloud Spanner Database Admin API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+          # # Ruby Client for Cloud Spanner Database Admin API
           #
           # [Cloud Spanner Database Admin API][Product Documentation]:
           #

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb
@@ -23,7 +23,7 @@ module Google
         # rubocop:disable LineLength
 
         ##
-        # # Ruby Client for Cloud Spanner Instance Admin API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+        # # Ruby Client for Cloud Spanner Instance Admin API
         #
         # [Cloud Spanner Instance Admin API][Product Documentation]:
         #

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1.rb
@@ -24,7 +24,7 @@ module Google
           # rubocop:disable LineLength
 
           ##
-          # # Ruby Client for Cloud Spanner Instance Admin API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+          # # Ruby Client for Cloud Spanner Instance Admin API
           #
           # [Cloud Spanner Instance Admin API][Product Documentation]:
           #

--- a/google-cloud-spanner/synth.py
+++ b/google-cloud-spanner/synth.py
@@ -147,6 +147,13 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    'lib/google/cloud/**/*.rb',
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2196
 s.replace(
     [

--- a/google-cloud-speech/README.md
+++ b/google-cloud-speech/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud Speech-to-Text API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud Speech-to-Text API
 
 [Cloud Speech-to-Text API][Product Documentation]:
 Converts audio to text by applying powerful neural network models.

--- a/google-cloud-speech/lib/google/cloud/speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud Speech-to-Text API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud Speech-to-Text API
     #
     # [Cloud Speech-to-Text API][Product Documentation]:
     # Converts audio to text by applying powerful neural network models.

--- a/google-cloud-speech/lib/google/cloud/speech/v1.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1.rb
@@ -23,7 +23,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Speech-to-Text API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Speech-to-Text API
       #
       # [Cloud Speech-to-Text API][Product Documentation]:
       # Converts audio to text by applying powerful neural network models.

--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1.rb
@@ -23,7 +23,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Speech-to-Text API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Speech-to-Text API
       #
       # [Cloud Speech-to-Text API][Product Documentation]:
       # Converts audio to text by applying powerful neural network models.

--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -181,6 +181,16 @@ s.replace(
     ])
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2122
 s.replace(
     [

--- a/google-cloud-talent/README.md
+++ b/google-cloud-talent/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud Talent Solution API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud Talent Solution API
 
 [Cloud Talent Solution API][Product Documentation]:
 Cloud Talent Solution provides the capability to create, read, update, and

--- a/google-cloud-talent/lib/google/cloud/talent.rb
+++ b/google-cloud-talent/lib/google/cloud/talent.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud Talent Solution API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud Talent Solution API
     #
     # [Cloud Talent Solution API][Product Documentation]:
     # Cloud Talent Solution provides the capability to create, read, update, and

--- a/google-cloud-talent/lib/google/cloud/talent/v4beta1.rb
+++ b/google-cloud-talent/lib/google/cloud/talent/v4beta1.rb
@@ -30,7 +30,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Talent Solution API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Talent Solution API
       #
       # [Cloud Talent Solution API][Product Documentation]:
       # Cloud Talent Solution provides the capability to create, read, update, and

--- a/google-cloud-talent/synth.py
+++ b/google-cloud-talent/synth.py
@@ -109,6 +109,17 @@ s.replace(
         '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
     ])
 )
+
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
     'lib/google/cloud/talent/*/*_client.rb',

--- a/google-cloud-tasks/README.md
+++ b/google-cloud-tasks/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud Tasks API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud Tasks API
 
 [Cloud Tasks API][Product Documentation]:
 Manages the execution of large numbers of distributed requests.

--- a/google-cloud-tasks/lib/google/cloud/tasks.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud Tasks API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud Tasks API
     #
     # [Cloud Tasks API][Product Documentation]:
     # Manages the execution of large numbers of distributed requests.

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Tasks API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Tasks API
       #
       # [Cloud Tasks API][Product Documentation]:
       # Manages the execution of large numbers of distributed requests.

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Tasks API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Tasks API
       #
       # [Cloud Tasks API][Product Documentation]:
       # Manages the execution of large numbers of distributed requests.

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta3.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta3.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Tasks API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Tasks API
       #
       # [Cloud Tasks API][Product Documentation]:
       # Manages the execution of large numbers of distributed requests.

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -111,6 +111,16 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-text_to_speech/README.md
+++ b/google-cloud-text_to_speech/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud Text-to-Speech API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud Text-to-Speech API
 
 [Cloud Text-to-Speech API][Product Documentation]:
 Synthesizes natural-sounding speech by applying powerful neural network

--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud Text-to-Speech API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud Text-to-Speech API
     #
     # [Cloud Text-to-Speech API][Product Documentation]:
     # Synthesizes natural-sounding speech by applying powerful neural network

--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Text-to-Speech API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Text-to-Speech API
       #
       # [Cloud Text-to-Speech API][Product Documentation]:
       # Synthesizes natural-sounding speech by applying powerful neural network

--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1beta1.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Text-to-Speech API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Text-to-Speech API
       #
       # [Cloud Text-to-Speech API][Product Documentation]:
       # Synthesizes natural-sounding speech by applying powerful neural network

--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -108,6 +108,17 @@ s.replace(
         '  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"'
     ])
 )
+
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
     'lib/google/cloud/text_to_speech/*/*_client.rb',

--- a/google-cloud-trace/lib/google/cloud/trace/v2.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2.rb
@@ -20,7 +20,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Stackdriver Trace API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Stackdriver Trace API
     #
     # [Stackdriver Trace API][Product Documentation]:
     # Sends application trace data to Stackdriver Trace for viewing. Trace data is

--- a/google-cloud-trace/synth.py
+++ b/google-cloud-trace/synth.py
@@ -82,6 +82,13 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    'lib/google/cloud/**/*.rb',
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2124
 s.replace(
     [

--- a/google-cloud-translate/lib/google/cloud/translate/v3.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/v3.rb
@@ -20,7 +20,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Translation API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Translation API
       #
       # [Cloud Translation API][Product Documentation]:
       # Integrates text translation into your website or application.

--- a/google-cloud-translate/synth.py
+++ b/google-cloud-translate/synth.py
@@ -92,6 +92,13 @@ s.replace(
     'port = service_port || self.class::DEFAULT_SERVICE_PORT'
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    'lib/google/cloud/**/*.rb',
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
     expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')

--- a/google-cloud-video_intelligence/README.md
+++ b/google-cloud-video_intelligence/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud Video Intelligence API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud Video Intelligence API
 
 [Cloud Video Intelligence API][Product Documentation]:
 Detects objects, explicit content, and scene changes in videos. It also

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud Video Intelligence API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud Video Intelligence API
     #
     # [Cloud Video Intelligence API][Product Documentation]:
     # Detects objects, explicit content, and scene changes in videos. It also

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1.rb
@@ -22,7 +22,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Video Intelligence API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Video Intelligence API
       #
       # [Cloud Video Intelligence API][Product Documentation]:
       # Detects objects, explicit content, and scene changes in videos. It also

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
@@ -23,7 +23,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Google Cloud Video Intelligence API ([GA](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Google Cloud Video Intelligence API
       #
       # [Google Cloud Video Intelligence API][Product Documentation]:
       # Detects objects, explicit content, and scene changes in videos. It also

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p1beta1.rb
@@ -23,7 +23,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Video Intelligence API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Video Intelligence API
       #
       # [Cloud Video Intelligence API][Product Documentation]:
       # Detects objects, explicit content, and scene changes in videos. It also

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1p2beta1.rb
@@ -23,7 +23,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Video Intelligence API ([Beta](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Video Intelligence API
       #
       # [Cloud Video Intelligence API][Product Documentation]:
       # Detects objects, explicit content, and scene changes in videos. It also

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -146,6 +146,16 @@ s.replace(
     ],
     '/video-intelligence\\.googleapis\\.com', '/videointelligence.googleapis.com')
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2232
 s.replace(
     [

--- a/google-cloud-vision/README.md
+++ b/google-cloud-vision/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Cloud Vision API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Cloud Vision API
 
 [Cloud Vision API][Product Documentation]:
 Integrates Google Vision features, including image labeling, face, logo,

--- a/google-cloud-vision/lib/google/cloud/vision.rb
+++ b/google-cloud-vision/lib/google/cloud/vision.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud Vision API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud Vision API
     #
     # [Cloud Vision API][Product Documentation]:
     # Integrates Google Vision features, including image labeling, face, logo,

--- a/google-cloud-vision/lib/google/cloud/vision/v1.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1.rb
@@ -25,7 +25,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Vision API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Vision API
       #
       # [Cloud Vision API][Product Documentation]:
       # Integrates Google Vision features, including image labeling, face, logo,

--- a/google-cloud-vision/lib/google/cloud/vision/v1p3beta1.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1p3beta1.rb
@@ -25,7 +25,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Cloud Vision API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Cloud Vision API
       #
       # [Cloud Vision API][Product Documentation]:
       # Integrates Google Vision features, including image labeling, face, logo, and

--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -119,6 +119,16 @@ s.replace(
     ])
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # PERMANENT: Add migration guide to docs
 s.replace(
     'lib/google/cloud/vision.rb',

--- a/google-cloud-webrisk/README.md
+++ b/google-cloud-webrisk/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Web Risk API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Web Risk API
 
 [Web Risk API][Product Documentation]:
 

--- a/google-cloud-webrisk/lib/google/cloud/webrisk.rb
+++ b/google-cloud-webrisk/lib/google/cloud/webrisk.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Web Risk API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+    # # Ruby Client for Web Risk API
     #
     # [Web Risk API][Product Documentation]:
     #

--- a/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1.rb
+++ b/google-cloud-webrisk/lib/google/cloud/webrisk/v1beta1.rb
@@ -21,7 +21,7 @@ module Google
       # rubocop:disable LineLength
 
       ##
-      # # Ruby Client for Web Risk API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+      # # Ruby Client for Web Risk API
       #
       # [Web Risk API][Product Documentation]:
       #

--- a/google-cloud-webrisk/synth.py
+++ b/google-cloud-webrisk/synth.py
@@ -100,6 +100,16 @@ s.replace(
     ])
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # https://github.com/googleapis/gapic-generator/issues/2243
 s.replace(
     f'lib/google/cloud/webrisk/v1beta1/*_client.rb',

--- a/grafeas-client/README.md
+++ b/grafeas-client/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Container Analysis API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Container Analysis API
 
 [Container Analysis API][Product Documentation]:
 An implementation of the Grafeas API, which stores, and enables querying and

--- a/grafeas/README.md
+++ b/grafeas/README.md
@@ -1,4 +1,4 @@
-# Ruby Client for Container Analysis API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# Ruby Client for Container Analysis API
 
 [Container Analysis API][Product Documentation]:
 An implementation of the Grafeas API, which stores, and enables querying and

--- a/grafeas/lib/grafeas.rb
+++ b/grafeas/lib/grafeas.rb
@@ -19,7 +19,7 @@ require "pathname"
 # rubocop:disable LineLength
 
 ##
-# # Ruby Client for Container Analysis API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+# # Ruby Client for Container Analysis API
 #
 # [Container Analysis API][Product Documentation]:
 # An implementation of the Grafeas API, which stores, and enables querying and

--- a/grafeas/lib/grafeas/v1.rb
+++ b/grafeas/lib/grafeas/v1.rb
@@ -19,7 +19,7 @@ module Grafeas
   # rubocop:disable LineLength
 
   ##
-  # # Ruby Client for Container Analysis API ([Alpha](https://github.com/googleapis/google-cloud-ruby#versioning))
+  # # Ruby Client for Container Analysis API
   #
   # [Container Analysis API][Product Documentation]:
   # An implementation of the Grafeas API, which stores, and enables querying and

--- a/grafeas/synth.py
+++ b/grafeas/synth.py
@@ -130,6 +130,16 @@ s.replace(
     ])
 )
 
+# Remove legacy release level from documentation
+s.replace(
+    [
+        'README.md',
+        'lib/google/cloud/**/*.rb'
+    ],
+    '\\s+\\(\\[\\w+\\]\\(https://github\\.com/(googleapis|GoogleCloudPlatform)/google-cloud-ruby#versioning\\)\\)',
+    ''
+)
+
 # Fix for tests that assume protos implement to_hash
 s.replace(
     'test/grafeas/v1/grafeas_client_test.rb',


### PR DESCRIPTION
We've been asked to remove the alpha/beta/ga labels from clients because they are confusing to users (e.g. client library release level vs service release level). From this point, the library version (0.x vs post-1.0) will indicate release quality.

(Furthermore, we have also been asked to move existing libraries towards GA, i.e. 1.0, as quickly as possible. I've pushed back on this step until we have the microgenerator stable and libraries migrated to it.)

This PR:

* Removes release level labels from the client library lists in the toplevel README, and updates the section explaining library versioning. (Also adds entries for libraries we added recently and forgot to add to the README.)
* Removes release level labels from library READMEs and yardocs.
* Updates synth scripts to remove those labels from generated files.