### PR TITLE
docs(language): fix a few errors in the language migration guide

### DIFF
--- a/google-cloud-language/MIGRATING.md
+++ b/google-cloud-language/MIGRATING.md
@@ -81,6 +81,16 @@ Google::Cloud::Language::V1::LanguageService::Client.configure do |config|
 end
 ```
 
+You can also set certain configuration defaults for all Language versions
+globally:
+
+```
+Google::Cloud::Language.configure do |config|
+  config.credentials = "/path/to/credentials.json"
+  config.timeout = 10_000
+end
+```
+
 ### Creating Clients
 
 In older releases, to create a client object, you would use the
@@ -133,7 +143,7 @@ response = client.analyze_sentiment document, encoding_type: encoding
 
 New:
 ```
-client = Google::Cloud::Language.new
+client = Google::Cloud::Language.language_service
 
 document = {
   content: "I love API calls!",
@@ -150,7 +160,7 @@ as a hash or as a protocol buffer.
 
 New:
 ```
-client = Google::Cloud::Language.new
+client = Google::Cloud::Language.language_service
 
 request = Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(
   document: {
@@ -184,7 +194,7 @@ response = client.analyze_sentiment document, options: options
 
 New:
 ```
-client = Google::Cloud::Language.new
+client = Google::Cloud::Language.language_service
 
 document = {
   content: "I love API calls!",

--- a/google-cloud-language/MIGRATING.md
+++ b/google-cloud-language/MIGRATING.md
@@ -1,10 +1,11 @@
 ## Migrating to google-cloud-language 1.0
 
 The 1.0 release of the google-cloud-language client is a significant upgrade
-based on a next-gen code generator. If you have used earlier versions of this
-library, there have been a number of significant changes that may require
-updates to calling code. This document will describe the changes that have been
-made, and what you need to do to update your usage.
+based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),
+and includes substantial interface changes. Existing code written for earlier
+versions of this library will likely require updates to use this version.
+This document describes the changes that have been made, and what you need to
+do to update your usage.
 
 To summarize:
 
@@ -14,15 +15,16 @@ To summarize:
     service, and the gem `google-cloud-language` now simply provides a
     convenience wrapper. See [Library Structure](#library-structure) for more
     info.
- *  This library uses a new configuration mechanism giving you closer control
+ *  The library uses a new configuration mechanism giving you closer control
     over endpoint address, network timeouts, and retry. See
     [Client Configuration](#client-configuration) for more info. Furthermore,
     when creating a client object, you can customize its configuration in a
     block rather than passing arguments to the constructor. See
     [Creating Clients](#creating-clients) for more info.
- *  Previously, methods typically had at least one positional argument. Now,
-    all arguments are keyword arguments. Additionally, you can pass a proto
-    request object instead of separate arguments. See
+ *  Previously, positional arguments were used to indicate required arguments.
+    Now, all method arguments are keyword arguments, with documentation that
+    specifies whether they are required or optional. Additionally, you can pass
+    a proto request object instead of separate arguments. See
     [Passing Arguments](#passing-arguments) for more info.
  *  Some classes have moved into different namespaces. See
     [Class Namespaces](#class-namespaces) for more info.
@@ -31,7 +33,7 @@ To summarize:
 
 Older 0.x releases of the `google-cloud-language` gem were all-in-one gems that
 included potentially multiple clients for multiple versions of the Natural
-Language service. The `Google::Cloud::Language.new()` factory method would
+Language service. The `Google::Cloud::Language.new` factory method would
 return you an instance of a `Google::Cloud::Language::V1::LanguageServiceClient`
 object for the V1 version of the service, or a
 `Google::Cloud::Language::V1beta2::LanguageServiceClient` object for the
@@ -40,18 +42,18 @@ V1beta2 version of the service. All these classes were defined in the same gem.
 With the 1.0 release, the `google-cloud-language` gem still provides factory
 methods for obtaining clients. (The method signatures will have changed. See
 [Creating Clients](#creating-clients) for details.) However, the actual client
-classes have been moved into separate gems, on per service version. The
+classes have been moved into separate gems, one per service version. The
 `Google::Cloud::Language::V1::LanguageService::Client` class, along with its
-helpers and data types, are now part of the `google-cloud-language-v1` gem.
+helpers and data types, is now part of the `google-cloud-language-v1` gem.
 Similarly, the `Google::Cloud::Language::V1beta2::LanguageService::Client`
 class is part of the `google-cloud-language-v1beta2` gem. 
 
 For normal usage, you can continue to install the `google-cloud-language` gem
-and continue to use factory methods to create clients. This will remain the
-easiest way to use the Natural Language client. However, you may alternatively
-choose to install only one of the versioned gems. For example, if you know you
-will only use `V1` of the service, you can install `google-cloud-language-v1`
-by itself, and construct instances of the
+(which will bring in the versioned client gems as dependencies) and continue to
+use factory methods to create clients. However, you may alternatively choose to
+install only one of the versioned gems. For example, if you know you will only
+`V1` of the service, you can install `google-cloud-language-v1` by itself, and
+construct instances of the
 `Google::Cloud::Language::V1::LanguageService::Client` client class directly.
 
 ### Client Configuration
@@ -61,9 +63,10 @@ low-level behavior of the client (such as credentials, timeouts, or
 instrumentation), you would pass a variety of keyword arguments to the client
 constructor. It was also extremely difficult to customize the default settings.
 
-With the 1.0 release, a configuration interface provides access to these
-parameters, both global defaults and per-client settings. For example, to set
-global credentials and default timeout for all language V1 clients:
+With the 1.0 release, a configuration interface provides control over these
+parameters, including defaults for all instances of a client, and settings for
+each specific client instance. For example, to set default credentials and
+timeout for all Language V1 clients:
 
 ```
 Google::Cloud::Language::V1::LanguageService::Client.configure do |config|
@@ -81,7 +84,7 @@ Google::Cloud::Language::V1::LanguageService::Client.configure do |config|
 end
 ```
 
-You can also set certain configuration defaults for all Language versions
+Defaults for certain configurations can be set for all Language versions
 globally:
 
 ```
@@ -91,6 +94,9 @@ Google::Cloud::Language.configure do |config|
 end
 ```
 
+Finally, you can override the configuration for each client instance. See the
+next section on [Creating Clients](#creating-clients) for details.
+
 ### Creating Clients
 
 In older releases, to create a client object, you would use the
@@ -98,7 +104,7 @@ In older releases, to create a client object, you would use the
 select a service version and to configure parameters such as credentials and
 timeouts.
 
-Wiht the 1.0 release, use the `Google::Cloud::Language.language_service` class
+With the 1.0 release, use the `Google::Cloud::Language.language_service` class
 method to create a client object. You may select a service version using the
 `:version` keyword argument. However, other configuration parameters should be
 set in a configuration block when you create the client.
@@ -121,7 +127,7 @@ set some configuration parameters, then the default configuration is used. See
 
 ### Passing Arguments
 
-In older releases, certain required arguments would be passed as positional
+In older releases, required arguments would be passed as positional method
 arguments, while most optional arguments would be passed as keyword arguments.
 
 With the 1.0 release, all RPC arguments are passed as keyword arguments,
@@ -219,9 +225,11 @@ In the 1.0 release, the client object is of class
 Note that most users will use the `Google::Cloud::Language.language_service`
 factory method to create instances of the client object, so you may not need to
 reference the actual class directly.
+See [Creating Clients](#creating-clients).
 
 In older releases, the credentials object was of class
 `Google::Cloud::Language::V1::Credentials`.
 In the 1.0 release, the credentials object is of class
 `Google::Cloud::Language::V1::LanguageService::Credentials`.
 Again, most users will not need to reference this class directly.
+See [Client Configuration](#client-configuration).

--- a/google-cloud-language/README.md
+++ b/google-cloud-language/README.md
@@ -37,9 +37,10 @@ $ gem install google-cloud-language
 ## Migrating from 0.x versions
 
 The 1.0 release of the google-cloud-language client is a significant upgrade
-based on a next-gen code generator. If you have used earlier versions of this
-library, there have been a number of changes that may require updates to
-calling code. See the MIGRATING.md document for more information.
+based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),
+and includes substantial interface changes. Existing code written for earlier
+versions of this library will likely require updates to use this version.
+See the {file:MIGRATING.md MIGRATING.md} document for more information.
 
 ## Enabling Logging
 

--- a/google-cloud-language/lib/google/cloud/language.rb
+++ b/google-cloud-language/lib/google/cloud/language.rb
@@ -45,16 +45,28 @@ module Google
       #
       # The following configuration parameters are supported:
       #
-      # * `credentials` - (String, Hash, Google::Auth::Credentials) The path to the keyfile as a String, the contents of
-      #   the keyfile as a Hash, or a Google::Auth::Credentials object.
-      # * `lib_name` (String)
-      # * `lib_version` (String)
-      # * `interceptors` (Array)
-      # * `timeout` - (Integer) Default timeout to use in requests.
-      # * `metadata` (Hash)
-      # * `retry_policy` (Hash, Proc)
+      # * `credentials` (*type:* `String, Hash, Google::Auth::Credentials`) -
+      #   The path to the keyfile as a String, the contents of the keyfile as a
+      #   Hash, or a Google::Auth::Credentials object.
+      # * `lib_name` (*type:* `String`) -
+      #   The library name as recorded in instrumentation and logging
+      # * `lib_version` (*type:* `String`) -
+      #   The library version as recorded in instrumentation and logging
+      # * `interceptors` (*type:* `Array<GRPC::ClientInterceptor>`) -
+      #   An array of interceptors that are run before calls are executed
+      # * `timeout` (*type:* `Integer`) -
+      #   Default timeout in milliseconds.
+      # * `metadata` (*type:* `Hash{Symbol=>String}`) -
+      #   Additional gRPC headers to be sent with the call
+      # * `retry_policy` (*type:* `Hash`) -
+      #   The retry policy. The value is a hash with the following keys:
+      #     * `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
+      #     * `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
+      #     * `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+      #     * `:retry_codes` (*type:* `Array<String>`) -
+      #       The error codes that should trigger a retry.
       #
-      # @return [Google::Cloud::Config] The configuration object the Google::Cloud::Language library uses.
+      # @return [Google::Cloud::Config] The default configuration used by this library
       #
       def self.configure
         yield Google::Cloud.configure.language if block_given?

--- a/google-cloud-language/lib/google/cloud/language.rb
+++ b/google-cloud-language/lib/google/cloud/language.rb
@@ -49,15 +49,15 @@ module Google
       #   The path to the keyfile as a String, the contents of the keyfile as a
       #   Hash, or a Google::Auth::Credentials object.
       # * `lib_name` (*type:* `String`) -
-      #   The library name as recorded in instrumentation and logging
+      #   The library name as recorded in instrumentation and logging.
       # * `lib_version` (*type:* `String`) -
-      #   The library version as recorded in instrumentation and logging
+      #   The library version as recorded in instrumentation and logging.
       # * `interceptors` (*type:* `Array<GRPC::ClientInterceptor>`) -
-      #   An array of interceptors that are run before calls are executed
+      #   An array of interceptors that are run before calls are executed.
       # * `timeout` (*type:* `Integer`) -
       #   Default timeout in milliseconds.
       # * `metadata` (*type:* `Hash{Symbol=>String}`) -
-      #   Additional gRPC headers to be sent with the call
+      #   Additional gRPC headers to be sent with the call.
       # * `retry_policy` (*type:* `Hash`) -
       #   The retry policy. The value is a hash with the following keys:
       #     * `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.


### PR DESCRIPTION
* Add a missing section on how to set global configs
* The sample code blocks illustrating the new calling conventions used the old client factory methods. Fixed.