### PR TITLE
chore: set correct description field in existing microsynthed libraries

### DIFF
--- a/google-cloud-access_approval-v1/synth.py
+++ b/google-cloud-access_approval-v1/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-access_approval-v1",
         "ruby-cloud-title": "Access Approval API V1",
-        "ruby-cloud-summary": "An API for controlling access to data by Google personnel.",
+        "ruby-cloud-description": "An API for controlling access to data by Google personnel.",
         "ruby-cloud-env-prefix": "ACCESS_APPROVAL",
     }
 )

--- a/google-cloud-bigquery-storage-v1/synth.py
+++ b/google-cloud-bigquery-storage-v1/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-bigquery-storage-v1",
         "ruby-cloud-title": "BigQuery Storage V1",
-        "ruby-cloud-summary": "The BigQuery Storage API provides fast access to BigQuery managed storage.",
+        "ruby-cloud-description": "The BigQuery Storage API provides fast access to BigQuery managed storage.",
         "ruby-cloud-env-prefix": "BIGQUERY_STORAGE",
         "ruby-cloud-grpc-service-config": "google/cloud/bigquery/storage/v1/bigquerystorage_grpc_service_config.json",
     }

--- a/google-cloud-billing-v1/synth.py
+++ b/google-cloud-billing-v1/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-billing-v1",
         "ruby-cloud-title": "Billing V1",
-        "ruby-cloud-summary": "Allows developers to manage billing for their Google Cloud Platform projects programmatically.",
+        "ruby-cloud-description": "Allows developers to manage billing for their Google Cloud Platform projects programmatically.",
         "ruby-cloud-env-prefix": "BILLING",
         "ruby-cloud-grpc-service-config": "google/cloud/billing/v1/cloud_billing_grpc_service_config.json;google/cloud/billing/v1/cloud_catalog_grpc_service_config.json",
     }

--- a/google-cloud-dialogflow-v2/synth.py
+++ b/google-cloud-dialogflow-v2/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-dialogflow-v2",
         "ruby-cloud-title": "Dialogflow V2",
-        "ruby-cloud-summary": "Creates conversational experiences across devices and platforms.",
+        "ruby-cloud-description": "Dialogflow is an end-to-end, build-once deploy-everywhere development suite for creating conversational interfaces for websites, mobile applications, popular messaging platforms, and IoT devices. You can use it to build interfaces (such as chatbots and conversational IVR) that enable natural and rich interactions between your users and your business.",
         "ruby-cloud-env-prefix": "DIALOGFLOW",
         "ruby-cloud-grpc-service-config": "google/cloud/dialogflow/v2/dialogflow_grpc_service_config.json",
     }

--- a/google-cloud-iot-v1/synth.py
+++ b/google-cloud-iot-v1/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-iot-v1",
         "ruby-cloud-title": "Cloud IoT API V1",
-        "ruby-cloud-summary": "Registers and manages IoT (Internet of Things) devices that connect to the Google Cloud Platform.",
+        "ruby-cloud-description": "Registers and manages IoT (Internet of Things) devices that connect to the Google Cloud Platform.",
         "ruby-cloud-env-prefix": "IOT",
         "ruby-cloud-grpc-service-config": "google/cloud/iot/v1/cloudiot_grpc_service_config.json",
     }

--- a/google-cloud-language-v1/synth.py
+++ b/google-cloud-language-v1/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-language-v1",
         "ruby-cloud-title": "Natural Language V1",
-        "ruby-cloud-summary": "Provides natural language understanding technologies, such as sentiment analysis, entity recognition, entity sentiment analysis, and other text annotations.",
+        "ruby-cloud-description": "Provides natural language understanding technologies, such as sentiment analysis, entity recognition, entity sentiment analysis, and other text annotations.",
         "ruby-cloud-env-prefix": "LANGUAGE",
         "ruby-cloud-grpc-service-config": "google/cloud/language/v1/language_grpc_service_config.json",
     }

--- a/google-cloud-language-v1beta2/synth.py
+++ b/google-cloud-language-v1beta2/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-language-v1beta2",
         "ruby-cloud-title": "Natural Language V1beta2",
-        "ruby-cloud-summary": "Provides natural language understanding technologies, such as sentiment analysis, entity recognition, entity sentiment analysis, and other text annotations.",
+        "ruby-cloud-description": "Provides natural language understanding technologies, such as sentiment analysis, entity recognition, entity sentiment analysis, and other text annotations.",
         "ruby-cloud-env-prefix": "LANGUAGE",
         "ruby-cloud-grpc-service-config": "google/cloud/language/v1beta2/language_grpc_service_config.json",
     }

--- a/google-cloud-recommender-v1/synth.py
+++ b/google-cloud-recommender-v1/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-recommender-v1",
         "ruby-cloud-title": "Recommender V1",
-        "ruby-cloud-summary": "recommender.googleapis.com",
+        "ruby-cloud-description": "Recommender is a service on Google Cloud that provides usage recommendations for Cloud products and services.",
         "ruby-cloud-env-prefix": "RECOMMENDER",
         "ruby-cloud-grpc-service-config": "google/cloud/recommender/v1/recommender_grpc_service_config.json",
     }

--- a/google-cloud-secret_manager-v1/synth.py
+++ b/google-cloud-secret_manager-v1/synth.py
@@ -30,7 +30,7 @@ library = gapic.ruby_library(
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-secret_manager-v1",
         "ruby-cloud-title": "Secret Manager V1",
-        "ruby-cloud-summary": "Stores, manages, and secures access to application secrets.",
+        "ruby-cloud-description": "Secret Manager is a secure and convenient storage system for API keys, passwords, certificates, and other sensitive data. Secret Manager provides a central place and single source of truth to manage, access, and audit secrets across Google Cloud.",
         "ruby-cloud-env-prefix": "SECRET_MANAGER",
         "ruby-cloud-grpc-service-config": "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json",
     }

--- a/google-cloud-secret_manager-v1beta1/synth.py
+++ b/google-cloud-secret_manager-v1beta1/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-secret_manager-v1beta1",
         "ruby-cloud-title": "Secret Manager V1beta1",
-        "ruby-cloud-summary": "Stores, manages, and secures access to application secrets.",
+        "ruby-cloud-description": "Secret Manager is a secure and convenient storage system for API keys, passwords, certificates, and other sensitive data. Secret Manager provides a central place and single source of truth to manage, access, and audit secrets across Google Cloud.",
         "ruby-cloud-env-prefix": "SECRET_MANAGER",
         "ruby-cloud-grpc-service-config": "google/cloud/secrets/v1beta1/secretmanager_grpc_service_config.json",
     }

--- a/google-cloud-service_directory-v1beta1/synth.py
+++ b/google-cloud-service_directory-v1beta1/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-service_directory-v1beta1",
         "ruby-cloud-title": "Service Directory V1beta1",
-        "ruby-cloud-summary": "Service directory is the single place to register, browse, and resolve application services.",
+        "ruby-cloud-description": "Service directory is the single place to register, browse, and resolve application services.",
         "ruby-cloud-env-prefix": "SERVICE_DIRECTORY",
         "ruby-cloud-grpc-service-config": "google/cloud/servicedirectory/v1beta1/servicedirectory_grpc_service_config.json",
     }


### PR DESCRIPTION
The custom description should be set in the rubygems description field, not the summary field. Fix this across all current micro-generated library synth files.