### PR TITLE
feat(pubsub): Rename Subscriber methods and alias deprecated originals

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -340,10 +340,11 @@ module Google
         def coerce_inventory inventory
           @inventory = inventory
           if @inventory.is_a? Hash
+            @inventory = @inventory.dup
             # Support deprecated field names
-            @inventory[:max_outstanding_messages] = @inventory[:limit] if @inventory[:limit]
-            @inventory[:max_outstanding_bytes] = @inventory[:bytesize] if @inventory[:bytesize]
-            @inventory[:max_total_lease_duration] = @inventory[:extension] if @inventory[:extension]
+            @inventory[:max_outstanding_messages] ||= @inventory.delete :limit
+            @inventory[:max_outstanding_bytes] ||= @inventory.delete :bytesize
+            @inventory[:max_total_lease_duration] ||= @inventory.delete :extension
           else
             @inventory = { max_outstanding_messages: @inventory }
           end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -693,11 +693,12 @@ module Google
         #
         #   Hash keys and values may include the following:
         #
-        #     * `:limit` (Integer) The number of received messages to be collected by subscriber. Default is 1,000.
-        #     * `:bytesize` (Integer) The total bytesize of received messages to be collected by subscriber. Default is
-        #       100,000,000 (100MB).
-        #     * `:extension` (Integer) The number of seconds that received messages can be held awaiting processing.
-        #       Default is 3,600 (1 hour).
+        #     * `:max_outstanding_messages` (or `:limit`) [Integer] The number of received messages to be collected by
+        #       subscriber. Default is 1,000.
+        #     * `:max_outstanding_bytes` (or `:bytesize`) [Integer] The total byte size of received messages to be
+        #       collected by subscriber. Default is 100,000,000 (100MB).
+        #     * `:max_total_lease_duration` (or `:extension`) [Integer] The number of seconds that received messages can
+        #       be held awaiting processing. Default is 3,600 (1 hour).
         # @param [Hash] threads The number of threads to create to handle
         #   concurrent calls by each stream opened by the subscriber. Optional.
         #

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -693,12 +693,12 @@ module Google
         #
         #   Hash keys and values may include the following:
         #
-        #     * `:max_outstanding_messages` (or `:limit`) [Integer] The number of received messages to be collected by
-        #       subscriber. Default is 1,000.
-        #     * `:max_outstanding_bytes` (or `:bytesize`) [Integer] The total byte size of received messages to be
-        #       collected by subscriber. Default is 100,000,000 (100MB).
-        #     * `:max_total_lease_duration` (or `:extension`) [Integer] The number of seconds that received messages can
-        #       be held awaiting processing. Default is 3,600 (1 hour).
+        #     * `:max_outstanding_messages` [Integer] The number of received messages to be collected by subscriber.
+        #       Default is 1,000. (Note: replaces `:limit`, which is deprecated.)
+        #     * `:max_outstanding_bytes` [Integer] The total byte size of received messages to be collected by
+        #       subscriber. Default is 100,000,000 (100MB). (Note: replaces `:bytesize`, which is deprecated.)
+        #     * `:max_total_lease_duration` [Integer] The number of seconds that received messages can be held awaiting
+        #       processing. Default is 3,600 (1 hour). (Note: replaces `:extension`, which is deprecated.)
         # @param [Hash] threads The number of threads to create to handle
         #   concurrent calls by each stream opened by the subscriber. Optional.
         #

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -32,8 +32,11 @@ describe Google::Cloud::PubSub::Subscriber, :mock_pubsub do
     subscriber.streams.must_equal streams
     subscriber.inventory.must_equal inventory
     subscriber.inventory_limit.must_equal inventory
+    subscriber.max_outstanding_messages.must_equal inventory
     subscriber.inventory_bytesize.must_equal 100_000_000
+    subscriber.max_outstanding_bytes.must_equal 100_000_000
     subscriber.inventory_extension.must_equal 3600
+    subscriber.max_total_lease_duration.must_equal 3600
     subscriber.stream_inventory.must_equal({limit: 250, bytesize: 12500000, extension: 3600})
     subscriber.callback_threads.must_equal callback_threads
     subscriber.push_threads.must_equal push_threads

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
@@ -31,8 +31,11 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.streams.must_equal 2
     subscriber.inventory.must_equal 1000
     subscriber.inventory_limit.must_equal 1000
+    subscriber.max_outstanding_messages.must_equal 1000
     subscriber.inventory_bytesize.must_equal 100000000
+    subscriber.max_outstanding_bytes.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
+    subscriber.max_total_lease_duration.must_equal 3600
   end
 
   it "will set deadline while creating a Subscriber" do
@@ -45,8 +48,11 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.streams.must_equal 2
     subscriber.inventory.must_equal 1000
     subscriber.inventory_limit.must_equal 1000
+    subscriber.max_outstanding_messages.must_equal 1000
     subscriber.inventory_bytesize.must_equal 100000000
+    subscriber.max_outstanding_bytes.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
+    subscriber.max_total_lease_duration.must_equal 3600
   end
 
   it "will set deadline while creating a Subscriber" do
@@ -59,8 +65,11 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.streams.must_equal 2
     subscriber.inventory.must_equal 1000
     subscriber.inventory_limit.must_equal 1000
+    subscriber.max_outstanding_messages.must_equal 1000
     subscriber.inventory_bytesize.must_equal 100000000
+    subscriber.max_outstanding_bytes.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
+    subscriber.max_total_lease_duration.must_equal 3600
   end
 
   it "will set inventory (deprecated) while creating a Subscriber" do
@@ -73,11 +82,31 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.streams.must_equal 2
     subscriber.inventory.must_equal 500
     subscriber.inventory_limit.must_equal 500
+    subscriber.max_outstanding_messages.must_equal 500
     subscriber.inventory_bytesize.must_equal 100000000
+    subscriber.max_outstanding_bytes.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
+    subscriber.max_total_lease_duration.must_equal 3600
   end
 
-  it "will set inventory while creating a Subscriber" do
+  it "will set inventory max_outstanding_messages while creating a Subscriber" do
+    subscriber = subscription.listen(inventory: { max_outstanding_messages: 500 }) do |msg|
+      puts msg.msg_id
+    end
+    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
+    subscriber.subscription_name.must_equal subscription.name
+    subscriber.deadline.must_equal 60
+    subscriber.streams.must_equal 2
+    subscriber.inventory.must_equal 500
+    subscriber.inventory_limit.must_equal 500
+    subscriber.max_outstanding_messages.must_equal 500
+    subscriber.inventory_bytesize.must_equal 100000000
+    subscriber.max_outstanding_bytes.must_equal 100000000
+    subscriber.inventory_extension.must_equal 3600
+    subscriber.max_total_lease_duration.must_equal 3600
+  end
+
+  it "will set inventory limit alias while creating a Subscriber" do
     subscriber = subscription.listen(inventory: { limit: 500 }) do |msg|
       puts msg.msg_id
     end
@@ -87,11 +116,31 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.streams.must_equal 2
     subscriber.inventory.must_equal 500
     subscriber.inventory_limit.must_equal 500
+    subscriber.max_outstanding_messages.must_equal 500
     subscriber.inventory_bytesize.must_equal 100000000
+    subscriber.max_outstanding_bytes.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
+    subscriber.max_total_lease_duration.must_equal 3600
   end
 
-  it "will set inventory while creating a Subscriber" do
+  it "will set inventory max_outstanding_bytes while creating a Subscriber" do
+    subscriber = subscription.listen(inventory: { max_outstanding_bytes: 50_000 }) do |msg|
+      puts msg.msg_id
+    end
+    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
+    subscriber.subscription_name.must_equal subscription.name
+    subscriber.deadline.must_equal 60
+    subscriber.streams.must_equal 2
+    subscriber.inventory.must_equal 1000
+    subscriber.inventory_limit.must_equal 1000
+    subscriber.max_outstanding_messages.must_equal 1000
+    subscriber.inventory_bytesize.must_equal 50_000
+    subscriber.max_outstanding_bytes.must_equal 50_000
+    subscriber.inventory_extension.must_equal 3600
+    subscriber.max_total_lease_duration.must_equal 3600
+  end
+
+  it "will set inventory bytesize alias while creating a Subscriber" do
     subscriber = subscription.listen(inventory: { bytesize: 50_000 }) do |msg|
       puts msg.msg_id
     end
@@ -101,11 +150,31 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.streams.must_equal 2
     subscriber.inventory.must_equal 1000
     subscriber.inventory_limit.must_equal 1000
+    subscriber.max_outstanding_messages.must_equal 1000
     subscriber.inventory_bytesize.must_equal 50_000
+    subscriber.max_outstanding_bytes.must_equal 50_000
     subscriber.inventory_extension.must_equal 3600
+    subscriber.max_total_lease_duration.must_equal 3600
   end
 
-  it "will set inventory while creating a Subscriber" do
+  it "will set inventory max_total_lease_duration while creating a Subscriber" do
+    subscriber = subscription.listen(inventory: { max_total_lease_duration: 7_200 }) do |msg|
+      puts msg.msg_id
+    end
+    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
+    subscriber.subscription_name.must_equal subscription.name
+    subscriber.deadline.must_equal 60
+    subscriber.streams.must_equal 2
+    subscriber.inventory.must_equal 1000
+    subscriber.inventory_limit.must_equal 1000
+    subscriber.max_outstanding_messages.must_equal 1000
+    subscriber.inventory_bytesize.must_equal 100000000
+    subscriber.max_outstanding_bytes.must_equal 100000000
+    subscriber.inventory_extension.must_equal 7200
+    subscriber.max_total_lease_duration.must_equal 7200
+  end
+
+  it "will set inventory extension alias while creating a Subscriber" do
     subscriber = subscription.listen(inventory: { extension: 7_200 }) do |msg|
       puts msg.msg_id
     end
@@ -115,7 +184,10 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.streams.must_equal 2
     subscriber.inventory.must_equal 1000
     subscriber.inventory_limit.must_equal 1000
+    subscriber.max_outstanding_messages.must_equal 1000
     subscriber.inventory_bytesize.must_equal 100000000
+    subscriber.max_outstanding_bytes.must_equal 100000000
     subscriber.inventory_extension.must_equal 7200
+    subscriber.max_total_lease_duration.must_equal 7200
   end
 end


### PR DESCRIPTION
Preparation for #4850, that can be reviewed and merged before work is started on #4850.

- [x] Rename `inventory_limit` to `max_outstanding_messages`
- [x] Rename `inventory_bytesize` to `max_outstanding_bytes`
- [x] Rename `inventory_extension` to `max_total_lease_duration`
- [x] Add deprecated aliases for renamed methods