### PR TITLE
feat(asset-v1): add project path helper

### DIFF
--- a/google-cloud-asset-v1/lib/google/cloud/asset/v1/asset_service/helpers.rb
+++ b/google-cloud-asset-v1/lib/google/cloud/asset/v1/asset_service/helpers.rb
@@ -1,0 +1,41 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Asset
+      module V1
+        module AssetService
+          # Path helper methods for the AssetService API.
+          module Paths
+            ##
+            # Create a fully-qualified Project resource string.
+            #
+            # The resource will be in the following format:
+            #
+            # `projects/{project}`
+            #
+            # @param project [String]
+            #
+            # @return [String]
+            def project_path project:
+              "projects/#{project}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-asset-v1/lib/google/cloud/asset/v1/asset_service/helpers.rb
+++ b/google-cloud-asset-v1/lib/google/cloud/asset/v1/asset_service/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google-cloud-asset-v1/test/google/cloud/asset/v1/additional_paths_test.rb
+++ b/google-cloud-asset-v1/test/google/cloud/asset/v1/additional_paths_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "simplecov"
+require "minitest/autorun"
+
+require "google/cloud/asset/v1"
+
+class AdditionalPathsTest < Minitest::Test
+  def test_project_path
+    path = Google::Cloud::Asset::V1::AssetService::Paths.project_path project: "my-project"
+    assert_equal "projects/my-project", path
+  end
+end


### PR DESCRIPTION
Asset is a bit of a snowflake, and we're not likely to be able to get the generator to generate a project path helper. So we're adding one manually in a partial gapic. (Note: this is also how the older version of google-cloud-asset obtained a project path helper.)

The generated code already loads `helpers.rb` if it is present.