### PR TITLE
fix(env): support faraday 1.x

### DIFF
--- a/google-cloud-env/google-cloud-env.gemspec
+++ b/google-cloud-env/google-cloud-env.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "faraday", "~> 0.11"
+  gem.add_dependency "faraday", ">= 0.17.3", "< 2.0"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "google-style", "~> 1.24.0"


### PR DESCRIPTION
Faraday 1.0 was released in January. This expands the dependency to allow the latest 0.x version and all 1.x versions. See also https://github.com/googleapis/signet/pull/159 and https://github.com/googleapis/google-auth-library-ruby/pull/252 for related upstream changes.