### PR TITLE
Release google-cloud-secret_manager-v1beta1 0.3.0

### DIFF
--- a/google-cloud-secret_manager-v1beta1/CHANGELOG.md
+++ b/google-cloud-secret_manager-v1beta1/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 0.3.0 / 2020-03-18
+
+* Support separate project setting for quota/billing
+* Include the correct default timeout and retry settings
+* Eliminate some Ruby 2.7 keyword argument warnings
+* Fix some formatting issues in the inline documentation
+
 ### 0.2.3 / 2020-03-04
 
 #### Documentation

--- a/google-cloud-secret_manager-v1beta1/lib/google/cloud/secret_manager/v1beta1/version.rb
+++ b/google-cloud-secret_manager-v1beta1/lib/google/cloud/secret_manager/v1beta1/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module SecretManager
       module V1beta1
-        VERSION = "0.2.3"
+        VERSION = "0.3.0"
       end
     end
   end


### PR DESCRIPTION
* Support separate project setting for quota/billing
* Include the correct default timeout and retry settings
* Eliminate some Ruby 2.7 keyword argument warnings
* Fix some formatting issues in the inline documentation

<details><summary>Commits since previous release</summary><pre><code>commit b3da6245b309c76a1a3c0db105f84ebed59fa052
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Mar 18 08:06:34 2020 -0700

    fix(secret_manager-v1beta1): Eliminate some Ruby 2.7 keyword argument warnings

commit 4dbd2c2869404d9c34747bfd3ffb5fd9ae219c75
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Fri Mar 13 15:55:53 2020 -0700

    docs(secret_manager-v1beta1): remove some spurious backslash escaping from code samples in inline documentation

commit 2fa27d1b27e7996061c58fa05c78ad0afdc8645f
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Thu Mar 12 09:25:57 2020 -0700

    chore(secret_manager-v1beta1): Set default network configuration from service config

commit 85c9fd48ddf1b66b5010c8617eeea87283f77200
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed Mar 11 10:42:13 2020 -0700

    chore: add grpc service configs to microgen library synth scripts

commit 919a8afcf3a82376aefc5792a1f058ff765a8c09
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Mar 9 12:21:41 2020 -0700

    chore(secret_manager-v1beta1): Add x-goog-user-project request header
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-secret_manager-v1beta1/.gitignore b/google-cloud-secret_manager-v1beta1/.gitignore
index 19f01259d..0135b6bc6 100644
--- a/google-cloud-secret_manager-v1beta1/.gitignore
+++ b/google-cloud-secret_manager-v1beta1/.gitignore
@@ -15,6 +15,8 @@ pkg/*
 # Ignore files commonly present in certain dev environments
 .vagrant
 .DS_STORE
+.idea
+*.iml
 
 # Ignore synth output
 __pycache__
diff --git a/google-cloud-secret_manager-v1beta1/AUTHENTICATION.md b/google-cloud-secret_manager-v1beta1/AUTHENTICATION.md
index 06cc18703..1404ca8ee 100644
--- a/google-cloud-secret_manager-v1beta1/AUTHENTICATION.md
+++ b/google-cloud-secret_manager-v1beta1/AUTHENTICATION.md
@@ -1,16 +1,17 @@
 # Authentication
 
-In general, the google-cloud-secret_manager-v1beta1 library uses [Service
-Account](https://cloud.google.com/iam/docs/creating-managing-service-accounts)
-credentials to connect to Google Cloud services. When running within [Google
-Cloud Platform environments](#google-cloud-platform-environments)
-the credentials will be discovered automatically. When running on other
+In general, the google-cloud-secret_manager-v1beta1 library uses
+[Service Account](https://cloud.google.com/iam/docs/creating-managing-service-accounts)
+credentials to connect to Google Cloud services. When running within
+[Google Cloud Platform environments](#google-cloud-platform-environments) the
+credentials will be discovered automatically. When running on other
 environments, the Service Account credentials can be specified by providing the
-path to the [JSON
-keyfile](https://cloud.google.com/iam/docs/managing-service-account-keys) for
-the account (or the JSON itself) in [environment
-variables](#environment-variables). Additionally, Cloud SDK credentials can also
-be discovered automatically, but this is only recommended during development.
+path to the
+[JSON keyfile](https://cloud.google.com/iam/docs/managing-service-account-keys)
+for the account (or the JSON itself) in
+[environment variables](#environment-variables). Additionally, Cloud SDK
+credentials can also be discovered automatically, but this is only recommended
+during development.
 
 ## Quickstart
 
@@ -46,23 +47,24 @@ without **Service Account Credentials** directly in code.
 
 ### Google Cloud Platform environments
 
-When running on Google Cloud Platform (GCP), including Google Compute Engine (GCE),
-Google Kubernetes Engine (GKE), Google App Engine (GAE), Google Cloud Functions
-(GCF) and Cloud Run, **Credentials** and are discovered
-automatically. Code should be written as if already authenticated.
+When running on Google Cloud Platform (GCP), including Google Compute Engine
+(GCE), Google Kubernetes Engine (GKE), Google App Engine (GAE), Google Cloud
+Functions (GCF) and Cloud Run, **Credentials** are discovered automatically.
+Code should be written as if already authenticated.
 
 ### Environment Variables
 
-The **Credentials JSON** can be placed in environment
-variables instead of declaring them directly in code. Each service has its own
-environment variable, allowing for different service accounts to be used for
-different services. (See the READMEs for the individual service gems for
-details.) The path to the **Credentials JSON** file can be stored in the
-environment variable, or the **Credentials JSON** itself can be stored for
-environments such as Docker containers where writing files is difficult or not
-encouraged.
+The **Credentials JSON** can be placed in environment variables instead of
+declaring them directly in code. Each service has its own environment variable,
+allowing for different service accounts to be used for different services. (See
+the READMEs for the individual service gems for details.) The path to the
+**Credentials JSON** file can be stored in the environment variable, or the
+**Credentials JSON** itself can be stored for environments such as Docker
+containers where writing files is difficult or not encouraged.
 
-The environment variables that google-cloud-secret_manager-v1beta1 checks for credentials are configured on the service Credentials class (such as {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Credentials}):
+The environment variables that google-cloud-secret_manager-v1beta1
+checks for credentials are configured on the service Credentials class (such as
+{Google::Cloud::SecretManager::V1beta1::SecretManagerService::Credentials}):
 
 1. `SECRET_MANAGER_CREDENTIALS` - Path to JSON file, or JSON contents
 2. `SECRET_MANAGER_KEYFILE` - Path to JSON file, or JSON contents
@@ -80,7 +82,8 @@ client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
 ### Configuration
 
-The **Credentials JSON** can be configured instead of placing them in environment variables. Either on an individual client initialization:
+The **Credentials JSON** can be configured instead of placing them in
+environment variables. Either on an individual client initialization:
 
 ```ruby
 require "google/cloud/secret_manager/v1beta1"
@@ -137,15 +140,15 @@ environments](#google-cloud-platform-environments), you need a Google
 Developers service account.
 
 1. Visit the [Google Developers Console][dev-console].
-1. Create a new project or click on an existing project.
-1. Activate the slide-out navigation tray and select **API Manager**. From
+2. Create a new project or click on an existing project.
+3. Activate the slide-out navigation tray and select **API Manager**. From
    here, you will enable the APIs that your application requires.
 
    ![Enable the APIs that your application requires][enable-apis]
 
    *Note: You may need to enable billing in order to use these services.*
 
-1. Select **Credentials** from the side navigation.
+4. Select **Credentials** from the side navigation.
 
    You should see a screen like one of the following.
 
diff --git a/google-cloud-secret_manager-v1beta1/google-cloud-secret_manager-v1beta1.gemspec b/google-cloud-secret_manager-v1beta1/google-cloud-secret_manager-v1beta1.gemspec
index d8eaafdef..4965380ed 100644
--- a/google-cloud-secret_manager-v1beta1/google-cloud-secret_manager-v1beta1.gemspec
+++ b/google-cloud-secret_manager-v1beta1/google-cloud-secret_manager-v1beta1.gemspec
@@ -23,13 +23,13 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.1.0"
+  gem.add_dependency "gapic-common", "~> 0.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
-  gem.add_development_dependency "rake", "~> 12.0"
+  gem.add_development_dependency "rake", ">= 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
   gem.add_development_dependency "simplecov", "~> 0.18"
   gem.add_development_dependency "yard", "~> 0.9"
diff --git a/google-cloud-secret_manager-v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb b/google-cloud-secret_manager-v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
index 624cb2240..bd50b1491 100644
--- a/google-cloud-secret_manager-v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
+++ b/google-cloud-secret_manager-v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
@@ -67,7 +67,45 @@ module Google
                                   break parent_const.configure if parent_const&.respond_to? :configure
                                   namespace.pop
                                 end
-                Client::Configuration.new parent_config
+                default_config = Client::Configuration.new parent_config
+
+                default_config.rpcs.list_secrets.timeout = 60.0
+
+                default_config.rpcs.create_secret.timeout = 60.0
+
+                default_config.rpcs.add_secret_version.timeout = 60.0
+
+                default_config.rpcs.get_secret.timeout = 60.0
+
+                default_config.rpcs.update_secret.timeout = 60.0
+
+                default_config.rpcs.delete_secret.timeout = 60.0
+
+                default_config.rpcs.list_secret_versions.timeout = 60.0
+
+                default_config.rpcs.get_secret_version.timeout = 60.0
+
+                default_config.rpcs.access_secret_version.timeout = 60.0
+                default_config.rpcs.access_secret_version.retry_policy = {
+                  initial_delay: 1.0,
+                  max_delay:     60.0,
+                  multiplier:    1.3,
+                  retry_codes:   ["UNAVAILABLE", "UNKNOWN"]
+                }
+
+                default_config.rpcs.disable_secret_version.timeout = 60.0
+
+                default_config.rpcs.enable_secret_version.timeout = 60.0
+
+                default_config.rpcs.destroy_secret_version.timeout = 60.0
+
+                default_config.rpcs.set_iam_policy.timeout = 60.0
+
+                default_config.rpcs.get_iam_policy.timeout = 60.0
+
+                default_config.rpcs.test_iam_permissions.timeout = 60.0
+
+                default_config
               end
               yield @configure if block_given?
               @configure
@@ -132,7 +170,7 @@ module Google
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
-
+              @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
               @secret_manager_service_stub = Gapic::ServiceStub.new(
                 Google::Cloud::SecretManager::V1beta1::SecretManagerService::Stub,
@@ -146,25 +184,25 @@ module Google
             # Service calls
 
             ##
-            # Lists [Secrets][google.cloud.secrets.v1beta1.Secret].
+            # Lists {Google::Cloud::SecretManager::V1beta1::Secret Secrets}.
             #
             # @overload list_secrets(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::ListSecretsRequest | Hash]
-            #     Lists [Secrets][google.cloud.secrets.v1beta1.Secret].
+            #     Lists {Google::Cloud::SecretManager::V1beta1::Secret Secrets}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload list_secrets(parent: nil, page_size: nil, page_token: nil)
             #   @param parent [String]
             #     Required. The resource name of the project associated with the
-            #     [Secrets][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`.
+            #     {Google::Cloud::SecretManager::V1beta1::Secret Secrets}, in the format `projects/*`.
             #   @param page_size [Integer]
             #     Optional. The maximum number of results to be returned in a single page. If
             #     set to 0, the server decides the number of results to return. If the
             #     number is greater than 25000, it is capped at 25000.
             #   @param page_token [String]
             #     Optional. Pagination token, returned earlier via
-            #     [ListSecretsResponse.next_page_token][google.cloud.secrets.v1beta1.ListSecretsResponse.next_page_token].
+            #     {Google::Cloud::SecretManager::V1beta1::ListSecretsResponse#next_page_token ListSecretsResponse.next_page_token}.
             #
             #
             # @yield [response, operation] Access the result along with the RPC operation
@@ -181,15 +219,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::ListSecretsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_secrets.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -213,22 +252,22 @@ module Google
             end
 
             ##
-            # Creates a new [Secret][google.cloud.secrets.v1beta1.Secret] containing no [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion].
+            # Creates a new {Google::Cloud::SecretManager::V1beta1::Secret Secret} containing no {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions}.
             #
             # @overload create_secret(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::CreateSecretRequest | Hash]
-            #     Creates a new [Secret][google.cloud.secrets.v1beta1.Secret] containing no [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion].
+            #     Creates a new {Google::Cloud::SecretManager::V1beta1::Secret Secret} containing no {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload create_secret(parent: nil, secret_id: nil, secret: nil)
             #   @param parent [String]
             #     Required. The resource name of the project to associate with the
-            #     [Secret][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`.
+            #     {Google::Cloud::SecretManager::V1beta1::Secret Secret}, in the format `projects/*`.
             #   @param secret_id [String]
             #     Required. This must be unique within the project.
             #   @param secret [Google::Cloud::SecretManager::V1beta1::Secret | Hash]
-            #     A [Secret][google.cloud.secrets.v1beta1.Secret] with initial field values.
+            #     A {Google::Cloud::SecretManager::V1beta1::Secret Secret} with initial field values.
             #
             #
             # @yield [response, operation] Access the result along with the RPC operation
@@ -245,15 +284,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::CreateSecretRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.create_secret.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -276,22 +316,22 @@ module Google
             end
 
             ##
-            # Creates a new [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] containing secret data and attaches
-            # it to an existing [Secret][google.cloud.secrets.v1beta1.Secret].
+            # Creates a new {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} containing secret data and attaches
+            # it to an existing {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload add_secret_version(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest | Hash]
-            #     Creates a new [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] containing secret data and attaches
-            #     it to an existing [Secret][google.cloud.secrets.v1beta1.Secret].
+            #     Creates a new {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} containing secret data and attaches
+            #     it to an existing {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload add_secret_version(parent: nil, payload: nil)
             #   @param parent [String]
-            #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] to associate with the
-            #     [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format `projects/*/secrets/*`.
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} to associate with the
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format `projects/*/secrets/*`.
             #   @param payload [Google::Cloud::SecretManager::V1beta1::SecretPayload | Hash]
-            #     Required. The secret payload of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     Required. The secret payload of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
             #
             # @yield [response, operation] Access the result along with the RPC operation
@@ -308,15 +348,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.add_secret_version.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -339,17 +380,17 @@ module Google
             end
 
             ##
-            # Gets metadata for a given [Secret][google.cloud.secrets.v1beta1.Secret].
+            # Gets metadata for a given {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload get_secret(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::GetSecretRequest | Hash]
-            #     Gets metadata for a given [Secret][google.cloud.secrets.v1beta1.Secret].
+            #     Gets metadata for a given {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload get_secret(name: nil)
             #   @param name [String]
-            #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret], in the format `projects/*/secrets/*`.
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret}, in the format `projects/*/secrets/*`.
             #
             #
             # @yield [response, operation] Access the result along with the RPC operation
@@ -366,15 +407,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::GetSecretRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_secret.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -397,17 +439,17 @@ module Google
             end
 
             ##
-            # Updates metadata of an existing [Secret][google.cloud.secrets.v1beta1.Secret].
+            # Updates metadata of an existing {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload update_secret(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest | Hash]
-            #     Updates metadata of an existing [Secret][google.cloud.secrets.v1beta1.Secret].
+            #     Updates metadata of an existing {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload update_secret(secret: nil, update_mask: nil)
             #   @param secret [Google::Cloud::SecretManager::V1beta1::Secret | Hash]
-            #     Required. [Secret][google.cloud.secrets.v1beta1.Secret] with updated field values.
+            #     Required. {Google::Cloud::SecretManager::V1beta1::Secret Secret} with updated field values.
             #   @param update_mask [Google::Protobuf::FieldMask | Hash]
             #     Required. Specifies the fields to be updated.
             #
@@ -426,15 +468,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.update_secret.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "secret.name" => request.secret.name
@@ -457,17 +500,17 @@ module Google
             end
 
             ##
-            # Deletes a [Secret][google.cloud.secrets.v1beta1.Secret].
+            # Deletes a {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload delete_secret(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest | Hash]
-            #     Deletes a [Secret][google.cloud.secrets.v1beta1.Secret].
+            #     Deletes a {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload delete_secret(name: nil)
             #   @param name [String]
-            #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] to delete in the format
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} to delete in the format
             #     `projects/*/secrets/*`.
             #
             #
@@ -485,15 +528,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.delete_secret.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -516,20 +560,20 @@ module Google
             end
 
             ##
-            # Lists [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion]. This call does not return secret
+            # Lists {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions}. This call does not return secret
             # data.
             #
             # @overload list_secret_versions(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest | Hash]
-            #     Lists [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion]. This call does not return secret
+            #     Lists {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions}. This call does not return secret
             #     data.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload list_secret_versions(parent: nil, page_size: nil, page_token: nil)
             #   @param parent [String]
-            #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] associated with the
-            #     [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] to list, in the format
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} associated with the
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions} to list, in the format
             #     `projects/*/secrets/*`.
             #   @param page_size [Integer]
             #     Optional. The maximum number of results to be returned in a single page. If
@@ -554,15 +598,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_secret_versions.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -586,26 +631,26 @@ module Google
             end
 
             ##
-            # Gets metadata for a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            # Gets metadata for a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
             # `projects/*/secrets/*/versions/latest` is an alias to the `latest`
-            # [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            # {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
             # @overload get_secret_version(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest | Hash]
-            #     Gets metadata for a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     Gets metadata for a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
             #     `projects/*/secrets/*/versions/latest` is an alias to the `latest`
-            #     [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload get_secret_version(name: nil)
             #   @param name [String]
-            #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format
             #     `projects/*/secrets/*/versions/*`.
             #     `projects/*/secrets/*/versions/latest` is an alias to the `latest`
-            #     [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
             #
             # @yield [response, operation] Access the result along with the RPC operation
@@ -622,15 +667,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_secret_version.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -653,23 +699,23 @@ module Google
             end
 
             ##
-            # Accesses a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]. This call returns the secret data.
+            # Accesses a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}. This call returns the secret data.
             #
             # `projects/*/secrets/*/versions/latest` is an alias to the `latest`
-            # [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            # {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
             # @overload access_secret_version(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest | Hash]
-            #     Accesses a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]. This call returns the secret data.
+            #     Accesses a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}. This call returns the secret data.
             #
             #     `projects/*/secrets/*/versions/latest` is an alias to the `latest`
-            #     [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload access_secret_version(name: nil)
             #   @param name [String]
-            #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format
             #     `projects/*/secrets/*/versions/*`.
             #
             #
@@ -687,15 +733,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.access_secret_version.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -718,23 +765,23 @@ module Google
             end
 
             ##
-            # Disables a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            # Disables a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
-            # Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-            # [DISABLED][google.cloud.secrets.v1beta1.SecretVersion.State.DISABLED].
+            # Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
+            # {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::DISABLED DISABLED}.
             #
             # @overload disable_secret_version(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest | Hash]
-            #     Disables a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     Disables a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
-            #     Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-            #     [DISABLED][google.cloud.secrets.v1beta1.SecretVersion.State.DISABLED].
+            #     Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::DISABLED DISABLED}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload disable_secret_version(name: nil)
             #   @param name [String]
-            #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to disable in the format
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to disable in the format
             #     `projects/*/secrets/*/versions/*`.
             #
             #
@@ -752,15 +799,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.disable_secret_version.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -783,23 +831,23 @@ module Google
             end
 
             ##
-            # Enables a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            # Enables a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
-            # Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-            # [ENABLED][google.cloud.secrets.v1beta1.SecretVersion.State.ENABLED].
+            # Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
+            # {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::ENABLED ENABLED}.
             #
             # @overload enable_secret_version(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest | Hash]
-            #     Enables a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     Enables a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
-            #     Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-            #     [ENABLED][google.cloud.secrets.v1beta1.SecretVersion.State.ENABLED].
+            #     Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::ENABLED ENABLED}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload enable_secret_version(name: nil)
             #   @param name [String]
-            #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to enable in the format
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to enable in the format
             #     `projects/*/secrets/*/versions/*`.
             #
             #
@@ -817,15 +865,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.enable_secret_version.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -848,25 +897,25 @@ module Google
             end
 
             ##
-            # Destroys a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            # Destroys a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
-            # Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-            # [DESTROYED][google.cloud.secrets.v1beta1.SecretVersion.State.DESTROYED] and irrevocably destroys the
+            # Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
+            # {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::DESTROYED DESTROYED} and irrevocably destroys the
             # secret data.
             #
             # @overload destroy_secret_version(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest | Hash]
-            #     Destroys a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     Destroys a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
-            #     Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-            #     [DESTROYED][google.cloud.secrets.v1beta1.SecretVersion.State.DESTROYED] and irrevocably destroys the
+            #     Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::DESTROYED DESTROYED} and irrevocably destroys the
             #     secret data.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload destroy_secret_version(name: nil)
             #   @param name [String]
-            #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to destroy in the format
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to destroy in the format
             #     `projects/*/secrets/*/versions/*`.
             #
             #
@@ -884,15 +933,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.destroy_secret_version.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -918,16 +968,16 @@ module Google
             # Sets the access control policy on the specified secret. Replaces any
             # existing policy.
             #
-            # Permissions on [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] are enforced according
-            # to the policy set on the associated [Secret][google.cloud.secrets.v1beta1.Secret].
+            # Permissions on {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions} are enforced according
+            # to the policy set on the associated {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload set_iam_policy(request, options = nil)
             #   @param request [Google::Iam::V1::SetIamPolicyRequest | Hash]
             #     Sets the access control policy on the specified secret. Replaces any
             #     existing policy.
             #
-            #     Permissions on [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] are enforced according
-            #     to the policy set on the associated [Secret][google.cloud.secrets.v1beta1.Secret].
+            #     Permissions on {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions} are enforced according
+            #     to the policy set on the associated {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -935,7 +985,7 @@ module Google
             #   @param resource [String]
             #     REQUIRED: The resource for which the policy is being specified.
             #     `resource` is usually specified as a path. For example, a Project
-            #     resource is specified as `projects/\\\{project\}`.
+            #     resource is specified as `projects/{project}`.
             #   @param policy [Google::Iam::V1::Policy | Hash]
             #     REQUIRED: The complete policy to be applied to the `resource`. The size of
             #     the policy is limited to a few 10s of KB. An empty policy is a
@@ -957,15 +1007,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Iam::V1::SetIamPolicyRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.set_iam_policy.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "resource" => request.resource
@@ -1002,7 +1053,7 @@ module Google
             #   @param resource [String]
             #     REQUIRED: The resource for which the policy is being requested.
             #     `resource` is usually specified as a path. For example, a Project
-            #     resource is specified as `projects/\\\{project\}`.
+            #     resource is specified as `projects/{project}`.
             #
             #
             # @yield [response, operation] Access the result along with the RPC operation
@@ -1019,15 +1070,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Iam::V1::GetIamPolicyRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_iam_policy.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "resource" => request.resource
@@ -1074,7 +1126,7 @@ module Google
             #   @param resource [String]
             #     REQUIRED: The resource for which the policy detail is being requested.
             #     `resource` is usually specified as a path. For example, a Project
-            #     resource is specified as `projects/\\\{project\}`.
+            #     resource is specified as `projects/{project}`.
             #   @param permissions [Array<String>]
             #     The set of permissions to check for the `resource`. Permissions with
             #     wildcards (such as '*' or 'storage.*') are not allowed. For more
@@ -1096,15 +1148,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Iam::V1::TestIamPermissionsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.test_iam_permissions.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "resource" => request.resource
diff --git a/google-cloud-secret_manager-v1beta1/proto_docs/google/api/resource.rb b/google-cloud-secret_manager-v1beta1/proto_docs/google/api/resource.rb
index 1c6aec8ac..ab300c8e4 100644
--- a/google-cloud-secret_manager-v1beta1/proto_docs/google/api/resource.rb
+++ b/google-cloud-secret_manager-v1beta1/proto_docs/google/api/resource.rb
@@ -27,110 +27,110 @@ module Google
     #
     # Example:
     #
-    #     message Topic \\\{
+    #     message Topic {
     #       // Indicates this message defines a resource schema.
-    #       // Declares the resource type in the format of \\\{service\}/\\\{kind\}.
-    #       // For Kubernetes resources, the format is \\\{api group\}/\\\{kind\}.
-    #       option (google.api.resource) = \\\{
+    #       // Declares the resource type in the format of {service}/{kind}.
+    #       // For Kubernetes resources, the format is {api group}/{kind}.
+    #       option (google.api.resource) = {
     #         type: "pubsub.googleapis.com/Topic"
-    #         name_descriptor: \\\{
-    #           pattern: "projects/\\\{project\}/topics/\\\{topic\}"
+    #         name_descriptor: {
+    #           pattern: "projects/{project}/topics/{topic}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/\\\{project\}"
-    #         \}
-    #       \};
-    #     \}
+    #           parent_name_extractor: "projects/{project}"
+    #         }
+    #       };
+    #     }
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #    resources:
     #    - type: "pubsub.googleapis.com/Topic"
     #      name_descriptor:
-    #        - pattern: "projects/\\\{project\}/topics/\\\{topic\}"
+    #        - pattern: "projects/\\{project}/topics/\\{topic}"
     #          parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #          parent_name_extractor: "projects/\\\{project\}"
+    #          parent_name_extractor: "projects/\\{project}"
     #
     # Sometimes, resources have multiple patterns, typically because they can
     # live under multiple parents.
     #
     # Example:
     #
-    #     message LogEntry \\\{
-    #       option (google.api.resource) = \\\{
+    #     message LogEntry {
+    #       option (google.api.resource) = {
     #         type: "logging.googleapis.com/LogEntry"
-    #         name_descriptor: \\\{
-    #           pattern: "projects/\\\{project\}/logs/\\\{log\}"
+    #         name_descriptor: {
+    #           pattern: "projects/{project}/logs/{log}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/\\\{project\}"
-    #         \}
-    #         name_descriptor: \\\{
-    #           pattern: "folders/\\\{folder\}/logs/\\\{log\}"
+    #           parent_name_extractor: "projects/{project}"
+    #         }
+    #         name_descriptor: {
+    #           pattern: "folders/{folder}/logs/{log}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #           parent_name_extractor: "folders/\\\{folder\}"
-    #         \}
-    #         name_descriptor: \\\{
-    #           pattern: "organizations/\\\{organization\}/logs/\\\{log\}"
+    #           parent_name_extractor: "folders/{folder}"
+    #         }
+    #         name_descriptor: {
+    #           pattern: "organizations/{organization}/logs/{log}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-    #           parent_name_extractor: "organizations/\\\{organization\}"
-    #         \}
-    #         name_descriptor: \\\{
-    #           pattern: "billingAccounts/\\\{billing_account\}/logs/\\\{log\}"
+    #           parent_name_extractor: "organizations/{organization}"
+    #         }
+    #         name_descriptor: {
+    #           pattern: "billingAccounts/{billing_account}/logs/{log}"
     #           parent_type: "billing.googleapis.com/BillingAccount"
-    #           parent_name_extractor: "billingAccounts/\\\{billing_account\}"
-    #         \}
-    #       \};
-    #     \}
+    #           parent_name_extractor: "billingAccounts/{billing_account}"
+    #         }
+    #       };
+    #     }
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #     resources:
     #     - type: 'logging.googleapis.com/LogEntry'
     #       name_descriptor:
-    #         - pattern: "projects/\\\{project\}/logs/\\\{log\}"
+    #         - pattern: "projects/{project}/logs/{log}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/\\\{project\}"
-    #         - pattern: "folders/\\\{folder\}/logs/\\\{log\}"
+    #           parent_name_extractor: "projects/{project}"
+    #         - pattern: "folders/{folder}/logs/{log}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #           parent_name_extractor: "folders/\\\{folder\}"
-    #         - pattern: "organizations/\\\{organization\}/logs/\\\{log\}"
+    #           parent_name_extractor: "folders/{folder}"
+    #         - pattern: "organizations/{organization}/logs/{log}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-    #           parent_name_extractor: "organizations/\\\{organization\}"
-    #         - pattern: "billingAccounts/\\\{billing_account\}/logs/\\\{log\}"
+    #           parent_name_extractor: "organizations/{organization}"
+    #         - pattern: "billingAccounts/{billing_account}/logs/{log}"
     #           parent_type: "billing.googleapis.com/BillingAccount"
-    #           parent_name_extractor: "billingAccounts/\\\{billing_account\}"
+    #           parent_name_extractor: "billingAccounts/{billing_account}"
     #
     # For flexible resources, the resource name doesn't contain parent names, but
     # the resource itself has parents for policy evaluation.
     #
     # Example:
     #
-    #     message Shelf \\\{
-    #       option (google.api.resource) = \\\{
+    #     message Shelf {
+    #       option (google.api.resource) = {
     #         type: "library.googleapis.com/Shelf"
-    #         name_descriptor: \\\{
-    #           pattern: "shelves/\\\{shelf\}"
+    #         name_descriptor: {
+    #           pattern: "shelves/{shelf}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #         \}
-    #         name_descriptor: \\\{
-    #           pattern: "shelves/\\\{shelf\}"
+    #         }
+    #         name_descriptor: {
+    #           pattern: "shelves/{shelf}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #         \}
-    #       \};
-    #     \}
+    #         }
+    #       };
+    #     }
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #     resources:
     #     - type: 'library.googleapis.com/Shelf'
     #       name_descriptor:
-    #         - pattern: "shelves/\\\{shelf\}"
+    #         - pattern: "shelves/{shelf}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #         - pattern: "shelves/\\\{shelf\}"
+    #         - pattern: "shelves/{shelf}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
     # @!attribute [rw] type
     #   @return [String]
     #     The resource type. It must be in the format of
-    #     \\\{service_name\}/\\\{resource_type_kind\}. The `resource_type_kind` must be
+    #     \\{service_name}/\\{resource_type_kind}. The `resource_type_kind` must be
     #     singular and must not include version numbers.
     #
     #     Example: `storage.googleapis.com/Bucket`
@@ -147,14 +147,14 @@ module Google
     #     The path pattern must follow the syntax, which aligns with HTTP binding
     #     syntax:
     #
-    #         Template = Segment \\\{ "/" Segment \} ;
+    #         Template = Segment { "/" Segment } ;
     #         Segment = LITERAL | Variable ;
-    #         Variable = "\\\{" LITERAL "\}" ;
+    #         Variable = "{" LITERAL "}" ;
     #
     #     Examples:
     #
-    #         - "projects/\\\{project\}/topics/\\\{topic\}"
-    #         - "projects/\\\{project\}/knowledgeBases/\\\{knowledge_base\}"
+    #         - "projects/\\{project}/topics/\\{topic}"
+    #         - "projects/\\{project}/knowledgeBases/\\{knowledge_base}"
     #
     #     The components in braces correspond to the IDs for each resource in the
     #     hierarchy. It is expected that, if multiple patterns are provided,
@@ -172,19 +172,19 @@ module Google
     #
     #         // The InspectTemplate message originally only supported resource
     #         // names with organization, and project was added later.
-    #         message InspectTemplate \\\{
-    #           option (google.api.resource) = \\\{
+    #         message InspectTemplate {
+    #           option (google.api.resource) = {
     #             type: "dlp.googleapis.com/InspectTemplate"
     #             pattern:
-    #             "organizations/\\\{organization\}/inspectTemplates/\\\{inspect_template\}"
-    #             pattern: "projects/\\\{project\}/inspectTemplates/\\\{inspect_template\}"
+    #             "organizations/{organization}/inspectTemplates/{inspect_template}"
+    #             pattern: "projects/{project}/inspectTemplates/{inspect_template}"
     #             history: ORIGINALLY_SINGLE_PATTERN
-    #           \};
-    #         \}
+    #           };
+    #         }
     # @!attribute [rw] plural
     #   @return [String]
     #     The plural name used in the resource name, such as 'projects' for
-    #     the name of 'projects/\\\{project\}'. It is the same concept of the `plural`
+    #     the name of 'projects/\\{project}'. It is the same concept of the `plural`
     #     field in k8s CRD spec
     #     https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
     # @!attribute [rw] singular
@@ -221,11 +221,11 @@ module Google
     #
     #     Example:
     #
-    #         message Subscription \\\{
-    #           string topic = 2 [(google.api.resource_reference) = \\\{
+    #         message Subscription {
+    #           string topic = 2 [(google.api.resource_reference) = {
     #             type: "pubsub.googleapis.com/Topic"
-    #           \}];
-    #         \}
+    #           }];
+    #         }
     # @!attribute [rw] child_type
     #   @return [String]
     #     The resource type of a child collection that the annotated field
@@ -234,11 +234,11 @@ module Google
     #
     #     Example:
     #
-    #       message ListLogEntriesRequest \\\{
-    #         string parent = 1 [(google.api.resource_reference) = \\\{
+    #       message ListLogEntriesRequest {
+    #         string parent = 1 [(google.api.resource_reference) = {
     #           child_type: "logging.googleapis.com/LogEntry"
-    #         \};
-    #       \}
+    #         };
+    #       }
     class ResourceReference
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
diff --git a/google-cloud-secret_manager-v1beta1/proto_docs/google/cloud/secrets/v1beta1/resources.rb b/google-cloud-secret_manager-v1beta1/proto_docs/google/cloud/secrets/v1beta1/resources.rb
index bb7ed2a0d..41a696187 100644
--- a/google-cloud-secret_manager-v1beta1/proto_docs/google/cloud/secrets/v1beta1/resources.rb
+++ b/google-cloud-secret_manager-v1beta1/proto_docs/google/cloud/secrets/v1beta1/resources.rb
@@ -21,33 +21,33 @@ module Google
   module Cloud
     module SecretManager
       module V1beta1
-        # A [Secret][google.cloud.secrets.v1beta1.Secret] is a logical secret whose value and versions can
+        # A {Google::Cloud::SecretManager::V1beta1::Secret Secret} is a logical secret whose value and versions can
         # be accessed.
         #
-        # A [Secret][google.cloud.secrets.v1beta1.Secret] is made up of zero or more [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] that
+        # A {Google::Cloud::SecretManager::V1beta1::Secret Secret} is made up of zero or more {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions} that
         # represent the secret data.
         # @!attribute [r] name
         #   @return [String]
-        #     Output only. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] in the format `projects/*/secrets/*`.
+        #     Output only. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} in the format `projects/*/secrets/*`.
         # @!attribute [rw] replication
         #   @return [Google::Cloud::SecretManager::V1beta1::Replication]
-        #     Required. Immutable. The replication policy of the secret data attached to the [Secret][google.cloud.secrets.v1beta1.Secret].
+        #     Required. Immutable. The replication policy of the secret data attached to the {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
         #
         #     The replication policy cannot be changed after the Secret has been created.
         # @!attribute [r] create_time
         #   @return [Google::Protobuf::Timestamp]
-        #     Output only. The time at which the [Secret][google.cloud.secrets.v1beta1.Secret] was created.
+        #     Output only. The time at which the {Google::Cloud::SecretManager::V1beta1::Secret Secret} was created.
         # @!attribute [rw] labels
         #   @return [Google::Protobuf::Map{String => String}]
         #     The labels assigned to this Secret.
         #
         #     Label keys must be between 1 and 63 characters long, have a UTF-8 encoding
         #     of maximum 128 bytes, and must conform to the following PCRE regular
-        #     expression: `[\p\\\{Ll\}\p\\\{Lo\}][\p\\\{Ll\}\p\\\{Lo\}\p\\\{N\}_-]\\\{0,62\}`
+        #     expression: `[\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}`
         #
         #     Label values must be between 0 and 63 characters long, have a UTF-8
         #     encoding of maximum 128 bytes, and must conform to the following PCRE
-        #     regular expression: `[\p\\\{Ll\}\p\\\{Lo\}\p\\\{N\}_-]\\\{0,63\}`
+        #     regular expression: `[\p{Ll}\p{Lo}\p{N}_-]{0,63}`
         #
         #     No more than 64 labels can be assigned to a given resource.
         class Secret
@@ -67,40 +67,40 @@ module Google
         # A secret version resource in the Secret Manager API.
         # @!attribute [r] name
         #   @return [String]
-        #     Output only. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the
+        #     Output only. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the
         #     format `projects/*/secrets/*/versions/*`.
         #
-        #     [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] IDs in a [Secret][google.cloud.secrets.v1beta1.Secret] start at 1 and
+        #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} IDs in a {Google::Cloud::SecretManager::V1beta1::Secret Secret} start at 1 and
         #     are incremented for each subsequent version of the secret.
         # @!attribute [r] create_time
         #   @return [Google::Protobuf::Timestamp]
-        #     Output only. The time at which the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] was created.
+        #     Output only. The time at which the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} was created.
         # @!attribute [r] destroy_time
         #   @return [Google::Protobuf::Timestamp]
-        #     Output only. The time this [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] was destroyed.
-        #     Only present if [state][google.cloud.secrets.v1beta1.SecretVersion.state] is
-        #     [DESTROYED][google.cloud.secrets.v1beta1.SecretVersion.State.DESTROYED].
+        #     Output only. The time this {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} was destroyed.
+        #     Only present if {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} is
+        #     {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::DESTROYED DESTROYED}.
         # @!attribute [r] state
         #   @return [Google::Cloud::SecretManager::V1beta1::SecretVersion::State]
-        #     Output only. The current state of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+        #     Output only. The current state of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
         class SecretVersion
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
 
-          # The state of a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion], indicating if it can be accessed.
+          # The state of a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}, indicating if it can be accessed.
           module State
             # Not specified. This value is unused and invalid.
             STATE_UNSPECIFIED = 0
 
-            # The [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] may be accessed.
+            # The {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} may be accessed.
             ENABLED = 1
 
-            # The [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] may not be accessed, but the secret data
-            # is still available and can be placed back into the [ENABLED][google.cloud.secrets.v1beta1.SecretVersion.State.ENABLED]
+            # The {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} may not be accessed, but the secret data
+            # is still available and can be placed back into the {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::ENABLED ENABLED}
             # state.
             DISABLED = 2
 
-            # The [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] is destroyed and the secret data is no longer
+            # The {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} is destroyed and the secret data is no longer
             # stored. A version may not leave this state once entered.
             DESTROYED = 3
           end
@@ -109,33 +109,33 @@ module Google
         # A policy that defines the replication configuration of data.
         # @!attribute [rw] automatic
         #   @return [Google::Cloud::SecretManager::V1beta1::Replication::Automatic]
-        #     The [Secret][google.cloud.secrets.v1beta1.Secret] will automatically be replicated without any restrictions.
+        #     The {Google::Cloud::SecretManager::V1beta1::Secret Secret} will automatically be replicated without any restrictions.
         # @!attribute [rw] user_managed
         #   @return [Google::Cloud::SecretManager::V1beta1::Replication::UserManaged]
-        #     The [Secret][google.cloud.secrets.v1beta1.Secret] will only be replicated into the locations specified.
+        #     The {Google::Cloud::SecretManager::V1beta1::Secret Secret} will only be replicated into the locations specified.
         class Replication
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
 
-          # A replication policy that replicates the [Secret][google.cloud.secrets.v1beta1.Secret] payload without any
+          # A replication policy that replicates the {Google::Cloud::SecretManager::V1beta1::Secret Secret} payload without any
           # restrictions.
           class Automatic
             include Google::Protobuf::MessageExts
             extend Google::Protobuf::MessageExts::ClassMethods
           end
 
-          # A replication policy that replicates the [Secret][google.cloud.secrets.v1beta1.Secret] payload into the
+          # A replication policy that replicates the {Google::Cloud::SecretManager::V1beta1::Secret Secret} payload into the
           # locations specified in [Secret.replication.user_managed.replicas][]
           # @!attribute [rw] replicas
           #   @return [Array<Google::Cloud::SecretManager::V1beta1::Replication::UserManaged::Replica>]
-          #     Required. The list of Replicas for this [Secret][google.cloud.secrets.v1beta1.Secret].
+          #     Required. The list of Replicas for this {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
           #
           #     Cannot be empty.
           class UserManaged
             include Google::Protobuf::MessageExts
             extend Google::Protobuf::MessageExts::ClassMethods
 
-            # Represents a Replica for this [Secret][google.cloud.secrets.v1beta1.Secret].
+            # Represents a Replica for this {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             # @!attribute [rw] location
             #   @return [String]
             #     The canonical IDs of the location to replicate data.
@@ -148,7 +148,7 @@ module Google
         end
 
         # A secret payload resource in the Secret Manager API. This contains the
-        # sensitive secret data that is associated with a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+        # sensitive secret data that is associated with a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
         # @!attribute [rw] data
         #   @return [String]
         #     The secret data. Must be no larger than 64KiB.
diff --git a/google-cloud-secret_manager-v1beta1/proto_docs/google/cloud/secrets/v1beta1/service.rb b/google-cloud-secret_manager-v1beta1/proto_docs/google/cloud/secrets/v1beta1/service.rb
index 871186b02..1927367f1 100644
--- a/google-cloud-secret_manager-v1beta1/proto_docs/google/cloud/secrets/v1beta1/service.rb
+++ b/google-cloud-secret_manager-v1beta1/proto_docs/google/cloud/secrets/v1beta1/service.rb
@@ -21,11 +21,11 @@ module Google
   module Cloud
     module SecretManager
       module V1beta1
-        # Request message for [SecretManagerService.ListSecrets][google.cloud.secrets.v1beta1.SecretManagerService.ListSecrets].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secrets SecretManagerService.ListSecrets}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the project associated with the
-        #     [Secrets][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`.
+        #     {Google::Cloud::SecretManager::V1beta1::Secret Secrets}, in the format `projects/*`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     Optional. The maximum number of results to be returned in a single page. If
@@ -34,72 +34,72 @@ module Google
         # @!attribute [rw] page_token
         #   @return [String]
         #     Optional. Pagination token, returned earlier via
-        #     [ListSecretsResponse.next_page_token][google.cloud.secrets.v1beta1.ListSecretsResponse.next_page_token].
+        #     {Google::Cloud::SecretManager::V1beta1::ListSecretsResponse#next_page_token ListSecretsResponse.next_page_token}.
         class ListSecretsRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Response message for [SecretManagerService.ListSecrets][google.cloud.secrets.v1beta1.SecretManagerService.ListSecrets].
+        # Response message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secrets SecretManagerService.ListSecrets}.
         # @!attribute [rw] secrets
         #   @return [Array<Google::Cloud::SecretManager::V1beta1::Secret>]
-        #     The list of [Secrets][google.cloud.secrets.v1beta1.Secret] sorted in reverse by create_time (newest
+        #     The list of {Google::Cloud::SecretManager::V1beta1::Secret Secrets} sorted in reverse by create_time (newest
         #     first).
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     A token to retrieve the next page of results. Pass this value in
-        #     [ListSecretsRequest.page_token][google.cloud.secrets.v1beta1.ListSecretsRequest.page_token] to retrieve the next page.
+        #     {Google::Cloud::SecretManager::V1beta1::ListSecretsRequest#page_token ListSecretsRequest.page_token} to retrieve the next page.
         # @!attribute [rw] total_size
         #   @return [Integer]
-        #     The total number of [Secrets][google.cloud.secrets.v1beta1.Secret].
+        #     The total number of {Google::Cloud::SecretManager::V1beta1::Secret Secrets}.
         class ListSecretsResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.CreateSecret][google.cloud.secrets.v1beta1.SecretManagerService.CreateSecret].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#create_secret SecretManagerService.CreateSecret}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the project to associate with the
-        #     [Secret][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`.
+        #     {Google::Cloud::SecretManager::V1beta1::Secret Secret}, in the format `projects/*`.
         # @!attribute [rw] secret_id
         #   @return [String]
         #     Required. This must be unique within the project.
         # @!attribute [rw] secret
         #   @return [Google::Cloud::SecretManager::V1beta1::Secret]
-        #     A [Secret][google.cloud.secrets.v1beta1.Secret] with initial field values.
+        #     A {Google::Cloud::SecretManager::V1beta1::Secret Secret} with initial field values.
         class CreateSecretRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.AddSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.AddSecretVersion].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#add_secret_version SecretManagerService.AddSecretVersion}.
         # @!attribute [rw] parent
         #   @return [String]
-        #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] to associate with the
-        #     [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format `projects/*/secrets/*`.
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} to associate with the
+        #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format `projects/*/secrets/*`.
         # @!attribute [rw] payload
         #   @return [Google::Cloud::SecretManager::V1beta1::SecretPayload]
-        #     Required. The secret payload of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+        #     Required. The secret payload of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
         class AddSecretVersionRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.GetSecret][google.cloud.secrets.v1beta1.SecretManagerService.GetSecret].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_secret SecretManagerService.GetSecret}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret], in the format `projects/*/secrets/*`.
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret}, in the format `projects/*/secrets/*`.
         class GetSecretRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.ListSecretVersions][google.cloud.secrets.v1beta1.SecretManagerService.ListSecretVersions].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secret_versions SecretManagerService.ListSecretVersions}.
         # @!attribute [rw] parent
         #   @return [String]
-        #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] associated with the
-        #     [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] to list, in the format
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} associated with the
+        #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions} to list, in the format
         #     `projects/*/secrets/*`.
         # @!attribute [rw] page_size
         #   @return [Integer]
@@ -115,39 +115,39 @@ module Google
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Response message for [SecretManagerService.ListSecretVersions][google.cloud.secrets.v1beta1.SecretManagerService.ListSecretVersions].
+        # Response message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secret_versions SecretManagerService.ListSecretVersions}.
         # @!attribute [rw] versions
         #   @return [Array<Google::Cloud::SecretManager::V1beta1::SecretVersion>]
-        #     The list of [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] sorted in reverse by
+        #     The list of {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions} sorted in reverse by
         #     create_time (newest first).
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     A token to retrieve the next page of results. Pass this value in
-        #     [ListSecretVersionsRequest.page_token][google.cloud.secrets.v1beta1.ListSecretVersionsRequest.page_token] to retrieve the next page.
+        #     {Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest#page_token ListSecretVersionsRequest.page_token} to retrieve the next page.
         # @!attribute [rw] total_size
         #   @return [Integer]
-        #     The total number of [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion].
+        #     The total number of {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions}.
         class ListSecretVersionsResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.GetSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.GetSecretVersion].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_secret_version SecretManagerService.GetSecretVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format
         #     `projects/*/secrets/*/versions/*`.
         #     `projects/*/secrets/*/versions/latest` is an alias to the `latest`
-        #     [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+        #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
         class GetSecretVersionRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.UpdateSecret][google.cloud.secrets.v1beta1.SecretManagerService.UpdateSecret].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#update_secret SecretManagerService.UpdateSecret}.
         # @!attribute [rw] secret
         #   @return [Google::Cloud::SecretManager::V1beta1::Secret]
-        #     Required. [Secret][google.cloud.secrets.v1beta1.Secret] with updated field values.
+        #     Required. {Google::Cloud::SecretManager::V1beta1::Secret Secret} with updated field values.
         # @!attribute [rw] update_mask
         #   @return [Google::Protobuf::FieldMask]
         #     Required. Specifies the fields to be updated.
@@ -156,20 +156,20 @@ module Google
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.AccessSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.AccessSecretVersion].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#access_secret_version SecretManagerService.AccessSecretVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format
         #     `projects/*/secrets/*/versions/*`.
         class AccessSecretVersionRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Response message for [SecretManagerService.AccessSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.AccessSecretVersion].
+        # Response message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#access_secret_version SecretManagerService.AccessSecretVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format
+        #     The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format
         #     `projects/*/secrets/*/versions/*`.
         # @!attribute [rw] payload
         #   @return [Google::Cloud::SecretManager::V1beta1::SecretPayload]
@@ -179,40 +179,40 @@ module Google
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.DeleteSecret][google.cloud.secrets.v1beta1.SecretManagerService.DeleteSecret].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#delete_secret SecretManagerService.DeleteSecret}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] to delete in the format
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} to delete in the format
         #     `projects/*/secrets/*`.
         class DeleteSecretRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.DisableSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.DisableSecretVersion].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#disable_secret_version SecretManagerService.DisableSecretVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to disable in the format
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to disable in the format
         #     `projects/*/secrets/*/versions/*`.
         class DisableSecretVersionRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.EnableSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.EnableSecretVersion].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#enable_secret_version SecretManagerService.EnableSecretVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to enable in the format
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to enable in the format
         #     `projects/*/secrets/*/versions/*`.
         class EnableSecretVersionRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.DestroySecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.DestroySecretVersion].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#destroy_secret_version SecretManagerService.DestroySecretVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to destroy in the format
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to destroy in the format
         #     `projects/*/secrets/*/versions/*`.
         class DestroySecretVersionRequest
           include Google::Protobuf::MessageExts
diff --git a/google-cloud-secret_manager-v1beta1/proto_docs/google/iam/v1/iam_policy.rb b/google-cloud-secret_manager-v1beta1/proto_docs/google/iam/v1/iam_policy.rb
index 0f529c20e..134b64a57 100644
--- a/google-cloud-secret_manager-v1beta1/proto_docs/google/iam/v1/iam_policy.rb
+++ b/google-cloud-secret_manager-v1beta1/proto_docs/google/iam/v1/iam_policy.rb
@@ -25,7 +25,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being specified.
       #     `resource` is usually specified as a path. For example, a Project
-      #     resource is specified as `projects/\\\{project\}`.
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] policy
       #   @return [Google::Iam::V1::Policy]
       #     REQUIRED: The complete policy to be applied to the `resource`. The size of
@@ -42,7 +42,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
       #     `resource` is usually specified as a path. For example, a Project
-      #     resource is specified as `projects/\\\{project\}`.
+      #     resource is specified as `projects/{project}`.
       class GetIamPolicyRequest
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
@@ -53,7 +53,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy detail is being requested.
       #     `resource` is usually specified as a path. For example, a Project
-      #     resource is specified as `projects/\\\{project\}`.
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
       #     The set of permissions to check for the `resource`. Permissions with
diff --git a/google-cloud-secret_manager-v1beta1/proto_docs/google/iam/v1/policy.rb b/google-cloud-secret_manager-v1beta1/proto_docs/google/iam/v1/policy.rb
index 7169f3678..476b506f3 100644
--- a/google-cloud-secret_manager-v1beta1/proto_docs/google/iam/v1/policy.rb
+++ b/google-cloud-secret_manager-v1beta1/proto_docs/google/iam/v1/policy.rb
@@ -31,9 +31,9 @@ module Google
       #
       # **Example**
       #
-      #     \\\{
+      #     {
       #       "bindings": [
-      #         \\\{
+      #         {
       #           "role": "roles/owner",
       #           "members": [
       #             "user:mike@example.com",
@@ -41,13 +41,13 @@ module Google
       #             "domain:google.com",
       #             "serviceAccount:my-other-app@appspot.gserviceaccount.com",
       #           ]
-      #         \},
-      #         \\\{
+      #         },
+      #         {
       #           "role": "roles/viewer",
       #           "members": ["user:sean@example.com"]
-      #         \}
+      #         }
       #       ]
-      #     \}
+      #     }
       #
       # For a description of IAM and its features, see the
       # [IAM developer's guide](https://cloud.google.com/iam).
@@ -93,17 +93,17 @@ module Google
       #     * `allAuthenticatedUsers`: A special identifier that represents anyone
       #        who is authenticated with a Google account or a service account.
       #
-      #     * `user:\\\{emailid\}`: An email address that represents a specific Google
+      #     * `user:{emailid}`: An email address that represents a specific Google
       #        account. For example, `alice@gmail.com` or `joe@example.com`.
       #
       #
-      #     * `serviceAccount:\\\{emailid\}`: An email address that represents a service
+      #     * `serviceAccount:{emailid}`: An email address that represents a service
       #        account. For example, `my-other-app@appspot.gserviceaccount.com`.
       #
-      #     * `group:\\\{emailid\}`: An email address that represents a Google group.
+      #     * `group:{emailid}`: An email address that represents a Google group.
       #        For example, `admins@example.com`.
       #
-      #     * `domain:\\\{domain\}`: A Google Apps domain name that represents all the
+      #     * `domain:{domain}`: A Google Apps domain name that represents all the
       #        users of that domain. For example, `google.com` or `example.com`.
       class Binding
         include Google::Protobuf::MessageExts
diff --git a/google-cloud-secret_manager-v1beta1/proto_docs/google/protobuf/empty.rb b/google-cloud-secret_manager-v1beta1/proto_docs/google/protobuf/empty.rb
index a895bd1df..3fdde5da6 100644
--- a/google-cloud-secret_manager-v1beta1/proto_docs/google/protobuf/empty.rb
+++ b/google-cloud-secret_manager-v1beta1/proto_docs/google/protobuf/empty.rb
@@ -23,11 +23,11 @@ module Google
     # empty messages in your APIs. A typical example is to use it as the request
     # or the response type of an API method. For instance:
     #
-    #     service Foo \\\{
+    #     service Foo {
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-    #     \}
+    #     }
     #
-    # The JSON representation for `Empty` is empty JSON object `\\\{\}`.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
diff --git a/google-cloud-secret_manager-v1beta1/proto_docs/google/protobuf/field_mask.rb b/google-cloud-secret_manager-v1beta1/proto_docs/google/protobuf/field_mask.rb
index 9e0c7c2c1..769103b14 100644
--- a/google-cloud-secret_manager-v1beta1/proto_docs/google/protobuf/field_mask.rb
+++ b/google-cloud-secret_manager-v1beta1/proto_docs/google/protobuf/field_mask.rb
@@ -39,14 +39,14 @@ module Google
     # specified in the mask. For example, if the mask in the previous
     # example is applied to a response message as follows:
     #
-    #     f \\\{
+    #     f {
     #       a : 22
-    #       b \\\{
+    #       b {
     #         d : 1
     #         x : 2
-    #       \}
+    #       }
     #       y : 13
-    #     \}
+    #     }
     #     z: 8
     #
     # The result will not contain specific values for fields x,y and z
@@ -54,12 +54,12 @@ module Google
     # output):
     #
     #
-    #     f \\\{
+    #     f {
     #       a : 22
-    #       b \\\{
+    #       b {
     #         d : 1
-    #       \}
-    #     \}
+    #       }
+    #     }
     #
     # A repeated field is not allowed except at the last position of a
     # paths string.
@@ -96,21 +96,21 @@ module Google
     # update operation, then the existing sub-message in the target resource is
     # overwritten. Given the target message:
     #
-    #     f \\\{
-    #       b \\\{
+    #     f {
+    #       b {
     #         d : 1
     #         x : 2
-    #       \}
+    #       }
     #       c : 1
-    #     \}
+    #     }
     #
     # And an update message:
     #
-    #     f \\\{
-    #       b \\\{
+    #     f {
+    #       b {
     #         d : 10
-    #       \}
-    #     \}
+    #       }
+    #     }
     #
     # then if the field mask is:
     #
@@ -118,12 +118,12 @@ module Google
     #
     # then the result will be:
     #
-    #     f \\\{
-    #       b \\\{
+    #     f {
+    #       b {
     #         d : 10
-    #       \}
+    #       }
     #       c : 1
-    #     \}
+    #     }
     #
     # However, if the update mask was:
     #
@@ -131,13 +131,13 @@ module Google
     #
     # then the result would be:
     #
-    #     f \\\{
-    #       b \\\{
+    #     f {
+    #       b {
     #         d : 10
     #         x : 2
-    #       \}
+    #       }
     #       c : 1
-    #     \}
+    #     }
     #
     # In order to reset a field's value to the default, the field must
     # be in the mask and set to the default value in the provided resource.
@@ -172,51 +172,51 @@ module Google
     #
     # As an example, consider the following message declarations:
     #
-    #     message Profile \\\{
+    #     message Profile {
     #       User user = 1;
     #       Photo photo = 2;
-    #     \}
-    #     message User \\\{
+    #     }
+    #     message User {
     #       string display_name = 1;
     #       string address = 2;
-    #     \}
+    #     }
     #
     # In proto a field mask for `Profile` may look as such:
     #
-    #     mask \\\{
+    #     mask {
     #       paths: "user.display_name"
     #       paths: "photo"
-    #     \}
+    #     }
     #
     # In JSON, the same mask is represented as below:
     #
-    #     \\\{
+    #     {
     #       mask: "user.displayName,photo"
-    #     \}
+    #     }
     #
     # # Field Masks and Oneof Fields
     #
     # Field masks treat fields in oneofs just as regular fields. Consider the
     # following message:
     #
-    #     message SampleMessage \\\{
-    #       oneof test_oneof \\\{
+    #     message SampleMessage {
+    #       oneof test_oneof {
     #         string name = 4;
     #         SubMessage sub_message = 9;
-    #       \}
-    #     \}
+    #       }
+    #     }
     #
     # The field mask can be:
     #
-    #     mask \\\{
+    #     mask {
     #       paths: "name"
-    #     \}
+    #     }
     #
     # Or:
     #
-    #     mask \\\{
+    #     mask {
     #       paths: "sub_message"
-    #     \}
+    #     }
     #
     # Note that oneof type names ("test_oneof" in this case) cannot be used in
     # paths.
diff --git a/google-cloud-secret_manager-v1beta1/proto_docs/google/protobuf/timestamp.rb b/google-cloud-secret_manager-v1beta1/proto_docs/google/protobuf/timestamp.rb
index 313e5fc02..321ed4fe2 100644
--- a/google-cloud-secret_manager-v1beta1/proto_docs/google/protobuf/timestamp.rb
+++ b/google-cloud-secret_manager-v1beta1/proto_docs/google/protobuf/timestamp.rb
@@ -77,9 +77,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "\\\{year\}-\\\{month\}-\\\{day\}T\\\{hour\}:\\\{min\}:\\\{sec\}[.\\\{frac_sec\}]Z"
-    # where \\\{year\} is always expressed using four digits while \\\{month\}, \\\{day\},
-    # \\\{hour\}, \\\{min\}, and \\\{sec\} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required. A proto3 JSON serializer should always use UTC (as indicated by
diff --git a/google-cloud-secret_manager-v1beta1/synth.metadata b/google-cloud-secret_manager-v1beta1/synth.metadata
index 204d75548..0624b675b 100644
--- a/google-cloud-secret_manager-v1beta1/synth.metadata
+++ b/google-cloud-secret_manager-v1beta1/synth.metadata
@@ -1,13 +1,13 @@
 {
-  "updateTime": "2020-03-04T11:43:39.092829Z",
+  "updateTime": "2020-03-18T10:45:39.262752Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "541b1ded4abadcc38e8178680b0677f65594ea6f",
-        "internalRef": "298686266",
-        "log": "541b1ded4abadcc38e8178680b0677f65594ea6f\nUpdate cloud asset api v1p4beta1.\n\nPiperOrigin-RevId: 298686266\n\nc0d171acecb4f5b0bfd2c4ca34fc54716574e300\n  Updated to include the Notification v1 API.\n\nPiperOrigin-RevId: 298652775\n\n2346a9186c0bff2c9cc439f2459d558068637e05\nAdd Service Directory v1beta1 protos and configs\n\nPiperOrigin-RevId: 298625638\n\na78ed801b82a5c6d9c5368e24b1412212e541bb7\nPublishing v3 protos and configs.\n\nPiperOrigin-RevId: 298607357\n\n4a180bfff8a21645b3a935c2756e8d6ab18a74e0\nautoml/v1beta1 publish proto updates\n\nPiperOrigin-RevId: 298484782\n\n6de6e938b7df1cd62396563a067334abeedb9676\nchore: use the latest gapic-generator and protoc-java-resource-name-plugin in Bazel workspace.\n\nPiperOrigin-RevId: 298474513\n\n244ab2b83a82076a1fa7be63b7e0671af73f5c02\nAdds service config definition for bigqueryreservation v1\n\nPiperOrigin-RevId: 298455048\n\n83c6f84035ee0f80eaa44d8b688a010461cc4080\nUpdate google/api/auth.proto to make AuthProvider to have JwtLocation\n\nPiperOrigin-RevId: 297918498\n\ne9e90a787703ec5d388902e2cb796aaed3a385b4\nDialogflow weekly v2/v2beta1 library update:\n  - adding get validation result\n  - adding field mask override control for output audio config\nImportant updates are also posted at:\nhttps://cloud.google.com/dialogflow/docs/release-notes\n\nPiperOrigin-RevId: 297671458\n\n1a2b05cc3541a5f7714529c665aecc3ea042c646\nAdding .yaml and .json config files.\n\nPiperOrigin-RevId: 297570622\n\ndfe1cf7be44dee31d78f78e485d8c95430981d6e\nPublish `QueryOptions` proto.\n\nIntroduced a `query_options` input in `ExecuteSqlRequest`.\n\nPiperOrigin-RevId: 297497710\n\ndafc905f71e5d46f500b41ed715aad585be062c3\npubsub: revert pull init_rpc_timeout & max_rpc_timeout back to 25 seconds and reset multiplier to 1.0\n\nPiperOrigin-RevId: 297486523\n\nf077632ba7fee588922d9e8717ee272039be126d\nfirestore: add update_transform\n\nPiperOrigin-RevId: 297405063\n\n"
+        "sha": "430375af011f8c7a5174884f0d0e539c6ffa7675",
+        "internalRef": "301538851",
+        "log": "430375af011f8c7a5174884f0d0e539c6ffa7675\ndocs: add missing closing backtick\n\nPiperOrigin-RevId: 301538851\n\n0e9f1f60ded9ad1c2e725e37719112f5b487ab65\nbazel: Use latest release of gax_java\n\nPiperOrigin-RevId: 301480457\n\n5058c1c96d0ece7f5301a154cf5a07b2ad03a571\nUpdate GAPIC v2 with batching parameters for Logging API\n\nPiperOrigin-RevId: 301443847\n\n64ab9744073de81fec1b3a6a931befc8a90edf90\nFix: Introduce location-based organization/folder/billing-account resources\nChore: Update copyright years\n\nPiperOrigin-RevId: 301373760\n\n23d5f09e670ebb0c1b36214acf78704e2ecfc2ac\nUpdate field_behavior annotations in V1 and V2.\n\nPiperOrigin-RevId: 301337970\n\nb2cf37e7fd62383a811aa4d54d013ecae638851d\nData Catalog V1 API\n\nPiperOrigin-RevId: 301282503\n\n1976b9981e2900c8172b7d34b4220bdb18c5db42\nCloud DLP api update. Adds missing fields to Finding and adds support for hybrid jobs.\n\nPiperOrigin-RevId: 301205325\n\nae78682c05e864d71223ce22532219813b0245ac\nfix: several sample code blocks in comments are now properly indented for markdown\n\nPiperOrigin-RevId: 301185150\n\ndcd171d04bda5b67db13049320f97eca3ace3731\nPublish Media Translation API V1Beta1\n\nPiperOrigin-RevId: 301180096\n\nff1713453b0fbc5a7544a1ef6828c26ad21a370e\nAdd protos and BUILD rules for v1 API.\n\nPiperOrigin-RevId: 301179394\n\n8386761d09819b665b6a6e1e6d6ff884bc8ff781\nfeat: chromeos/modlab publish protos and config for Chrome OS Moblab API.\n\nPiperOrigin-RevId: 300843960\n\nb2e2bc62fab90e6829e62d3d189906d9b79899e4\nUpdates to GCS gRPC API spec:\n\n1. Changed GetIamPolicy and TestBucketIamPermissions to use wrapper messages around google.iam.v1 IAM requests messages, and added CommonRequestParams. This lets us support RequesterPays buckets.\n2. Added a metadata field to GetObjectMediaResponse, to support resuming an object media read safely (by extracting the generation of the object being read, and using it in the resumed read request).\n\nPiperOrigin-RevId: 300817706\n\n7fd916ce12335cc9e784bb9452a8602d00b2516c\nAdd deprecated_collections field for backward-compatiblity in PHP and monolith-generated Python and Ruby clients.\n\nGenerate TopicName class in Java which covers the functionality of both ProjectTopicName and DeletedTopicName. Introduce breaking changes to be fixed by synth.py.\n\nDelete default retry parameters.\n\nRetry codes defs can be deleted once # https://github.com/googleapis/gapic-generator/issues/3137 is fixed.\n\nPiperOrigin-RevId: 300813135\n\n047d3a8ac7f75383855df0166144f891d7af08d9\nfix!: google/rpc refactor ErrorInfo.type to ErrorInfo.reason and comment updates.\n\nPiperOrigin-RevId: 300773211\n\nfae4bb6d5aac52aabe5f0bb4396466c2304ea6f6\nAdding RetryPolicy to pubsub.proto\n\nPiperOrigin-RevId: 300769420\n\n"
       }
     }
   ],
diff --git a/google-cloud-secret_manager-v1beta1/synth.py b/google-cloud-secret_manager-v1beta1/synth.py
index bf41d763a..cd109aa92 100644
--- a/google-cloud-secret_manager-v1beta1/synth.py
+++ b/google-cloud-secret_manager-v1beta1/synth.py
@@ -31,6 +31,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Secret Manager V1beta1",
         "ruby-cloud-summary": "Stores, manages, and secures access to application secrets.",
         "ruby-cloud-env-prefix": "SECRET_MANAGER",
+        "ruby-cloud-grpc-service-config": "google/cloud/secrets/v1beta1/secretmanager_grpc_service_config.json",
     }
 )
 

```

</details>

This pull request was generated using releasetool.