### PR TITLE
Bump Rake version to prepare Ruby 3 keyword arguments support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rake", "~> 12.3"
+gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"

--- a/gcloud/Gemfile
+++ b/gcloud/Gemfile
@@ -43,7 +43,7 @@ gem "google-cloud-video_intelligence",
 gem "google-cloud-vision", path: "../google-cloud-vision"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-bigquery-data_transfer/Gemfile
+++ b/google-cloud-bigquery-data_transfer/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -8,7 +8,7 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-bigtable/Gemfile
+++ b/google-cloud-bigtable/Gemfile
@@ -7,7 +7,7 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-billing/Gemfile
+++ b/google-cloud-billing/Gemfile
@@ -7,7 +7,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-container/Gemfile
+++ b/google-cloud-container/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -7,7 +7,7 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "google-gax", "~> 1.0"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-dataproc/Gemfile
+++ b/google-cloud-dataproc/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -6,7 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -8,7 +8,7 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-dialogflow/Gemfile
+++ b/google-cloud-dialogflow/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-dlp/Gemfile
+++ b/google-cloud-dlp/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-dns/Gemfile
+++ b/google-cloud-dns/Gemfile
@@ -6,7 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-env/Gemfile
+++ b/google-cloud-env/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-error_reporting/Gemfile
+++ b/google-cloud-error_reporting/Gemfile
@@ -7,7 +7,7 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-errors/Gemfile
+++ b/google-cloud-errors/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem "google-api-client", "~> 0.36"
 gem "google-gax", "~> 1.8"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-firestore/Gemfile
+++ b/google-cloud-firestore/Gemfile
@@ -6,7 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 gem "stackprof" unless Gem.win_platform?
 

--- a/google-cloud-language/Gemfile
+++ b/google-cloud-language/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -10,7 +10,7 @@ gem "google-cloud-storage", path: "../google-cloud-storage"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-monitoring/Gemfile
+++ b/google-cloud-monitoring/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-os_login/Gemfile
+++ b/google-cloud-os_login/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -7,7 +7,7 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-recommender/Gemfile
+++ b/google-cloud-recommender/Gemfile
@@ -7,7 +7,7 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "google-cloud-recommender-v1", path: "../google-cloud-recommender-v1"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-redis/Gemfile
+++ b/google-cloud-redis/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-resource_manager/Gemfile
+++ b/google-cloud-resource_manager/Gemfile
@@ -6,7 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-secret_manager/Gemfile
+++ b/google-cloud-secret_manager/Gemfile
@@ -7,7 +7,7 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "google-cloud-secret_manager-v1beta1", path: "../google-cloud-secret_manager-v1beta1"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-security_center/Gemfile
+++ b/google-cloud-security_center/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -6,7 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-speech/Gemfile
+++ b/google-cloud-speech/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -8,7 +8,7 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "google-cloud-pubsub", path: "../google-cloud-pubsub"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-tasks/Gemfile
+++ b/google-cloud-tasks/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-text_to_speech/Gemfile
+++ b/google-cloud-text_to_speech/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-trace/Gemfile
+++ b/google-cloud-trace/Gemfile
@@ -7,7 +7,7 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-translate/Gemfile
+++ b/google-cloud-translate/Gemfile
@@ -6,7 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-video_intelligence/Gemfile
+++ b/google-cloud-video_intelligence/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud-vision/Gemfile
+++ b/google-cloud-vision/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/google-cloud/Gemfile
+++ b/google-cloud/Gemfile
@@ -42,7 +42,7 @@ gem "google-cloud-video_intelligence",
 gem "google-cloud-vision", path: "../google-cloud-vision"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/stackdriver-core/Gemfile
+++ b/stackdriver-core/Gemfile
@@ -6,7 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110

--- a/stackdriver/Gemfile
+++ b/stackdriver/Gemfile
@@ -11,7 +11,7 @@ gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "google-cloud-trace", path: "../google-cloud-trace"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake", "~> 12.3"
+gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110


### PR DESCRIPTION
Related to #4884

To prepare Ruby 3 keyword arguments support, there are some other gems also need update. `rake` is one of them.

* Rake 13.0.0 supports Ruby 3 keyword arguments by https://github.com/ruby/rake/pull/326
* Rake 13 drops Ruby 2.1 or older support by https://github.com/ruby/rake/pull/325
* Gems under `google-cloud-ruby` repository only support Ruby 2.4 or higher then dropping Ruby 2.1 support should not be an issue.

I have bumped all of Rake under `google-cloud-ruby` repository.