### PR TITLE
chore: for all ci jobs, build docs locally and check for broken links

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -568,10 +568,6 @@ namespace :kokoro do
     exit kokoro.exit_status
   end
 
-  task :thingy do
-    kokoro.should_link_check?
-  end
-
   desc "Runs post-build logic on kokoro."
   task :post do
     kokoro.post

--- a/Rakefile
+++ b/Rakefile
@@ -568,6 +568,10 @@ namespace :kokoro do
     exit kokoro.exit_status
   end
 
+  task :thingy do
+    kokoro.should_link_check?
+  end
+
   desc "Runs post-build logic on kokoro."
   task :post do
     kokoro.post

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -35,7 +35,7 @@ class Kokoro < Command
     @updated_gems.each do |gem|
       run_ci gem do
         run "bundle exec rake ci", 1800
-        local_docs_test
+        local_docs_test if should_link_check?
       end
     end
   end
@@ -49,7 +49,7 @@ class Kokoro < Command
         header "Gem Unchanged - Skipping Acceptance"
         run "bundle exec rake ci", 3600
       end
-      local_docs_test
+      local_docs_test if @should_release
     end
     release_please if @should_release && @updated
   end
@@ -132,8 +132,6 @@ class Kokoro < Command
   end
 
   def local_docs_test
-    return unless should_link_check?
-
     run "bundle exec rake yard"
     broken_links = check_links ["doc"], ".", ""
     puts_broken_links broken_links

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -36,7 +36,9 @@ class Kokoro < Command
     @updated_gems.each do |gem|
       run_ci gem do
         run "bundle exec rake ci", 1800
-        local_docs_test if should_link_check? && pr_title.include? "Release"
+        local_docs_test if should_link_check? || (
+          pr_title.include?("Release") && @should_release
+        )
       end
     end
   end

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -34,6 +34,7 @@ class Kokoro < Command
     @updated_gems.each do |gem|
       run_ci gem do
         run "bundle exec rake ci", 1800
+        local_docs_test
       end
     end
   end
@@ -43,9 +44,11 @@ class Kokoro < Command
       if @updated
         header "Gem Updated - Running Acceptance"
         run "bundle exec rake ci:acceptance", 3600
+        local_docs_test
       else
         header "Gem Unchanged - Skipping Acceptance"
         run "bundle exec rake ci", 3600
+        local_docs_test
       end
     end
     release_please if @should_release && @updated
@@ -77,6 +80,7 @@ class Kokoro < Command
   def nightly
     run_ci do
       run "bundle exec rake ci:acceptance", 3600
+      local_docs_test
     end
     release_please if @should_release
   end
@@ -125,6 +129,12 @@ class Kokoro < Command
       end
     end
     broken_links
+  end
+
+  def local_docs_test
+    run "bundle exec rake yard"
+    broken_links = check_links ["doc"], ".", ""
+    puts_broken_links broken_links
   end
 
   def header str, token = "#"

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -20,7 +20,6 @@ class Kokoro < Command
     @tag            = nil
     @updated        = @updated_gems.include? @gem
     @should_release = ENV.fetch("OS", "") == "linux" && RUBY_VERSION == @ruby_versions.sort.last
-    @commit_hash    = ENV["KOKORO_GIT_COMMIT"]
   end
 
   def build
@@ -49,7 +48,7 @@ class Kokoro < Command
         header "Gem Unchanged - Skipping Acceptance"
         run "bundle exec rake ci", 3600
       end
-      local_docs_test if @should_release
+      local_docs_test if should_link_check?
     end
     release_please if @should_release && @updated
   end
@@ -140,9 +139,8 @@ class Kokoro < Command
   def should_link_check?
     return false unless @gem && @should_release
 
-    commit_message = `git log --format=%B -n 1 #{@commit_hash}`
     gem_search = `gem search #{gem}`
-    gem_search.include?(gem) || commit_message.include?("Release")
+    gem_search.include?(gem)
   end
 
   def header str, token = "#"

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -36,7 +36,7 @@ class Kokoro < Command
     @updated_gems.each do |gem|
       run_ci gem do
         run "bundle exec rake ci", 1800
-        local_docs_test if should_link_check?
+        local_docs_test if should_link_check? && pr_title.include? "Release"
       end
     end
   end
@@ -142,7 +142,7 @@ class Kokoro < Command
     return false unless @gem && @should_release
 
     gem_search = `gem search #{gem}`
-    gem_search.include?(gem) || pr_title.include? "Release"
+    gem_search.include?(gem)
   end
 
   def pr_title

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -36,7 +36,7 @@ class Kokoro < Command
     @updated_gems.each do |gem|
       run_ci gem do
         run "bundle exec rake ci", 1800
-        local_docs_test if should_link_check? || (
+        local_docs_test if should_link_check? gem || (
           autorelease_pending? && @should_release
         )
       end
@@ -140,11 +140,12 @@ class Kokoro < Command
     puts_broken_links broken_links
   end
 
-  def should_link_check?
-    return false unless @gem && @should_release
+  def should_link_check? gem = nil
+    gem ||= @gem
+    return false unless gem && @should_release
 
-    gem_search = `gem search #{@gem}`
-    gem_search.include? @gem
+    gem_search = `gem search #{gem}`
+    gem_search.include? gem
   end
 
   def autorelease_pending?

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -136,7 +136,7 @@ class Kokoro < Command
 
   def local_docs_test
     run "bundle exec rake yard"
-    broken_links = check_links ["doc"], ".", ""
+    broken_links = check_links ["doc"], ".", " -r"
     puts_broken_links broken_links
   end
 
@@ -144,7 +144,7 @@ class Kokoro < Command
     return false unless @gem && @should_release
 
     gem_search = `gem search #{@gem}`
-    gem_search.include?(@gem)
+    gem_search.include? @gem
   end
 
   def autorelease_pending?

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -79,7 +79,7 @@ class Kokoro < Command
   def nightly
     run_ci do
       run "bundle exec rake ci:acceptance", 3600
-      local_docs_test
+      local_docs_test if should_link_check?
     end
     release_please if @should_release
   end

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -44,12 +44,11 @@ class Kokoro < Command
       if @updated
         header "Gem Updated - Running Acceptance"
         run "bundle exec rake ci:acceptance", 3600
-        local_docs_test
       else
         header "Gem Unchanged - Skipping Acceptance"
         run "bundle exec rake ci", 3600
-        local_docs_test
       end
+      local_docs_test
     end
     release_please if @should_release && @updated
   end
@@ -132,9 +131,11 @@ class Kokoro < Command
   end
 
   def local_docs_test
-    run "bundle exec rake yard"
-    broken_links = check_links ["doc"], ".", ""
-    puts_broken_links broken_links
+    if @should_release
+      run "bundle exec rake yard"
+      broken_links = check_links ["doc"], ".", ""
+      puts_broken_links broken_links
+    end
   end
 
   def header str, token = "#"

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -143,8 +143,8 @@ class Kokoro < Command
   def should_link_check?
     return false unless @gem && @should_release
 
-    gem_search = `gem search #{gem}`
-    gem_search.include?(gem)
+    gem_search = `gem search #{@gem}`
+    gem_search.include?(@gem)
   end
 
   def autorelease_pending?

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -37,7 +37,7 @@ class Kokoro < Command
       run_ci gem do
         run "bundle exec rake ci", 1800
         local_docs_test if should_link_check? || (
-          pr_title.include?("Release") && @should_release
+          autorelease_pending? && @should_release
         )
       end
     end
@@ -147,12 +147,12 @@ class Kokoro < Command
     gem_search.include?(gem)
   end
 
-  def pr_title
+  def autorelease_pending?
     net = Net::HTTP.new("api.github.com", 443)
     net.use_ssl = true
-    response = net.get "/repos/googleapis/google-cloud-ruby/pulls/#{@pr_number}"
+    response = net.get "/repos/googleapis/google-cloud-ruby/pulls/#{pr_number}"
     parsed = JSON.parse response.body
-    parsed["title"]
+    parsed["labels"].any? { |label| label["name"] == "autorelease: pending" }
   end
 
   def header str, token = "#"

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -150,7 +150,7 @@ class Kokoro < Command
   def autorelease_pending?
     net = Net::HTTP.new("api.github.com", 443)
     net.use_ssl = true
-    response = net.get "/repos/googleapis/google-cloud-ruby/pulls/#{pr_number}"
+    response = net.get "/repos/googleapis/google-cloud-ruby/pulls/#{@pr_number}"
     parsed = JSON.parse response.body
     parsed["labels"].any? { |label| label["name"] == "autorelease: pending" }
   end


### PR DESCRIPTION
This change has kokoro build the docs locally and check them for broken links when:
- (It's a presubmit, and the gem has been updated, and the gem has either been published or is currently being released) OR
- it's a continuous/merge-to-master commit)
AND
- it's running on linux and using the version of ruby we use to publish docs and gems

new clients will likely fail ci as the cloud.google.com links will fail, but that should be a minority of cases. Happy to account for these if anyone knows of a good way to check

won't be as thorough as .kokoro/continuous/linux/post but should make it way easier to catch/fix issues