### PR TITLE
Add max_duration_per_lease_extension to Subscription#listen and Subscriber

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
@@ -30,14 +30,15 @@ module Google
 
           include MonitorMixin
 
-          attr_reader :stream, :limit, :bytesize, :extension
+          attr_reader :stream, :limit, :bytesize, :extension, :max_duration_per_lease_extension
 
-          def initialize stream, limit:, bytesize:, extension:
+          def initialize stream, limit:, bytesize:, extension:, max_duration_per_lease_extension:
             super()
             @stream = stream
             @limit = limit
             @bytesize = bytesize
             @extension = extension
+            @max_duration_per_lease_extension = max_duration_per_lease_extension
             @inventory = {}
             @wait_cond = new_cond
           end
@@ -152,7 +153,9 @@ module Google
           end
 
           def calc_delay
-            (stream.subscriber.deadline - 3) * rand(0.8..0.9)
+            delay = (stream.subscriber.deadline - 3) * rand(0.8..0.9)
+            delay = [delay, max_duration_per_lease_extension].min if max_duration_per_lease_extension.positive?
+            delay
           end
         end
       end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -699,6 +699,9 @@ module Google
         #       subscriber. Default is 100,000,000 (100MB). (Note: replaces `:bytesize`, which is deprecated.)
         #     * `:max_total_lease_duration` [Integer] The number of seconds that received messages can be held awaiting
         #       processing. Default is 3,600 (1 hour). (Note: replaces `:extension`, which is deprecated.)
+        #     * `:max_duration_per_lease_extension` [Integer] The maximum amount of time in seconds for a single lease
+        #       extension attempt. Bounds the delay before a message redelivery if the subscriber fails to extend the
+        #       deadline. Default is 0 (disabled).
         # @param [Hash] threads The number of threads to create to handle
         #   concurrent calls by each stream opened by the subscriber. Optional.
         #
@@ -766,6 +769,25 @@ module Google
         #     # messsages with the same ordering_key are received
         #     # in the order in which they were published.
         #     received_message.acknowledge!
+        #   end
+        #
+        #   # Start background threads that will call block passed to listen.
+        #   subscriber.start
+        #
+        #   # Shut down the subscriber when ready to stop receiving messages.
+        #   subscriber.stop.wait!
+        #
+        # @example Set the maximum amount of time before redelivery if the subscriber fails to extend the deadline:
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   sub = pubsub.subscription "my-topic-sub"
+        #
+        #   subscriber = sub.listen inventory: { max_duration_per_lease_extension: 20 } do |received_message|
+        #     # Process message very slowly with possibility of failure.
+        #     process rec_message.data # takes minutes
+        #     rec_message.acknowledge!
         #   end
         #
         #   # Start background threads that will call block passed to listen.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
@@ -156,7 +156,7 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
 
   it "knows its count limit" do
     subscriber_mock = Minitest::Mock.new
-    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 2, bytesize: 100_000, extension: 3600
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 2, bytesize: 100_000, extension: 3600, max_duration_per_lease_extension: 0
 
     inventory.add rec_msg1_grpc
     inventory.wont_be :full?
@@ -168,7 +168,7 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
 
   it "knows its bytesize limit" do
     subscriber_mock = Minitest::Mock.new
-    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100, extension: 3600
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100, extension: 3600, max_duration_per_lease_extension: 0
 
     inventory.add rec_msg1_grpc
     inventory.wont_be :full?
@@ -180,7 +180,7 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
 
   it "removes expired items" do
     subscriber_mock = Minitest::Mock.new
-    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100_000, extension: 3600
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100_000, extension: 3600, max_duration_per_lease_extension: 0
 
     expired_time = Time.now - 7200
 
@@ -194,5 +194,12 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
     inventory.remove_expired!
 
     inventory.ack_ids.must_equal ["ack-id-1112", "ack-id-1113"]
+  end
+
+  it "knows its max_duration_per_lease_extension limit" do
+    subscriber_mock = Minitest::Mock.new
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100, extension: 3600, max_duration_per_lease_extension: 10
+
+    inventory.max_duration_per_lease_extension.must_equal 10
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -37,7 +37,8 @@ describe Google::Cloud::PubSub::Subscriber, :mock_pubsub do
     subscriber.max_outstanding_bytes.must_equal 100_000_000
     subscriber.inventory_extension.must_equal 3600
     subscriber.max_total_lease_duration.must_equal 3600
-    subscriber.stream_inventory.must_equal({limit: 250, bytesize: 12500000, extension: 3600})
+    subscriber.max_duration_per_lease_extension.must_equal 0
+    subscriber.stream_inventory.must_equal({limit: 250, bytesize: 12500000, max_duration_per_lease_extension: 0, extension: 3600})
     subscriber.callback_threads.must_equal callback_threads
     subscriber.push_threads.must_equal push_threads
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
@@ -36,6 +36,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.max_outstanding_bytes.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
     subscriber.max_total_lease_duration.must_equal 3600
+    subscriber.max_duration_per_lease_extension.must_equal 0
   end
 
   it "will set deadline while creating a Subscriber" do
@@ -53,6 +54,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.max_outstanding_bytes.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
     subscriber.max_total_lease_duration.must_equal 3600
+    subscriber.max_duration_per_lease_extension.must_equal 0
   end
 
   it "will set deadline while creating a Subscriber" do
@@ -70,6 +72,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.max_outstanding_bytes.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
     subscriber.max_total_lease_duration.must_equal 3600
+    subscriber.max_duration_per_lease_extension.must_equal 0
   end
 
   it "will set inventory (deprecated) while creating a Subscriber" do
@@ -87,10 +90,11 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.max_outstanding_bytes.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
     subscriber.max_total_lease_duration.must_equal 3600
+    subscriber.max_duration_per_lease_extension.must_equal 0
   end
 
   it "will set inventory max_outstanding_messages while creating a Subscriber" do
-    subscriber = subscription.listen(inventory: { max_outstanding_messages: 500 }) do |msg|
+    subscriber = subscription.listen inventory: { max_outstanding_messages: 500 } do |msg|
       puts msg.msg_id
     end
     subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
@@ -104,10 +108,11 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.max_outstanding_bytes.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
     subscriber.max_total_lease_duration.must_equal 3600
+    subscriber.max_duration_per_lease_extension.must_equal 0
   end
 
   it "will set inventory limit alias while creating a Subscriber" do
-    subscriber = subscription.listen(inventory: { limit: 500 }) do |msg|
+    subscriber = subscription.listen inventory: { limit: 500 } do |msg|
       puts msg.msg_id
     end
     subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
@@ -121,10 +126,11 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.max_outstanding_bytes.must_equal 100000000
     subscriber.inventory_extension.must_equal 3600
     subscriber.max_total_lease_duration.must_equal 3600
+    subscriber.max_duration_per_lease_extension.must_equal 0
   end
 
   it "will set inventory max_outstanding_bytes while creating a Subscriber" do
-    subscriber = subscription.listen(inventory: { max_outstanding_bytes: 50_000 }) do |msg|
+    subscriber = subscription.listen inventory: { max_outstanding_bytes: 50_000 } do |msg|
       puts msg.msg_id
     end
     subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
@@ -138,10 +144,11 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.max_outstanding_bytes.must_equal 50_000
     subscriber.inventory_extension.must_equal 3600
     subscriber.max_total_lease_duration.must_equal 3600
+    subscriber.max_duration_per_lease_extension.must_equal 0
   end
 
   it "will set inventory bytesize alias while creating a Subscriber" do
-    subscriber = subscription.listen(inventory: { bytesize: 50_000 }) do |msg|
+    subscriber = subscription.listen inventory: { bytesize: 50_000 } do |msg|
       puts msg.msg_id
     end
     subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
@@ -155,10 +162,11 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.max_outstanding_bytes.must_equal 50_000
     subscriber.inventory_extension.must_equal 3600
     subscriber.max_total_lease_duration.must_equal 3600
+    subscriber.max_duration_per_lease_extension.must_equal 0
   end
 
   it "will set inventory max_total_lease_duration while creating a Subscriber" do
-    subscriber = subscription.listen(inventory: { max_total_lease_duration: 7_200 }) do |msg|
+    subscriber = subscription.listen inventory: { max_total_lease_duration: 7_200 } do |msg|
       puts msg.msg_id
     end
     subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
@@ -172,10 +180,11 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.max_outstanding_bytes.must_equal 100000000
     subscriber.inventory_extension.must_equal 7200
     subscriber.max_total_lease_duration.must_equal 7200
+    subscriber.max_duration_per_lease_extension.must_equal 0
   end
 
   it "will set inventory extension alias while creating a Subscriber" do
-    subscriber = subscription.listen(inventory: { extension: 7_200 }) do |msg|
+    subscriber = subscription.listen inventory: { extension: 7_200 } do |msg|
       puts msg.msg_id
     end
     subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
@@ -189,5 +198,24 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber.max_outstanding_bytes.must_equal 100000000
     subscriber.inventory_extension.must_equal 7200
     subscriber.max_total_lease_duration.must_equal 7200
+    subscriber.max_duration_per_lease_extension.must_equal 0
+  end
+
+  it "will set inventory max_duration_per_lease_extension while creating a Subscriber" do
+    subscriber = subscription.listen inventory: { max_duration_per_lease_extension: 10 } do |msg|
+      puts msg.msg_id
+    end
+    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
+    subscriber.subscription_name.must_equal subscription.name
+    subscriber.deadline.must_equal 60
+    subscriber.streams.must_equal 2
+    subscriber.inventory.must_equal 1000
+    subscriber.inventory_limit.must_equal 1000
+    subscriber.max_outstanding_messages.must_equal 1000
+    subscriber.inventory_bytesize.must_equal 100000000
+    subscriber.max_outstanding_bytes.must_equal 100000000
+    subscriber.inventory_extension.must_equal 3600
+    subscriber.max_total_lease_duration.must_equal 3600
+    subscriber.max_duration_per_lease_extension.must_equal 10
   end
 end


### PR DESCRIPTION
* Add `max_duration_per_lease_extension` to the `inventory` hash argument for `Subscription#listen`.
* Add `Subscriber#max_duration_per_lease_extension`.

closes: #4850