### PR TITLE
docs: several fixes to docs of umbrella veneers for microgenerated clients

### DIFF
--- a/google-cloud-billing/.gitignore
+++ b/google-cloud-billing/.gitignore
@@ -1,13 +1,22 @@
+# Ignore bundler lockfiles
 Gemfile.lock
-coverage/*
+gems.locked
+
+# Ignore documentation output
 doc/*
+.yardoc/*
+
+# Ignore test output
+coverage/*
+
+# Ignore build artifacts
 pkg/*
-html/*
-jsondoc/*
 
-# Ignore YARD stuffs
-.yardoc
-
-# IDE settings
+# Ignore files commonly present in certain dev environments
+.vagrant
+.DS_STORE
 .idea
 *.iml
+
+# Ignore synth output
+__pycache__

--- a/google-cloud-billing/.repo-metadata.json
+++ b/google-cloud-billing/.repo-metadata.json
@@ -2,8 +2,5 @@
     "name": "billing",
     "language": "ruby",
     "distribution_name": "google-cloud-billing",
-    "module_name": "Billing",
-    "module_name_credentials": "Billing::V1",
-    "env_var_prefix": "BILLING",
     "client_documentation": "https://googleapis.dev/ruby/google-cloud-billing/latest"
 }

--- a/google-cloud-billing/AUTHENTICATION.md
+++ b/google-cloud-billing/AUTHENTICATION.md
@@ -49,7 +49,7 @@ code.
 
 When running on Google Cloud Platform (GCP), including Google Compute Engine (GCE),
 Google Kubernetes Engine (GKE), Google App Engine (GAE), Google Cloud Functions
-(GCF) and Cloud Run, the **Credentials** and are discovered
+(GCF) and Cloud Run, the **Credentials** are discovered
 automatically. Code should be written as if already authenticated.
 
 ### Environment Variables

--- a/google-cloud-billing/AUTHENTICATION.md
+++ b/google-cloud-billing/AUTHENTICATION.md
@@ -26,7 +26,7 @@ export BILLING_CREDENTIALS=path/to/keyfile.json
 ```ruby
 require "google/cloud/billing"
 
-client = Google::Cloud::Billing.new
+client = Google::Cloud::Billing.cloud_billing_service
 ```
 
 ## Credential Lookup
@@ -49,7 +49,7 @@ code.
 
 When running on Google Cloud Platform (GCP), including Google Compute Engine (GCE),
 Google Kubernetes Engine (GKE), Google App Engine (GAE), Google Cloud Functions
-(GCF) and Cloud Run, the **Project ID** and **Credentials** and are discovered
+(GCF) and Cloud Run, the **Credentials** and are discovered
 automatically. Code should be written as if already authenticated.
 
 ### Environment Variables
@@ -63,7 +63,8 @@ environment variable, or the **Credentials JSON** itself can be stored for
 environments such as Docker containers where writing files is difficult or not
 encouraged.
 
-The environment variables that google-cloud-billing checks for credentials are configured on `Google::Cloud::Billing::V1::CloudBilling::Credentials`:
+The environment variables that google-cloud-billing checks for credentials are
+configured on `Google::Cloud::Billing::V1::CloudBilling::Credentials`:
 
 1. `BILLING_CREDENTIALS` - Path to JSON file, or JSON contents
 2. `BILLING_KEYFILE` - Path to JSON file, or JSON contents
@@ -76,17 +77,18 @@ require "google/cloud/billing"
 
 ENV["BILLING_CREDENTIALS"] = "path/to/keyfile.json"
 
-client = Google::Cloud::Billing.new
+client = Google::Cloud::Billing.cloud_billing_service
 ```
 
 ### Configuration
 
-The **Credentials JSON** can be configured instead of placing them in environment variables. Either on an individual client initialization:
+The **Credentials JSON** can be configured instead of placing them in
+environment variables. Either on an individual client initialization:
 
 ```ruby
 require "google/cloud/billing"
 
-client = Google::Cloud::Billing.new do |config|
+client = Google::Cloud::Billing.cloud_billing_service do |config|
   config.credentials = "path/to/keyfile.json"
 end
 ```
@@ -100,7 +102,7 @@ Google::Cloud::Billing.configure do |config|
   config.credentials = "path/to/keyfile.json"
 end
 
-client = Google::Cloud::Billing.new
+client = Google::Cloud::Billing.cloud_billing_service
 ```
 
 ### Cloud SDK
@@ -138,15 +140,15 @@ environments](#google-cloud-platform-environments), you need a Google
 Developers service account.
 
 1. Visit the [Google Developers Console][dev-console].
-1. Create a new project or click on an existing project.
-1. Activate the slide-out navigation tray and select **API Manager**. From
+2. Create a new project or click on an existing project.
+3. Activate the slide-out navigation tray and select **API Manager**. From
    here, you will enable the APIs that your application requires.
 
    ![Enable the APIs that your application requires][enable-apis]
 
    *Note: You may need to enable billing in order to use these services.*
 
-1. Select **Credentials** from the side navigation.
+4. Select **Credentials** from the side navigation.
 
    You should see a screen like one of the following.
 
@@ -165,8 +167,3 @@ Developers service account.
 
    The key file you download will be used by this library to authenticate API
    requests and should be stored in a secure location.
-
-## Troubleshooting
-
-If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.

--- a/google-cloud-billing/lib/google-cloud-billing.rb
+++ b/google-cloud-billing/lib/google-cloud-billing.rb
@@ -14,9 +14,8 @@
 
 
 ##
-# This file is here to be autorequired by bundler, so that the .langage and
-# #langage methods can be available, but the library and all dependencies
-# won't be loaded until required and used.
+# This file is here to be autorequired by bundler, but the library and all
+# dependencies won't be loaded until required and used.
 
 
 gem "google-cloud-core"
@@ -24,7 +23,7 @@ require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 
-# Set the default langage configuration
+# Set the default configuration
 Google::Cloud.configure.add_config! :billing do |config|
   config.add_field! :credentials,  nil, match: [String, Hash, Google::Auth::Credentials]
   config.add_field! :lib_name,     nil, match: String

--- a/google-cloud-recommender/.gitignore
+++ b/google-cloud-recommender/.gitignore
@@ -1,13 +1,22 @@
+# Ignore bundler lockfiles
 Gemfile.lock
-coverage/*
+gems.locked
+
+# Ignore documentation output
 doc/*
+.yardoc/*
+
+# Ignore test output
+coverage/*
+
+# Ignore build artifacts
 pkg/*
-html/*
-jsondoc/*
 
-# Ignore YARD stuffs
-.yardoc
-
-# IDE settings
+# Ignore files commonly present in certain dev environments
+.vagrant
+.DS_STORE
 .idea
 *.iml
+
+# Ignore synth output
+__pycache__

--- a/google-cloud-recommender/.repo-metadata.json
+++ b/google-cloud-recommender/.repo-metadata.json
@@ -2,8 +2,5 @@
     "name": "recommender",
     "language": "ruby",
     "distribution_name": "google-cloud-recommender",
-    "module_name": "Recommender",
-    "module_name_credentials": "Recommender::V1",
-    "env_var_prefix": "RECOMMENDER",
     "client_documentation": "https://googleapis.dev/ruby/google-cloud-recommender/latest"
 }

--- a/google-cloud-recommender/AUTHENTICATION.md
+++ b/google-cloud-recommender/AUTHENTICATION.md
@@ -26,7 +26,7 @@ export RECOMMENDER_CREDENTIALS=path/to/keyfile.json
 ```ruby
 require "google/cloud/recommender"
 
-client = Google::Cloud::Recommender.new
+client = Google::Cloud::Recommender.recommender_service
 ```
 
 ## Credential Lookup
@@ -49,7 +49,7 @@ code.
 
 When running on Google Cloud Platform (GCP), including Google Compute Engine (GCE),
 Google Kubernetes Engine (GKE), Google App Engine (GAE), Google Cloud Functions
-(GCF) and Cloud Run, the **Project ID** and **Credentials** and are discovered
+(GCF) and Cloud Run, the **Credentials** and are discovered
 automatically. Code should be written as if already authenticated.
 
 ### Environment Variables
@@ -63,7 +63,8 @@ environment variable, or the **Credentials JSON** itself can be stored for
 environments such as Docker containers where writing files is difficult or not
 encouraged.
 
-The environment variables that google-cloud-recommender checks for credentials are configured on `Google::Cloud::Recommender::V1::Recommender::Credentials`:
+The environment variables that google-cloud-recommender checks for credentials
+are configured on `Google::Cloud::Recommender::V1::Recommender::Credentials`:
 
 1. `RECOMMENDER_CREDENTIALS` - Path to JSON file, or JSON contents
 2. `RECOMMENDER_KEYFILE` - Path to JSON file, or JSON contents
@@ -76,17 +77,18 @@ require "google/cloud/recommender"
 
 ENV["RECOMMENDER_CREDENTIALS"] = "path/to/keyfile.json"
 
-client = Google::Cloud::Recommender.new
+client = Google::Cloud::Recommender.recommender_service
 ```
 
 ### Configuration
 
-The **Credentials JSON** can be configured instead of placing them in environment variables. Either on an individual client initialization:
+The **Credentials JSON** can be configured instead of placing them in
+environment variables. Either on an individual client initialization:
 
 ```ruby
 require "google/cloud/recommender"
 
-client = Google::Cloud::Recommender.new do |config|
+client = Google::Cloud::Recommender.recommender_service do |config|
   config.credentials = "path/to/keyfile.json"
 end
 ```
@@ -100,7 +102,7 @@ Google::Cloud::Recommender.configure do |config|
   config.credentials = "path/to/keyfile.json"
 end
 
-client = Google::Cloud::Recommender.new
+client = Google::Cloud::Recommender.recommender_service
 ```
 
 ### Cloud SDK
@@ -138,15 +140,15 @@ environments](#google-cloud-platform-environments), you need a Google
 Developers service account.
 
 1. Visit the [Google Developers Console][dev-console].
-1. Create a new project or click on an existing project.
-1. Activate the slide-out navigation tray and select **API Manager**. From
+2. Create a new project or click on an existing project.
+3. Activate the slide-out navigation tray and select **API Manager**. From
    here, you will enable the APIs that your application requires.
 
    ![Enable the APIs that your application requires][enable-apis]
 
    *Note: You may need to enable billing in order to use these services.*
 
-1. Select **Credentials** from the side navigation.
+4. Select **Credentials** from the side navigation.
 
    You should see a screen like one of the following.
 
@@ -165,8 +167,3 @@ Developers service account.
 
    The key file you download will be used by this library to authenticate API
    requests and should be stored in a secure location.
-
-## Troubleshooting
-
-If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.

--- a/google-cloud-recommender/AUTHENTICATION.md
+++ b/google-cloud-recommender/AUTHENTICATION.md
@@ -49,7 +49,7 @@ code.
 
 When running on Google Cloud Platform (GCP), including Google Compute Engine (GCE),
 Google Kubernetes Engine (GKE), Google App Engine (GAE), Google Cloud Functions
-(GCF) and Cloud Run, the **Credentials** and are discovered
+(GCF) and Cloud Run, the **Credentials** are discovered
 automatically. Code should be written as if already authenticated.
 
 ### Environment Variables

--- a/google-cloud-recommender/lib/google-cloud-recommender.rb
+++ b/google-cloud-recommender/lib/google-cloud-recommender.rb
@@ -14,9 +14,8 @@
 
 
 ##
-# This file is here to be autorequired by bundler, so that the .langage and
-# #langage methods can be available, but the library and all dependencies
-# won't be loaded until required and used.
+# This file is here to be autorequired by bundler, but the library and all
+# dependencies won't be loaded until required and used.
 
 
 gem "google-cloud-core"
@@ -24,7 +23,7 @@ require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 
-# Set the default langage configuration
+# Set the default configuration
 Google::Cloud.configure.add_config! :recommender do |config|
   config.add_field! :credentials,  nil, match: [String, Hash, Google::Auth::Credentials]
   config.add_field! :lib_name,     nil, match: String

--- a/google-cloud-secret_manager/.gitignore
+++ b/google-cloud-secret_manager/.gitignore
@@ -1,13 +1,22 @@
+# Ignore bundler lockfiles
 Gemfile.lock
-coverage/*
+gems.locked
+
+# Ignore documentation output
 doc/*
+.yardoc/*
+
+# Ignore test output
+coverage/*
+
+# Ignore build artifacts
 pkg/*
-html/*
-jsondoc/*
 
-# Ignore YARD stuffs
-.yardoc
-
-# IDE settings
+# Ignore files commonly present in certain dev environments
+.vagrant
+.DS_STORE
 .idea
 *.iml
+
+# Ignore synth output
+__pycache__

--- a/google-cloud-secret_manager/.repo-metadata.json
+++ b/google-cloud-secret_manager/.repo-metadata.json
@@ -2,8 +2,5 @@
     "name": "secret_manager",
     "language": "ruby",
     "distribution_name": "google-cloud-secret_manager",
-    "module_name": "SecretManager",
-    "module_name_credentials": "SecretManager::V1beta1",
-    "env_var_prefix": "SECRET_MANAGER",
     "client_documentation": "https://googleapis.dev/ruby/google-cloud-secret_manager/latest"
 }

--- a/google-cloud-secret_manager/AUTHENTICATION.md
+++ b/google-cloud-secret_manager/AUTHENTICATION.md
@@ -49,7 +49,7 @@ code.
 
 When running on Google Cloud Platform (GCP), including Google Compute Engine (GCE),
 Google Kubernetes Engine (GKE), Google App Engine (GAE), Google Cloud Functions
-(GCF) and Cloud Run, the **Credentials** and are discovered
+(GCF) and Cloud Run, the **Credentials** are discovered
 automatically. Code should be written as if already authenticated.
 
 ### Environment Variables

--- a/google-cloud-secret_manager/AUTHENTICATION.md
+++ b/google-cloud-secret_manager/AUTHENTICATION.md
@@ -26,7 +26,7 @@ export SECRET_MANAGER_CREDENTIALS=path/to/keyfile.json
 ```ruby
 require "google/cloud/secret_manager"
 
-client = Google::Cloud::SecretManager.new
+client = Google::Cloud::SecretManager.secret_manager_service
 ```
 
 ## Credential Lookup
@@ -49,7 +49,7 @@ code.
 
 When running on Google Cloud Platform (GCP), including Google Compute Engine (GCE),
 Google Kubernetes Engine (GKE), Google App Engine (GAE), Google Cloud Functions
-(GCF) and Cloud Run, the **Project ID** and **Credentials** and are discovered
+(GCF) and Cloud Run, the **Credentials** and are discovered
 automatically. Code should be written as if already authenticated.
 
 ### Environment Variables
@@ -63,7 +63,8 @@ environment variable, or the **Credentials JSON** itself can be stored for
 environments such as Docker containers where writing files is difficult or not
 encouraged.
 
-The environment variables that google-cloud-secret_manager checks for credentials are configured on `Google::Cloud::SecretManager::V1beta1::SecretManagerService::Credentials`:
+The environment variables that google-cloud-secret_manager checks for
+credentials are configured on `Google::Cloud::SecretManager::V1beta1::SecretManagerService::Credentials`:
 
 1. `SECRET_MANAGER_CREDENTIALS` - Path to JSON file, or JSON contents
 2. `SECRET_MANAGER_KEYFILE` - Path to JSON file, or JSON contents
@@ -76,17 +77,18 @@ require "google/cloud/secret_manager"
 
 ENV["SECRET_MANAGER_CREDENTIALS"] = "path/to/keyfile.json"
 
-client = Google::Cloud::SecretManager.new
+client = Google::Cloud::SecretManager.secret_manager_service
 ```
 
 ### Configuration
 
-The **Credentials JSON** can be configured instead of placing them in environment variables. Either on an individual client initialization:
+The **Credentials JSON** can be configured instead of placing them in
+environment variables. Either on an individual client initialization:
 
 ```ruby
 require "google/cloud/secret_manager"
 
-client = Google::Cloud::SecretManager.new do |config|
+client = Google::Cloud::SecretManager.secret_manager_service do |config|
   config.credentials = "path/to/keyfile.json"
 end
 ```
@@ -100,7 +102,7 @@ Google::Cloud::SecretManager.configure do |config|
   config.credentials = "path/to/keyfile.json"
 end
 
-client = Google::Cloud::SecretManager.new
+client = Google::Cloud::SecretManager.secret_manager_service
 ```
 
 ### Cloud SDK
@@ -138,15 +140,15 @@ environments](#google-cloud-platform-environments), you need a Google
 Developers service account.
 
 1. Visit the [Google Developers Console][dev-console].
-1. Create a new project or click on an existing project.
-1. Activate the slide-out navigation tray and select **API Manager**. From
+2. Create a new project or click on an existing project.
+3. Activate the slide-out navigation tray and select **API Manager**. From
    here, you will enable the APIs that your application requires.
 
    ![Enable the APIs that your application requires][enable-apis]
 
    *Note: You may need to enable billing in order to use these services.*
 
-1. Select **Credentials** from the side navigation.
+4. Select **Credentials** from the side navigation.
 
    You should see a screen like one of the following.
 
@@ -165,8 +167,3 @@ Developers service account.
 
    The key file you download will be used by this library to authenticate API
    requests and should be stored in a secure location.
-
-## Troubleshooting
-
-If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.

--- a/google-cloud-secret_manager/lib/google-cloud-secret_manager.rb
+++ b/google-cloud-secret_manager/lib/google-cloud-secret_manager.rb
@@ -14,9 +14,8 @@
 
 
 ##
-# This file is here to be autorequired by bundler, so that the .langage and
-# #langage methods can be available, but the library and all dependencies
-# won't be loaded until required and used.
+# This file is here to be autorequired by bundler, but the library and all
+# dependencies won't be loaded until required and used.
 
 
 gem "google-cloud-core"
@@ -24,7 +23,7 @@ require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 
-# Set the default langage configuration
+# Set the default configuration
 Google::Cloud.configure.add_config! :secret_manager do |config|
   config.add_field! :credentials,  nil, match: [String, Hash, Google::Auth::Credentials]
   config.add_field! :lib_name,     nil, match: String


### PR DESCRIPTION
Covers all the wrapper veneers for current microgenerated libraries: `google-cloud-billing`, `google-cloud-recommender`, and `google-cloud-secret_manager`.

Specifics:
* Use the same `.gitignore` that is generated by the microgenerator
* Remove `.repo-metadata` entries that were used only to "generate" the authentication docs.
* Several fixes in the authentication docs including:
    * Fixed the client factory method calls (e.g. from `Google::Cloud::Billing.new` to `Google::Cloud::Billing.billing_service`)
    * Remove mentions of project ID environment variables which are not relevant to these libraries
    * Remove mention of the troubleshooting guide which doesn't exist for these libraries
* Remove some mentions of "langage" methods which were a copy-paste error.