### PR TITLE
feat(translate): send quota project header in the V2 client

### DIFF
--- a/google-cloud-translate/lib/google/cloud/translate/v2/service.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/v2/service.rb
@@ -110,12 +110,16 @@ module Google
           ##
           # The default HTTP headers to be sent on all API calls.
           def default_http_headers
-            @default_http_headers ||= {
-              "User-Agent"                   => "gcloud-ruby/#{Google::Cloud::Translate::VERSION}",
-              "google-cloud-resource-prefix" => "projects/#{@project}",
-              "Content-Type"                 => "application/json",
-              "x-goog-api-client"            => "gl-ruby/#{RUBY_VERSION} gccl/#{Google::Cloud::Translate::VERSION}"
-            }
+            @default_http_headers ||= begin
+              headers = {
+                "User-Agent"                   => "gcloud-ruby/#{Google::Cloud::Translate::VERSION}",
+                "google-cloud-resource-prefix" => "projects/#{@project}",
+                "Content-Type"                 => "application/json",
+                "x-goog-api-client"            => "gl-ruby/#{RUBY_VERSION} gccl/#{Google::Cloud::Translate::VERSION}"
+              }
+              headers["x-goog-user-project"] = credentials.quota_project_id if credentials.respond_to? :quota_project_id
+              headers
+            end
           end
 
           ##

--- a/google-cloud-translate/test/google/cloud/translate/v2/service_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/v2/service_test.rb
@@ -14,6 +14,7 @@
 
 require "helper"
 
+# Conforms to the usage of `Google::Cloud::Translate::V2::Service#sign_http_request!`
 class FakeClient
   def expires_within? _
     false

--- a/google-cloud-translate/test/google/cloud/translate/v2/service_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/v2/service_test.rb
@@ -14,9 +14,19 @@
 
 require "helper"
 
+class FakeClient
+  def expires_within? _
+    false
+  end
+
+  def generate_authenticated_request request:
+  end
+end
+
 describe Google::Cloud::Translate::V2::Service, :service do
   let(:project) { "test" }
-  let(:credentials) { OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {})) }
+  let(:quota_project) { "test2" }
+  let(:credentials) { OpenStruct.new client: FakeClient.new, quota_project_id: quota_project }
   let(:service) { Google::Cloud::Translate::V2::Service.new(project, credentials, retries: 1) }
   let(:mock_http) { MockHttp.new }
 
@@ -105,5 +115,13 @@ describe Google::Cloud::Translate::V2::Service, :service do
     end
 
     mock_http.request_count.must_equal(2)
+  end
+
+  it "sends x-goog-user-project header" do
+    mock_http.stub_response(200, "{}")
+    service.stub(:http, mock_http) do
+      service.detect("hello")
+      mock_http.last_request.headers["x-goog-user-project"].must_equal(quota_project)
+    end
   end
 end

--- a/google-cloud-translate/test/helper.rb
+++ b/google-cloud-translate/test/helper.rb
@@ -36,10 +36,11 @@ class MockTranslate < Minitest::Spec
 end
 
 class MockHttp
-  attr_reader :request_count
+  attr_reader :request_count, :last_request
 
   def initialize
     @request_count = 0
+    @last_request = nil
   end
 
   def stub_response(status, body)
@@ -48,6 +49,8 @@ class MockHttp
   end
 
   def post(*_)
+    @last_request = OpenStruct.new headers: {}, body: ""
+    yield @last_request if block_given?
     @request_count += 1
     Faraday::Response.new.tap do |response|
       response.finish(status: @stub_status, body: @stub_body)


### PR DESCRIPTION
This is, I believe, our only client that calls HTTP directly without going through a generated client (either gapic or apiary). Make sure it sets the `x-goog-user-project` header properly, as we have already done in all the generated clients.