### PR TITLE
Release google-cloud-billing-v1 1.0.0

### DIFF
--- a/google-cloud-billing-v1/CHANGELOG.md
+++ b/google-cloud-billing-v1/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+### 1.0.0 / 2020-03-18
+
+* Support separate project setting for quota/billing
+* Include the correct default timeout and retry settings
+* Eliminate some Ruby 2.7 keyword argument warnings
+* Add Configuration docs and update enum return types
+* Fix various formatting issues in inline documentation
+
 ### 0.1.1 / 2020-02-24
 
 #### Documentation

--- a/google-cloud-billing-v1/lib/google/cloud/billing/v1/version.rb
+++ b/google-cloud-billing-v1/lib/google/cloud/billing/v1/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Billing
       module V1
-        VERSION = "0.1.1"
+        VERSION = "1.0.0"
       end
     end
   end


### PR DESCRIPTION
* Support separate project setting for quota/billing
* Include the correct default timeout and retry settings
* Eliminate some Ruby 2.7 keyword argument warnings
* Add Configuration docs and update enum return types
* Fix various formatting issues in inline documentation

<details><summary>Commits since previous release</summary><pre><code>commit 16cf33ebb16fc1485be0568761f33484ba761612
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Mar 18 08:11:39 2020 -0700

    fix(billing-v1): Eliminate some Ruby 2.7 keyword argument warnings

commit 699796790aa6fca7ce6c617563c36003681e6791
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Fri Mar 13 15:57:30 2020 -0700

    docs(billing-v1): remove some spurious backslash escaping from code samples in inline documentation

commit 7226bb9c84724a21b4be25981800f0af064f8ef4
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Thu Mar 12 09:23:46 2020 -0700

    chore(billing-v1): Set default network configuration from service config

commit 85c9fd48ddf1b66b5010c8617eeea87283f77200
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed Mar 11 10:42:13 2020 -0700

    chore: add grpc service configs to microgen library synth scripts

commit 28a7f60cbb4b513cb23bcc3e21658b17101b54ef
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Mar 9 12:19:01 2020 -0700

    chore(billing-v1): Add x-goog-user-project request header

commit 5b64890ab6098323e22380488f212c9621c90ebd
Author: Chris Smith <quartzmo@gmail.com>
Date:   Wed Mar 4 11:05:47 2020 -0700

    docs(billing-v1): Add Configuration docs and update enum return types

commit 0ee26447b943e6d73a4a98f1110e2a88911f2a9c
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Feb 26 08:03:35 2020 -0800

    tests(billing-v1): Update simplecov dependency

commit 828319ec4b794ecfbe352940d5f5347db24d1877
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Feb 25 14:21:29 2020 -0800

    chore: require the simplecov library explicitly in test helpers
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-billing-v1/.gitignore b/google-cloud-billing-v1/.gitignore
index 19f01259d..0135b6bc6 100644
--- a/google-cloud-billing-v1/.gitignore
+++ b/google-cloud-billing-v1/.gitignore
@@ -15,6 +15,8 @@ pkg/*
 # Ignore files commonly present in certain dev environments
 .vagrant
 .DS_STORE
+.idea
+*.iml
 
 # Ignore synth output
 __pycache__
diff --git a/google-cloud-billing-v1/AUTHENTICATION.md b/google-cloud-billing-v1/AUTHENTICATION.md
index 2c9b43445..13df964bc 100644
--- a/google-cloud-billing-v1/AUTHENTICATION.md
+++ b/google-cloud-billing-v1/AUTHENTICATION.md
@@ -1,16 +1,17 @@
 # Authentication
 
-In general, the google-cloud-billing-v1 library uses [Service
-Account](https://cloud.google.com/iam/docs/creating-managing-service-accounts)
-credentials to connect to Google Cloud services. When running within [Google
-Cloud Platform environments](#google-cloud-platform-environments)
-the credentials will be discovered automatically. When running on other
+In general, the google-cloud-billing-v1 library uses
+[Service Account](https://cloud.google.com/iam/docs/creating-managing-service-accounts)
+credentials to connect to Google Cloud services. When running within
+[Google Cloud Platform environments](#google-cloud-platform-environments) the
+credentials will be discovered automatically. When running on other
 environments, the Service Account credentials can be specified by providing the
-path to the [JSON
-keyfile](https://cloud.google.com/iam/docs/managing-service-account-keys) for
-the account (or the JSON itself) in [environment
-variables](#environment-variables). Additionally, Cloud SDK credentials can also
-be discovered automatically, but this is only recommended during development.
+path to the
+[JSON keyfile](https://cloud.google.com/iam/docs/managing-service-account-keys)
+for the account (or the JSON itself) in
+[environment variables](#environment-variables). Additionally, Cloud SDK
+credentials can also be discovered automatically, but this is only recommended
+during development.
 
 ## Quickstart
 
@@ -46,23 +47,24 @@ without **Service Account Credentials** directly in code.
 
 ### Google Cloud Platform environments
 
-When running on Google Cloud Platform (GCP), including Google Compute Engine (GCE),
-Google Kubernetes Engine (GKE), Google App Engine (GAE), Google Cloud Functions
-(GCF) and Cloud Run, **Credentials** and are discovered
-automatically. Code should be written as if already authenticated.
+When running on Google Cloud Platform (GCP), including Google Compute Engine
+(GCE), Google Kubernetes Engine (GKE), Google App Engine (GAE), Google Cloud
+Functions (GCF) and Cloud Run, **Credentials** are discovered automatically.
+Code should be written as if already authenticated.
 
 ### Environment Variables
 
-The **Credentials JSON** can be placed in environment
-variables instead of declaring them directly in code. Each service has its own
-environment variable, allowing for different service accounts to be used for
-different services. (See the READMEs for the individual service gems for
-details.) The path to the **Credentials JSON** file can be stored in the
-environment variable, or the **Credentials JSON** itself can be stored for
-environments such as Docker containers where writing files is difficult or not
-encouraged.
+The **Credentials JSON** can be placed in environment variables instead of
+declaring them directly in code. Each service has its own environment variable,
+allowing for different service accounts to be used for different services. (See
+the READMEs for the individual service gems for details.) The path to the
+**Credentials JSON** file can be stored in the environment variable, or the
+**Credentials JSON** itself can be stored for environments such as Docker
+containers where writing files is difficult or not encouraged.
 
-The environment variables that google-cloud-billing-v1 checks for credentials are configured on the service Credentials class (such as {Google::Cloud::Billing::V1::CloudBilling::Credentials}):
+The environment variables that google-cloud-billing-v1
+checks for credentials are configured on the service Credentials class (such as
+{Google::Cloud::Billing::V1::CloudBilling::Credentials}):
 
 1. `BILLING_CREDENTIALS` - Path to JSON file, or JSON contents
 2. `BILLING_KEYFILE` - Path to JSON file, or JSON contents
@@ -80,7 +82,8 @@ client = Google::Cloud::Billing::V1::CloudBilling::Client.new
 
 ### Configuration
 
-The **Credentials JSON** can be configured instead of placing them in environment variables. Either on an individual client initialization:
+The **Credentials JSON** can be configured instead of placing them in
+environment variables. Either on an individual client initialization:
 
 ```ruby
 require "google/cloud/billing/v1"
@@ -137,15 +140,15 @@ environments](#google-cloud-platform-environments), you need a Google
 Developers service account.
 
 1. Visit the [Google Developers Console][dev-console].
-1. Create a new project or click on an existing project.
-1. Activate the slide-out navigation tray and select **API Manager**. From
+2. Create a new project or click on an existing project.
+3. Activate the slide-out navigation tray and select **API Manager**. From
    here, you will enable the APIs that your application requires.
 
    ![Enable the APIs that your application requires][enable-apis]
 
    *Note: You may need to enable billing in order to use these services.*
 
-1. Select **Credentials** from the side navigation.
+4. Select **Credentials** from the side navigation.
 
    You should see a screen like one of the following.
 
diff --git a/google-cloud-billing-v1/google-cloud-billing-v1.gemspec b/google-cloud-billing-v1/google-cloud-billing-v1.gemspec
index 84661c16f..09dde4595 100644
--- a/google-cloud-billing-v1/google-cloud-billing-v1.gemspec
+++ b/google-cloud-billing-v1/google-cloud-billing-v1.gemspec
@@ -23,14 +23,14 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.1.0"
+  gem.add_dependency "gapic-common", "~> 0.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"
-  gem.add_development_dependency "rake", "~> 12.0"
+  gem.add_development_dependency "rake", ">= 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "simplecov", "~> 0.18"
   gem.add_development_dependency "yard", "~> 0.9"
 end
diff --git a/google-cloud-billing-v1/lib/google/cloud/billing/v1/cloud_billing/client.rb b/google-cloud-billing-v1/lib/google/cloud/billing/v1/cloud_billing/client.rb
index 7fe4bbd90..5739c14b3 100644
--- a/google-cloud-billing-v1/lib/google/cloud/billing/v1/cloud_billing/client.rb
+++ b/google-cloud-billing-v1/lib/google/cloud/billing/v1/cloud_billing/client.rb
@@ -40,7 +40,18 @@ module Google
             attr_reader :cloud_billing_stub
 
             ##
-            # Configuration for the CloudBilling Client API.
+            # Configure the CloudBilling Client class.
+            #
+            # See {Google::Cloud::Billing::V1::CloudBilling::Client::Configuration}
+            # for a description of the configuration fields.
+            #
+            # ## Example
+            #
+            # To modify the configuration for all CloudBilling clients:
+            #
+            #     Google::Cloud::Billing::V1::CloudBilling::Client.configure do |config|
+            #       config.timeout = 10_000
+            #     end
             #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Client::Configuration]
@@ -56,7 +67,83 @@ module Google
                                   break parent_const.configure if parent_const&.respond_to? :configure
                                   namespace.pop
                                 end
-                Client::Configuration.new parent_config
+                default_config = Client::Configuration.new parent_config
+
+                default_config.rpcs.get_billing_account.timeout = 60.0
+                default_config.rpcs.get_billing_account.retry_policy = {
+                  initial_delay: 0.1,
+                  max_delay:     60.0,
+                  multiplier:    1.3,
+                  retry_codes:   ["DEADLINE_EXCEEDED", "UNAVAILABLE"]
+                }
+
+                default_config.rpcs.list_billing_accounts.timeout = 60.0
+                default_config.rpcs.list_billing_accounts.retry_policy = {
+                  initial_delay: 0.1,
+                  max_delay:     60.0,
+                  multiplier:    1.3,
+                  retry_codes:   ["DEADLINE_EXCEEDED", "UNAVAILABLE"]
+                }
+
+                default_config.rpcs.update_billing_account.timeout = 60.0
+                default_config.rpcs.update_billing_account.retry_policy = {
+                  initial_delay: 0.1,
+                  max_delay:     60.0,
+                  multiplier:    1.3,
+                  retry_codes:   ["DEADLINE_EXCEEDED", "UNAVAILABLE"]
+                }
+
+                default_config.rpcs.create_billing_account.timeout = 60.0
+
+                default_config.rpcs.list_project_billing_info.timeout = 60.0
+                default_config.rpcs.list_project_billing_info.retry_policy = {
+                  initial_delay: 0.1,
+                  max_delay:     60.0,
+                  multiplier:    1.3,
+                  retry_codes:   ["DEADLINE_EXCEEDED", "UNAVAILABLE"]
+                }
+
+                default_config.rpcs.get_project_billing_info.timeout = 60.0
+                default_config.rpcs.get_project_billing_info.retry_policy = {
+                  initial_delay: 0.1,
+                  max_delay:     60.0,
+                  multiplier:    1.3,
+                  retry_codes:   ["DEADLINE_EXCEEDED", "UNAVAILABLE"]
+                }
+
+                default_config.rpcs.update_project_billing_info.timeout = 60.0
+                default_config.rpcs.update_project_billing_info.retry_policy = {
+                  initial_delay: 0.1,
+                  max_delay:     60.0,
+                  multiplier:    1.3,
+                  retry_codes:   ["DEADLINE_EXCEEDED", "UNAVAILABLE"]
+                }
+
+                default_config.rpcs.get_iam_policy.timeout = 60.0
+                default_config.rpcs.get_iam_policy.retry_policy = {
+                  initial_delay: 0.1,
+                  max_delay:     60.0,
+                  multiplier:    1.3,
+                  retry_codes:   ["DEADLINE_EXCEEDED", "UNAVAILABLE"]
+                }
+
+                default_config.rpcs.set_iam_policy.timeout = 60.0
+                default_config.rpcs.set_iam_policy.retry_policy = {
+                  initial_delay: 0.1,
+                  max_delay:     60.0,
+                  multiplier:    1.3,
+                  retry_codes:   ["DEADLINE_EXCEEDED", "UNAVAILABLE"]
+                }
+
+                default_config.rpcs.test_iam_permissions.timeout = 60.0
+                default_config.rpcs.test_iam_permissions.retry_policy = {
+                  initial_delay: 0.1,
+                  max_delay:     60.0,
+                  multiplier:    1.3,
+                  retry_codes:   ["DEADLINE_EXCEEDED", "UNAVAILABLE"]
+                }
+
+                default_config
               end
               yield @configure if block_given?
               @configure
@@ -69,6 +156,9 @@ module Google
             # but structural changes (adding new fields, etc.) are not allowed. Structural changes
             # should be made on {Client.configure}.
             #
+            # See {Google::Cloud::Billing::V1::CloudBilling::Client::Configuration}
+            # for a description of the configuration fields.
+            #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Client::Configuration]
             #
@@ -80,9 +170,23 @@ module Google
             end
 
             ##
-            # Create a new Client client object.
+            # Create a new CloudBilling client object.
             #
-            # @yield [config] Configure the Client client.
+            # ## Examples
+            #
+            # To create a new CloudBilling client with the default
+            # configuration:
+            #
+            #     client = Google::Cloud::Billing::V1::CloudBilling::Client.new
+            #
+            # To create a new CloudBilling client with a custom
+            # configuration:
+            #
+            #     client = Google::Cloud::Billing::V1::CloudBilling::Client.new do |config|
+            #       config.timeout = 10_000
+            #     end
+            #
+            # @yield [config] Configure the CloudBilling client.
             # @yieldparam config [Client::Configuration]
             #
             def initialize
@@ -104,7 +208,7 @@ module Google
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
-
+              @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
               @cloud_billing_stub = Gapic::ServiceStub.new(
                 Google::Cloud::Billing::V1::CloudBilling::Stub,
@@ -150,15 +254,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Billing::V1::GetBillingAccountRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_billing_account.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Billing::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -224,15 +329,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Billing::V1::ListBillingAccountsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_billing_accounts.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Billing::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.list_billing_accounts.timeout,
                                      metadata:     metadata,
@@ -292,15 +398,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Billing::V1::UpdateBillingAccountRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.update_billing_account.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Billing::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -371,15 +478,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Billing::V1::CreateBillingAccountRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.create_billing_account.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Billing::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.create_billing_account.timeout,
                                      metadata:     metadata,
@@ -437,15 +545,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Billing::V1::ListProjectBillingInfoRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_project_billing_info.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Billing::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -503,15 +612,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Billing::V1::GetProjectBillingInfoRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_project_billing_info.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Billing::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -625,15 +735,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Billing::V1::UpdateProjectBillingInfoRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.update_project_billing_info.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Billing::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -674,7 +785,7 @@ module Google
             #   @param resource [String]
             #     REQUIRED: The resource for which the policy is being requested.
             #     `resource` is usually specified as a path. For example, a Project
-            #     resource is specified as `projects/\\\{project\}`.
+            #     resource is specified as `projects/{project}`.
             #
             #
             # @yield [response, operation] Access the result along with the RPC operation
@@ -691,15 +802,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Iam::V1::GetIamPolicyRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_iam_policy.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Billing::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "resource" => request.resource
@@ -742,7 +854,7 @@ module Google
             #   @param resource [String]
             #     REQUIRED: The resource for which the policy is being specified.
             #     `resource` is usually specified as a path. For example, a Project
-            #     resource is specified as `projects/\\\{project\}`.
+            #     resource is specified as `projects/{project}`.
             #   @param policy [Google::Iam::V1::Policy | Hash]
             #     REQUIRED: The complete policy to be applied to the `resource`. The size of
             #     the policy is limited to a few 10s of KB. An empty policy is a
@@ -764,15 +876,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Iam::V1::SetIamPolicyRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.set_iam_policy.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Billing::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "resource" => request.resource
@@ -811,7 +924,7 @@ module Google
             #   @param resource [String]
             #     REQUIRED: The resource for which the policy detail is being requested.
             #     `resource` is usually specified as a path. For example, a Project
-            #     resource is specified as `projects/\\\{project\}`.
+            #     resource is specified as `projects/{project}`.
             #   @param permissions [Array<String>]
             #     The set of permissions to check for the `resource`. Permissions with
             #     wildcards (such as '*' or 'storage.*') are not allowed. For more
@@ -833,15 +946,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Iam::V1::TestIamPermissionsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.test_iam_permissions.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Billing::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "resource" => request.resource
@@ -865,6 +979,81 @@ module Google
 
             ##
             # Configuration class for the CloudBilling API.
+            #
+            # This class represents the configuration for CloudBilling,
+            # providing control over timeouts, retry behavior, logging, transport
+            # parameters, and other low-level controls. Certain parameters can also be
+            # applied individually to specific RPCs. See
+            # {Google::Cloud::Billing::V1::CloudBilling::Client::Configuration::Rpcs}
+            # for a list of RPCs that can be configured independently.
+            #
+            # Configuration can be applied globally to all clients, or to a single client
+            # on construction.
+            #
+            # # Examples
+            #
+            # To modify the global config, setting the timeout for get_billing_account
+            # to 20 seconds, and all remaining timeouts to 10 seconds:
+            #
+            #     Google::Cloud::Billing::V1::CloudBilling::Client.configure do |config|
+            #       config.timeout = 10_000
+            #       config.rpcs.get_billing_account.timeout = 20_000
+            #     end
+            #
+            # To apply the above configuration only to a new client:
+            #
+            #     client = Google::Cloud::Billing::V1::CloudBilling::Client.new do |config|
+            #       config.timeout = 10_000
+            #       config.rpcs.get_billing_account.timeout = 20_000
+            #     end
+            #
+            # @!attribute [rw] endpoint
+            #   The hostname or hostname:port of the service endpoint.
+            #   Defaults to `"cloudbilling.googleapis.com"`.
+            #   @return [String]
+            # @!attribute [rw] credentials
+            #   Credentials to send with calls. You may provide any of the following types:
+            #    *  (`String`) The path to a service account key file in JSON format
+            #    *  (`Hash`) A service account key as a Hash
+            #    *  (`Google::Auth::Credentials`) A googleauth credentials object
+            #       (see the [googleauth docs](https://googleapis.dev/ruby/googleauth/latest/index.html))
+            #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
+            #       (see the [signet docs](https://googleapis.dev/ruby/signet/latest/Signet/OAuth2/Client.html))
+            #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
+            #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
+            #    *  (`nil`) indicating no credentials
+            #   @return [Object]
+            # @!attribute [rw] scope
+            #   The OAuth scopes
+            #   @return [Array<String>]
+            # @!attribute [rw] lib_name
+            #   The library name as recorded in instrumentation and logging
+            #   @return [String]
+            # @!attribute [rw] lib_version
+            #   The library version as recorded in instrumentation and logging
+            #   @return [String]
+            # @!attribute [rw] channel_args
+            #   Extra parameters passed to the gRPC channel. Note: this is ignored if a
+            #   `GRPC::Core::Channel` object is provided as the credential.
+            #   @return [Hash]
+            # @!attribute [rw] interceptors
+            #   An array of interceptors that are run before calls are executed.
+            #   @return [Array<GRPC::ClientInterceptor>]
+            # @!attribute [rw] timeout
+            #   The call timeout in milliseconds.
+            #   @return [Numeric]
+            # @!attribute [rw] metadata
+            #   Additional gRPC headers to be sent with the call.
+            #   @return [Hash{Symbol=>String}]
+            # @!attribute [rw] retry_policy
+            #   The retry policy. The value is a hash with the following keys:
+            #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
+            #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
+            #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
+            #       trigger a retry.
+            #   @return [Hash]
+            #
             class Configuration
               extend Gapic::Config
 
@@ -883,12 +1072,17 @@ module Google
               config_attr :metadata,     nil, Hash, nil
               config_attr :retry_policy, nil, Hash, Proc, nil
 
+              # @private
               def initialize parent_config = nil
                 @parent_config = parent_config unless parent_config.nil?
 
                 yield self if block_given?
               end
 
+              ##
+              # Configurations for individual RPCs
+              # @return [Rpcs]
+              #
               def rpcs
                 @rpcs ||= begin
                   parent_rpcs = nil
@@ -899,18 +1093,74 @@ module Google
 
               ##
               # Configuration RPC class for the CloudBilling API.
+              #
+              # Includes fields providing the configuration for each RPC in this service.
+              # Each configuration object is of type `Gapic::Config::Method` and includes
+              # the following configuration fields:
+              #
+              #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+              #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
+              #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
+              #     include the following keys:
+              #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
+              #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
+              #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
+              #         trigger a retry.
+              #
               class Rpcs
+                ##
+                # RPC-specific configuration for `get_billing_account`
+                # @return [Gapic::Config::Method]
+                #
                 attr_reader :get_billing_account
+                ##
+                # RPC-specific configuration for `list_billing_accounts`
+                # @return [Gapic::Config::Method]
+                #
                 attr_reader :list_billing_accounts
+                ##
+                # RPC-specific configuration for `update_billing_account`
+                # @return [Gapic::Config::Method]
+                #
                 attr_reader :update_billing_account
+                ##
+                # RPC-specific configuration for `create_billing_account`
+                # @return [Gapic::Config::Method]
+                #
                 attr_reader :create_billing_account
+                ##
+                # RPC-specific configuration for `list_project_billing_info`
+                # @return [Gapic::Config::Method]
+                #
                 attr_reader :list_project_billing_info
+                ##
+                # RPC-specific configuration for `get_project_billing_info`
+                # @return [Gapic::Config::Method]
+                #
                 attr_reader :get_project_billing_info
+                ##
+                # RPC-specific configuration for `update_project_billing_info`
+                # @return [Gapic::Config::Method]
+                #
                 attr_reader :update_project_billing_info
+                ##
+                # RPC-specific configuration for `get_iam_policy`
+                # @return [Gapic::Config::Method]
+                #
                 attr_reader :get_iam_policy
+                ##
+                # RPC-specific configuration for `set_iam_policy`
+                # @return [Gapic::Config::Method]
+                #
                 attr_reader :set_iam_policy
+                ##
+                # RPC-specific configuration for `test_iam_permissions`
+                # @return [Gapic::Config::Method]
+                #
                 attr_reader :test_iam_permissions
 
+                # @private
                 def initialize parent_rpcs = nil
                   get_billing_account_config = parent_rpcs&.get_billing_account if parent_rpcs&.respond_to? :get_billing_account
                   @get_billing_account = Gapic::Config::Method.new get_billing_account_config
diff --git a/google-cloud-billing-v1/lib/google/cloud/billing/v1/cloud_catalog/client.rb b/google-cloud-billing-v1/lib/google/cloud/billing/v1/cloud_catalog/client.rb
index a88bd3079..d75c1024b 100644
--- a/google-cloud-billing-v1/lib/google/cloud/billing/v1/cloud_catalog/client.rb
+++ b/google-cloud-billing-v1/lib/google/cloud/billing/v1/cloud_catalog/client.rb
@@ -40,7 +40,18 @@ module Google
             attr_reader :cloud_catalog_stub
 
             ##
-            # Configuration for the CloudCatalog Client API.
+            # Configure the CloudCatalog Client class.
+            #
+            # See {Google::Cloud::Billing::V1::CloudCatalog::Client::Configuration}
+            # for a description of the configuration fields.
+            #
+            # ## Example
+            #
+            # To modify the configuration for all CloudCatalog clients:
+            #
+            #     Google::Cloud::Billing::V1::CloudCatalog::Client.configure do |config|
+            #       config.timeout = 10_000
+            #     end
             #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Client::Configuration]
@@ -56,7 +67,13 @@ module Google
                                   break parent_const.configure if parent_const&.respond_to? :configure
                                   namespace.pop
                                 end
-                Client::Configuration.new parent_config
+                default_config = Client::Configuration.new parent_config
+
+                default_config.rpcs.list_services.timeout = 60.0
+
+                default_config.rpcs.list_skus.timeout = 60.0
+
+                default_config
               end
               yield @configure if block_given?
               @configure
@@ -69,6 +86,9 @@ module Google
             # but structural changes (adding new fields, etc.) are not allowed. Structural changes
             # should be made on {Client.configure}.
             #
+            # See {Google::Cloud::Billing::V1::CloudCatalog::Client::Configuration}
+            # for a description of the configuration fields.
+            #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Client::Configuration]
             #
@@ -80,9 +100,23 @@ module Google
             end
 
             ##
-            # Create a new Client client object.
+            # Create a new CloudCatalog client object.
             #
-            # @yield [config] Configure the Client client.
+            # ## Examples
+            #
+            # To create a new CloudCatalog client with the default
+            # configuration:
+            #
+            #     client = Google::Cloud::Billing::V1::CloudCatalog::Client.new
+            #
+            # To create a new CloudCatalog client with a custom
+            # configuration:
+            #
+            #     client = Google::Cloud::Billing::V1::CloudCatalog::Client.new do |config|
+            #       config.timeout = 10_000
+            #     end
+            #
+            # @yield [config] Configure the CloudCatalog client.
             # @yieldparam config [Client::Configuration]
             #
             def initialize
@@ -104,7 +138,7 @@ module Google
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
-
+              @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
               @cloud_catalog_stub = Gapic::ServiceStub.new(
                 Google::Cloud::Billing::V1::CloudCatalog::Stub,
@@ -149,15 +183,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Billing::V1::ListServicesRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_services.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Billing::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.list_services.timeout,
                                      metadata:     metadata,
@@ -227,15 +262,16 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Billing::V1::ListSkusRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_skus.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Billing::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -260,6 +296,81 @@ module Google
 
             ##
             # Configuration class for the CloudCatalog API.
+            #
+            # This class represents the configuration for CloudCatalog,
+            # providing control over timeouts, retry behavior, logging, transport
+            # parameters, and other low-level controls. Certain parameters can also be
+            # applied individually to specific RPCs. See
+            # {Google::Cloud::Billing::V1::CloudCatalog::Client::Configuration::Rpcs}
+            # for a list of RPCs that can be configured independently.
+            #
+            # Configuration can be applied globally to all clients, or to a single client
+            # on construction.
+            #
+            # # Examples
+            #
+            # To modify the global config, setting the timeout for list_services
+            # to 20 seconds, and all remaining timeouts to 10 seconds:
+            #
+            #     Google::Cloud::Billing::V1::CloudCatalog::Client.configure do |config|
+            #       config.timeout = 10_000
+            #       config.rpcs.list_services.timeout = 20_000
+            #     end
+            #
+            # To apply the above configuration only to a new client:
+            #
+            #     client = Google::Cloud::Billing::V1::CloudCatalog::Client.new do |config|
+            #       config.timeout = 10_000
+            #       config.rpcs.list_services.timeout = 20_000
+            #     end
+            #
+            # @!attribute [rw] endpoint
+            #   The hostname or hostname:port of the service endpoint.
+            #   Defaults to `"cloudbilling.googleapis.com"`.
+            #   @return [String]
+            # @!attribute [rw] credentials
+            #   Credentials to send with calls. You may provide any of the following types:
+            #    *  (`String`) The path to a service account key file in JSON format
+            #    *  (`Hash`) A service account key as a Hash
+            #    *  (`Google::Auth::Credentials`) A googleauth credentials object
+            #       (see the [googleauth docs](https://googleapis.dev/ruby/googleauth/latest/index.html))
+            #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
+            #       (see the [signet docs](https://googleapis.dev/ruby/signet/latest/Signet/OAuth2/Client.html))
+            #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
+            #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
+            #    *  (`nil`) indicating no credentials
+            #   @return [Object]
+            # @!attribute [rw] scope
+            #   The OAuth scopes
+            #   @return [Array<String>]
+            # @!attribute [rw] lib_name
+            #   The library name as recorded in instrumentation and logging
+            #   @return [String]
+            # @!attribute [rw] lib_version
+            #   The library version as recorded in instrumentation and logging
+            #   @return [String]
+            # @!attribute [rw] channel_args
+            #   Extra parameters passed to the gRPC channel. Note: this is ignored if a
+            #   `GRPC::Core::Channel` object is provided as the credential.
+            #   @return [Hash]
+            # @!attribute [rw] interceptors
+            #   An array of interceptors that are run before calls are executed.
+            #   @return [Array<GRPC::ClientInterceptor>]
+            # @!attribute [rw] timeout
+            #   The call timeout in milliseconds.
+            #   @return [Numeric]
+            # @!attribute [rw] metadata
+            #   Additional gRPC headers to be sent with the call.
+            #   @return [Hash{Symbol=>String}]
+            # @!attribute [rw] retry_policy
+            #   The retry policy. The value is a hash with the following keys:
+            #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
+            #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
+            #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
+            #       trigger a retry.
+            #   @return [Hash]
+            #
             class Configuration
               extend Gapic::Config
 
@@ -278,12 +389,17 @@ module Google
               config_attr :metadata,     nil, Hash, nil
               config_attr :retry_policy, nil, Hash, Proc, nil
 
+              # @private
               def initialize parent_config = nil
                 @parent_config = parent_config unless parent_config.nil?
 
                 yield self if block_given?
               end
 
+              ##
+              # Configurations for individual RPCs
+              # @return [Rpcs]
+              #
               def rpcs
                 @rpcs ||= begin
                   parent_rpcs = nil
@@ -294,10 +410,34 @@ module Google
 
               ##
               # Configuration RPC class for the CloudCatalog API.
+              #
+              # Includes fields providing the configuration for each RPC in this service.
+              # Each configuration object is of type `Gapic::Config::Method` and includes
+              # the following configuration fields:
+              #
+              #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+              #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
+              #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
+              #     include the following keys:
+              #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
+              #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
+              #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
+              #         trigger a retry.
+              #
               class Rpcs
+                ##
+                # RPC-specific configuration for `list_services`
+                # @return [Gapic::Config::Method]
+                #
                 attr_reader :list_services
+                ##
+                # RPC-specific configuration for `list_skus`
+                # @return [Gapic::Config::Method]
+                #
                 attr_reader :list_skus
 
+                # @private
                 def initialize parent_rpcs = nil
                   list_services_config = parent_rpcs&.list_services if parent_rpcs&.respond_to? :list_services
                   @list_services = Gapic::Config::Method.new list_services_config
diff --git a/google-cloud-billing-v1/proto_docs/google/api/resource.rb b/google-cloud-billing-v1/proto_docs/google/api/resource.rb
index 635b17307..ab300c8e4 100644
--- a/google-cloud-billing-v1/proto_docs/google/api/resource.rb
+++ b/google-cloud-billing-v1/proto_docs/google/api/resource.rb
@@ -27,110 +27,110 @@ module Google
     #
     # Example:
     #
-    #     message Topic \\\{
+    #     message Topic {
     #       // Indicates this message defines a resource schema.
-    #       // Declares the resource type in the format of \\\{service\}/\\\{kind\}.
-    #       // For Kubernetes resources, the format is \\\{api group\}/\\\{kind\}.
-    #       option (google.api.resource) = \\\{
+    #       // Declares the resource type in the format of {service}/{kind}.
+    #       // For Kubernetes resources, the format is {api group}/{kind}.
+    #       option (google.api.resource) = {
     #         type: "pubsub.googleapis.com/Topic"
-    #         name_descriptor: \\\{
-    #           pattern: "projects/\\\{project\}/topics/\\\{topic\}"
+    #         name_descriptor: {
+    #           pattern: "projects/{project}/topics/{topic}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/\\\{project\}"
-    #         \}
-    #       \};
-    #     \}
+    #           parent_name_extractor: "projects/{project}"
+    #         }
+    #       };
+    #     }
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #    resources:
     #    - type: "pubsub.googleapis.com/Topic"
     #      name_descriptor:
-    #        - pattern: "projects/\\\{project\}/topics/\\\{topic\}"
+    #        - pattern: "projects/\\{project}/topics/\\{topic}"
     #          parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #          parent_name_extractor: "projects/\\\{project\}"
+    #          parent_name_extractor: "projects/\\{project}"
     #
     # Sometimes, resources have multiple patterns, typically because they can
     # live under multiple parents.
     #
     # Example:
     #
-    #     message LogEntry \\\{
-    #       option (google.api.resource) = \\\{
+    #     message LogEntry {
+    #       option (google.api.resource) = {
     #         type: "logging.googleapis.com/LogEntry"
-    #         name_descriptor: \\\{
-    #           pattern: "projects/\\\{project\}/logs/\\\{log\}"
+    #         name_descriptor: {
+    #           pattern: "projects/{project}/logs/{log}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/\\\{project\}"
-    #         \}
-    #         name_descriptor: \\\{
-    #           pattern: "folders/\\\{folder\}/logs/\\\{log\}"
+    #           parent_name_extractor: "projects/{project}"
+    #         }
+    #         name_descriptor: {
+    #           pattern: "folders/{folder}/logs/{log}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #           parent_name_extractor: "folders/\\\{folder\}"
-    #         \}
-    #         name_descriptor: \\\{
-    #           pattern: "organizations/\\\{organization\}/logs/\\\{log\}"
+    #           parent_name_extractor: "folders/{folder}"
+    #         }
+    #         name_descriptor: {
+    #           pattern: "organizations/{organization}/logs/{log}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-    #           parent_name_extractor: "organizations/\\\{organization\}"
-    #         \}
-    #         name_descriptor: \\\{
-    #           pattern: "billingAccounts/\\\{billing_account\}/logs/\\\{log\}"
+    #           parent_name_extractor: "organizations/{organization}"
+    #         }
+    #         name_descriptor: {
+    #           pattern: "billingAccounts/{billing_account}/logs/{log}"
     #           parent_type: "billing.googleapis.com/BillingAccount"
-    #           parent_name_extractor: "billingAccounts/\\\{billing_account\}"
-    #         \}
-    #       \};
-    #     \}
+    #           parent_name_extractor: "billingAccounts/{billing_account}"
+    #         }
+    #       };
+    #     }
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #     resources:
     #     - type: 'logging.googleapis.com/LogEntry'
     #       name_descriptor:
-    #         - pattern: "projects/\\\{project\}/logs/\\\{log\}"
+    #         - pattern: "projects/{project}/logs/{log}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/\\\{project\}"
-    #         - pattern: "folders/\\\{folder\}/logs/\\\{log\}"
+    #           parent_name_extractor: "projects/{project}"
+    #         - pattern: "folders/{folder}/logs/{log}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #           parent_name_extractor: "folders/\\\{folder\}"
-    #         - pattern: "organizations/\\\{organization\}/logs/\\\{log\}"
+    #           parent_name_extractor: "folders/{folder}"
+    #         - pattern: "organizations/{organization}/logs/{log}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-    #           parent_name_extractor: "organizations/\\\{organization\}"
-    #         - pattern: "billingAccounts/\\\{billing_account\}/logs/\\\{log\}"
+    #           parent_name_extractor: "organizations/{organization}"
+    #         - pattern: "billingAccounts/{billing_account}/logs/{log}"
     #           parent_type: "billing.googleapis.com/BillingAccount"
-    #           parent_name_extractor: "billingAccounts/\\\{billing_account\}"
+    #           parent_name_extractor: "billingAccounts/{billing_account}"
     #
     # For flexible resources, the resource name doesn't contain parent names, but
     # the resource itself has parents for policy evaluation.
     #
     # Example:
     #
-    #     message Shelf \\\{
-    #       option (google.api.resource) = \\\{
+    #     message Shelf {
+    #       option (google.api.resource) = {
     #         type: "library.googleapis.com/Shelf"
-    #         name_descriptor: \\\{
-    #           pattern: "shelves/\\\{shelf\}"
+    #         name_descriptor: {
+    #           pattern: "shelves/{shelf}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #         \}
-    #         name_descriptor: \\\{
-    #           pattern: "shelves/\\\{shelf\}"
+    #         }
+    #         name_descriptor: {
+    #           pattern: "shelves/{shelf}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #         \}
-    #       \};
-    #     \}
+    #         }
+    #       };
+    #     }
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #     resources:
     #     - type: 'library.googleapis.com/Shelf'
     #       name_descriptor:
-    #         - pattern: "shelves/\\\{shelf\}"
+    #         - pattern: "shelves/{shelf}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #         - pattern: "shelves/\\\{shelf\}"
+    #         - pattern: "shelves/{shelf}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
     # @!attribute [rw] type
     #   @return [String]
     #     The resource type. It must be in the format of
-    #     \\\{service_name\}/\\\{resource_type_kind\}. The `resource_type_kind` must be
+    #     \\{service_name}/\\{resource_type_kind}. The `resource_type_kind` must be
     #     singular and must not include version numbers.
     #
     #     Example: `storage.googleapis.com/Bucket`
@@ -147,14 +147,14 @@ module Google
     #     The path pattern must follow the syntax, which aligns with HTTP binding
     #     syntax:
     #
-    #         Template = Segment \\\{ "/" Segment \} ;
+    #         Template = Segment { "/" Segment } ;
     #         Segment = LITERAL | Variable ;
-    #         Variable = "\\\{" LITERAL "\}" ;
+    #         Variable = "{" LITERAL "}" ;
     #
     #     Examples:
     #
-    #         - "projects/\\\{project\}/topics/\\\{topic\}"
-    #         - "projects/\\\{project\}/knowledgeBases/\\\{knowledge_base\}"
+    #         - "projects/\\{project}/topics/\\{topic}"
+    #         - "projects/\\{project}/knowledgeBases/\\{knowledge_base}"
     #
     #     The components in braces correspond to the IDs for each resource in the
     #     hierarchy. It is expected that, if multiple patterns are provided,
@@ -165,26 +165,26 @@ module Google
     #     Optional. The field on the resource that designates the resource name
     #     field. If omitted, this is assumed to be "name".
     # @!attribute [rw] history
-    #   @return [ENUM(History)]
+    #   @return [Google::Api::ResourceDescriptor::History]
     #     Optional. The historical or future-looking state of the resource pattern.
     #
     #     Example:
     #
     #         // The InspectTemplate message originally only supported resource
     #         // names with organization, and project was added later.
-    #         message InspectTemplate \\\{
-    #           option (google.api.resource) = \\\{
+    #         message InspectTemplate {
+    #           option (google.api.resource) = {
     #             type: "dlp.googleapis.com/InspectTemplate"
     #             pattern:
-    #             "organizations/\\\{organization\}/inspectTemplates/\\\{inspect_template\}"
-    #             pattern: "projects/\\\{project\}/inspectTemplates/\\\{inspect_template\}"
+    #             "organizations/{organization}/inspectTemplates/{inspect_template}"
+    #             pattern: "projects/{project}/inspectTemplates/{inspect_template}"
     #             history: ORIGINALLY_SINGLE_PATTERN
-    #           \};
-    #         \}
+    #           };
+    #         }
     # @!attribute [rw] plural
     #   @return [String]
     #     The plural name used in the resource name, such as 'projects' for
-    #     the name of 'projects/\\\{project\}'. It is the same concept of the `plural`
+    #     the name of 'projects/\\{project}'. It is the same concept of the `plural`
     #     field in k8s CRD spec
     #     https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
     # @!attribute [rw] singular
@@ -221,11 +221,11 @@ module Google
     #
     #     Example:
     #
-    #         message Subscription \\\{
-    #           string topic = 2 [(google.api.resource_reference) = \\\{
+    #         message Subscription {
+    #           string topic = 2 [(google.api.resource_reference) = {
     #             type: "pubsub.googleapis.com/Topic"
-    #           \}];
-    #         \}
+    #           }];
+    #         }
     # @!attribute [rw] child_type
     #   @return [String]
     #     The resource type of a child collection that the annotated field
@@ -234,11 +234,11 @@ module Google
     #
     #     Example:
     #
-    #       message ListLogEntriesRequest \\\{
-    #         string parent = 1 [(google.api.resource_reference) = \\\{
+    #       message ListLogEntriesRequest {
+    #         string parent = 1 [(google.api.resource_reference) = {
     #           child_type: "logging.googleapis.com/LogEntry"
-    #         \};
-    #       \}
+    #         };
+    #       }
     class ResourceReference
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
diff --git a/google-cloud-billing-v1/proto_docs/google/cloud/billing/v1/cloud_billing.rb b/google-cloud-billing-v1/proto_docs/google/cloud/billing/v1/cloud_billing.rb
index 6cb1a3f20..c3d069605 100644
--- a/google-cloud-billing-v1/proto_docs/google/cloud/billing/v1/cloud_billing.rb
+++ b/google-cloud-billing-v1/proto_docs/google/cloud/billing/v1/cloud_billing.rb
@@ -26,7 +26,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The resource name of the billing account. The resource name has the form
-        #     `billingAccounts/\\\{billing_account_id\}`. For example,
+        #     `billingAccounts/{billing_account_id}`. For example,
         #     `billingAccounts/012345-567890-ABCDEF` would be the resource name for
         #     billing account `012345-567890-ABCDEF`.
         # @!attribute [r] open
@@ -56,7 +56,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The resource name for the `ProjectBillingInfo`; has the form
-        #     `projects/\\\{project_id\}/billingInfo`. For example, the resource name for the
+        #     `projects/{project_id}/billingInfo`. For example, the resource name for the
         #     billing information for project `tokyo-rain-123` would be
         #     `projects/tokyo-rain-123/billingInfo`. This field is read-only.
         # @!attribute [rw] project_id
diff --git a/google-cloud-billing-v1/proto_docs/google/cloud/billing/v1/cloud_catalog.rb b/google-cloud-billing-v1/proto_docs/google/cloud/billing/v1/cloud_catalog.rb
index 7c0cce81a..8c99ad0d8 100644
--- a/google-cloud-billing-v1/proto_docs/google/cloud/billing/v1/cloud_catalog.rb
+++ b/google-cloud-billing-v1/proto_docs/google/cloud/billing/v1/cloud_catalog.rb
@@ -198,9 +198,9 @@ module Google
 
         # Represents the aggregation level and interval for pricing of a single SKU.
         # @!attribute [rw] aggregation_level
-        #   @return [ENUM(AggregationLevel)]
+        #   @return [Google::Cloud::Billing::V1::AggregationInfo::AggregationLevel]
         # @!attribute [rw] aggregation_interval
-        #   @return [ENUM(AggregationInterval)]
+        #   @return [Google::Cloud::Billing::V1::AggregationInfo::AggregationInterval]
         # @!attribute [rw] aggregation_count
         #   @return [Integer]
         #     The number of intervals to aggregate over.
diff --git a/google-cloud-billing-v1/proto_docs/google/iam/v1/iam_policy.rb b/google-cloud-billing-v1/proto_docs/google/iam/v1/iam_policy.rb
index 0f529c20e..134b64a57 100644
--- a/google-cloud-billing-v1/proto_docs/google/iam/v1/iam_policy.rb
+++ b/google-cloud-billing-v1/proto_docs/google/iam/v1/iam_policy.rb
@@ -25,7 +25,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being specified.
       #     `resource` is usually specified as a path. For example, a Project
-      #     resource is specified as `projects/\\\{project\}`.
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] policy
       #   @return [Google::Iam::V1::Policy]
       #     REQUIRED: The complete policy to be applied to the `resource`. The size of
@@ -42,7 +42,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
       #     `resource` is usually specified as a path. For example, a Project
-      #     resource is specified as `projects/\\\{project\}`.
+      #     resource is specified as `projects/{project}`.
       class GetIamPolicyRequest
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
@@ -53,7 +53,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy detail is being requested.
       #     `resource` is usually specified as a path. For example, a Project
-      #     resource is specified as `projects/\\\{project\}`.
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
       #     The set of permissions to check for the `resource`. Permissions with
diff --git a/google-cloud-billing-v1/proto_docs/google/iam/v1/policy.rb b/google-cloud-billing-v1/proto_docs/google/iam/v1/policy.rb
index bfbf7d260..476b506f3 100644
--- a/google-cloud-billing-v1/proto_docs/google/iam/v1/policy.rb
+++ b/google-cloud-billing-v1/proto_docs/google/iam/v1/policy.rb
@@ -31,9 +31,9 @@ module Google
       #
       # **Example**
       #
-      #     \\\{
+      #     {
       #       "bindings": [
-      #         \\\{
+      #         {
       #           "role": "roles/owner",
       #           "members": [
       #             "user:mike@example.com",
@@ -41,13 +41,13 @@ module Google
       #             "domain:google.com",
       #             "serviceAccount:my-other-app@appspot.gserviceaccount.com",
       #           ]
-      #         \},
-      #         \\\{
+      #         },
+      #         {
       #           "role": "roles/viewer",
       #           "members": ["user:sean@example.com"]
-      #         \}
+      #         }
       #       ]
-      #     \}
+      #     }
       #
       # For a description of IAM and its features, see the
       # [IAM developer's guide](https://cloud.google.com/iam).
@@ -93,17 +93,17 @@ module Google
       #     * `allAuthenticatedUsers`: A special identifier that represents anyone
       #        who is authenticated with a Google account or a service account.
       #
-      #     * `user:\\\{emailid\}`: An email address that represents a specific Google
+      #     * `user:{emailid}`: An email address that represents a specific Google
       #        account. For example, `alice@gmail.com` or `joe@example.com`.
       #
       #
-      #     * `serviceAccount:\\\{emailid\}`: An email address that represents a service
+      #     * `serviceAccount:{emailid}`: An email address that represents a service
       #        account. For example, `my-other-app@appspot.gserviceaccount.com`.
       #
-      #     * `group:\\\{emailid\}`: An email address that represents a Google group.
+      #     * `group:{emailid}`: An email address that represents a Google group.
       #        For example, `admins@example.com`.
       #
-      #     * `domain:\\\{domain\}`: A Google Apps domain name that represents all the
+      #     * `domain:{domain}`: A Google Apps domain name that represents all the
       #        users of that domain. For example, `google.com` or `example.com`.
       class Binding
         include Google::Protobuf::MessageExts
@@ -122,7 +122,7 @@ module Google
       # One delta entry for Binding. Each individual change (only one member in each
       # entry) to a binding will be a separate entry.
       # @!attribute [rw] action
-      #   @return [ENUM(Action)]
+      #   @return [Google::Iam::V1::BindingDelta::Action]
       #     The action that was performed on a Binding.
       #     Required
       # @!attribute [rw] role
diff --git a/google-cloud-billing-v1/proto_docs/google/protobuf/field_mask.rb b/google-cloud-billing-v1/proto_docs/google/protobuf/field_mask.rb
index 9e0c7c2c1..769103b14 100644
--- a/google-cloud-billing-v1/proto_docs/google/protobuf/field_mask.rb
+++ b/google-cloud-billing-v1/proto_docs/google/protobuf/field_mask.rb
@@ -39,14 +39,14 @@ module Google
     # specified in the mask. For example, if the mask in the previous
     # example is applied to a response message as follows:
     #
-    #     f \\\{
+    #     f {
     #       a : 22
-    #       b \\\{
+    #       b {
     #         d : 1
     #         x : 2
-    #       \}
+    #       }
     #       y : 13
-    #     \}
+    #     }
     #     z: 8
     #
     # The result will not contain specific values for fields x,y and z
@@ -54,12 +54,12 @@ module Google
     # output):
     #
     #
-    #     f \\\{
+    #     f {
     #       a : 22
-    #       b \\\{
+    #       b {
     #         d : 1
-    #       \}
-    #     \}
+    #       }
+    #     }
     #
     # A repeated field is not allowed except at the last position of a
     # paths string.
@@ -96,21 +96,21 @@ module Google
     # update operation, then the existing sub-message in the target resource is
     # overwritten. Given the target message:
     #
-    #     f \\\{
-    #       b \\\{
+    #     f {
+    #       b {
     #         d : 1
     #         x : 2
-    #       \}
+    #       }
     #       c : 1
-    #     \}
+    #     }
     #
     # And an update message:
     #
-    #     f \\\{
-    #       b \\\{
+    #     f {
+    #       b {
     #         d : 10
-    #       \}
-    #     \}
+    #       }
+    #     }
     #
     # then if the field mask is:
     #
@@ -118,12 +118,12 @@ module Google
     #
     # then the result will be:
     #
-    #     f \\\{
-    #       b \\\{
+    #     f {
+    #       b {
     #         d : 10
-    #       \}
+    #       }
     #       c : 1
-    #     \}
+    #     }
     #
     # However, if the update mask was:
     #
@@ -131,13 +131,13 @@ module Google
     #
     # then the result would be:
     #
-    #     f \\\{
-    #       b \\\{
+    #     f {
+    #       b {
     #         d : 10
     #         x : 2
-    #       \}
+    #       }
     #       c : 1
-    #     \}
+    #     }
     #
     # In order to reset a field's value to the default, the field must
     # be in the mask and set to the default value in the provided resource.
@@ -172,51 +172,51 @@ module Google
     #
     # As an example, consider the following message declarations:
     #
-    #     message Profile \\\{
+    #     message Profile {
     #       User user = 1;
     #       Photo photo = 2;
-    #     \}
-    #     message User \\\{
+    #     }
+    #     message User {
     #       string display_name = 1;
     #       string address = 2;
-    #     \}
+    #     }
     #
     # In proto a field mask for `Profile` may look as such:
     #
-    #     mask \\\{
+    #     mask {
     #       paths: "user.display_name"
     #       paths: "photo"
-    #     \}
+    #     }
     #
     # In JSON, the same mask is represented as below:
     #
-    #     \\\{
+    #     {
     #       mask: "user.displayName,photo"
-    #     \}
+    #     }
     #
     # # Field Masks and Oneof Fields
     #
     # Field masks treat fields in oneofs just as regular fields. Consider the
     # following message:
     #
-    #     message SampleMessage \\\{
-    #       oneof test_oneof \\\{
+    #     message SampleMessage {
+    #       oneof test_oneof {
     #         string name = 4;
     #         SubMessage sub_message = 9;
-    #       \}
-    #     \}
+    #       }
+    #     }
     #
     # The field mask can be:
     #
-    #     mask \\\{
+    #     mask {
     #       paths: "name"
-    #     \}
+    #     }
     #
     # Or:
     #
-    #     mask \\\{
+    #     mask {
     #       paths: "sub_message"
-    #     \}
+    #     }
     #
     # Note that oneof type names ("test_oneof" in this case) cannot be used in
     # paths.
diff --git a/google-cloud-billing-v1/proto_docs/google/protobuf/timestamp.rb b/google-cloud-billing-v1/proto_docs/google/protobuf/timestamp.rb
index 313e5fc02..321ed4fe2 100644
--- a/google-cloud-billing-v1/proto_docs/google/protobuf/timestamp.rb
+++ b/google-cloud-billing-v1/proto_docs/google/protobuf/timestamp.rb
@@ -77,9 +77,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "\\\{year\}-\\\{month\}-\\\{day\}T\\\{hour\}:\\\{min\}:\\\{sec\}[.\\\{frac_sec\}]Z"
-    # where \\\{year\} is always expressed using four digits while \\\{month\}, \\\{day\},
-    # \\\{hour\}, \\\{min\}, and \\\{sec\} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required. A proto3 JSON serializer should always use UTC (as indicated by
diff --git a/google-cloud-billing-v1/synth.metadata b/google-cloud-billing-v1/synth.metadata
index d1600411f..0b0f34a09 100644
--- a/google-cloud-billing-v1/synth.metadata
+++ b/google-cloud-billing-v1/synth.metadata
@@ -1,27 +1,13 @@
 {
-  "updateTime": "2020-02-20T11:39:14.113733Z",
+  "updateTime": "2020-03-18T10:39:10.220503Z",
   "sources": [
-    {
-      "git": {
-        "name": ".",
-        "remote": "https://github.com/googleapis/google-cloud-ruby.git",
-        "sha": "feb41a6634b88ee7e3e7e235f03e8b0f1c31cd38"
-      }
-    },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a9639a0a9854fd6e1be08bba1ac3897f4f16cb2f",
-        "internalRef": "295983266",
-        "log": "a9639a0a9854fd6e1be08bba1ac3897f4f16cb2f\nAdd secretmanager.googleapis.com v1 protos\n\nPiperOrigin-RevId: 295983266\n\nce4f4c21d9dd2bfab18873a80449b9d9851efde8\nasset: v1p1beta1 remove SearchResources and SearchIamPolicies\n\nPiperOrigin-RevId: 295861722\n\ncb61d6c2d070b589980c779b68ffca617f789116\nasset: v1p1beta1 remove SearchResources and SearchIamPolicies\n\nPiperOrigin-RevId: 295855449\n\nab2685d8d3a0e191dc8aef83df36773c07cb3d06\nfix: Dataproc v1 - AutoscalingPolicy annotation\n\nThis adds the second resource name pattern to the\nAutoscalingPolicy resource.\n\nCommitter: @lukesneeringer\nPiperOrigin-RevId: 295738415\n\n8a1020bf6828f6e3c84c3014f2c51cb62b739140\nUpdate cloud asset api v1p4beta1.\n\nPiperOrigin-RevId: 295286165\n\n5cfa105206e77670369e4b2225597386aba32985\nAdd service control related proto build rule.\n\nPiperOrigin-RevId: 295262088\n\nee4dddf805072004ab19ac94df2ce669046eec26\nmonitoring v3: Add prefix \"https://cloud.google.com/\" into the link for global access\ncl 295167522, get ride of synth.py hacks\n\nPiperOrigin-RevId: 295238095\n\nd9835e922ea79eed8497db270d2f9f85099a519c\nUpdate some minor docs changes about user event proto\n\nPiperOrigin-RevId: 295185610\n\n5f311e416e69c170243de722023b22f3df89ec1c\nfix: use correct PHP package name in gapic configuration\n\nPiperOrigin-RevId: 295161330\n\n6cdd74dcdb071694da6a6b5a206e3a320b62dd11\npubsub: v1 add client config annotations and retry config\n\nPiperOrigin-RevId: 295158776\n\n5169f46d9f792e2934d9fa25c36d0515b4fd0024\nAdded cloud asset api v1p4beta1.\n\nPiperOrigin-RevId: 295026522\n\n56b55aa8818cd0a532a7d779f6ef337ba809ccbd\nFix: Resource annotations for CreateTimeSeriesRequest and ListTimeSeriesRequest should refer to valid resources. TimeSeries is not a named resource.\n\nPiperOrigin-RevId: 294931650\n\n0646bc775203077226c2c34d3e4d50cc4ec53660\nRemove unnecessary languages from bigquery-related artman configuration files.\n\nPiperOrigin-RevId: 294809380\n\n8b78aa04382e3d4147112ad6d344666771bb1909\nUpdate backend.proto for schemes and protocol\n\nPiperOrigin-RevId: 294788800\n\n80b8f8b3de2359831295e24e5238641a38d8488f\nAdds artman config files for bigquerystorage endpoints v1beta2, v1alpha2, v1\n\nPiperOrigin-RevId: 294763931\n\n2c17ac33b226194041155bb5340c3f34733f1b3a\nAdd parameter to sample generated for UpdateInstance. Related to https://github.com/googleapis/python-redis/issues/4\n\nPiperOrigin-RevId: 294734008\n\nd5e8a8953f2acdfe96fb15e85eb2f33739623957\nMove bigquery datatransfer to gapic v2.\n\nPiperOrigin-RevId: 294703703\n\nefd36705972cfcd7d00ab4c6dfa1135bafacd4ae\nfix: Add two annotations that we missed.\n\nPiperOrigin-RevId: 294664231\n\n8a36b928873ff9c05b43859b9d4ea14cd205df57\nFix: Define the \"bigquery.googleapis.com/Table\" resource in the BigQuery Storage API (v1beta2).\n\nPiperOrigin-RevId: 294459768\n\nc7a3caa2c40c49f034a3c11079dd90eb24987047\nFix: Define the \"bigquery.googleapis.com/Table\" resource in the BigQuery Storage API (v1).\n\nPiperOrigin-RevId: 294456889\n\n5006247aa157e59118833658084345ee59af7c09\nFix: Make deprecated fields optional\nFix: Deprecate SetLoggingServiceRequest.zone in line with the comments\nFeature: Add resource name method signatures where appropriate\n\nPiperOrigin-RevId: 294383128\n\neabba40dac05c5cbe0fca3a35761b17e372036c4\nFix: C# and PHP package/namespace capitalization for BigQuery Storage v1.\n\nPiperOrigin-RevId: 294382444\n\nf8d9a858a7a55eba8009a23aa3f5cc5fe5e88dde\nfix: artman configuration file for bigtable-admin\n\nPiperOrigin-RevId: 294322616\n\n0f29555d1cfcf96add5c0b16b089235afbe9b1a9\nAPI definition for (not-yet-launched) GCS gRPC.\n\nPiperOrigin-RevId: 294321472\n\nfcc86bee0e84dc11e9abbff8d7c3529c0626f390\nfix: Bigtable Admin v2\n\nChange LRO metadata from PartialUpdateInstanceMetadata\nto UpdateInstanceMetadata. (Otherwise, it will not build.)\n\nPiperOrigin-RevId: 294264582\n\n6d9361eae2ebb3f42d8c7ce5baf4bab966fee7c0\nrefactor: Add annotations to Bigtable Admin v2.\n\nPiperOrigin-RevId: 294243406\n\nad7616f3fc8e123451c8b3a7987bc91cea9e6913\nFix: Resource type in CreateLogMetricRequest should use logging.googleapis.com.\nFix: ListLogEntries should have a method signature for convenience of calling it.\n\nPiperOrigin-RevId: 294222165\n\n63796fcbb08712676069e20a3e455c9f7aa21026\nFix: Remove extraneous resource definition for cloudkms.googleapis.com/CryptoKey.\n\nPiperOrigin-RevId: 294176658\n\ne7d8a694f4559201e6913f6610069cb08b39274e\nDepend on the latest gapic-generator and resource names plugin.\n\nThis fixes the very old an very annoying bug: https://github.com/googleapis/gapic-generator/pull/3087\n\nPiperOrigin-RevId: 293903652\n\n806b2854a966d55374ee26bb0cef4e30eda17b58\nfix: correct capitalization of Ruby namespaces in SecurityCenter V1p1beta1\n\nPiperOrigin-RevId: 293903613\n\n1b83c92462b14d67a7644e2980f723112472e03a\nPublish annotations and grpc service config for Logging API.\n\nPiperOrigin-RevId: 293893514\n\ne46f761cd6ec15a9e3d5ed4ff321a4bcba8e8585\nGenerate the Bazel build file for recommendengine public api\n\nPiperOrigin-RevId: 293710856\n\n68477017c4173c98addac0373950c6aa9d7b375f\nMake `language_code` optional for UpdateIntentRequest and BatchUpdateIntentsRequest.\n\nThe comments and proto annotations describe this parameter as optional.\n\nPiperOrigin-RevId: 293703548\n\n16f823f578bca4e845a19b88bb9bc5870ea71ab2\nAdd BUILD.bazel files for managedidentities API\n\nPiperOrigin-RevId: 293698246\n\n2f53fd8178c9a9de4ad10fae8dd17a7ba36133f2\nAdd v1p1beta1 config file\n\nPiperOrigin-RevId: 293696729\n\n052b274138fce2be80f97b6dcb83ab343c7c8812\nAdd source field for user event and add field behavior annotations\n\nPiperOrigin-RevId: 293693115\n\n1e89732b2d69151b1b3418fff3d4cc0434f0dded\ndatacatalog: v1beta1 add three new RPCs to gapic v1beta1 config\n\nPiperOrigin-RevId: 293692823\n\n9c8bd09bbdc7c4160a44f1fbab279b73cd7a2337\nchange the name of AccessApproval service to AccessApprovalAdmin\n\nPiperOrigin-RevId: 293690934\n\n2e23b8fbc45f5d9e200572ca662fe1271bcd6760\nAdd ListEntryGroups method, add http bindings to support entry group tagging, and update some comments.\n\nPiperOrigin-RevId: 293666452\n\n0275e38a4ca03a13d3f47a9613aac8c8b0d3f1f2\nAdd proto_package field to managedidentities API. It is needed for APIs that still depend on artman generation.\n\nPiperOrigin-RevId: 293643323\n\n4cdfe8278cb6f308106580d70648001c9146e759\nRegenerating public protos for Data Catalog to add new Custom Type Entry feature.\n\nPiperOrigin-RevId: 293614782\n\n"
-      }
-    },
-    {
-      "git": {
-        "name": "synthtool",
-        "remote": "rpc://devrel/cloud/libraries/tools/autosynth",
-        "sha": "43dc756ddb00adbf32e9a07a6f2059ebea1fd3fa"
+        "sha": "430375af011f8c7a5174884f0d0e539c6ffa7675",
+        "internalRef": "301538851",
+        "log": "430375af011f8c7a5174884f0d0e539c6ffa7675\ndocs: add missing closing backtick\n\nPiperOrigin-RevId: 301538851\n\n0e9f1f60ded9ad1c2e725e37719112f5b487ab65\nbazel: Use latest release of gax_java\n\nPiperOrigin-RevId: 301480457\n\n5058c1c96d0ece7f5301a154cf5a07b2ad03a571\nUpdate GAPIC v2 with batching parameters for Logging API\n\nPiperOrigin-RevId: 301443847\n\n64ab9744073de81fec1b3a6a931befc8a90edf90\nFix: Introduce location-based organization/folder/billing-account resources\nChore: Update copyright years\n\nPiperOrigin-RevId: 301373760\n\n23d5f09e670ebb0c1b36214acf78704e2ecfc2ac\nUpdate field_behavior annotations in V1 and V2.\n\nPiperOrigin-RevId: 301337970\n\nb2cf37e7fd62383a811aa4d54d013ecae638851d\nData Catalog V1 API\n\nPiperOrigin-RevId: 301282503\n\n1976b9981e2900c8172b7d34b4220bdb18c5db42\nCloud DLP api update. Adds missing fields to Finding and adds support for hybrid jobs.\n\nPiperOrigin-RevId: 301205325\n\nae78682c05e864d71223ce22532219813b0245ac\nfix: several sample code blocks in comments are now properly indented for markdown\n\nPiperOrigin-RevId: 301185150\n\ndcd171d04bda5b67db13049320f97eca3ace3731\nPublish Media Translation API V1Beta1\n\nPiperOrigin-RevId: 301180096\n\nff1713453b0fbc5a7544a1ef6828c26ad21a370e\nAdd protos and BUILD rules for v1 API.\n\nPiperOrigin-RevId: 301179394\n\n8386761d09819b665b6a6e1e6d6ff884bc8ff781\nfeat: chromeos/modlab publish protos and config for Chrome OS Moblab API.\n\nPiperOrigin-RevId: 300843960\n\nb2e2bc62fab90e6829e62d3d189906d9b79899e4\nUpdates to GCS gRPC API spec:\n\n1. Changed GetIamPolicy and TestBucketIamPermissions to use wrapper messages around google.iam.v1 IAM requests messages, and added CommonRequestParams. This lets us support RequesterPays buckets.\n2. Added a metadata field to GetObjectMediaResponse, to support resuming an object media read safely (by extracting the generation of the object being read, and using it in the resumed read request).\n\nPiperOrigin-RevId: 300817706\n\n7fd916ce12335cc9e784bb9452a8602d00b2516c\nAdd deprecated_collections field for backward-compatiblity in PHP and monolith-generated Python and Ruby clients.\n\nGenerate TopicName class in Java which covers the functionality of both ProjectTopicName and DeletedTopicName. Introduce breaking changes to be fixed by synth.py.\n\nDelete default retry parameters.\n\nRetry codes defs can be deleted once # https://github.com/googleapis/gapic-generator/issues/3137 is fixed.\n\nPiperOrigin-RevId: 300813135\n\n047d3a8ac7f75383855df0166144f891d7af08d9\nfix!: google/rpc refactor ErrorInfo.type to ErrorInfo.reason and comment updates.\n\nPiperOrigin-RevId: 300773211\n\nfae4bb6d5aac52aabe5f0bb4396466c2304ea6f6\nAdding RetryPolicy to pubsub.proto\n\nPiperOrigin-RevId: 300769420\n\n"
       }
     }
   ],
diff --git a/google-cloud-billing-v1/synth.py b/google-cloud-billing-v1/synth.py
index 3594ee92f..19b5bf9f4 100644
--- a/google-cloud-billing-v1/synth.py
+++ b/google-cloud-billing-v1/synth.py
@@ -31,6 +31,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Billing V1",
         "ruby-cloud-summary": "Allows developers to manage billing for their Google Cloud Platform projects programmatically.",
         "ruby-cloud-env-prefix": "BILLING",
+        "ruby-cloud-grpc-service-config": "google/cloud/billing/v1/cloud_billing_grpc_service_config.json;google/cloud/billing/v1/cloud_catalog_grpc_service_config.json",
     }
 )
 
diff --git a/google-cloud-billing-v1/test/google/cloud/billing/v1/cloud_billing_test.rb b/google-cloud-billing-v1/test/google/cloud/billing/v1/cloud_billing_test.rb
index 41963200d..1fb0c2164 100644
--- a/google-cloud-billing-v1/test/google/cloud/billing/v1/cloud_billing_test.rb
+++ b/google-cloud-billing-v1/test/google/cloud/billing/v1/cloud_billing_test.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"
diff --git a/google-cloud-billing-v1/test/google/cloud/billing/v1/cloud_catalog_test.rb b/google-cloud-billing-v1/test/google/cloud/billing/v1/cloud_catalog_test.rb
index cdef9fd1e..a1a12e039 100644
--- a/google-cloud-billing-v1/test/google/cloud/billing/v1/cloud_catalog_test.rb
+++ b/google-cloud-billing-v1/test/google/cloud/billing/v1/cloud_catalog_test.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

```

</details>

This pull request was generated using releasetool.