### PR TITLE
Release google-cloud-access_approval 0.1.0

### DIFF
--- a/google-cloud-access_approval/CHANGELOG.md
+++ b/google-cloud-access_approval/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-03-27
+
+Initial release.
+

--- a/google-cloud-access_approval/lib/google/cloud/access_approval/version.rb
+++ b/google-cloud-access_approval/lib/google/cloud/access_approval/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module AccessApproval
-      VERSION = "0.0.1"
+      VERSION = "0.1.0"
     end
   end
 end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff

```

</details>

This pull request was generated using releasetool.