### PR TITLE
Support Ruby 2.8 keyword arguments for google-cloud-storage

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1269,7 +1269,7 @@ module Google
           path ||= file if file.is_a? String
           raise ArgumentError, "must provide path" if path.nil?
 
-          gapi = service.insert_file name, file, path, options
+          gapi = service.insert_file name, file, path, **options
           File.from_gapi gapi, service, user_project: user_project
         end
         alias upload_file create_file
@@ -1379,7 +1379,7 @@ module Google
             updater.check_for_changed_metadata!
           end
           gapi = service.compose_file name, sources, destination,
-                                      destination_gapi, options
+                                      destination_gapi, **options
           File.from_gapi gapi, service, user_project: user_project
         end
         alias compose_file compose
@@ -2163,7 +2163,7 @@ module Google
                       prefix: prefix, payload: payload,
                       user_project: user_project }
 
-          gapi = service.insert_notification name, topic, options
+          gapi = service.insert_notification name, topic, **options
           Notification.from_gapi name, gapi, service, user_project: user_project
         end
         alias new_notification create_notification
@@ -2249,7 +2249,7 @@ module Google
           patch_args = Hash[attributes.map do |attr|
             [attr, @gapi.send(attr)]
           end]
-          patch_gapi = API::Bucket.new patch_args
+          patch_gapi = API::Bucket.new **patch_args
           @gapi = service.patch_bucket name, patch_gapi,
                                        user_project: user_project
           @lazy = nil

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -1766,7 +1766,7 @@ module Google
           # Sending nil metadata results in an Apiary runtime error:
           # NoMethodError: undefined method `each' for nil:NilClass
           attr_params.reject! { |k, v| k == :metadata && v.nil? }
-          Google::Apis::StorageV1::Object.new **attr_params
+          Google::Apis::StorageV1::Object.new(**attr_params)
         end
 
         protected

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -1766,7 +1766,7 @@ module Google
           # Sending nil metadata results in an Apiary runtime error:
           # NoMethodError: undefined method `each' for nil:NilClass
           attr_params.reject! { |k, v| k == :metadata && v.nil? }
-          Google::Apis::StorageV1::Object.new attr_params
+          Google::Apis::StorageV1::Object.new **attr_params
         end
 
         protected
@@ -1817,12 +1817,12 @@ module Google
                       user_project: user_project }.delete_if { |_k, v| v.nil? }
 
           resp = service.rewrite_file \
-            bucket, name, new_bucket, new_name, updated_gapi, options
+            bucket, name, new_bucket, new_name, updated_gapi, **options
           until resp.done
             sleep 1
             retry_options = options.merge token: resp.rewrite_token
             resp = service.rewrite_file \
-              bucket, name, new_bucket, new_name, updated_gapi, retry_options
+              bucket, name, new_bucket, new_name, updated_gapi, **retry_options
           end
           resp.resource
         end

--- a/google-cloud-storage/lib/google/cloud/storage/file/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/list.rb
@@ -81,7 +81,7 @@ module Google
               prefix: @prefix, delimiter: @delimiter, token: @token, max: @max,
               versions: @versions, user_project: @user_project
             }
-            gapi = @service.list_files @bucket, options
+            gapi = @service.list_files @bucket, **options
             File::List.from_gapi gapi, @service, @bucket, @prefix,
                                  @delimiter, @max, @versions,
                                  user_project: @user_project

--- a/google-cloud-storage/lib/google/cloud/storage/file/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/list.rb
@@ -77,11 +77,13 @@ module Google
           def next
             return nil unless next?
             ensure_service!
-            options = {
-              prefix: @prefix, delimiter: @delimiter, token: @token, max: @max,
-              versions: @versions, user_project: @user_project
-            }
-            gapi = @service.list_files @bucket, **options
+
+            gapi = @service.list_files @bucket, prefix: @prefix,
+                                                delimiter: @delimiter,
+                                                token: @token,
+                                                max: @max,
+                                                versions: @versions,
+                                                user_project: @user_project
             File::List.from_gapi gapi, @service, @bucket, @prefix,
                                  @delimiter, @max, @versions,
                                  user_project: @user_project

--- a/google-cloud-storage/lib/google/cloud/storage/policy/binding.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy/binding.rb
@@ -230,11 +230,12 @@ module Google
           ##
           # @private
           def to_gapi
-            Google::Apis::StorageV1::Policy::Binding.new({
+            params = {
               role: @role,
               members: @members,
               condition: @condition&.to_gapi
-            }.delete_if { |_, v| v.nil? })
+            }.delete_if { |_, v| v.nil? }
+            Google::Apis::StorageV1::Policy::Binding.new(**params)
           end
         end
       end

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -357,10 +357,11 @@ module Google
                           logging_bucket: nil, logging_prefix: nil,
                           website_main: nil, website_404: nil, versioning: nil,
                           requester_pays: nil, user_project: nil
-          new_bucket = Google::Apis::StorageV1::Bucket.new({
+          params = {
             name: bucket_name,
             location: location
-          }.delete_if { |_, v| v.nil? })
+          }.delete_if { |_, v| v.nil? }
+          new_bucket = Google::Apis::StorageV1::Bucket.new(**params)
           storage_class = storage_class_for storage_class
           updater = Bucket::Updater.new(new_bucket).tap do |b|
             b.logging_bucket = logging_bucket unless logging_bucket.nil?

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -152,9 +152,8 @@ module Google
         ##
         # Creates a new bucket ACL.
         def insert_bucket_acl bucket_name, entity, role, user_project: nil
-          new_acl = Google::Apis::StorageV1::BucketAccessControl.new(
-            { entity: entity, role: role }.delete_if { |_k, v| v.nil? }
-          )
+          params = { entity: entity, role: role }.delete_if { |_k, v| v.nil? }
+          new_acl = Google::Apis::StorageV1::BucketAccessControl.new(**params)
           execute do
             service.insert_bucket_access_control \
               bucket_name, new_acl, user_project: user_project(user_project)
@@ -182,9 +181,8 @@ module Google
         ##
         # Creates a new default ACL.
         def insert_default_acl bucket_name, entity, role, user_project: nil
-          new_acl = Google::Apis::StorageV1::ObjectAccessControl.new(
-            { entity: entity, role: role }.delete_if { |_k, v| v.nil? }
-          )
+          param  = { entity: entity, role: role }.delete_if { |_k, v| v.nil? }
+          new_acl = Google::Apis::StorageV1::ObjectAccessControl.new(**param)
           execute do
             service.insert_default_object_access_control \
               bucket_name, new_acl, user_project: user_project(user_project)
@@ -243,13 +241,13 @@ module Google
         def insert_notification bucket_name, topic_name, custom_attrs: nil,
                                 event_types: nil, prefix: nil, payload: nil,
                                 user_project: nil
-          new_notification = Google::Apis::StorageV1::Notification.new(
+          params =
             { custom_attributes: custom_attrs,
               event_types: event_types(event_types),
               object_name_prefix: prefix,
               payload_format: payload_format(payload),
               topic: topic_path(topic_name) }.delete_if { |_k, v| v.nil? }
-          )
+          new_notification = Google::Apis::StorageV1::Notification.new(**params)
 
           execute do
             service.insert_notification \
@@ -298,14 +296,14 @@ module Google
                         storage_class: nil, key: nil, kms_key: nil,
                         temporary_hold: nil, event_based_hold: nil,
                         user_project: nil
-          file_obj = Google::Apis::StorageV1::Object.new(
+          params =
             { cache_control: cache_control, content_type: content_type,
               content_disposition: content_disposition, md5_hash: md5,
               content_encoding: content_encoding, crc32c: crc32c,
               content_language: content_language, metadata: metadata,
               storage_class: storage_class, temporary_hold: temporary_hold,
               event_based_hold: event_based_hold }.delete_if { |_k, v| v.nil? }
-          )
+          file_obj = Google::Apis::StorageV1::Object.new(**params)
           content_type ||= mime_type_for(path || Pathname(source).to_path)
 
           execute do
@@ -432,9 +430,8 @@ module Google
         # Creates a new file ACL.
         def insert_file_acl bucket_name, file_name, entity, role,
                             generation: nil, user_project: nil
-          new_acl = Google::Apis::StorageV1::ObjectAccessControl.new(
-            { entity: entity, role: role }.delete_if { |_k, v| v.nil? }
-          )
+          params = { entity: entity, role: role }.delete_if { |_k, v| v.nil? }
+          new_acl = Google::Apis::StorageV1::ObjectAccessControl.new(**params)
           execute do
             service.insert_object_access_control \
               bucket_name, file_name, new_acl,

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -181,7 +181,7 @@ module Google
         ##
         # Creates a new default ACL.
         def insert_default_acl bucket_name, entity, role, user_project: nil
-          param  = { entity: entity, role: role }.delete_if { |_k, v| v.nil? }
+          param = { entity: entity, role: role }.delete_if { |_k, v| v.nil? }
           new_acl = Google::Apis::StorageV1::ObjectAccessControl.new(**param)
           execute do
             service.insert_default_object_access_control \

--- a/google-cloud-storage/test/google/cloud/storage/bucket_encryption_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_encryption_test.rb
@@ -133,12 +133,13 @@ describe Google::Cloud::Storage::Bucket, :encryption, :mock_storage do
                       content_encoding: nil, content_language: nil,
                       content_type: nil, crc32c: nil, md5: nil, metadata: nil,
                       storage_class: nil
-    Google::Apis::StorageV1::Object.new({
+    params = {
       cache_control: cache_control, content_type: content_type,
       content_disposition: content_disposition, md5_hash: md5,
       content_encoding: content_encoding, crc32c: crc32c,
       content_language: content_language, metadata: metadata,
-      storage_class: storage_class }.delete_if { |_k, v| v.nil? })
+      storage_class: storage_class }.delete_if { |_k, v| v.nil? }
+    Google::Apis::StorageV1::Object.new(**params)
   end
 
   def find_file_gapi bucket=nil, name = nil

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -285,11 +285,11 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi(options), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: options[:content_encoding], content_type: options[:content_type], kms_key_name: nil, user_project: nil, options: {}]
+        [bucket.name, empty_file_gapi(**options), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: options[:content_encoding], content_type: options[:content_type], kms_key_name: nil, user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
 
-      bucket.create_file tmpfile, new_file_name, options
+      bucket.create_file tmpfile, new_file_name, **options
 
       mock.verify
     end
@@ -1086,13 +1086,14 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
                       content_type: nil, crc32c: nil, md5: nil, metadata: nil,
                       storage_class: nil, temporary_hold: nil,
                       event_based_hold: nil
-    Google::Apis::StorageV1::Object.new({
+    params = {
       cache_control: cache_control, content_type: content_type,
       content_disposition: content_disposition, md5_hash: md5,
       content_encoding: content_encoding, crc32c: crc32c,
       content_language: content_language, metadata: metadata,
       storage_class: storage_class, temporary_hold: temporary_hold,
-      event_based_hold: event_based_hold }.delete_if { |_k, v| v.nil? })
+      event_based_hold: event_based_hold }.delete_if { |_k, v| v.nil? }
+    Google::Apis::StorageV1::Object.new(**params)
   end
 
   def find_file_gapi bucket=nil, name = nil

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
@@ -240,11 +240,11 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi(options), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: options[:content_encoding], content_type: options[:content_type], kms_key_name: nil, user_project: nil, options: {}]
+        [bucket.name, empty_file_gapi(**options), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: options[:content_encoding], content_type: options[:content_type], kms_key_name: nil, user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
 
-      bucket.create_file tmpfile, new_file_name, options
+      bucket.create_file tmpfile, new_file_name, **options
 
       mock.verify
     end
@@ -1039,12 +1039,13 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
                       content_encoding: nil, content_language: nil,
                       content_type: nil, crc32c: nil, md5: nil, metadata: nil,
                       storage_class: nil
-    Google::Apis::StorageV1::Object.new({
+    params = {
       cache_control: cache_control, content_type: content_type,
       content_disposition: content_disposition, md5_hash: md5,
       content_encoding: content_encoding, crc32c: crc32c,
       content_language: content_language, metadata: metadata,
-      storage_class: storage_class }.delete_if { |_k, v| v.nil? })
+      storage_class: storage_class }.delete_if { |_k, v| v.nil? }
+    Google::Apis::StorageV1::Object.new(**params)
   end
 
   def find_file_gapi bucket=nil, name = nil

--- a/google-cloud-storage/test/google/cloud/storage/project_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Storage::Project, :mock_storage do
                          origin: ["http://example.org", "https://example.org"],
                          http_method: ["*"],
                          response_header: ["X-My-Custom-Header"] }] }
-  let(:bucket_cors_gapi) { bucket_cors.map { |c| Google::Apis::StorageV1::Bucket::CorsConfiguration.new c } }
+  let(:bucket_cors_gapi) { bucket_cors.map { |c| Google::Apis::StorageV1::Bucket::CorsConfiguration.new **c } }
   let(:kms_key) { "path/to/encryption_key_name" }
   let(:bucket_retention_period) { 86400 }
 
@@ -765,7 +765,7 @@ describe Google::Cloud::Storage::Project, :mock_storage do
       versioning: versioning, logging: logging, website: website,
       cors_configurations: cors, billing: billing, lifecycle: lifecycle
     }.delete_if { |_, v| v.nil? }
-    Google::Apis::StorageV1::Bucket.new options
+    Google::Apis::StorageV1::Bucket.new **options
   end
 
   def find_bucket_gapi name = nil


### PR DESCRIPTION
This pull request supports Ruby 2.8 keyword arguments for google-cloud-storage

[Fully separate positional arguments and keyword arguments](https://github.com/ruby/ruby/pull/2794) support is required to use google-cloud-storage gem with currently developed Ruby 2.8.0-dev.

### Note
* `test/google/cloud/storage_test.rb` failure will be addressed once the newer version of minitest is released including [If a callable mock includes kwargs, Ruby 2.7 warns](https://github.com/seattlerb/minitest/pull/824)

* Workaround to force install grpc gem Refer https://github.com/grpc/grpc/issues/21514#issuecomment-581417788
Note: This commit must be reverted once the newer version of grpc is released to rubygems.org including https://github.com/grpc/grpc/pull/22039