### PR TITLE
fix(translate): support faraday 1.x

### DIFF
--- a/google-cloud-translate/google-cloud-translate.gemspec
+++ b/google-cloud-translate/google-cloud-translate.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
     https://googleapis.dev/ruby/google-cloud-translate/v2.0.0/file.CHANGELOG.html#2_0_0___2019-10-28
   POSTINSTALL
 
-  gem.add_dependency "faraday", "~> 0.13"
+  gem.add_dependency "faraday", ">= 0.17.3", "< 2.0"
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "google-gax", "~> 1.8"
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"


### PR DESCRIPTION
Faraday 1.0 was released in January. This expands the dependency to allow the latest 0.x version and all 1.x versions. See also https://github.com/googleapis/signet/pull/159 and https://github.com/googleapis/google-auth-library-ruby/pull/252 for related upstream changes.