### PR TITLE
Unlock minitest version of google-cloud-storage

### DIFF
--- a/google-cloud-storage/.rubocop.yml
+++ b/google-cloud-storage/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-minitest
+
 inherit_gem:
   google-style: google-style.yml
 

--- a/google-cloud-storage/.rubocop.yml
+++ b/google-cloud-storage/.rubocop.yml
@@ -7,7 +7,6 @@ AllCops:
     - "conformance/**/*"
     - "google-cloud-storage.gemspec"
     - "Rakefile"
-    - "test/**/*"
     - "support/**/*"
 
 Documentation:

--- a/google-cloud-storage/.rubocop.yml
+++ b/google-cloud-storage/.rubocop.yml
@@ -5,7 +5,6 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
     - "conformance/**/*"
     - "google-cloud-storage.gemspec"
     - "Rakefile"

--- a/google-cloud-storage/.rubocop.yml
+++ b/google-cloud-storage/.rubocop.yml
@@ -5,6 +5,7 @@ inherit_gem:
 
 AllCops:
   Exclude:
+    - "acceptance/**/*"
     - "conformance/**/*"
     - "google-cloud-storage.gemspec"
     - "Rakefile"

--- a/google-cloud-storage/.rubocop.yml
+++ b/google-cloud-storage/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "conformance/**/*"
     - "google-cloud-storage.gemspec"
     - "Rakefile"
+    - "test/**/*"
     - "support/**/*"
 
 Documentation:

--- a/google-cloud-storage/.rubocop.yml
+++ b/google-cloud-storage/.rubocop.yml
@@ -1,5 +1,3 @@
-require: rubocop-minitest
-
 inherit_gem:
   google-style: google-style.yml
 

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -11,3 +11,4 @@ gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
 
 gem "minitest"
+gem "rubocop-minitest"

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -11,4 +11,4 @@ gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
 
 gem "minitest"
-gem "rubocop-minitest"
+gem "rubocop-minitest", github: "koic/rubocop-minitest", branch: "work_on_file_names_end_with_test_rb"

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -11,4 +11,4 @@ gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
 
 gem "minitest"
-gem "rubocop-minitest", github: "koic/rubocop-minitest", branch: "fix_false_negative_for_global_expectations_using_without_arguments"
+gem "rubocop-minitest", github: "koic/rubocop-minitest", branch: "work_on_file_names_end_with_test_rb"

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -11,4 +11,3 @@ gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
 
 gem "minitest"
-gem "rubocop-minitest"

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -10,6 +10,4 @@ gem "google-cloud-pubsub", path: "../google-cloud-pubsub"
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
 
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"
+gem "minitest"

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -11,4 +11,4 @@ gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
 
 gem "minitest"
-gem "rubocop-minitest", github: "koic/rubocop-minitest", branch: "work_on_file_names_end_with_test_rb"
+gem "rubocop-minitest"

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -11,4 +11,4 @@ gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
 
 gem "minitest"
-gem "rubocop-minitest", github: "koic/rubocop-minitest", branch: "work_on_file_names_end_with_test_rb"
+gem "rubocop-minitest", github: "koic/rubocop-minitest", branch: "fix_false_negative_for_global_expectations_using_without_arguments"

--- a/google-cloud-storage/acceptance/storage/bucket_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_acl_test.rb
@@ -28,92 +28,92 @@ describe Google::Cloud::Storage::Bucket, :acl, :storage do
   end
 
   it "adds a reader" do
-    bucket.acl.readers.wont_include user_val
+    _(bucket.acl.readers).wont_include user_val
     bucket.acl.add_reader user_val
-    bucket.acl.readers.must_include user_val
+    _(bucket.acl.readers).must_include user_val
     bucket.acl.refresh!
-    bucket.acl.readers.must_include user_val
+    _(bucket.acl.readers).must_include user_val
     bucket.refresh!
-    bucket.acl.readers.must_include user_val
+    _(bucket.acl.readers).must_include user_val
   end
 
   it "adds a writer" do
-    bucket.acl.writers.wont_include user_val
+    _(bucket.acl.writers).wont_include user_val
     bucket.acl.add_writer user_val
-    bucket.acl.writers.must_include user_val
+    _(bucket.acl.writers).must_include user_val
     bucket.acl.refresh!
-    bucket.acl.writers.must_include user_val
+    _(bucket.acl.writers).must_include user_val
     bucket.refresh!
-    bucket.acl.writers.must_include user_val
+    _(bucket.acl.writers).must_include user_val
   end
 
   it "adds an owner" do
-    bucket.acl.owners.wont_include user_val
+    _(bucket.acl.owners).wont_include user_val
     bucket.acl.add_owner user_val
-    bucket.acl.owners.must_include user_val
+    _(bucket.acl.owners).must_include user_val
     bucket.acl.refresh!
-    bucket.acl.owners.must_include user_val
+    _(bucket.acl.owners).must_include user_val
     bucket.refresh!
-    bucket.acl.owners.must_include user_val
+    _(bucket.acl.owners).must_include user_val
   end
 
   it "updates predefined rules" do
-    bucket.acl.readers.wont_include "allAuthenticatedUsers"
+    _(bucket.acl.readers).wont_include "allAuthenticatedUsers"
     bucket.acl.auth!
-    bucket.acl.readers.must_include "allAuthenticatedUsers"
+    _(bucket.acl.readers).must_include "allAuthenticatedUsers"
     bucket.acl.refresh!
-    bucket.acl.readers.must_include "allAuthenticatedUsers"
+    _(bucket.acl.readers).must_include "allAuthenticatedUsers"
     bucket.refresh!
-    bucket.acl.readers.must_include "allAuthenticatedUsers"
+    _(bucket.acl.readers).must_include "allAuthenticatedUsers"
   end
 
   it "deletes rules" do
     bucket.acl.auth!
-    bucket.acl.readers.must_include "allAuthenticatedUsers"
+    _(bucket.acl.readers).must_include "allAuthenticatedUsers"
     bucket.acl.delete "allAuthenticatedUsers"
-    bucket.acl.readers.wont_include "allAuthenticatedUsers"
+    _(bucket.acl.readers).wont_include "allAuthenticatedUsers"
     bucket.acl.refresh!
-    bucket.acl.readers.wont_include "allAuthenticatedUsers"
+    _(bucket.acl.readers).wont_include "allAuthenticatedUsers"
     bucket.refresh!
-    bucket.acl.readers.wont_include "allAuthenticatedUsers"
+    _(bucket.acl.readers).wont_include "allAuthenticatedUsers"
   end
 
   it "retrieves and modifies the ACL" do
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.must_be :empty?
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).must_be :empty?
 
     bucket.acl.add_writer user_val
 
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.wont_be :empty?
-    bucket.acl.readers.must_be :empty?
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).wont_be :empty?
+    _(bucket.acl.readers).must_be :empty?
 
-    bucket.acl.writers.must_include user_val
+    _(bucket.acl.writers).must_include user_val
 
     bucket.acl.reload!
 
-    bucket.acl.writers.must_include user_val
+    _(bucket.acl.writers).must_include user_val
 
     bucket.reload!
 
-    bucket.acl.writers.must_include user_val
+    _(bucket.acl.writers).must_include user_val
 
     bucket.acl.delete user_val
 
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.must_be :empty?
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).must_be :empty?
 
-    bucket.acl.writers.wont_include user_val
+    _(bucket.acl.writers).wont_include user_val
 
     bucket.acl.reload!
 
-    bucket.acl.writers.wont_include user_val
+    _(bucket.acl.writers).wont_include user_val
 
     bucket.reload!
 
-    bucket.acl.writers.wont_include user_val
+    _(bucket.acl.writers).wont_include user_val
   end
 
   it "sets predefined ACL rules" do

--- a/google-cloud-storage/acceptance/storage/bucket_default_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_default_acl_test.rb
@@ -29,80 +29,80 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :storage do
 
   it "adds a reader" do
     user_val = "user-blowmage@gmail.com"
-    bucket.default_acl.readers.wont_include user_val
+    _(bucket.default_acl.readers).wont_include user_val
     bucket.default_acl.add_reader user_val
-    bucket.default_acl.readers.must_include user_val
+    _(bucket.default_acl.readers).must_include user_val
     bucket.default_acl.refresh!
-    bucket.default_acl.readers.must_include user_val
+    _(bucket.default_acl.readers).must_include user_val
     bucket.refresh!
-    bucket.default_acl.readers.must_include user_val
+    _(bucket.default_acl.readers).must_include user_val
   end
 
   it "adds an owner" do
     user_val = "user-blowmage@gmail.com"
-    bucket.default_acl.owners.wont_include user_val
+    _(bucket.default_acl.owners).wont_include user_val
     bucket.default_acl.add_owner user_val
-    bucket.default_acl.owners.must_include user_val
+    _(bucket.default_acl.owners).must_include user_val
     bucket.default_acl.refresh!
-    bucket.default_acl.owners.must_include user_val
+    _(bucket.default_acl.owners).must_include user_val
     bucket.refresh!
-    bucket.default_acl.owners.must_include user_val
+    _(bucket.default_acl.owners).must_include user_val
   end
 
   it "updates predefined rules" do
-    bucket.default_acl.readers.wont_include "allAuthenticatedUsers"
+    _(bucket.default_acl.readers).wont_include "allAuthenticatedUsers"
     bucket.default_acl.auth!
-    bucket.default_acl.readers.must_include "allAuthenticatedUsers"
+    _(bucket.default_acl.readers).must_include "allAuthenticatedUsers"
     bucket.default_acl.refresh!
-    bucket.default_acl.readers.must_include "allAuthenticatedUsers"
+    _(bucket.default_acl.readers).must_include "allAuthenticatedUsers"
     bucket.refresh!
-    bucket.default_acl.readers.must_include "allAuthenticatedUsers"
+    _(bucket.default_acl.readers).must_include "allAuthenticatedUsers"
   end
 
   it "deletes rules" do
     bucket.default_acl.auth!
-    bucket.default_acl.readers.must_include "allAuthenticatedUsers"
+    _(bucket.default_acl.readers).must_include "allAuthenticatedUsers"
     bucket.default_acl.delete "allAuthenticatedUsers"
-    bucket.default_acl.readers.wont_include "allAuthenticatedUsers"
+    _(bucket.default_acl.readers).wont_include "allAuthenticatedUsers"
     bucket.default_acl.refresh!
-    bucket.default_acl.readers.wont_include "allAuthenticatedUsers"
+    _(bucket.default_acl.readers).wont_include "allAuthenticatedUsers"
     bucket.refresh!
-    bucket.default_acl.readers.wont_include "allAuthenticatedUsers"
+    _(bucket.default_acl.readers).wont_include "allAuthenticatedUsers"
   end
 
   it "retrieves and modifies the ACL" do
-    bucket.default_acl.owners.must_be  :empty?
-    bucket.default_acl.readers.must_be :empty?
+    _(bucket.default_acl.owners).must_be  :empty?
+    _(bucket.default_acl.readers).must_be :empty?
 
     bucket.default_acl.add_reader user_val
 
-    bucket.default_acl.owners.must_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
+    _(bucket.default_acl.owners).must_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
 
-    bucket.default_acl.readers.must_include user_val
+    _(bucket.default_acl.readers).must_include user_val
 
     bucket.default_acl.reload!
 
-    bucket.default_acl.readers.must_include user_val
+    _(bucket.default_acl.readers).must_include user_val
 
     bucket.reload!
 
-    bucket.default_acl.readers.must_include user_val
+    _(bucket.default_acl.readers).must_include user_val
 
     bucket.default_acl.delete user_val
 
-    bucket.default_acl.owners.must_be  :empty?
-    bucket.default_acl.readers.must_be :empty?
+    _(bucket.default_acl.owners).must_be  :empty?
+    _(bucket.default_acl.readers).must_be :empty?
 
-    bucket.default_acl.readers.wont_include user_val
+    _(bucket.default_acl.readers).wont_include user_val
 
     bucket.default_acl.reload!
 
-    bucket.default_acl.readers.wont_include user_val
+    _(bucket.default_acl.readers).wont_include user_val
 
     bucket.reload!
 
-    bucket.default_acl.readers.wont_include user_val
+    _(bucket.default_acl.readers).wont_include user_val
   end
 
   it "sets predefined ACL rules" do

--- a/google-cloud-storage/acceptance/storage/bucket_encryption_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_encryption_test.rb
@@ -48,27 +48,27 @@ describe Google::Cloud::Storage::Bucket, :encryption, :storage do
   describe "KMS customer-managed encryption key (CMEK)" do
 
     it "knows its encryption configuration" do
-      bucket.default_kms_key.wont_be :nil?
-      bucket.default_kms_key.must_equal kms_key
+      _(bucket.default_kms_key).wont_be :nil?
+      _(bucket.default_kms_key).must_equal kms_key
       bucket.reload!
-      bucket.default_kms_key.wont_be :nil?
-      bucket.default_kms_key.must_equal kms_key
+      _(bucket.default_kms_key).wont_be :nil?
+      _(bucket.default_kms_key).must_equal kms_key
     end
 
     it "can update its default kms key to another key" do
-      bucket.default_kms_key.must_equal kms_key
+      _(bucket.default_kms_key).must_equal kms_key
       bucket.default_kms_key = kms_key_2
-      bucket.default_kms_key.must_equal kms_key_2
+      _(bucket.default_kms_key).must_equal kms_key_2
       bucket.reload!
-      bucket.default_kms_key.must_equal kms_key_2
+      _(bucket.default_kms_key).must_equal kms_key_2
     end
 
     it "can remove its default kms key by setting encryption to nil" do
-      bucket.default_kms_key.must_equal kms_key
+      _(bucket.default_kms_key).must_equal kms_key
       bucket.default_kms_key = nil
-      bucket.default_kms_key.must_be :nil?
+      _(bucket.default_kms_key).must_be :nil?
       bucket.reload!
-      bucket.default_kms_key.must_be :nil?
+      _(bucket.default_kms_key).must_be :nil?
     end
   end
 end

--- a/google-cloud-storage/acceptance/storage/bucket_generate_signed_post_policy_v4_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_generate_signed_post_policy_v4_test.rb
@@ -42,13 +42,13 @@ describe Google::Cloud::Storage::Bucket, :generate_signed_post_policy_v4, :stora
 
     response = http.request request
 
-    response.code.must_equal "204"
+    _(response.code).must_equal "204"
     file = bucket.file(post_object.fields["key"])
-    file.wont_be :nil?
+    _(file).wont_be :nil?
     Tempfile.open ["google-cloud-logo", ".jpg"] do |tmpfile|
       tmpfile.binmode
       downloaded = file.download tmpfile
-      File.read(downloaded.path, mode: "rb").must_equal File.read(data, mode: "rb")
+      _(File.read(downloaded.path, mode: "rb")).must_equal File.read(data, mode: "rb")
     end
   end
 
@@ -67,13 +67,13 @@ describe Google::Cloud::Storage::Bucket, :generate_signed_post_policy_v4, :stora
     request.set_form form_data, 'multipart/form-data'
 
     response = http.request request
-    response.code.must_equal "204"
+    _(response.code).must_equal "204"
     file = bucket.file(post_object.fields["key"])
-    file.wont_be :nil?
+    _(file).wont_be :nil?
     Tempfile.open ["google-cloud-logo", ".jpg"] do |tmpfile|
       tmpfile.binmode
       downloaded = file.download tmpfile
-      File.read(downloaded.path, mode: "rb").must_equal File.read(data, mode: "rb")
+      _(File.read(downloaded.path, mode: "rb")).must_equal File.read(data, mode: "rb")
     end
   end
 
@@ -97,13 +97,13 @@ describe Google::Cloud::Storage::Bucket, :generate_signed_post_policy_v4, :stora
 
     response = http.request request
 
-    response.code.must_equal "204"
+    _(response.code).must_equal "204"
     file = bucket.file(post_object.fields["key"])
-    file.wont_be :nil?
+    _(file).wont_be :nil?
     Tempfile.open ["google-cloud-logo", ".jpg"] do |tmpfile|
       tmpfile.binmode
       downloaded = file.download tmpfile
-      File.read(downloaded.path, mode: "rb").must_equal File.read(data, mode: "rb")
+      _(File.read(downloaded.path, mode: "rb")).must_equal File.read(data, mode: "rb")
     end
   end
 
@@ -126,13 +126,13 @@ describe Google::Cloud::Storage::Bucket, :generate_signed_post_policy_v4, :stora
 
     response = http.request request
 
-    response.code.must_equal "200"
+    _(response.code).must_equal "200"
     file = bucket.file(post_object.fields["key"])
-    file.wont_be :nil?
+    _(file).wont_be :nil?
     Tempfile.open ["google-cloud-logo", ".jpg"] do |tmpfile|
       tmpfile.binmode
       downloaded = file.download tmpfile
-      File.read(downloaded.path, mode: "rb").must_equal File.read(data, mode: "rb")
+      _(File.read(downloaded.path, mode: "rb")).must_equal File.read(data, mode: "rb")
     end
   end
 

--- a/google-cloud-storage/acceptance/storage/bucket_lock_retention_policy_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_lock_retention_policy_test.rb
@@ -45,10 +45,10 @@ describe Google::Cloud::Storage::Bucket, :lock_retention_policy, :storage do
       if b.name == bucket_name
         found = true
 
-        b.retention_period.must_equal 10
-        b.retention_effective_at.must_be_kind_of DateTime
-        b.retention_policy_locked?.must_equal false
-        b.default_event_based_hold?.must_equal true
+        _(b.retention_period).must_equal 10
+        _(b.retention_effective_at).must_be_kind_of DateTime
+        _(b.retention_policy_locked?).must_equal false
+        _(b.default_event_based_hold?).must_equal true
       end
     end
     assert found
@@ -61,10 +61,10 @@ describe Google::Cloud::Storage::Bucket, :lock_retention_policy, :storage do
     end
 
     bucket.reload!
-    bucket.retention_period.must_equal 10
-    bucket.retention_effective_at.must_be_kind_of DateTime
-    bucket.retention_policy_locked?.must_equal false
-    bucket.default_event_based_hold?.must_equal false
+    _(bucket.retention_period).must_equal 10
+    _(bucket.retention_effective_at).must_be_kind_of DateTime
+    _(bucket.retention_policy_locked?).must_equal false
+    _(bucket.default_event_based_hold?).must_equal false
 
     original = File.new file_path
 
@@ -73,34 +73,34 @@ describe Google::Cloud::Storage::Bucket, :lock_retention_policy, :storage do
 
     # files get
     file = bucket.file file.name
-    file.temporary_hold?.must_equal false
-    file.event_based_hold?.must_equal false
-    file.retention_expires_at.must_be_kind_of DateTime
+    _(file.temporary_hold?).must_equal false
+    _(file.event_based_hold?).must_equal false
+    _(file.retention_expires_at).must_be_kind_of DateTime
 
     # files list
     bucket.files.all.each do |f|
-      f.temporary_hold?.must_equal false
-      f.event_based_hold?.must_equal false
-      f.retention_expires_at.must_be_kind_of DateTime
+      _(f.temporary_hold?).must_equal false
+      _(f.event_based_hold?).must_equal false
+      _(f.retention_expires_at).must_be_kind_of DateTime
     end
 
     err = expect { file.delete }.must_raise Google::Cloud::PermissionDeniedError
-    err.message.must_match /is subject to bucket's retention policy/
+    _(err.message).must_match /is subject to bucket's retention policy/
 
     bucket.update do |b|
       b.retention_period = nil
     end
 
     bucket.reload!
-    bucket.retention_period.must_be :nil?
-    bucket.retention_effective_at.must_be :nil?
-    bucket.retention_policy_locked?.must_equal false
-    bucket.default_event_based_hold?.must_equal false
+    _(bucket.retention_period).must_be :nil?
+    _(bucket.retention_effective_at).must_be :nil?
+    _(bucket.retention_policy_locked?).must_equal false
+    _(bucket.default_event_based_hold?).must_equal false
 
     file.reload!
-    file.temporary_hold?.must_equal false
-    file.event_based_hold?.must_equal false
-    file.retention_expires_at.must_be :nil?
+    _(file.temporary_hold?).must_equal false
+    _(file.event_based_hold?).must_equal false
+    _(file.retention_expires_at).must_be :nil?
 
     file.delete
   end
@@ -112,65 +112,65 @@ describe Google::Cloud::Storage::Bucket, :lock_retention_policy, :storage do
     end
 
     bucket.reload!
-    bucket.retention_period.must_be :nil?
-    bucket.retention_effective_at.must_be :nil?
-    bucket.retention_policy_locked?.must_equal false
-    bucket.default_event_based_hold?.must_equal true
+    _(bucket.retention_period).must_be :nil?
+    _(bucket.retention_effective_at).must_be :nil?
+    _(bucket.retention_policy_locked?).must_equal false
+    _(bucket.default_event_based_hold?).must_equal true
 
     original = File.new file_path
 
     # create file
     file = bucket.create_file original, "CloudLogo.png"
-    file.temporary_hold?.must_equal false
-    file.event_based_hold?.must_equal true
-    file.retention_expires_at.must_be :nil?
+    _(file.temporary_hold?).must_equal false
+    _(file.event_based_hold?).must_equal true
+    _(file.retention_expires_at).must_be :nil?
 
     err = expect { file.delete }.must_raise Google::Cloud::PermissionDeniedError
-    err.message.must_match /is under active Event-Based hold/
+    _(err.message).must_match /is under active Event-Based hold/
 
     bucket.update do |b|
       b.default_event_based_hold = false
     end
 
     bucket.reload!
-    bucket.retention_period.must_be :nil?
-    bucket.retention_effective_at.must_be :nil?
-    bucket.retention_policy_locked?.must_equal false
-    bucket.default_event_based_hold?.must_equal false
+    _(bucket.retention_period).must_be :nil?
+    _(bucket.retention_effective_at).must_be :nil?
+    _(bucket.retention_policy_locked?).must_equal false
+    _(bucket.default_event_based_hold?).must_equal false
 
     file.release_event_based_hold!
 
     file.reload!
-    file.temporary_hold?.must_equal false
-    file.event_based_hold?.must_equal false
-    file.retention_expires_at.must_be :nil?
+    _(file.temporary_hold?).must_equal false
+    _(file.event_based_hold?).must_equal false
+    _(file.retention_expires_at).must_be :nil?
 
     file.delete
   end
 
   it "manages a file with temporary_hold" do
-    bucket.retention_period.must_be :nil?
-    bucket.retention_effective_at.must_be :nil?
-    bucket.retention_policy_locked?.must_equal false
-    bucket.default_event_based_hold?.must_equal false
+    _(bucket.retention_period).must_be :nil?
+    _(bucket.retention_effective_at).must_be :nil?
+    _(bucket.retention_policy_locked?).must_equal false
+    _(bucket.default_event_based_hold?).must_equal false
 
     original = File.new file_path
 
     # create file
     file = bucket.create_file original, "CloudLogo.png", temporary_hold: true
-    file.temporary_hold?.must_equal true
-    file.event_based_hold?.must_equal false
-    file.retention_expires_at.must_be :nil?
+    _(file.temporary_hold?).must_equal true
+    _(file.event_based_hold?).must_equal false
+    _(file.retention_expires_at).must_be :nil?
 
     err = expect { file.delete }.must_raise Google::Cloud::PermissionDeniedError
-    err.message.must_match /is under active Temporary hold/
+    _(err.message).must_match /is under active Temporary hold/
 
     file.release_temporary_hold!
 
     file.reload!
-    file.temporary_hold?.must_equal false
-    file.event_based_hold?.must_equal false
-    file.retention_expires_at.must_be :nil?
+    _(file.temporary_hold?).must_equal false
+    _(file.event_based_hold?).must_equal false
+    _(file.retention_expires_at).must_be :nil?
 
     file.delete
   end
@@ -181,13 +181,13 @@ describe Google::Cloud::Storage::Bucket, :lock_retention_policy, :storage do
     end
 
     bucket.reload!
-    bucket.retention_period.must_equal 10
-    bucket.retention_policy_locked?.must_equal false
+    _(bucket.retention_period).must_equal 10
+    _(bucket.retention_policy_locked?).must_equal false
 
     bucket_ref = storage.bucket bucket.name, skip_lookup: true
 
     err = expect { bucket_ref.lock_retention_policy! }.must_raise Google::Cloud::InvalidArgumentError
-    err.message.must_match /Required parameter: ifMetagenerationMatch/
+    _(err.message).must_match /Required parameter: ifMetagenerationMatch/
   end
 
   it "locks its retention_period with lock_retention_policy!" do
@@ -196,21 +196,21 @@ describe Google::Cloud::Storage::Bucket, :lock_retention_policy, :storage do
     end
 
     bucket.reload!
-    bucket.retention_period.must_equal 10
-    bucket.retention_policy_locked?.must_equal false
+    _(bucket.retention_period).must_equal 10
+    _(bucket.retention_policy_locked?).must_equal false
 
     bucket.lock_retention_policy!
 
     # Call to lock_retention_policy! should update bucket state
-    bucket.retention_policy_locked?.must_equal true
+    _(bucket.retention_policy_locked?).must_equal true
 
-    bucket.location_type.must_equal "multi-region"
+    _(bucket.location_type).must_equal "multi-region"
 
     err = expect do
       bucket.update do |b|
         b.retention_period = nil
       end
     end.must_raise Google::Cloud::PermissionDeniedError
-    err.message.must_match /has a locked Retention Policy which cannot be removed/
+    _(err.message).must_match /has a locked Retention Policy which cannot be removed/
   end
 end

--- a/google-cloud-storage/acceptance/storage/bucket_notification_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_notification_test.rb
@@ -42,22 +42,22 @@ describe Google::Cloud::Storage::Bucket, :notification, :storage do
 
       notification.wont_be_nil
       notification.id.wont_be_nil
-      notification.custom_attrs.must_equal custom_attrs
-      notification.event_types.must_equal event_types
-      notification.prefix.must_equal filename_prefix
-      notification.payload.must_equal payload
-      notification.topic.must_equal topic_name_full_path
+      _(notification.custom_attrs).must_equal custom_attrs
+      _(notification.event_types).must_equal event_types
+      _(notification.prefix).must_equal filename_prefix
+      _(notification.payload).must_equal payload
+      _(notification.topic).must_equal topic_name_full_path
 
-      bucket.notifications.wont_be :empty?
+      _(bucket.notifications).wont_be :empty?
 
       fresh_notification = bucket.notification notification.id
       fresh_notification.wont_be_nil
       fresh_notification.id.wont_be_nil
-      fresh_notification.custom_attrs.must_equal custom_attrs
-      fresh_notification.event_types.must_equal event_types
-      fresh_notification.prefix.must_equal filename_prefix
-      fresh_notification.payload.must_equal payload
-      fresh_notification.topic.must_equal topic_name_full_path
+      _(fresh_notification.custom_attrs).must_equal custom_attrs
+      _(fresh_notification.event_types).must_equal event_types
+      _(fresh_notification.prefix).must_equal filename_prefix
+      _(fresh_notification.payload).must_equal payload
+      _(fresh_notification.topic).must_equal topic_name_full_path
 
 
       fresh_notification.delete

--- a/google-cloud-storage/acceptance/storage/bucket_notification_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_notification_test.rb
@@ -40,8 +40,8 @@ describe Google::Cloud::Storage::Bucket, :notification, :storage do
                                                             prefix: filename_prefix,
                                                             payload: payload
 
-      notification.wont_be_nil
-      notification.id.wont_be_nil
+      _(notification).wont_be_nil
+      _(notification.id).wont_be_nil
       _(notification.custom_attrs).must_equal custom_attrs
       _(notification.event_types).must_equal event_types
       _(notification.prefix).must_equal filename_prefix
@@ -51,8 +51,8 @@ describe Google::Cloud::Storage::Bucket, :notification, :storage do
       _(bucket.notifications).wont_be :empty?
 
       fresh_notification = bucket.notification notification.id
-      fresh_notification.wont_be_nil
-      fresh_notification.id.wont_be_nil
+      _(fresh_notification).wont_be_nil
+      _(fresh_notification.id).wont_be_nil
       _(fresh_notification.custom_attrs).must_equal custom_attrs
       _(fresh_notification.event_types).must_equal event_types
       _(fresh_notification.prefix).must_equal filename_prefix

--- a/google-cloud-storage/acceptance/storage/bucket_policy_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_policy_test.rb
@@ -33,11 +33,11 @@ describe Google::Cloud::Storage::Bucket, :policy, :storage do
       permissions = bucket.test_permissions roles
       skip "Don't have permissions to get/set bucket's policy" unless permissions == roles
 
-      bucket.policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(bucket.policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
 
       # We need a valid service account in order to update the policy
       service_account = storage.service.credentials.client.issuer
-      service_account.wont_be :nil?
+      _(service_account).wont_be :nil?
       role = "roles/storage.objectCreator"
       member = "serviceAccount:#{service_account}"
       bucket.policy do |p|
@@ -46,13 +46,13 @@ describe Google::Cloud::Storage::Bucket, :policy, :storage do
       end
 
       role_member = bucket.policy.role(role).select { |x| x == member }
-      role_member.count.must_equal 1
+      _(role_member.count).must_equal 1
     end
 
     it "allows permissions to be tested" do
       roles = ["storage.buckets.delete", "storage.buckets.get"]
       permissions = bucket.test_permissions roles
-      permissions.must_equal roles
+      _(permissions).must_equal roles
     end
   end
 
@@ -65,31 +65,31 @@ describe Google::Cloud::Storage::Bucket, :policy, :storage do
       skip "Don't have permissions to get/set bucket's policy" unless permissions == roles
 
       policy = bucket_policy_v3.policy
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.version.must_equal 1
-      policy.roles.count.must_equal 2
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.version).must_equal 1
+      _(policy.roles.count).must_equal 2
       expect { policy.bindings }.must_raise RuntimeError
 
       policy = bucket_policy_v3.policy requested_policy_version: 1
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.version.must_equal 1
-      policy.roles.count.must_equal 2
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.version).must_equal 1
+      _(policy.roles.count).must_equal 2
       expect { policy.bindings }.must_raise RuntimeError
 
       bucket_policy_v3.policy requested_policy_version: 3 do |p|
-        p.version.must_equal 1
+        _(p.version).must_equal 1
         p.version = 3 # Won't be persisted by the service.
       end
 
       policy = bucket_policy_v3.policy requested_policy_version: 3
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.version.must_equal 1
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.version).must_equal 1
       expect { policy.roles }.must_raise RuntimeError
-      policy.bindings.count.must_equal 2
+      _(policy.bindings.count).must_equal 2
 
       # We need a valid service account in order to update the policy
       service_account = storage.service.credentials.client.issuer
-      service_account.wont_be :nil?
+      _(service_account).wont_be :nil?
       role = "roles/storage.admin"
       member = "serviceAccount:#{service_account}"
 
@@ -113,7 +113,7 @@ describe Google::Cloud::Storage::Bucket, :policy, :storage do
       # end.must_raise Google::Cloud::Error # Fails without version = 3 TODO: uncomment after project is whitelisted
 
       bucket_policy_v3.policy requested_policy_version: 3 do |p|
-        p.version.must_equal 1
+        _(p.version).must_equal 1
         expect { p.roles }.must_raise RuntimeError
         expect { p.add role, member }.must_raise RuntimeError
         expect { p.remove role, member }.must_raise RuntimeError
@@ -132,7 +132,7 @@ describe Google::Cloud::Storage::Bucket, :policy, :storage do
 
       expect do
         bucket_policy_v3.policy requested_policy_version: 3 do |p|
-          p.version.must_equal 3
+          _(p.version).must_equal 3
           p.version = 1 # Not allowed.
         end
       end.must_raise RuntimeError
@@ -141,21 +141,21 @@ describe Google::Cloud::Storage::Bucket, :policy, :storage do
       # Requested policy version (1) cannot be less than the existing policy version (3).
       # expect { bucket_policy_v3.policy requested_policy_version: 1 }.must_raise Google::Cloud::Error # TODO: uncomment after project is whitelisted
       policy = bucket_policy_v3.policy requested_policy_version: 3
-      policy.version.must_equal 3
+      _(policy.version).must_equal 3
       expect { policy.roles }.must_raise RuntimeError
       expect { policy.deep_dup }.must_raise RuntimeError
-      policy.bindings.count.must_equal 3
+      _(policy.bindings.count).must_equal 3
       binding = policy.bindings.find do |b|
         b.role == role
       end
-      binding.wont_be :nil?
-      binding.role.must_equal role
-      binding.members.count.must_equal 1
-      binding.members[0].must_equal member
-      binding.condition.wont_be :nil?
-      binding.condition.title.must_equal "always-true"
-      binding.condition.description.must_equal "test condition always-true"
-      binding.condition.expression.must_equal "true"
+      _(binding).wont_be :nil?
+      _(binding.role).must_equal role
+      _(binding.members.count).must_equal 1
+      _(binding.members[0]).must_equal member
+      _(binding.condition).wont_be :nil?
+      _(binding.condition.title).must_equal "always-true"
+      _(binding.condition.description).must_equal "test condition always-true"
+      _(binding.condition.expression).must_equal "true"
     end
   end
 end

--- a/google-cloud-storage/acceptance/storage/bucket_post_object_v2_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_post_object_v2_test.rb
@@ -37,7 +37,7 @@ describe Google::Cloud::Storage::Bucket, :post_object, :v2, :storage do
   it "generates a signed post object V2" do
     file_name = "logo-#{SecureRandom.hex(4).downcase}.jpg"
 
-    bucket.file(file_name).must_be :nil?
+    _(bucket.file(file_name)).must_be :nil?
 
     post_object = bucket.post_object file_name, policy: policy
     http = Net::HTTP.new uri.host, uri.port
@@ -55,8 +55,8 @@ describe Google::Cloud::Storage::Bucket, :post_object, :v2, :storage do
 
     response = http.request request
 
-    response.code.must_equal "204"
-    bucket.file(file_name).wont_be :nil?
+    _(response.code).must_equal "204"
+    _(bucket.file(file_name)).wont_be :nil?
   end
 
   it "generates a signed post object with special variable key ${filename}" do
@@ -64,7 +64,7 @@ describe Google::Cloud::Storage::Bucket, :post_object, :v2, :storage do
     #  https://cloud.google.com/storage/docs/xml-api/post-object
     special_key = "${filename}"
 
-    bucket.file(data_file).must_be :nil?
+    _(bucket.file(data_file)).must_be :nil?
 
     post_object = bucket.post_object special_key, policy: policy
 
@@ -83,7 +83,7 @@ describe Google::Cloud::Storage::Bucket, :post_object, :v2, :storage do
 
     response = http.request request
 
-    response.code.must_equal "204"
-    bucket.file(data_file).wont_be :nil?
+    _(response.code).must_equal "204"
+    _(bucket.file(data_file)).wont_be :nil?
   end
 end

--- a/google-cloud-storage/acceptance/storage/bucket_requester_pays_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_requester_pays_test.rb
@@ -133,8 +133,8 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
                                                             prefix: filename_prefix,
                                                             payload: payload
 
-      notification.wont_be_nil
-      notification.id.wont_be_nil
+      _(notification).wont_be_nil
+      _(notification.id).wont_be_nil
       _(notification.custom_attrs).must_equal custom_attrs
       _(notification.event_types).must_equal event_types
       _(notification.prefix).must_equal filename_prefix
@@ -144,8 +144,8 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
       _(bucket.notifications).wont_be :empty?
 
       fresh_notification = bucket.notification notification.id
-      fresh_notification.wont_be_nil
-      fresh_notification.id.wont_be_nil
+      _(fresh_notification).wont_be_nil
+      _(fresh_notification.id).wont_be_nil
       _(fresh_notification.custom_attrs).must_equal custom_attrs
       _(fresh_notification.event_types).must_equal event_types
       _(fresh_notification.prefix).must_equal filename_prefix

--- a/google-cloud-storage/acceptance/storage/bucket_requester_pays_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_requester_pays_test.rb
@@ -76,48 +76,48 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
     e = expect do
       storage.bucket bucket_name
     end.must_raise Google::Cloud::InvalidArgumentError
-    e.message.must_equal "required: Bucket is requester pays bucket but no user project provided."
+    _(e.message).must_equal "required: Bucket is requester pays bucket but no user project provided."
   end
 
   it "gets and updates the bucket" do
-    bucket.website_main.must_be :nil?
+    _(bucket.website_main).must_be :nil?
     bucket.update do |b|
       b.website_main = "index.html"
     end
     fresh = storage.bucket bucket_name, user_project: true
-    fresh.website_main.must_equal "index.html"
+    _(fresh.website_main).must_equal "index.html"
   end
 
   describe "Bucket ACL" do
 
     it "adds an ACL reader" do
-      bucket.acl.readers.wont_include user_val
+      _(bucket.acl.readers).wont_include user_val
       bucket.acl.add_reader user_val
-      bucket.acl.readers.must_include user_val
+      _(bucket.acl.readers).must_include user_val
     end
 
     it "adds an ACL writer" do
-      bucket.acl.writers.wont_include user_val
+      _(bucket.acl.writers).wont_include user_val
       bucket.acl.add_writer user_val
-      bucket.acl.writers.must_include user_val
+      _(bucket.acl.writers).must_include user_val
     end
 
     it "adds an ACL owner" do
-      bucket.acl.owners.wont_include user_val
+      _(bucket.acl.owners).wont_include user_val
       bucket.acl.add_owner user_val
-      bucket.acl.owners.must_include user_val
+      _(bucket.acl.owners).must_include user_val
     end
 
     it "adds a default ACL reader" do
-      bucket.default_acl.readers.wont_include user_val
+      _(bucket.default_acl.readers).wont_include user_val
       bucket.default_acl.add_reader user_val
-      bucket.default_acl.readers.must_include user_val
+      _(bucket.default_acl.readers).must_include user_val
     end
 
     it "adds an default ACL owner" do
-      bucket.default_acl.owners.wont_include user_val
+      _(bucket.default_acl.owners).wont_include user_val
       bucket.default_acl.add_owner user_val
-      bucket.default_acl.owners.must_include user_val
+      _(bucket.default_acl.owners).must_include user_val
     end
   end
 
@@ -135,22 +135,22 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
 
       notification.wont_be_nil
       notification.id.wont_be_nil
-      notification.custom_attrs.must_equal custom_attrs
-      notification.event_types.must_equal event_types
-      notification.prefix.must_equal filename_prefix
-      notification.payload.must_equal payload
-      notification.topic.must_equal topic_name_full_path
+      _(notification.custom_attrs).must_equal custom_attrs
+      _(notification.event_types).must_equal event_types
+      _(notification.prefix).must_equal filename_prefix
+      _(notification.payload).must_equal payload
+      _(notification.topic).must_equal topic_name_full_path
 
-      bucket.notifications.wont_be :empty?
+      _(bucket.notifications).wont_be :empty?
 
       fresh_notification = bucket.notification notification.id
       fresh_notification.wont_be_nil
       fresh_notification.id.wont_be_nil
-      fresh_notification.custom_attrs.must_equal custom_attrs
-      fresh_notification.event_types.must_equal event_types
-      fresh_notification.prefix.must_equal filename_prefix
-      fresh_notification.payload.must_equal payload
-      fresh_notification.topic.must_equal topic_name_full_path
+      _(fresh_notification.custom_attrs).must_equal custom_attrs
+      _(fresh_notification.event_types).must_equal event_types
+      _(fresh_notification.prefix).must_equal filename_prefix
+      _(fresh_notification.payload).must_equal payload
+      _(fresh_notification.topic).must_equal topic_name_full_path
 
 
       fresh_notification.delete
@@ -169,11 +169,11 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
                  max_age: 300
     end
 
-    bucket.cors.wont_be :empty?
-    bucket.cors.last.origin.must_equal ["http://example.org", "https://example.org"]
-    bucket.cors.last.methods.must_equal ["*"]
-    bucket.cors.last.headers.must_equal ["X-My-Custom-Header"]
-    bucket.cors.last.max_age.must_equal 300
+    _(bucket.cors).wont_be :empty?
+    _(bucket.cors.last.origin).must_equal ["http://example.org", "https://example.org"]
+    _(bucket.cors.last.methods).must_equal ["*"]
+    _(bucket.cors.last.headers).must_equal ["X-My-Custom-Header"]
+    _(bucket.cors.last.max_age).must_equal 300
 
     bucket.reload!
 
@@ -186,10 +186,10 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
 
     bucket.reload!
 
-    bucket.cors.last.origin.must_equal ["http://example.org", "https://example.org", "https://example.com"]
-    bucket.cors.last.methods.must_equal ["PUT"]
-    bucket.cors.last.headers.must_equal ["X-My-Custom-Header", "X-Another-Custom-Header"]
-    bucket.cors.last.max_age.must_equal 600
+    _(bucket.cors.last.origin).must_equal ["http://example.org", "https://example.org", "https://example.com"]
+    _(bucket.cors.last.methods).must_equal ["PUT"]
+    _(bucket.cors.last.headers).must_equal ["X-My-Custom-Header", "X-Another-Custom-Header"]
+    _(bucket.cors.last.max_age).must_equal 600
   end
 
   describe "IAM Policies and Permissions" do
@@ -200,24 +200,24 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
       permissions = bucket.test_permissions roles
       skip "Don't have permissions to get/set bucket's policy" unless permissions == roles
 
-      bucket.policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(bucket.policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
 
       # We need a valid service account in order to update the policy
       service_account = storage.service.credentials.client.issuer
-      service_account.wont_be :nil?
+      _(service_account).wont_be :nil?
       role = "roles/storage.objectCreator"
       member = "serviceAccount:#{service_account}"
       bucket.policy do |p|
         p.add role, member
       end
 
-      bucket.policy.role(role).must_include member
+      _(bucket.policy.role(role)).must_include member
     end
 
     it "allows permissions to be tested on a bucket" do
       roles = ["storage.buckets.get"]
       permissions = bucket.test_permissions roles
-      permissions.must_equal roles
+      _(permissions).must_equal roles
     end
   end
 
@@ -231,25 +231,25 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
     bucket.create_file original, "CloudLogo-2.png" # second file for pagination
 
     # list
-    uploaded.cache_control.must_equal "public, max-age=3600"
-    uploaded.metadata["title"].must_equal "Logo Image"
+    _(uploaded.cache_control).must_equal "public, max-age=3600"
+    _(uploaded.metadata["title"]).must_equal "Logo Image"
     first_files = bucket.files(max: 1)
-    first_files.wont_be :empty?
-    first_files.next?.must_equal true
+    _(first_files).wont_be :empty?
+    _(first_files.next?).must_equal true
     # pagination
     second_files = first_files.next
-    second_files.wont_be :empty?
+    _(second_files).wont_be :empty?
 
     # get
-    bucket.file(uploaded.name).wont_be :nil?
+    _(bucket.file(uploaded.name)).wont_be :nil?
 
     # download
     Tempfile.open ["google-cloud", ".png"] do |tmpfile|
       tmpfile.binmode
       downloaded = uploaded.download tmpfile
 
-      downloaded.size.must_equal original.size
-      File.read(downloaded.path, mode: "rb").must_equal File.read(original.path, mode: "rb")
+      _(downloaded.size).must_equal original.size
+      _(File.read(downloaded.path, mode: "rb")).must_equal File.read(original.path, mode: "rb")
     end
 
     # update
@@ -258,8 +258,8 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
       f.metadata["title"] = "Logo Image II"
     end
     uploaded.reload!
-    uploaded.cache_control.must_equal "private, max-age=0, no-cache"
-    uploaded.metadata["title"].must_equal "Logo Image II"
+    _(uploaded.cache_control).must_equal "private, max-age=0, no-cache"
+    _(uploaded.metadata["title"]).must_equal "Logo Image II"
 
     # delete
     uploaded.delete
@@ -271,9 +271,9 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
       uploaded.copy "CloudLogoCopy"
     end
 
-    uploaded.name.must_equal "CloudLogo"
-    copied.name.must_equal "CloudLogoCopy"
-    copied.size.must_equal uploaded.size
+    _(uploaded.name).must_equal "CloudLogo"
+    _(copied.name).must_equal "CloudLogoCopy"
+    _(copied.size).must_equal uploaded.size
 
     Tempfile.open ["CloudLogo", ".png"] do |tmpfile1|
       tmpfile1.binmode
@@ -281,9 +281,9 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
         tmpfile2.binmode
         downloaded1 = uploaded.download tmpfile1
         downloaded2 = copied.download tmpfile2
-        downloaded1.size.must_equal downloaded2.size
+        _(downloaded1.size).must_equal downloaded2.size
 
-        File.read(downloaded1.path, mode: "rb").must_equal File.read(downloaded2.path, mode: "rb")
+        _(File.read(downloaded1.path, mode: "rb")).must_equal File.read(downloaded2.path, mode: "rb")
       end
     end
 
@@ -296,13 +296,13 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
     it "adds and deletes a reader" do
       file = bucket.create_file file_path, "ReaderTest.png"
       file.acl.add_reader group_val
-      file.acl.readers.must_include group_val
+      _(file.acl.readers).must_include group_val
       file.acl.refresh!
-      file.acl.readers.must_include group_val
+      _(file.acl.readers).must_include group_val
       file.refresh!
-      file.acl.readers.must_include group_val
+      _(file.acl.readers).must_include group_val
       file.acl.delete group_val
-      file.acl.readers.wont_include group_val
+      _(file.acl.readers).wont_include group_val
     end
 
     it "adds an owner" do

--- a/google-cloud-storage/acceptance/storage/bucket_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_test.rb
@@ -29,19 +29,19 @@ describe Google::Cloud::Storage::Bucket, :storage do
   it "creates and gets and updates and deletes a bucket" do
     one_off_bucket_name = "#{bucket_name}_one_off"
 
-    storage.bucket(one_off_bucket_name).must_be :nil?
+    _(storage.bucket(one_off_bucket_name)).must_be :nil?
 
     one_off_bucket = safe_gcs_execute { storage.create_bucket one_off_bucket_name, user_project: true }
 
-    storage.bucket(one_off_bucket_name).wont_be :nil?
+    _(storage.bucket(one_off_bucket_name)).wont_be :nil?
 
-    one_off_bucket.storage_class.wont_be :nil?
-    one_off_bucket.website_main.must_be :nil?
-    one_off_bucket.website_404.must_be :nil?
-    one_off_bucket.requester_pays.must_be :nil?
-    one_off_bucket.labels.must_equal({})
-    one_off_bucket.location_type.must_equal "multi-region"
-    one_off_bucket.user_project.must_equal true
+    _(one_off_bucket.storage_class).wont_be :nil?
+    _(one_off_bucket.website_main).must_be :nil?
+    _(one_off_bucket.website_404).must_be :nil?
+    _(one_off_bucket.requester_pays).must_be :nil?
+    _(one_off_bucket.labels).must_equal({})
+    _(one_off_bucket.location_type).must_equal "multi-region"
+    _(one_off_bucket.user_project).must_equal true
     one_off_bucket.update do |b|
       b.storage_class = :nearline
       b.website_main = "index.html"
@@ -50,60 +50,60 @@ describe Google::Cloud::Storage::Bucket, :storage do
       # update labels with symbols
       b.labels[:foo] = :bar
     end
-    one_off_bucket.storage_class.must_equal "NEARLINE"
-    one_off_bucket.website_main.must_equal "index.html"
-    one_off_bucket.website_404.must_equal "not_found.html"
-    one_off_bucket.requester_pays.must_equal true
+    _(one_off_bucket.storage_class).must_equal "NEARLINE"
+    _(one_off_bucket.website_main).must_equal "index.html"
+    _(one_off_bucket.website_404).must_equal "not_found.html"
+    _(one_off_bucket.requester_pays).must_equal true
     # labels with symbols are not strings
-    one_off_bucket.labels.must_equal({ "foo" => "bar" })
-    one_off_bucket.location_type.must_equal "multi-region"
+    _(one_off_bucket.labels).must_equal({ "foo" => "bar" })
+    _(one_off_bucket.location_type).must_equal "multi-region"
 
     one_off_bucket_copy = storage.bucket one_off_bucket_name, user_project: true
-    one_off_bucket_copy.wont_be :nil?
-    one_off_bucket_copy.storage_class.must_equal "NEARLINE"
-    one_off_bucket_copy.website_main.must_equal "index.html"
-    one_off_bucket_copy.website_404.must_equal "not_found.html"
-    one_off_bucket_copy.requester_pays.must_equal true
-    one_off_bucket_copy.user_project.must_equal true
+    _(one_off_bucket_copy).wont_be :nil?
+    _(one_off_bucket_copy.storage_class).must_equal "NEARLINE"
+    _(one_off_bucket_copy.website_main).must_equal "index.html"
+    _(one_off_bucket_copy.website_404).must_equal "not_found.html"
+    _(one_off_bucket_copy.requester_pays).must_equal true
+    _(one_off_bucket_copy.user_project).must_equal true
 
     one_off_bucket.files.all &:delete
     safe_gcs_execute { one_off_bucket.delete }
 
-    storage.bucket(one_off_bucket_name).must_be :nil?
+    _(storage.bucket(one_off_bucket_name)).must_be :nil?
   end
 
   it "knows its attributes" do
-    bucket.id.must_be_kind_of String
-    bucket.name.must_equal bucket_name
-    bucket.created_at.must_be_kind_of DateTime
-    bucket.api_url.must_equal "https://www.googleapis.com/storage/v1/b/#{bucket_name}"
-    bucket.location.must_be_kind_of String
-    bucket.location_type.must_equal "multi-region"
-    bucket.logging_bucket.must_be :nil?
-    bucket.logging_prefix.must_be :nil?
-    bucket.storage_class.must_equal "STANDARD"
-    bucket.versioning?.wont_equal true
-    bucket.website_main.must_be :nil?
-    bucket.website_404.must_be :nil?
-    bucket.requester_pays.must_be :nil?
-    bucket.labels.must_be :empty?
+    _(bucket.id).must_be_kind_of String
+    _(bucket.name).must_equal bucket_name
+    _(bucket.created_at).must_be_kind_of DateTime
+    _(bucket.api_url).must_equal "https://www.googleapis.com/storage/v1/b/#{bucket_name}"
+    _(bucket.location).must_be_kind_of String
+    _(bucket.location_type).must_equal "multi-region"
+    _(bucket.logging_bucket).must_be :nil?
+    _(bucket.logging_prefix).must_be :nil?
+    _(bucket.storage_class).must_equal "STANDARD"
+    _(bucket.versioning?).wont_equal true
+    _(bucket.website_main).must_be :nil?
+    _(bucket.website_404).must_be :nil?
+    _(bucket.requester_pays).must_be :nil?
+    _(bucket.labels).must_be :empty?
 
-    bucket.retention_period.must_be :nil?
-    bucket.retention_effective_at.must_be :nil?
-    bucket.retention_policy_locked?.must_equal false
-    bucket.default_event_based_hold?.must_equal false
+    _(bucket.retention_period).must_be :nil?
+    _(bucket.retention_effective_at).must_be :nil?
+    _(bucket.retention_policy_locked?).must_equal false
+    _(bucket.default_event_based_hold?).must_equal false
 
     bucket.cors.each do |cors|
-      cors.must_be_kind_of Google::Cloud::Storage::Bucket::Cors::Rule
-      cors.frozen?.must_equal true
+      _(cors).must_be_kind_of Google::Cloud::Storage::Bucket::Cors::Rule
+      _(cors.frozen?).must_equal true
     end
-    bucket.cors.frozen?.must_equal true
+    _(bucket.cors.frozen?).must_equal true
 
     bucket.lifecycle.each do |r|
-      r.must_be_kind_of Google::Cloud::Storage::Bucket::Lifecycle::Rule
-      r.frozen?.must_equal true
+      _(r).must_be_kind_of Google::Cloud::Storage::Bucket::Lifecycle::Rule
+      _(r.frozen?).must_equal true
     end
-    bucket.lifecycle.frozen?.must_equal true
+    _(bucket.lifecycle.frozen?).must_equal true
   end
 
   it "sets and updates cors rules" do
@@ -114,11 +114,11 @@ describe Google::Cloud::Storage::Bucket, :storage do
                  max_age: 300
     end
 
-    bucket.cors.wont_be :empty?
-    bucket.cors.last.origin.must_equal ["http://example.org", "https://example.org"]
-    bucket.cors.last.methods.must_equal ["*"]
-    bucket.cors.last.headers.must_equal ["X-My-Custom-Header"]
-    bucket.cors.last.max_age.must_equal 300
+    _(bucket.cors).wont_be :empty?
+    _(bucket.cors.last.origin).must_equal ["http://example.org", "https://example.org"]
+    _(bucket.cors.last.methods).must_equal ["*"]
+    _(bucket.cors.last.headers).must_equal ["X-My-Custom-Header"]
+    _(bucket.cors.last.max_age).must_equal 300
 
     bucket.reload!
 
@@ -131,10 +131,10 @@ describe Google::Cloud::Storage::Bucket, :storage do
 
     bucket.reload!
 
-    bucket.cors.last.origin.must_equal ["http://example.org", "https://example.org", "https://example.com"]
-    bucket.cors.last.methods.must_equal ["PUT"]
-    bucket.cors.last.headers.must_equal ["X-My-Custom-Header", "X-Another-Custom-Header"]
-    bucket.cors.last.max_age.must_equal 600
+    _(bucket.cors.last.origin).must_equal ["http://example.org", "https://example.org", "https://example.com"]
+    _(bucket.cors.last.methods).must_equal ["PUT"]
+    _(bucket.cors.last.headers).must_equal ["X-My-Custom-Header", "X-Another-Custom-Header"]
+    _(bucket.cors.last.max_age).must_equal 600
   end
 
   it "sets and updates lifecycle rules" do
@@ -150,15 +150,15 @@ describe Google::Cloud::Storage::Bucket, :storage do
 
     end
 
-    bucket.lifecycle.wont_be :empty?
-    bucket.lifecycle.count.must_equal original_count + 1
-    bucket.lifecycle.last.action.must_equal "SetStorageClass"
-    bucket.lifecycle.last.storage_class.must_equal "NEARLINE"
-    bucket.lifecycle.last.age.must_equal 10
-    bucket.lifecycle.last.created_before.must_equal Date.parse("2013-01-15")
-    bucket.lifecycle.last.is_live.must_equal true
-    bucket.lifecycle.last.matches_storage_class.must_equal ["STANDARD"]
-    bucket.lifecycle.last.num_newer_versions.must_equal 3
+    _(bucket.lifecycle).wont_be :empty?
+    _(bucket.lifecycle.count).must_equal original_count + 1
+    _(bucket.lifecycle.last.action).must_equal "SetStorageClass"
+    _(bucket.lifecycle.last.storage_class).must_equal "NEARLINE"
+    _(bucket.lifecycle.last.age).must_equal 10
+    _(bucket.lifecycle.last.created_before).must_equal Date.parse("2013-01-15")
+    _(bucket.lifecycle.last.is_live).must_equal true
+    _(bucket.lifecycle.last.matches_storage_class).must_equal ["STANDARD"]
+    _(bucket.lifecycle.last.num_newer_versions).must_equal 3
 
     bucket.reload!
 
@@ -173,15 +173,15 @@ describe Google::Cloud::Storage::Bucket, :storage do
 
     bucket.reload!
 
-    bucket.lifecycle.wont_be :empty?
-    bucket.lifecycle.count.must_equal original_count + 1
-    bucket.lifecycle.last.action.must_equal "SetStorageClass"
-    bucket.lifecycle.last.storage_class.must_equal "COLDLINE"
-    bucket.lifecycle.last.age.must_equal 20
-    bucket.lifecycle.last.created_before.must_equal Date.parse("2013-01-20")
-    bucket.lifecycle.last.is_live.must_equal false
-    bucket.lifecycle.last.matches_storage_class.must_equal ["NEARLINE"]
-    bucket.lifecycle.last.num_newer_versions.must_equal 4
+    _(bucket.lifecycle).wont_be :empty?
+    _(bucket.lifecycle.count).must_equal original_count + 1
+    _(bucket.lifecycle.last.action).must_equal "SetStorageClass"
+    _(bucket.lifecycle.last.storage_class).must_equal "COLDLINE"
+    _(bucket.lifecycle.last.age).must_equal 20
+    _(bucket.lifecycle.last.created_before).must_equal Date.parse("2013-01-20")
+    _(bucket.lifecycle.last.is_live).must_equal false
+    _(bucket.lifecycle.last.matches_storage_class).must_equal ["NEARLINE"]
+    _(bucket.lifecycle.last.num_newer_versions).must_equal 4
 
     bucket.lifecycle do |l|
       l.delete_at(bucket.lifecycle.count - 1)
@@ -189,12 +189,12 @@ describe Google::Cloud::Storage::Bucket, :storage do
 
     bucket.reload!
 
-    bucket.lifecycle.count.must_equal original_count
+    _(bucket.lifecycle.count).must_equal original_count
   end
 
   it "does not error when getting a file that does not exist" do
     random_bucket = storage.bucket "#{bucket_name}_does_not_exist"
-    random_bucket.must_be :nil?
+    _(random_bucket).must_be :nil?
   end
 
   describe "anonymous project" do

--- a/google-cloud-storage/acceptance/storage/bucket_uniform_bucket_level_access_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_uniform_bucket_level_access_test.rb
@@ -39,17 +39,17 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
 
   it "sets uniform_bucket_level_access true and is unable to modify file ACL rules" do
     refute bucket.uniform_bucket_level_access?
-    bucket.uniform_bucket_level_access_locked_at.must_be :nil?
+    _(bucket.uniform_bucket_level_access_locked_at).must_be :nil?
     file = bucket.create_file local_file, "ReaderTest.png"
 
     bucket.uniform_bucket_level_access = true
     assert bucket.uniform_bucket_level_access?
-    bucket.uniform_bucket_level_access_locked_at.must_be_kind_of DateTime
+    _(bucket.uniform_bucket_level_access_locked_at).must_be_kind_of DateTime
 
     err = expect do
       file.acl.add_reader user_val
     end.must_raise Google::Cloud::PermissionDeniedError
-    err.message.must_match /does not have storage.objects.get access to/
+    _(err.message).must_match /does not have storage.objects.get access to/
   end
 
   it "sets uniform_bucket_level_access true and is unable to get the file" do
@@ -61,7 +61,7 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
     err = expect do
       file.reload!
     end.must_raise Google::Cloud::PermissionDeniedError
-    err.message.must_match /does not have storage.objects.get access to/
+    _(err.message).must_match /does not have storage.objects.get access to/
 
     bucket.uniform_bucket_level_access = false
     file.reload!
@@ -101,36 +101,36 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
 
   it "sets uniform_bucket_level_access true and default object acl and object acls are preserved" do
     bucket.default_acl.public!
-    bucket.default_acl.readers.must_equal ["allUsers"]
+    _(bucket.default_acl.readers).must_equal ["allUsers"]
     file_default_acl = bucket.create_file StringIO.new("default_acl"), "default_acl.txt"
-    file_default_acl.acl.readers.must_equal ["allUsers"]
+    _(file_default_acl.acl.readers).must_equal ["allUsers"]
     refute bucket.uniform_bucket_level_access?
 
     bucket.uniform_bucket_level_access = true
     assert bucket.uniform_bucket_level_access?
-    bucket.uniform_bucket_level_access_locked_at.must_be_kind_of DateTime
+    _(bucket.uniform_bucket_level_access_locked_at).must_be_kind_of DateTime
     bucket.uniform_bucket_level_access = false
 
     refute bucket.uniform_bucket_level_access?
-    bucket.uniform_bucket_level_access_locked_at.must_be :nil?
+    _(bucket.uniform_bucket_level_access_locked_at).must_be :nil?
 
     file_default_acl.reload!
-    file_default_acl.acl.readers.must_equal ["allUsers"]
+    _(file_default_acl.acl.readers).must_equal ["allUsers"]
   end
 
   it "sets DEPRECATED policy_only true and is unable to modify file ACL rules" do
     refute bucket.policy_only?
-    bucket.policy_only_locked_at.must_be :nil?
+    _(bucket.policy_only_locked_at).must_be :nil?
     file = bucket.create_file local_file, "ReaderTest.png"
 
     bucket.policy_only = true
     assert bucket.policy_only?
-    bucket.policy_only_locked_at.must_be_kind_of DateTime
+    _(bucket.policy_only_locked_at).must_be_kind_of DateTime
 
     err = expect do
       file.acl.add_reader user_val
     end.must_raise Google::Cloud::PermissionDeniedError
-    err.message.must_match /does not have storage.objects.get access to/
+    _(err.message).must_match /does not have storage.objects.get access to/
   end
 
   it "sets DEPRECATED policy_only true and is unable to get the file" do
@@ -142,7 +142,7 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
     err = expect do
       file.reload!
     end.must_raise Google::Cloud::PermissionDeniedError
-    err.message.must_match /does not have storage.objects.get access to/
+    _(err.message).must_match /does not have storage.objects.get access to/
 
     bucket.policy_only = false
     file.reload!
@@ -182,20 +182,20 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
 
   it "sets DEPRECATED policy_only true and default object acl and object acls are preserved" do
     bucket.default_acl.public!
-    bucket.default_acl.readers.must_equal ["allUsers"]
+    _(bucket.default_acl.readers).must_equal ["allUsers"]
     file_default_acl = bucket.create_file StringIO.new("default_acl"), "default_acl.txt"
-    file_default_acl.acl.readers.must_equal ["allUsers"]
+    _(file_default_acl.acl.readers).must_equal ["allUsers"]
     refute bucket.policy_only?
 
     bucket.policy_only = true
     assert bucket.policy_only?
-    bucket.policy_only_locked_at.must_be_kind_of DateTime
+    _(bucket.policy_only_locked_at).must_be_kind_of DateTime
     bucket.policy_only = false
 
     refute bucket.policy_only?
-    bucket.policy_only_locked_at.must_be :nil?
+    _(bucket.policy_only_locked_at).must_be :nil?
 
     file_default_acl.reload!
-    file_default_acl.acl.readers.must_equal ["allUsers"]
+    _(file_default_acl.acl.readers).must_equal ["allUsers"]
   end
 end

--- a/google-cloud-storage/acceptance/storage/buckets_test.rb
+++ b/google-cloud-storage/acceptance/storage/buckets_test.rb
@@ -29,35 +29,35 @@ describe "Storage", :buckets, :storage do
 
   it "gets pages of buckets" do
     first_buckets = storage.buckets max: 2
-    first_buckets.next?.must_equal true
+    _(first_buckets.next?).must_equal true
     first_buckets.each do |b|
-      b.must_be_kind_of Google::Cloud::Storage::Bucket
-      b.location_type.must_equal "multi-region"
+      _(b).must_be_kind_of Google::Cloud::Storage::Bucket
+      _(b.location_type).must_equal "multi-region"
     end
     second_buckets = first_buckets.next
     second_buckets.each do |b|
-      b.must_be_kind_of Google::Cloud::Storage::Bucket
-      b.location_type.must_equal "multi-region"
+      _(b).must_be_kind_of Google::Cloud::Storage::Bucket
+      _(b.location_type).must_equal "multi-region"
     end
   end
 
   it "gets pages of buckets with user_project set to true" do
     first_buckets = storage.buckets max: 2, user_project: true
-    first_buckets.next?.must_equal true
+    _(first_buckets.next?).must_equal true
     first_buckets.each do |b|
-      b.must_be_kind_of Google::Cloud::Storage::Bucket
-      b.user_project.must_equal true
+      _(b).must_be_kind_of Google::Cloud::Storage::Bucket
+      _(b.user_project).must_equal true
     end
     second_buckets = first_buckets.next
     second_buckets.each do |b|
-      b.must_be_kind_of Google::Cloud::Storage::Bucket
-      b.user_project.must_equal true
+      _(b).must_be_kind_of Google::Cloud::Storage::Bucket
+      _(b.user_project).must_equal true
     end
   end
 
   it "gets all buckets with request_limit" do
     storage.buckets(max: 2).all(request_limit: 1) do |bucket|
-      bucket.must_be_kind_of Google::Cloud::Storage::Bucket
+      _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
     end
   end
 

--- a/google-cloud-storage/acceptance/storage/file_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_acl_test.rb
@@ -41,84 +41,84 @@ describe Google::Cloud::Storage::File, :acl, :storage do
   it "adds a reader" do
     file = bucket.create_file local_file, "ReaderTest.png"
     user_val = "user-blowmage@gmail.com"
-    file.acl.readers.wont_include user_val
+    _(file.acl.readers).wont_include user_val
     file.acl.add_reader user_val
-    file.acl.readers.must_include user_val
+    _(file.acl.readers).must_include user_val
     file.acl.refresh!
-    file.acl.readers.must_include user_val
+    _(file.acl.readers).must_include user_val
     file.refresh!
-    file.acl.readers.must_include user_val
+    _(file.acl.readers).must_include user_val
   end
 
   it "adds an owner" do
     file = bucket.create_file local_file, "OwnerTest.png"
     user_val = "user-blowmage@gmail.com"
-    file.acl.owners.wont_include user_val
+    _(file.acl.owners).wont_include user_val
     file.acl.add_owner user_val
-    file.acl.owners.must_include user_val
+    _(file.acl.owners).must_include user_val
     file.acl.refresh!
-    file.acl.owners.must_include user_val
+    _(file.acl.owners).must_include user_val
     file.refresh!
-    file.acl.owners.must_include user_val
+    _(file.acl.owners).must_include user_val
   end
 
   it "updates predefined rules" do
     file = bucket.create_file local_file, "AclTest.png"
-    file.acl.readers.must_include "allAuthenticatedUsers"
+    _(file.acl.readers).must_include "allAuthenticatedUsers"
     file.acl.private!
-    file.acl.readers.must_be :empty?
+    _(file.acl.readers).must_be :empty?
     file.acl.refresh!
-    file.acl.readers.must_be :empty?
+    _(file.acl.readers).must_be :empty?
     file.refresh!
-    file.acl.readers.must_be :empty?
+    _(file.acl.readers).must_be :empty?
   end
 
   it "deletes rules" do
     file = bucket.create_file local_file, "DeleteTest.png"
-    file.acl.readers.must_include "allAuthenticatedUsers"
+    _(file.acl.readers).must_include "allAuthenticatedUsers"
     file.acl.delete "allAuthenticatedUsers"
-    file.acl.readers.must_be :empty?
+    _(file.acl.readers).must_be :empty?
     file.acl.refresh!
-    file.acl.readers.must_be :empty?
+    _(file.acl.readers).must_be :empty?
     file.refresh!
-    file.acl.readers.must_be :empty?
+    _(file.acl.readers).must_be :empty?
   end
 
   it "retrieves and modifies the ACL" do
     bucket.default_acl.private!
     file = bucket.create_file local_file, "CRUDTest.png"
-    bucket.default_acl.owners.must_be  :empty?
-    bucket.default_acl.readers.must_be :empty?
+    _(bucket.default_acl.owners).must_be  :empty?
+    _(bucket.default_acl.readers).must_be :empty?
 
     bucket.default_acl.add_reader user_val
 
-    bucket.default_acl.owners.must_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
+    _(bucket.default_acl.owners).must_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
 
-    bucket.default_acl.readers.must_include user_val
+    _(bucket.default_acl.readers).must_include user_val
 
     bucket.default_acl.reload!
 
-    bucket.default_acl.readers.must_include user_val
+    _(bucket.default_acl.readers).must_include user_val
 
     bucket.reload!
 
-    bucket.default_acl.readers.must_include user_val
+    _(bucket.default_acl.readers).must_include user_val
 
     bucket.default_acl.delete user_val
 
-    bucket.default_acl.owners.must_be  :empty?
-    bucket.default_acl.readers.must_be :empty?
+    _(bucket.default_acl.owners).must_be  :empty?
+    _(bucket.default_acl.readers).must_be :empty?
 
-    bucket.default_acl.readers.wont_include user_val
+    _(bucket.default_acl.readers).wont_include user_val
 
     bucket.default_acl.reload!
 
-    bucket.default_acl.readers.wont_include user_val
+    _(bucket.default_acl.readers).wont_include user_val
 
     bucket.reload!
 
-    bucket.default_acl.readers.wont_include user_val
+    _(bucket.default_acl.readers).wont_include user_val
   end
 
   it "sets predefined ACL rules" do

--- a/google-cloud-storage/acceptance/storage/file_encryption_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_encryption_test.rb
@@ -55,11 +55,11 @@ describe Google::Cloud::Storage::File, :storage do
       Tempfile.open ["abc", ".txt"] do |tmpfile|
         downloaded = uploaded.download tmpfile.path, encryption_key: encryption_key
 
-        downloaded.size.must_equal original.size
-        downloaded.size.must_equal uploaded.size
-        downloaded.size.must_equal original.size # Same file
+        _(downloaded.size).must_equal original.size
+        _(downloaded.size).must_equal uploaded.size
+        _(downloaded.size).must_equal original.size # Same file
 
-        File.read(downloaded.path).must_equal "abc"
+        _(File.read(downloaded.path)).must_equal "abc"
       end
 
       uploaded.delete
@@ -71,8 +71,8 @@ describe Google::Cloud::Storage::File, :storage do
 
       Tempfile.open ["CloudLogo", ".png"] do |tmpfile|
         downloaded = uploaded.download tmpfile.path, range: 1..2, encryption_key: encryption_key
-        downloaded.size.must_equal 2
-        File.read(downloaded.path, mode: "rb").must_equal File.read(original.path, mode: "rb")[1..2]
+        _(downloaded.size).must_equal 2
+        _(File.read(downloaded.path, mode: "rb")).must_equal File.read(original.path, mode: "rb")[1..2]
       end
 
       uploaded.delete
@@ -83,17 +83,17 @@ describe Google::Cloud::Storage::File, :storage do
       copied = try_with_backoff "copying existing file with encryption key" do
         uploaded.copy "CloudLogoCopy.png", encryption_key: encryption_key
       end
-      uploaded.name.must_equal file_name
-      copied.name.must_equal "CloudLogoCopy.png"
-      copied.size.must_equal uploaded.size
+      _(uploaded.name).must_equal file_name
+      _(copied.name).must_equal "CloudLogoCopy.png"
+      _(copied.size).must_equal uploaded.size
 
       Tempfile.open ["abc", ".txt"] do |tmpfile1|
         Tempfile.open ["abc-copy", ".txt"] do |tmpfile2|
           downloaded1 = uploaded.download tmpfile1.path, encryption_key: encryption_key
           downloaded2 = copied.download tmpfile2.path, encryption_key: encryption_key
-          downloaded1.size.must_equal downloaded2.size
+          _(downloaded1.size).must_equal downloaded2.size
 
-          File.read(downloaded1.path).must_equal "abc"
+          _(File.read(downloaded1.path)).must_equal "abc"
         end
       end
 
@@ -107,30 +107,30 @@ describe Google::Cloud::Storage::File, :storage do
       rewritten = try_with_backoff "add encryption key" do
         uploaded.rotate new_encryption_key: encryption_key
       end
-      rewritten.name.must_equal uploaded.name
-      rewritten.size.must_equal uploaded.size
-      rewritten.content_language.must_equal "en"
+      _(rewritten.name).must_equal uploaded.name
+      _(rewritten.size).must_equal uploaded.size
+      _(rewritten.content_language).must_equal "en"
 
       rewritten2 = try_with_backoff "rotate encryption keys" do
         uploaded.rotate encryption_key: encryption_key, new_encryption_key: encryption_key_2
       end
-      rewritten2.name.must_equal uploaded.name
-      rewritten2.size.must_equal uploaded.size
+      _(rewritten2.name).must_equal uploaded.name
+      _(rewritten2.size).must_equal uploaded.size
 
       Tempfile.open ["abc", ".txt"] do |tmpfile|
         downloaded = rewritten2.download tmpfile.path, encryption_key: encryption_key_2
-        downloaded.size.must_equal uploaded.size
+        _(downloaded.size).must_equal uploaded.size
       end
 
       rewritten4 = try_with_backoff "remove encryption key" do
         uploaded.rotate encryption_key: encryption_key_2
       end
-      rewritten4.name.must_equal uploaded.name
-      rewritten4.size.must_equal uploaded.size
+      _(rewritten4.name).must_equal uploaded.name
+      _(rewritten4.size).must_equal uploaded.size
 
       Tempfile.open ["abc", ".txt"] do |tmpfile|
         downloaded = rewritten4.download tmpfile.path
-        downloaded.size.must_equal uploaded.size
+        _(downloaded.size).must_equal uploaded.size
       end
 
       rewritten4.delete
@@ -144,13 +144,13 @@ describe Google::Cloud::Storage::File, :storage do
         bucket.compose [uploaded_a, uploaded_b], "ab.txt", encryption_key: encryption_key
       end
 
-      composed.name.must_equal "ab.txt"
-      composed.size.must_equal uploaded_a.size + uploaded_b.size
+      _(composed.name).must_equal "ab.txt"
+      _(composed.size).must_equal uploaded_a.size + uploaded_b.size
 
       Tempfile.open ["ab", ".txt"] do |tmpfile|
         downloaded = composed.download tmpfile, encryption_key: encryption_key
 
-        File.read(downloaded.path).must_equal "ab"
+        _(File.read(downloaded.path)).must_equal "ab"
       end
 
       uploaded_a.delete
@@ -174,22 +174,22 @@ describe Google::Cloud::Storage::File, :storage do
       original = File.new file_path
 
       uploaded = bucket.create_file original, file_name
-      uploaded.kms_key.must_equal versioned(kms_key)
+      _(uploaded.kms_key).must_equal versioned(kms_key)
 
       uploaded_copy = bucket.file file_name
-      uploaded_copy.kms_key.must_equal versioned(kms_key)
+      _(uploaded_copy.kms_key).must_equal versioned(kms_key)
 
       Tempfile.open ["abc", ".txt"] do |tmpfile|
         downloaded = uploaded_copy.download tmpfile.path
 
-        downloaded.size.must_equal original.size
-        File.read(downloaded.path).must_equal "abc"
+        _(downloaded.size).must_equal original.size
+        _(File.read(downloaded.path)).must_equal "abc"
       end
 
       # Ensure kms_key is visible in file listings.
       uploaded_from_list = bucket.files.find { |f| f.name == file_name }
-      uploaded_from_list.wont_be :nil?
-      uploaded_from_list.kms_key.must_equal versioned(kms_key)
+      _(uploaded_from_list).wont_be :nil?
+      _(uploaded_from_list.kms_key).must_equal versioned(kms_key)
 
       uploaded_copy.delete
     end
@@ -197,25 +197,25 @@ describe Google::Cloud::Storage::File, :storage do
     it "should upload and download a file with kms_key option" do
       original = File.new file_path
 
-      bucket.default_kms_key.must_be :nil?
+      _(bucket.default_kms_key).must_be :nil?
 
       uploaded = bucket.create_file original, file_name, kms_key: kms_key_2
-      uploaded.kms_key.must_equal versioned(kms_key_2)
+      _(uploaded.kms_key).must_equal versioned(kms_key_2)
 
       uploaded_copy = bucket.file file_name
-      uploaded_copy.kms_key.must_equal versioned(kms_key_2)
+      _(uploaded_copy.kms_key).must_equal versioned(kms_key_2)
 
       Tempfile.open ["abc", ".txt"] do |tmpfile|
         downloaded = uploaded_copy.download tmpfile.path
 
-        downloaded.size.must_equal original.size
-        File.read(downloaded.path).must_equal "abc"
+        _(downloaded.size).must_equal original.size
+        _(File.read(downloaded.path)).must_equal "abc"
       end
 
       # Ensure kms_key is visible in file listings.
       uploaded_from_list = bucket.files.find { |f| f.name == file_name }
-      uploaded_from_list.wont_be :nil?
-      uploaded_from_list.kms_key.must_equal versioned(kms_key_2)
+      _(uploaded_from_list).wont_be :nil?
+      _(uploaded_from_list.kms_key).must_equal versioned(kms_key_2)
 
       uploaded_copy.delete
     end
@@ -223,67 +223,67 @@ describe Google::Cloud::Storage::File, :storage do
     it "should upload a file with no kms key" do
       original = File.new file_path
 
-      bucket.default_kms_key.must_be :nil?
+      _(bucket.default_kms_key).must_be :nil?
 
       uploaded = bucket.create_file original, file_name
-      uploaded.kms_key.must_be :nil?
+      _(uploaded.kms_key).must_be :nil?
 
       uploaded_copy = bucket.file file_name
-      uploaded_copy.kms_key.must_be :nil?
+      _(uploaded_copy.kms_key).must_be :nil?
 
       uploaded_copy.delete
     end
 
     it "should rotate a customer-supplied encryption key (CSEK) to a kms key (CMEK), to no key and back to CSEK" do
       uploaded = bucket.create_file file_path, file_name, encryption_key: encryption_key
-      uploaded.kms_key.must_be :nil?
+      _(uploaded.kms_key).must_be :nil?
 
       rewritten = try_with_backoff "rotate from CSEK to CMEK" do
         uploaded.rotate encryption_key: encryption_key, new_kms_key: kms_key
       end
-      rewritten.kms_key.must_equal versioned(kms_key)
-      rewritten.size.must_equal uploaded.size
+      _(rewritten.kms_key).must_equal versioned(kms_key)
+      _(rewritten.size).must_equal uploaded.size
 
       Tempfile.open ["abc", ".txt"] do |tmpfile|
         downloaded = rewritten.download tmpfile.path
-        downloaded.size.must_equal uploaded.size
-        File.read(downloaded.path).must_equal "abc"
+        _(downloaded.size).must_equal uploaded.size
+        _(File.read(downloaded.path)).must_equal "abc"
       end
 
       rewritten2 = try_with_backoff "rotate from CMEK to default encryption" do
         uploaded.rotate
       end
-      rewritten2.kms_key.must_be :nil?
-      rewritten2.size.must_equal uploaded.size
+      _(rewritten2.kms_key).must_be :nil?
+      _(rewritten2.size).must_equal uploaded.size
 
       Tempfile.open ["abc", ".txt"] do |tmpfile|
         downloaded = rewritten2.download tmpfile.path
-        downloaded.size.must_equal uploaded.size
-        File.read(downloaded.path).must_equal "abc"
+        _(downloaded.size).must_equal uploaded.size
+        _(File.read(downloaded.path)).must_equal "abc"
       end
 
       rewritten3 = try_with_backoff "rotate from default encryption to CMEK" do
         uploaded.rotate  new_kms_key: kms_key_2
       end
-      rewritten3.kms_key.must_equal versioned(kms_key_2)
-      rewritten3.size.must_equal uploaded.size
+      _(rewritten3.kms_key).must_equal versioned(kms_key_2)
+      _(rewritten3.size).must_equal uploaded.size
 
       Tempfile.open ["abc", ".txt"] do |tmpfile|
         downloaded = rewritten3.download tmpfile.path
-        downloaded.size.must_equal uploaded.size
-        File.read(downloaded.path).must_equal "abc"
+        _(downloaded.size).must_equal uploaded.size
+        _(File.read(downloaded.path)).must_equal "abc"
       end
 
       rewritten4 = try_with_backoff "rotate from CMEK to CSEK" do
         uploaded.rotate  new_encryption_key: encryption_key_2
       end
-      rewritten4.kms_key.must_be :nil?
-      rewritten4.size.must_equal uploaded.size
+      _(rewritten4.kms_key).must_be :nil?
+      _(rewritten4.size).must_equal uploaded.size
 
       Tempfile.open ["abc", ".txt"] do |tmpfile|
         downloaded = rewritten4.download tmpfile.path, encryption_key: encryption_key_2
-        downloaded.size.must_equal uploaded.size
-        File.read(downloaded.path).must_equal "abc"
+        _(downloaded.size).must_equal uploaded.size
+        _(File.read(downloaded.path)).must_equal "abc"
       end
 
       rewritten4.delete

--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -253,7 +253,7 @@ describe Google::Cloud::Storage::File, :storage do
     Tempfile.open ["google-cloud", ".png"] do |tmpfile|
       tmpfile.binmode
       downloaded = uploaded.download tmpfile
-      downloaded.must_be_kind_of File
+      _(downloaded).must_be_kind_of Tempfile
 
       _(downloaded.size).must_equal original.size
       _(downloaded.size).must_equal uploaded.size

--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -253,7 +253,7 @@ describe Google::Cloud::Storage::File, :storage do
     Tempfile.open ["google-cloud", ".png"] do |tmpfile|
       tmpfile.binmode
       downloaded = uploaded.download tmpfile
-      _(downloaded).must_be_kind_of File
+      downloaded.must_be_kind_of File
 
       _(downloaded.size).must_equal original.size
       _(downloaded.size).must_equal uploaded.size

--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -56,34 +56,34 @@ describe Google::Cloud::Storage::File, :storage do
       tmpfile.binmode
       downloaded = uploaded.download tmpfile
 
-      downloaded.size.must_equal original.size
-      downloaded.size.must_equal uploaded.size
-      downloaded.size.must_equal tmpfile.size # Same file
+      _(downloaded.size).must_equal original.size
+      _(downloaded.size).must_equal uploaded.size
+      _(downloaded.size).must_equal tmpfile.size # Same file
 
-      File.read(downloaded.path, mode: "rb").must_equal File.read(original.path, mode: "rb")
+      _(File.read(downloaded.path, mode: "rb")).must_equal File.read(original.path, mode: "rb")
     end
 
-    uploaded.created_at.must_be_kind_of DateTime
-    uploaded.api_url.must_be_kind_of String
-    uploaded.media_url.must_be_kind_of String
-    uploaded.public_url.must_be_kind_of String
-    uploaded.url.must_be_kind_of String
+    _(uploaded.created_at).must_be_kind_of DateTime
+    _(uploaded.api_url).must_be_kind_of String
+    _(uploaded.media_url).must_be_kind_of String
+    _(uploaded.public_url).must_be_kind_of String
+    _(uploaded.url).must_be_kind_of String
 
-    uploaded.md5.must_be_kind_of String
-    uploaded.crc32c.must_be_kind_of String
-    uploaded.etag.must_be_kind_of String
+    _(uploaded.md5).must_be_kind_of String
+    _(uploaded.crc32c).must_be_kind_of String
+    _(uploaded.etag).must_be_kind_of String
 
-    uploaded.cache_control.must_equal "public, max-age=3600"
-    uploaded.content_disposition.must_equal "attachment; filename=filename.ext"
-    uploaded.content_encoding.must_be :nil?
-    uploaded.content_language.must_equal "en"
-    uploaded.content_type.must_equal "text/plain"
+    _(uploaded.cache_control).must_equal "public, max-age=3600"
+    _(uploaded.content_disposition).must_equal "attachment; filename=filename.ext"
+    _(uploaded.content_encoding).must_be :nil?
+    _(uploaded.content_language).must_equal "en"
+    _(uploaded.content_type).must_equal "text/plain"
 
-    uploaded.metadata.must_be_kind_of Hash
-    uploaded.metadata.size.must_equal 2
-    uploaded.metadata.frozen?.must_equal true
-    uploaded.metadata["player"].must_equal "Alice"
-    uploaded.metadata["score"].must_equal "101"
+    _(uploaded.metadata).must_be_kind_of Hash
+    _(uploaded.metadata.size).must_equal 2
+    _(uploaded.metadata.frozen?).must_equal true
+    _(uploaded.metadata["player"]).must_equal "Alice"
+    _(uploaded.metadata["score"]).must_equal "101"
 
     uploaded.delete
   end
@@ -94,27 +94,27 @@ describe Google::Cloud::Storage::File, :storage do
     uploaded_1 = bucket.create_file StringIO.new("generation 1"), filename
     generation_1 = uploaded_1.generation
     uploaded_1.reload!
-    uploaded_1.generation.must_equal generation_1
+    _(uploaded_1.generation).must_equal generation_1
 
     uploaded_2 = bucket.create_file StringIO.new("generation 2"), filename
     generation_2 = uploaded_2.generation
-    generation_2.wont_equal generation_1
+    _(generation_2).wont_equal generation_1
 
     uploaded_1.reload! generation: true
-    uploaded_1.generation.must_equal generation_1
+    _(uploaded_1.generation).must_equal generation_1
     uploaded_2.reload!
-    uploaded_2.generation.must_equal generation_2
+    _(uploaded_2.generation).must_equal generation_2
     uploaded_1.reload!
-    uploaded_1.generation.must_equal generation_2
+    _(uploaded_1.generation).must_equal generation_2
 
     Tempfile.open ["generation_file", ".txt"] do |tmpfile|
       downloaded = bucket.file(filename).download tmpfile
-      File.read(downloaded.path).must_equal "generation 2"
+      _(File.read(downloaded.path)).must_equal "generation 2"
     end
 
     Tempfile.open ["generation_file", ".txt"] do |tmpfile|
       downloaded =  bucket.file(filename, generation: generation_1).download tmpfile
-      File.read(downloaded.path).must_equal "generation 1"
+      _(File.read(downloaded.path)).must_equal "generation 1"
     end
 
     uploaded_2.delete generation: generation_1
@@ -140,45 +140,45 @@ describe Google::Cloud::Storage::File, :storage do
       tmpfile.binmode
       downloaded = uploaded.download tmpfile, verify: :all
 
-      downloaded.size.must_equal original.size
-      downloaded.size.must_equal uploaded.size
-      downloaded.size.must_equal tmpfile.size # Same file
+      _(downloaded.size).must_equal original.size
+      _(downloaded.size).must_equal uploaded.size
+      _(downloaded.size).must_equal tmpfile.size # Same file
 
-      File.read(downloaded.path, mode: "rb").must_equal File.read(original.path, mode: "rb")
+      _(File.read(downloaded.path, mode: "rb")).must_equal File.read(original.path, mode: "rb")
     end
     uploaded.delete
   end
 
   it "creates and gets and updates and deletes a file" do
-    bucket.file("CRUDLogo").must_be :nil?
+    _(bucket.file("CRUDLogo")).must_be :nil?
 
     original = File.new files[:logo][:path]
     uploaded = bucket.create_file original, "CRUDLogo.png"
 
-    bucket.file("CRUDLogo.png").wont_be :nil?
+    _(bucket.file("CRUDLogo.png")).wont_be :nil?
 
     generation = uploaded.generation
-    generation.must_be_kind_of Integer
+    _(generation).must_be_kind_of Integer
 
-    uploaded.created_at.must_be_kind_of DateTime
-    uploaded.api_url.must_be_kind_of String
-    uploaded.media_url.must_be_kind_of String
-    uploaded.public_url.must_be_kind_of String
-    uploaded.url.must_be_kind_of String
+    _(uploaded.created_at).must_be_kind_of DateTime
+    _(uploaded.api_url).must_be_kind_of String
+    _(uploaded.media_url).must_be_kind_of String
+    _(uploaded.public_url).must_be_kind_of String
+    _(uploaded.url).must_be_kind_of String
 
-    uploaded.md5.must_be_kind_of String
-    uploaded.crc32c.must_be_kind_of String
-    uploaded.etag.must_be_kind_of String
+    _(uploaded.md5).must_be_kind_of String
+    _(uploaded.crc32c).must_be_kind_of String
+    _(uploaded.etag).must_be_kind_of String
 
-    uploaded.cache_control.must_be :nil?
-    uploaded.content_disposition.must_be :nil?
-    uploaded.content_encoding.must_be :nil?
-    uploaded.content_language.must_be :nil?
-    uploaded.content_type.must_equal "image/png"
+    _(uploaded.cache_control).must_be :nil?
+    _(uploaded.content_disposition).must_be :nil?
+    _(uploaded.content_encoding).must_be :nil?
+    _(uploaded.content_language).must_be :nil?
+    _(uploaded.content_type).must_equal "image/png"
 
-    uploaded.metadata.must_be_kind_of Hash
-    uploaded.metadata.must_be :empty?
-    uploaded.metageneration.must_equal 1
+    _(uploaded.metadata).must_be_kind_of Hash
+    _(uploaded.metadata).must_be :empty?
+    _(uploaded.metageneration).must_equal 1
 
     uploaded.update do |f|
       f.cache_control = "private, max-age=0, no-cache"
@@ -189,77 +189,77 @@ describe Google::Cloud::Storage::File, :storage do
       f.metadata[:score] = 101
     end
 
-    uploaded.created_at.must_be_kind_of DateTime
-    uploaded.api_url.must_be_kind_of String
-    uploaded.media_url.must_be_kind_of String
-    uploaded.public_url.must_be_kind_of String
-    uploaded.url.must_be_kind_of String
+    _(uploaded.created_at).must_be_kind_of DateTime
+    _(uploaded.api_url).must_be_kind_of String
+    _(uploaded.media_url).must_be_kind_of String
+    _(uploaded.public_url).must_be_kind_of String
+    _(uploaded.url).must_be_kind_of String
 
-    uploaded.md5.must_be_kind_of String
-    uploaded.crc32c.must_be_kind_of String
-    uploaded.etag.must_be_kind_of String
+    _(uploaded.md5).must_be_kind_of String
+    _(uploaded.crc32c).must_be_kind_of String
+    _(uploaded.etag).must_be_kind_of String
 
-    uploaded.cache_control.must_equal "private, max-age=0, no-cache"
-    uploaded.content_disposition.must_equal "attachment; filename=filename.ext"
-    uploaded.content_encoding.must_be :nil?
-    uploaded.content_language.must_equal "en"
-    uploaded.content_type.must_equal "text/plain"
+    _(uploaded.cache_control).must_equal "private, max-age=0, no-cache"
+    _(uploaded.content_disposition).must_equal "attachment; filename=filename.ext"
+    _(uploaded.content_encoding).must_be :nil?
+    _(uploaded.content_language).must_equal "en"
+    _(uploaded.content_type).must_equal "text/plain"
 
-    uploaded.metadata.must_be_kind_of Hash
-    uploaded.metadata.size.must_equal 2
-    uploaded.metadata.frozen?.must_equal true
-    uploaded.metadata["player"].must_equal "Alice"
-    uploaded.metadata["score"].must_equal "101"
-    uploaded.metageneration.must_equal 2
+    _(uploaded.metadata).must_be_kind_of Hash
+    _(uploaded.metadata.size).must_equal 2
+    _(uploaded.metadata.frozen?).must_equal true
+    _(uploaded.metadata["player"]).must_equal "Alice"
+    _(uploaded.metadata["score"]).must_equal "101"
+    _(uploaded.metageneration).must_equal 2
 
     uploaded.reload!
 
-    uploaded.generation.must_equal generation
+    _(uploaded.generation).must_equal generation
 
-    uploaded.created_at.must_be_kind_of DateTime
-    uploaded.api_url.must_be_kind_of String
-    uploaded.media_url.must_be_kind_of String
-    uploaded.public_url.must_be_kind_of String
-    uploaded.url.must_be_kind_of String
+    _(uploaded.created_at).must_be_kind_of DateTime
+    _(uploaded.api_url).must_be_kind_of String
+    _(uploaded.media_url).must_be_kind_of String
+    _(uploaded.public_url).must_be_kind_of String
+    _(uploaded.url).must_be_kind_of String
 
-    uploaded.md5.must_be_kind_of String
-    uploaded.crc32c.must_be_kind_of String
-    uploaded.etag.must_be_kind_of String
+    _(uploaded.md5).must_be_kind_of String
+    _(uploaded.crc32c).must_be_kind_of String
+    _(uploaded.etag).must_be_kind_of String
 
-    uploaded.cache_control.must_equal "private, max-age=0, no-cache"
-    uploaded.content_disposition.must_equal "attachment; filename=filename.ext"
-    uploaded.content_encoding.must_be :nil?
-    uploaded.content_language.must_equal "en"
-    uploaded.content_type.must_equal "text/plain"
+    _(uploaded.cache_control).must_equal "private, max-age=0, no-cache"
+    _(uploaded.content_disposition).must_equal "attachment; filename=filename.ext"
+    _(uploaded.content_encoding).must_be :nil?
+    _(uploaded.content_language).must_equal "en"
+    _(uploaded.content_type).must_equal "text/plain"
 
-    uploaded.metadata.must_be_kind_of Hash
-    uploaded.metadata.size.must_equal 2
-    uploaded.metadata.frozen?.must_equal true
-    uploaded.metadata["player"].must_equal "Alice"
-    uploaded.metadata["score"].must_equal "101"
+    _(uploaded.metadata).must_be_kind_of Hash
+    _(uploaded.metadata.size).must_equal 2
+    _(uploaded.metadata.frozen?).must_equal true
+    _(uploaded.metadata["player"]).must_equal "Alice"
+    _(uploaded.metadata["score"]).must_equal "101"
 
-    bucket.file("CRUDLogo.png").wont_be :nil?
+    _(bucket.file("CRUDLogo.png")).wont_be :nil?
 
     uploaded.delete
 
-    bucket.file("CRUDLogo.png").must_be :nil?
+    _(bucket.file("CRUDLogo.png")).must_be :nil?
   end
 
   it "should upload and download a file without specifying path" do
     original = File.new files[:logo][:path]
     uploaded = bucket.create_file original
-    uploaded.name.must_equal original.path
+    _(uploaded.name).must_equal original.path
 
     Tempfile.open ["google-cloud", ".png"] do |tmpfile|
       tmpfile.binmode
       downloaded = uploaded.download tmpfile
-      downloaded.must_be_kind_of File
+      _(downloaded).must_be_kind_of File
 
-      downloaded.size.must_equal original.size
-      downloaded.size.must_equal uploaded.size
-      downloaded.size.must_equal tmpfile.size # Same file
+      _(downloaded.size).must_equal original.size
+      _(downloaded.size).must_equal uploaded.size
+      _(downloaded.size).must_equal tmpfile.size # Same file
 
-      File.read(downloaded.path, mode: "rb").must_equal File.read(original.path, mode: "rb")
+      _(File.read(downloaded.path, mode: "rb")).must_equal File.read(original.path, mode: "rb")
     end
 
     uploaded.delete
@@ -269,17 +269,17 @@ describe Google::Cloud::Storage::File, :storage do
     inmemory = StringIO.new(File.read(files[:logo][:path], mode: "rb"))
 
     uploaded = bucket.create_file inmemory, "uploaded/with/inmemory.png"
-    uploaded.name.must_equal "uploaded/with/inmemory.png"
+    _(uploaded.name).must_equal "uploaded/with/inmemory.png"
 
     downloaded = uploaded.download
-    downloaded.must_be_kind_of StringIO
+    _(downloaded).must_be_kind_of StringIO
 
     inmemory.rewind
-    downloaded.size.must_equal inmemory.size
-    downloaded.size.must_equal uploaded.size
+    _(downloaded.size).must_equal inmemory.size
+    _(downloaded.size).must_equal uploaded.size
 
-    downloaded.read.must_equal inmemory.read
-    downloaded.read.encoding.must_equal inmemory.read.encoding
+    _(downloaded.read).must_equal inmemory.read
+    _(downloaded.read.encoding).must_equal inmemory.read.encoding
 
     uploaded.delete
   end
@@ -287,19 +287,19 @@ describe Google::Cloud::Storage::File, :storage do
   it "should upload and download text using IO" do
     inmemory = StringIO.new "Hello world!"
     uploaded = bucket.create_file inmemory, "uploaded/with/inmemory.txt"
-    uploaded.name.must_equal "uploaded/with/inmemory.txt"
+    _(uploaded.name).must_equal "uploaded/with/inmemory.txt"
 
     downloadio = StringIO.new()
     downloaded = uploaded.download downloadio
-    downloaded.must_be_kind_of StringIO
-    downloaded.must_equal downloadio # The object returned is the object provided
+    _(downloaded).must_be_kind_of StringIO
+    _(downloaded).must_equal downloadio # The object returned is the object provided
 
     inmemory.rewind
-    downloaded.size.must_equal inmemory.size
-    downloaded.size.must_equal uploaded.size
+    _(downloaded.size).must_equal inmemory.size
+    _(downloaded.size).must_equal uploaded.size
 
-    downloaded.read.must_equal inmemory.read
-    downloaded.read.encoding.must_equal inmemory.read.encoding
+    _(downloaded.read).must_equal inmemory.read
+    _(downloaded.read.encoding).must_equal inmemory.read.encoding
 
     uploaded.delete
   end
@@ -312,22 +312,22 @@ describe Google::Cloud::Storage::File, :storage do
     gzipped = StringIO.new gz.string
 
     uploaded = bucket.create_file gzipped, "uploaded/with/gzip-type.txt", content_type: "application/gzip"
-    uploaded.name.must_equal "uploaded/with/gzip-type.txt"
-    uploaded.content_type.must_equal "application/gzip"
+    _(uploaded.name).must_equal "uploaded/with/gzip-type.txt"
+    _(uploaded.content_type).must_equal "application/gzip"
     uploaded.content_encoding.must_be_nil
     downloadio = StringIO.new()
     downloaded = uploaded.download downloadio
-    downloaded.must_be_kind_of StringIO
-    downloaded.must_equal downloadio # The object returned is the object provided
+    _(downloaded).must_be_kind_of StringIO
+    _(downloaded).must_equal downloadio # The object returned is the object provided
     gzipped.rewind
 
-    downloaded.size.must_equal gzipped.size
-    downloaded.size.must_equal uploaded.size
+    _(downloaded.size).must_equal gzipped.size
+    _(downloaded.size).must_equal uploaded.size
 
     data = downloaded.read
-    data.must_equal gzipped.read
+    _(data).must_equal gzipped.read
     gzr = Zlib::GzipReader.new StringIO.new(data)
-    gzr.read.must_equal "Hello world!"
+    _(gzr.read).must_equal "Hello world!"
 
     uploaded.delete
   end
@@ -341,18 +341,18 @@ describe Google::Cloud::Storage::File, :storage do
     gzipped = StringIO.new gz.string
 
     uploaded = bucket.create_file gzipped, "uploaded/with/gzip-encoding.txt", content_type: "text/plain", content_encoding: "gzip"
-    uploaded.name.must_equal "uploaded/with/gzip-encoding.txt"
-    uploaded.content_type.must_equal "text/plain"
-    uploaded.content_encoding.must_equal "gzip"
+    _(uploaded.name).must_equal "uploaded/with/gzip-encoding.txt"
+    _(uploaded.content_type).must_equal "text/plain"
+    _(uploaded.content_encoding).must_equal "gzip"
 
     downloadio = StringIO.new()
     downloaded = uploaded.download downloadio
-    downloaded.must_be_kind_of StringIO
-    downloaded.wont_equal downloadio # The object returned is NOT the object provided
+    _(downloaded).must_be_kind_of StringIO
+    _(downloaded).wont_equal downloadio # The object returned is NOT the object provided
 
     downloaded_data = downloaded.read
-    downloaded_data.must_equal data
-    downloaded_data.encoding.must_equal data.encoding
+    _(downloaded_data).must_equal data
+    _(downloaded_data.encoding).must_equal data.encoding
 
     uploaded.delete
   end
@@ -360,14 +360,14 @@ describe Google::Cloud::Storage::File, :storage do
   it "should download and verify when Content-Encoding gzip response header with skip_decompress" do
     bucket = storage.bucket bucket_public_test_name
     file = bucket.file file_public_test_gzip_name
-    file.content_encoding.must_equal "gzip"
+    _(file.content_encoding).must_equal "gzip"
     Tempfile.open ["hello_world", ".txt"] do |tmpfile|
       tmpfile.binmode
       downloaded = file.download tmpfile, skip_decompress: true
 
       data = File.read(downloaded.path, mode: "rb")
       gzr = Zlib::GzipReader.new StringIO.new(data)
-      gzr.read.must_equal "hello world"
+      _(gzr.read).must_equal "hello world"
     end
   end
 
@@ -380,7 +380,7 @@ describe Google::Cloud::Storage::File, :storage do
       tmpfile.binmode
       downloaded = file.download tmpfile
 
-      File.read(downloaded.path, mode: "rb").must_equal "hello world"
+      _(File.read(downloaded.path, mode: "rb")).must_equal "hello world"
     end
   end
 
@@ -392,7 +392,7 @@ describe Google::Cloud::Storage::File, :storage do
       tmpfile.binmode
       downloaded = lazy_file.download tmpfile,  verify: :crc32c
 
-      File.read(downloaded.path, mode: "rb").must_equal "hello world" # decompressed file data
+      _(File.read(downloaded.path, mode: "rb")).must_equal "hello world" # decompressed file data
     end
   end
 
@@ -401,7 +401,7 @@ describe Google::Cloud::Storage::File, :storage do
     uploaded = bucket.create_file inmemory, "uploaded/with/inmemory.txt"
 
     downloaded = uploaded.download range: 3..6
-    downloaded.must_be_kind_of StringIO
+    _(downloaded).must_be_kind_of StringIO
 
     downloaded.rewind
     downloaded_partial = downloaded.read
@@ -428,18 +428,18 @@ describe Google::Cloud::Storage::File, :storage do
     lazy_bucket = storage.bucket bucket_name, skip_lookup: true
     lazy_file = lazy_bucket.file "CloudLogo.png", skip_lookup: true
 
-    lazy_bucket.must_be :lazy?
-    lazy_file.must_be :lazy?
+    _(lazy_bucket).must_be :lazy?
+    _(lazy_file).must_be :lazy?
 
     Tempfile.open ["google-cloud", ".png"] do |tmpfile|
       tmpfile.binmode
       downloaded = lazy_file.download tmpfile
 
-      downloaded.size.must_equal original.size
-      downloaded.size.must_equal uploaded.size
-      downloaded.size.must_equal tmpfile.size # Same file
+      _(downloaded.size).must_equal original.size
+      _(downloaded.size).must_equal uploaded.size
+      _(downloaded.size).must_equal tmpfile.size # Same file
 
-      File.read(downloaded.path, mode: "rb").must_equal File.read(original.path, mode: "rb")
+      _(File.read(downloaded.path, mode: "rb")).must_equal File.read(original.path, mode: "rb")
     end
 
     uploaded.delete
@@ -452,45 +452,45 @@ describe Google::Cloud::Storage::File, :storage do
                                   "CloudLogo",
                                   meta
 
-    uploaded.content_type.must_equal meta[:content_type]
-    uploaded.metadata["title"].must_equal meta[:metadata][:title]
+    _(uploaded.content_type).must_equal meta[:content_type]
+    _(uploaded.metadata["title"]).must_equal meta[:metadata][:title]
   end
 
   it "should list generations" do
     uploaded = bucket.create_file files[:logo][:path],
                                   "CloudLogo"
 
-    uploaded.generation.wont_be :nil?
-    uploaded.generations.wont_be :nil?
+    _(uploaded.generation).wont_be :nil?
+    _(uploaded.generations).wont_be :nil?
   end
 
   it "should create and update storage_class" do
     uploaded = bucket.create_file files[:logo][:path], "CloudLogo-storage_class.png", storage_class: :nearline
 
-    uploaded.storage_class.must_equal "NEARLINE"
+    _(uploaded.storage_class).must_equal "NEARLINE"
     uploaded.storage_class = :archive
-    uploaded.storage_class.must_equal "ARCHIVE"
+    _(uploaded.storage_class).must_equal "ARCHIVE"
 
     retrieved1 = bucket.file "CloudLogo-storage_class.png"
 
-    retrieved1.storage_class.must_equal "ARCHIVE"
+    _(retrieved1.storage_class).must_equal "ARCHIVE"
   end
 
   it "should copy an existing file" do
     uploaded = bucket.create_file files[:logo][:path], "CloudLogo", acl: "public_read", content_language: "en"
-    uploaded.acl.readers.must_include "allUsers" # has "public_read"
-    uploaded.content_language.must_equal "en"
+    _(uploaded.acl.readers).must_include "allUsers" # has "public_read"
+    _(uploaded.content_language).must_equal "en"
 
     copied = try_with_backoff "copying existing file" do
       uploaded.copy "CloudLogoCopy"
     end
 
-    uploaded.name.must_equal "CloudLogo"
-    uploaded.content_language.must_equal "en"
-    copied.name.must_equal "CloudLogoCopy"
-    copied.acl.readers.wont_include "allUsers" # does NOT have "public_read"
-    copied.content_language.must_equal "en"
-    copied.size.must_equal uploaded.size
+    _(uploaded.name).must_equal "CloudLogo"
+    _(uploaded.content_language).must_equal "en"
+    _(copied.name).must_equal "CloudLogoCopy"
+    _(copied.acl.readers).wont_include "allUsers" # does NOT have "public_read"
+    _(copied.content_language).must_equal "en"
+    _(copied.size).must_equal uploaded.size
 
     Tempfile.open ["CloudLogo", ".png"] do |tmpfile1|
       tmpfile1.binmode
@@ -498,9 +498,9 @@ describe Google::Cloud::Storage::File, :storage do
         tmpfile2.binmode
         downloaded1 = uploaded.download tmpfile1
         downloaded2 = copied.download tmpfile2
-        downloaded1.size.must_equal downloaded2.size
+        _(downloaded1.size).must_equal downloaded2.size
 
-        File.read(downloaded1.path, mode: "rb").must_equal File.read(downloaded2.path, mode: "rb")
+        _(File.read(downloaded1.path, mode: "rb")).must_equal File.read(downloaded2.path, mode: "rb")
       end
     end
 
@@ -510,23 +510,23 @@ describe Google::Cloud::Storage::File, :storage do
 
   it "should copy an existing file, with updates" do
     uploaded = bucket.create_file files[:logo][:path], "CloudLogo", acl: "public_read", content_language: "en", content_type: "image/png"
-    uploaded.acl.readers.must_include "allUsers" # has "public_read"
-    uploaded.content_language.must_equal "en"
-    uploaded.content_type.must_equal "image/png"
+    _(uploaded.acl.readers).must_include "allUsers" # has "public_read"
+    _(uploaded.content_language).must_equal "en"
+    _(uploaded.content_type).must_equal "image/png"
 
     copied = try_with_backoff "copying existing file" do
       uploaded.copy "CloudLogoCopy" do |copy|
         copy.content_language = "de"
       end
     end
-    uploaded.content_language.must_equal "en"
-    copied.acl.readers.wont_include "allUsers" # does NOT have "public_read"
-    copied.content_language.must_equal "de"
-    copied.content_type.must_be :nil?
+    _(uploaded.content_language).must_equal "en"
+    _(copied.acl.readers).wont_include "allUsers" # does NOT have "public_read"
+    _(copied.content_language).must_equal "de"
+    _(copied.content_type).must_be :nil?
 
-    uploaded.name.must_equal "CloudLogo"
-    copied.name.must_equal "CloudLogoCopy"
-    copied.size.must_equal uploaded.size
+    _(uploaded.name).must_equal "CloudLogo"
+    _(copied.name).must_equal "CloudLogoCopy"
+    _(copied.size).must_equal uploaded.size
 
     Tempfile.open ["CloudLogo", ".png"] do |tmpfile1|
       tmpfile1.binmode
@@ -534,9 +534,9 @@ describe Google::Cloud::Storage::File, :storage do
         tmpfile2.binmode
         downloaded1 = uploaded.download tmpfile1
         downloaded2 = copied.download tmpfile2
-        downloaded1.size.must_equal downloaded2.size
+        _(downloaded1.size).must_equal downloaded2.size
 
-        File.read(downloaded1.path, mode: "rb").must_equal File.read(downloaded2.path, mode: "rb")
+        _(File.read(downloaded1.path, mode: "rb")).must_equal File.read(downloaded2.path, mode: "rb")
       end
     end
 
@@ -546,27 +546,27 @@ describe Google::Cloud::Storage::File, :storage do
 
   it "should copy an existing file, with force_copy_metadata set to true" do
     uploaded = bucket.create_file files[:logo][:path], "CloudLogo", acl: "public_read", content_language: "en", content_type: "image/png"
-    uploaded.acl.readers.must_include "allUsers" # has "public_read"
-    uploaded.content_language.must_equal "en"
-    uploaded.content_type.must_equal "image/png"
-    uploaded.metadata.must_be :empty?
+    _(uploaded.acl.readers).must_include "allUsers" # has "public_read"
+    _(uploaded.content_language).must_equal "en"
+    _(uploaded.content_type).must_equal "image/png"
+    _(uploaded.metadata).must_be :empty?
 
     copied = try_with_backoff "copying existing file" do
       uploaded.copy "CloudLogoCopy", force_copy_metadata: true do |copy|
         copy.content_language = "de"
       end
     end
-    uploaded.content_language.must_equal "en"
+    _(uploaded.content_language).must_equal "en"
     copied2 = bucket.file copied.name
-    copied2.acl.readers.wont_include "allUsers" # does NOT have "public_read"
-    copied.acl.readers.wont_include "allUsers" # does NOT have "public_read"
-    copied.content_language.must_equal "de"
-    copied.content_type.must_equal "image/png"
-    copied.metadata.must_be :empty?
+    _(copied2.acl.readers).wont_include "allUsers" # does NOT have "public_read"
+    _(copied.acl.readers).wont_include "allUsers" # does NOT have "public_read"
+    _(copied.content_language).must_equal "de"
+    _(copied.content_type).must_equal "image/png"
+    _(copied.metadata).must_be :empty?
 
-    uploaded.name.must_equal "CloudLogo"
-    copied.name.must_equal "CloudLogoCopy"
-    copied.size.must_equal uploaded.size
+    _(uploaded.name).must_equal "CloudLogo"
+    _(copied.name).must_equal "CloudLogoCopy"
+    _(copied.size).must_equal uploaded.size
 
     Tempfile.open ["CloudLogo", ".png"] do |tmpfile1|
       tmpfile1.binmode
@@ -574,9 +574,9 @@ describe Google::Cloud::Storage::File, :storage do
         tmpfile2.binmode
         downloaded1 = uploaded.download tmpfile1
         downloaded2 = copied.download tmpfile2
-        downloaded1.size.must_equal downloaded2.size
+        _(downloaded1.size).must_equal downloaded2.size
 
-        File.read(downloaded1.path, mode: "rb").must_equal File.read(downloaded2.path, mode: "rb")
+        _(File.read(downloaded1.path, mode: "rb")).must_equal File.read(downloaded2.path, mode: "rb")
       end
     end
 
@@ -586,22 +586,22 @@ describe Google::Cloud::Storage::File, :storage do
 
   it "should rewrite an existing file, with updates" do
     uploaded = bucket.create_file files[:logo][:path], "CloudLogo.png"
-    uploaded.cache_control.must_be :nil?
-    uploaded.content_type.must_equal "image/png"
+    _(uploaded.cache_control).must_be :nil?
+    _(uploaded.content_type).must_equal "image/png"
 
     copied = try_with_backoff "rewriting existing file" do
       uploaded.rewrite "CloudLogoCopy.png" do |f|
         f.cache_control = "public, max-age: 7200"
       end
     end
-    uploaded.cache_control.must_be :nil?
-    uploaded.content_type.must_equal "image/png"
-    copied.cache_control.must_equal "public, max-age: 7200"
-    copied.content_type.must_be :nil?
+    _(uploaded.cache_control).must_be :nil?
+    _(uploaded.content_type).must_equal "image/png"
+    _(copied.cache_control).must_equal "public, max-age: 7200"
+    _(copied.content_type).must_be :nil?
 
-    uploaded.name.must_equal "CloudLogo.png"
-    copied.name.must_equal "CloudLogoCopy.png"
-    copied.size.must_equal uploaded.size
+    _(uploaded.name).must_equal "CloudLogo.png"
+    _(copied.name).must_equal "CloudLogoCopy.png"
+    _(copied.size).must_equal uploaded.size
 
     Tempfile.open ["CloudLogo", ".png"] do |tmpfile1|
       tmpfile1.binmode
@@ -609,9 +609,9 @@ describe Google::Cloud::Storage::File, :storage do
         tmpfile2.binmode
         downloaded1 = uploaded.download tmpfile1
         downloaded2 = copied.download tmpfile2
-        downloaded1.size.must_equal downloaded2.size
+        _(downloaded1.size).must_equal downloaded2.size
 
-        File.read(downloaded1.path, mode: "rb").must_equal File.read(downloaded2.path, mode: "rb")
+        _(File.read(downloaded1.path, mode: "rb")).must_equal File.read(downloaded2.path, mode: "rb")
       end
     end
 
@@ -621,22 +621,22 @@ describe Google::Cloud::Storage::File, :storage do
 
   it "should rewrite an existing file, with force_copy_metadata set to true" do
     uploaded = bucket.create_file files[:logo][:path], "CloudLogo.png"
-    uploaded.cache_control.must_be :nil?
-    uploaded.content_type.must_equal "image/png"
+    _(uploaded.cache_control).must_be :nil?
+    _(uploaded.content_type).must_equal "image/png"
 
     copied = try_with_backoff "rewriting existing file" do
       uploaded.rewrite "CloudLogoCopy.png", force_copy_metadata: true do |f|
         f.cache_control = "public, max-age: 7200"
       end
     end
-    uploaded.cache_control.must_be :nil?
-    uploaded.content_type.must_equal "image/png"
-    copied.cache_control.must_equal "public, max-age: 7200"
-    copied.content_type.must_equal "image/png"
+    _(uploaded.cache_control).must_be :nil?
+    _(uploaded.content_type).must_equal "image/png"
+    _(copied.cache_control).must_equal "public, max-age: 7200"
+    _(copied.content_type).must_equal "image/png"
 
-    uploaded.name.must_equal "CloudLogo.png"
-    copied.name.must_equal "CloudLogoCopy.png"
-    copied.size.must_equal uploaded.size
+    _(uploaded.name).must_equal "CloudLogo.png"
+    _(copied.name).must_equal "CloudLogoCopy.png"
+    _(copied.size).must_equal uploaded.size
 
     Tempfile.open ["CloudLogo", ".png"] do |tmpfile1|
       tmpfile1.binmode
@@ -644,9 +644,9 @@ describe Google::Cloud::Storage::File, :storage do
         tmpfile2.binmode
         downloaded1 = uploaded.download tmpfile1
         downloaded2 = copied.download tmpfile2
-        downloaded1.size.must_equal downloaded2.size
+        _(downloaded1.size).must_equal downloaded2.size
 
-        File.read(downloaded1.path, mode: "rb").must_equal File.read(downloaded2.path, mode: "rb")
+        _(File.read(downloaded1.path, mode: "rb")).must_equal File.read(downloaded2.path, mode: "rb")
       end
     end
 
@@ -656,7 +656,7 @@ describe Google::Cloud::Storage::File, :storage do
 
   it "does not error when getting a file that does not exist" do
     file = bucket.file "this/file/does/not/exist.png"
-    file.must_be :nil?
+    _(file).must_be :nil?
   end
 
   it "should compose existing files into a new file" do
@@ -667,13 +667,13 @@ describe Google::Cloud::Storage::File, :storage do
       bucket.compose [uploaded_a, uploaded_b], "ab.txt"
     end
 
-    composed.name.must_equal "ab.txt"
-    composed.size.must_equal uploaded_a.size + uploaded_b.size
+    _(composed.name).must_equal "ab.txt"
+    _(composed.size).must_equal uploaded_a.size + uploaded_b.size
 
     Tempfile.open ["ab", ".txt"] do |tmpfile|
       downloaded = composed.download tmpfile
 
-      File.read(downloaded.path).must_equal "ab"
+      _(File.read(downloaded.path)).must_equal "ab"
     end
 
     uploaded_a.delete
@@ -687,7 +687,7 @@ describe Google::Cloud::Storage::File, :storage do
       public_bucket = anonymous_storage.bucket bucket_public_test_name, skip_lookup: true
       files = public_bucket.files
 
-      files.wont_be :empty?
+      _(files).wont_be :empty?
     end
 
     it "should download a public file without authentication" do
@@ -698,7 +698,7 @@ describe Google::Cloud::Storage::File, :storage do
         tmpfile.binmode
         downloaded = file.download tmpfile, verify: :none # gzipped file verification bug #1835, does not affect this test
 
-        File.read(downloaded.path, mode: "rb").must_equal "hello world" # decompressed file data
+        _(File.read(downloaded.path, mode: "rb")).must_equal "hello world" # decompressed file data
       end
     end
 

--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -314,7 +314,7 @@ describe Google::Cloud::Storage::File, :storage do
     uploaded = bucket.create_file gzipped, "uploaded/with/gzip-type.txt", content_type: "application/gzip"
     _(uploaded.name).must_equal "uploaded/with/gzip-type.txt"
     _(uploaded.content_type).must_equal "application/gzip"
-    uploaded.content_encoding.must_be_nil
+    _(uploaded.content_encoding).must_be_nil
     downloadio = StringIO.new()
     downloaded = uploaded.download downloadio
     _(downloaded).must_be_kind_of StringIO
@@ -374,8 +374,8 @@ describe Google::Cloud::Storage::File, :storage do
   it "should download, verify, and decompress when Content-Encoding gzip response header with skip_lookup" do
     bucket = storage.bucket bucket_public_test_name, skip_lookup: true
     file = bucket.file file_public_test_gzip_name, skip_lookup: true
-    file.content_encoding.must_be_nil # metadata not loaded
-    file.content_type.must_be_nil # metadata not loaded
+    _(file.content_encoding).must_be_nil # metadata not loaded
+    _(file.content_type).must_be_nil # metadata not loaded
     Tempfile.open ["hello_world", ".txt"] do |tmpfile|
       tmpfile.binmode
       downloaded = file.download tmpfile

--- a/google-cloud-storage/acceptance/storage/filename_test.rb
+++ b/google-cloud-storage/acceptance/storage/filename_test.rb
@@ -32,10 +32,10 @@ describe Google::Cloud::Storage::File, :storage do
   it "does not perform any file name normalization" do
     filenames.each_with_index do |name, i|
       file = bucket.file name
-      file.name.must_equal name
+      _(file.name).must_equal name
       Tempfile.open "cafe" do |tmpfile|
         downloaded = file.download tmpfile
-        File.read(downloaded.path).must_equal filecontent[i]
+        _(File.read(downloaded.path)).must_equal filecontent[i]
       end
     end
   end

--- a/google-cloud-storage/acceptance/storage/files_test.rb
+++ b/google-cloud-storage/acceptance/storage/files_test.rb
@@ -46,21 +46,21 @@ describe "Storage", :files, :storage do
 
   it "get all files" do
     bucket.files.all.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
+      _(file).must_be_kind_of Google::Cloud::Storage::File
     end
   end
 
   it "gets pages of files" do
     first_files = bucket.files max: 2
-    first_files.next?.must_equal true
-    first_files.each { |f| f.must_be_kind_of Google::Cloud::Storage::File }
+    _(first_files.next?).must_equal true
+    first_files.each { |f| _(f).must_be_kind_of Google::Cloud::Storage::File }
     second_files = first_files.next
-    second_files.each { |f| f.must_be_kind_of Google::Cloud::Storage::File }
+    second_files.each { |f| _(f).must_be_kind_of Google::Cloud::Storage::File }
   end
 
   it "gets all files with request_limit" do
     bucket.files(max: 2).all(request_limit: 1) do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
+      _(file).must_be_kind_of Google::Cloud::Storage::File
     end
   end
 end

--- a/google-cloud-storage/acceptance/storage/project_test.rb
+++ b/google-cloud-storage/acceptance/storage/project_test.rb
@@ -17,10 +17,10 @@ require "storage_helper"
 describe Google::Cloud::Storage::Project, :storage do
   it "should get its project service account email" do
     email = storage.service_account_email
-    email.wont_be :nil?
-    email.must_be_kind_of String
+    _(email).wont_be :nil?
+    _(email).must_be_kind_of String
     # https://stackoverflow.com/questions/22993545/ruby-email-validation-with-regex
-    email.must_match /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+    _(email).must_match /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
   end
 
   it "should create a new HMAC key" do
@@ -30,29 +30,29 @@ describe Google::Cloud::Storage::Project, :storage do
       # Create key.
       hmac_key = storage.create_hmac_key service_account_email
 
-      hmac_key.wont_be :nil?
-      hmac_key.must_be_kind_of Google::Cloud::Storage::HmacKey
+      _(hmac_key).wont_be :nil?
+      _(hmac_key).must_be_kind_of Google::Cloud::Storage::HmacKey
 
       # Check response fields.
-      hmac_key.secret.must_be_kind_of String
-      hmac_key.secret.length.must_equal 40
+      _(hmac_key.secret).must_be_kind_of String
+      _(hmac_key.secret.length).must_equal 40
 
-      hmac_key.access_id.must_be_kind_of String
-      hmac_key.project_id.must_equal storage.project_id
-      hmac_key.etag.must_be_kind_of String
-      hmac_key.id.must_be_kind_of String
-      hmac_key.created_at.must_be_kind_of DateTime
-      hmac_key.updated_at.must_be_kind_of DateTime
-      hmac_key.service_account_email.must_equal service_account_email
-      hmac_key.state.must_equal "ACTIVE"
-      hmac_key.must_be :active?
+      _(hmac_key.access_id).must_be_kind_of String
+      _(hmac_key.project_id).must_equal storage.project_id
+      _(hmac_key.etag).must_be_kind_of String
+      _(hmac_key.id).must_be_kind_of String
+      _(hmac_key.created_at).must_be_kind_of DateTime
+      _(hmac_key.updated_at).must_be_kind_of DateTime
+      _(hmac_key.service_account_email).must_equal service_account_email
+      _(hmac_key.state).must_equal "ACTIVE"
+      _(hmac_key).must_be :active?
 
       hmac_keys = storage.hmac_keys
-      hmac_keys.wont_be :empty?
+      _(hmac_keys).wont_be :empty?
 
       # Verify it shows up in list.
       hmac_key_list_item = hmac_keys.find { |k| k.access_id == hmac_key.access_id }
-      hmac_key_list_item.wont_be :nil?
+      _(hmac_key_list_item).wont_be :nil?
 
       # sleep to ensure etag consistency
       sleep 1
@@ -62,23 +62,23 @@ describe Google::Cloud::Storage::Project, :storage do
 
       # Update key to INACTIVE state
       hmac_key_list_item.inactive!
-      hmac_key_list_item.state.must_equal "INACTIVE"
-      hmac_key_list_item.must_be :inactive?
+      _(hmac_key_list_item.state).must_equal "INACTIVE"
+      _(hmac_key_list_item).must_be :inactive?
 
       # Delete key.
       hmac_key.delete!
-      hmac_key.state.must_equal "DELETED"
-      hmac_key.must_be :deleted?
+      _(hmac_key.state).must_equal "DELETED"
+      _(hmac_key).must_be :deleted?
 
       # Verify it does not show up in list.
       hmac_keys = storage.hmac_keys
       hmac_key_list_item = hmac_keys.find { |k| k.access_id == hmac_key.access_id }
-      hmac_key_list_item.must_be :nil?
+      _(hmac_key_list_item).must_be :nil?
 
       # GET the deleted key.
       hmac_key = storage.hmac_key hmac_key.access_id # similar to reload! above
-      hmac_key.state.must_equal "DELETED"
-      hmac_key.must_be :deleted?
+      _(hmac_key.state).must_equal "DELETED"
+      _(hmac_key).must_be :deleted?
     ensure
       if hmac_key && !hmac_key.deleted?
         safe_gcs_execute { hmac_key.inactive! }

--- a/google-cloud-storage/acceptance/storage/signed_url_v2_test.rb
+++ b/google-cloud-storage/acceptance/storage/signed_url_v2_test.rb
@@ -58,14 +58,14 @@ describe Google::Cloud::Storage, :signed_url, :v2, :storage do
       http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
 
       resp = http.get uri.request_uri
-      resp.code.must_equal "200"
+      _(resp.code).must_equal "200"
 
       Tempfile.open ["google-cloud", ".png"] do |tmpfile|
         tmpfile.binmode
         tmpfile.write resp.body
-        tmpfile.size.must_equal local_file.size
+        _(tmpfile.size).must_equal local_file.size
 
-        File.read(local_file.path, mode: "rb").must_equal File.read(tmpfile.path, mode: "rb")
+        _(File.read(local_file.path, mode: "rb")).must_equal File.read(tmpfile.path, mode: "rb")
       end
     end
 
@@ -84,8 +84,8 @@ describe Google::Cloud::Storage, :signed_url, :v2, :storage do
       req.content_type = "image/png"    # Required for V2
       resp = https.request(req)
 
-      resp.message.must_equal "Created"
-      resp.code.must_equal "201"
+      _(resp.message).must_equal "Created"
+      _(resp.code).must_equal "201"
     end
   end
 
@@ -104,14 +104,14 @@ describe Google::Cloud::Storage, :signed_url, :v2, :storage do
       http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
   
       resp = http.get uri.request_uri
-      resp.code.must_equal "200"
+      _(resp.code).must_equal "200"
   
       Tempfile.open ["google-cloud", ".png"] do |tmpfile|
         tmpfile.binmode
         tmpfile.write resp.body
-        tmpfile.size.must_equal local_file.size
+        _(tmpfile.size).must_equal local_file.size
   
-        File.read(local_file.path, mode: "rb").must_equal File.read(tmpfile.path, mode: "rb")
+        _(File.read(local_file.path, mode: "rb")).must_equal File.read(tmpfile.path, mode: "rb")
       end
     end
   
@@ -130,8 +130,8 @@ describe Google::Cloud::Storage, :signed_url, :v2, :storage do
       http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
   
       resp = http.get uri.request_uri
-      resp.code.must_equal "200"
-      resp["Content-Disposition"].must_equal "attachment; filename=\"google-cloud.png\""
+      _(resp.code).must_equal "200"
+      _(resp["Content-Disposition"]).must_equal "attachment; filename=\"google-cloud.png\""
     end
 
     it "should create a signed read url to list objects with version v2" do
@@ -142,15 +142,15 @@ describe Google::Cloud::Storage, :signed_url, :v2, :storage do
       url = bucket.signed_url method: "GET", expires: five_min_from_now
 
       uri = URI url
-      uri.path.must_equal "/#{bucket_name}/"
+      _(uri.path).must_equal "/#{bucket_name}/"
 
       http = Net::HTTP.new uri.host, uri.port
       http.use_ssl = true
       http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
 
       resp = http.get uri.request_uri
-      resp.code.must_equal "200"
-      resp.body.must_match "CloudLogoSignedUrlGetBucket.png" # in XML
+      _(resp.code).must_equal "200"
+      _(resp.body).must_match "CloudLogoSignedUrlGetBucket.png" # in XML
     end
   end
 
@@ -169,14 +169,14 @@ describe Google::Cloud::Storage, :signed_url, :v2, :storage do
       http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
 
       resp = http.get uri.request_uri
-      resp.code.must_equal "200"
+      _(resp.code).must_equal "200"
 
       Tempfile.open ["google-cloud", ".png"] do |tmpfile|
         tmpfile.binmode
         tmpfile.write resp.body
-        tmpfile.size.must_equal local_file.size
+        _(tmpfile.size).must_equal local_file.size
 
-        File.read(local_file.path, mode: "rb").must_equal File.read(tmpfile.path, mode: "rb")
+        _(File.read(local_file.path, mode: "rb")).must_equal File.read(tmpfile.path, mode: "rb")
       end
     end
   
@@ -195,8 +195,8 @@ describe Google::Cloud::Storage, :signed_url, :v2, :storage do
       http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
   
       resp = http.get uri.request_uri
-      resp.code.must_equal "200"
-      resp["Content-Disposition"].must_equal "attachment; filename=\"google-cloud.png\""
+      _(resp.code).must_equal "200"
+      _(resp["Content-Disposition"]).must_equal "attachment; filename=\"google-cloud.png\""
     end
   
     it "should create a signed delete url" do
@@ -212,7 +212,7 @@ describe Google::Cloud::Storage, :signed_url, :v2, :storage do
       http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
   
       resp = http.delete uri.request_uri
-      resp.code.must_equal "204"
+      _(resp.code).must_equal "204"
     end
   
     it "should create a signed url with public-read acl" do
@@ -231,14 +231,14 @@ describe Google::Cloud::Storage, :signed_url, :v2, :storage do
   
       resp = http.get uri.request_uri, { "X-Goog-meta-foo" => "bar,baz",
                                          "X-Goog-ACL" => "public-read" }
-      resp.code.must_equal "200"
+      _(resp.code).must_equal "200"
   
       Tempfile.open ["google-cloud", ".png"] do |tmpfile|
         tmpfile.binmode
         tmpfile.write resp.body
-        tmpfile.size.must_equal local_file.size
+        _(tmpfile.size).must_equal local_file.size
   
-        File.read(local_file.path, mode: "rb").must_equal File.read(tmpfile.path, mode: "rb")
+        _(File.read(local_file.path, mode: "rb")).must_equal File.read(tmpfile.path, mode: "rb")
       end
     end
   end

--- a/google-cloud-storage/acceptance/storage/signed_url_v4_test.rb
+++ b/google-cloud-storage/acceptance/storage/signed_url_v4_test.rb
@@ -58,14 +58,14 @@ describe Google::Cloud::Storage, :signed_url, :v4, :storage do
       http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
 
       resp = http.get uri.request_uri
-      resp.code.must_equal "200"
+      _(resp.code).must_equal "200"
 
       Tempfile.open ["google-cloud", ".png"] do |tmpfile|
         tmpfile.binmode
         tmpfile.write resp.body
-        tmpfile.size.must_equal local_file.size
+        _(tmpfile.size).must_equal local_file.size
 
-        File.read(local_file.path, mode: "rb").must_equal File.read(tmpfile.path, mode: "rb")
+        _(File.read(local_file.path, mode: "rb")).must_equal File.read(tmpfile.path, mode: "rb")
       end
     end
 
@@ -84,8 +84,8 @@ describe Google::Cloud::Storage, :signed_url, :v4, :storage do
       req = Net::HTTP::Post.new url, { "X-Goog-Resumable" => "start" }
       resp = https.request(req)
 
-      resp.message.must_equal "Created"
-      resp.code.must_equal "201"
+      _(resp.message).must_equal "Created"
+      _(resp.code).must_equal "201"
     end
   end
 
@@ -104,14 +104,14 @@ describe Google::Cloud::Storage, :signed_url, :v4, :storage do
       http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
   
       resp = http.get uri.request_uri
-      resp.code.must_equal "200"
+      _(resp.code).must_equal "200"
   
       Tempfile.open ["google-cloud", ".png"] do |tmpfile|
         tmpfile.binmode
         tmpfile.write resp.body
-        tmpfile.size.must_equal local_file.size
+        _(tmpfile.size).must_equal local_file.size
   
-        File.read(local_file.path, mode: "rb").must_equal File.read(tmpfile.path, mode: "rb")
+        _(File.read(local_file.path, mode: "rb")).must_equal File.read(tmpfile.path, mode: "rb")
       end
     end
 
@@ -123,15 +123,15 @@ describe Google::Cloud::Storage, :signed_url, :v4, :storage do
       url = bucket.signed_url method: "GET", expires: five_min_from_now, version: :v4
 
       uri = URI url
-      uri.path.must_equal "/#{bucket_name}"
+      _(uri.path).must_equal "/#{bucket_name}"
 
       http = Net::HTTP.new uri.host, uri.port
       http.use_ssl = true
       http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
 
       resp = http.get uri.request_uri
-      resp.code.must_equal "200"
-      resp.body.must_match "CloudLogoSignedUrlGetBucket.png" # in XML
+      _(resp.code).must_equal "200"
+      _(resp.body).must_match "CloudLogoSignedUrlGetBucket.png" # in XML
     end
 
     it "should create a signed POST url version v4" do
@@ -149,8 +149,8 @@ describe Google::Cloud::Storage, :signed_url, :v4, :storage do
       req.body = "abc123"
       resp = https.request(req)
 
-      resp.message.must_equal "Created"
-      resp.code.must_equal "201"
+      _(resp.message).must_equal "Created"
+      _(resp.code).must_equal "201"
     end
   end
 
@@ -169,14 +169,14 @@ describe Google::Cloud::Storage, :signed_url, :v4, :storage do
       http.ca_file ||= ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]
   
       resp = http.get uri.request_uri
-      resp.code.must_equal "200"
+      _(resp.code).must_equal "200"
   
       Tempfile.open ["google-cloud", ".png"] do |tmpfile|
         tmpfile.binmode
         tmpfile.write resp.body
-        tmpfile.size.must_equal local_file.size
+        _(tmpfile.size).must_equal local_file.size
   
-        File.read(local_file.path, mode: "rb").must_equal File.read(tmpfile.path, mode: "rb")
+        _(File.read(local_file.path, mode: "rb")).must_equal File.read(tmpfile.path, mode: "rb")
       end
     end
 
@@ -194,8 +194,8 @@ describe Google::Cloud::Storage, :signed_url, :v4, :storage do
       req.body = "abc123"
       resp = https.request(req)
   
-      resp.message.must_equal "Created"
-      resp.code.must_equal "201"
+      _(resp.message).must_equal "Created"
+      _(resp.code).must_equal "201"
     end
   end
 end

--- a/google-cloud-storage/test/google/cloud/storage/bucket_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_acl_test.rb
@@ -31,10 +31,10 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name
-    bucket.name.must_equal bucket_name
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
 
     mock.verify
   end
@@ -49,10 +49,10 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, user_project: true
-    bucket.name.must_equal bucket_name
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
 
     mock.verify
   end
@@ -82,16 +82,16 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name
-    bucket.name.must_equal bucket_name
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
 
     bucket.acl.add_writer entity
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.wont_be :empty?
-    bucket.acl.readers.wont_be :empty?
-    bucket.acl.writers.must_include entity
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).wont_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
+    _(bucket.acl.writers).must_include entity
 
     mock.verify
   end
@@ -149,16 +149,16 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, user_project: true
-    bucket.name.must_equal bucket_name
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
 
     bucket.acl.add_writer entity
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.wont_be :empty?
-    bucket.acl.readers.wont_be :empty?
-    bucket.acl.writers.must_include entity
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).wont_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
+    _(bucket.acl.writers).must_include entity
 
     mock.verify
   end
@@ -205,16 +205,16 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name
-    bucket.name.must_equal bucket_name
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
 
     reader_entity = bucket.acl.readers.first
     bucket.acl.delete reader_entity
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.must_be :empty?
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).must_be :empty?
 
     mock.verify
   end
@@ -233,16 +233,16 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, user_project: true
-    bucket.name.must_equal bucket_name
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
 
     reader_entity = bucket.acl.readers.first
     bucket.acl.delete reader_entity
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.must_be :empty?
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).must_be :empty?
 
     mock.verify
   end

--- a/google-cloud-storage/test/google/cloud/storage/bucket_compose_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_compose_test.rb
@@ -55,8 +55,8 @@ describe Google::Cloud::Storage::Bucket, :compose, :mock_storage do
     bucket.service.mocked_service = mock
 
     new_file = bucket.compose [file_name, file_2_name], file_3_name
-    new_file.must_be_kind_of Google::Cloud::Storage::File
-    new_file.name.must_equal file_3_name
+    _(new_file).must_be_kind_of Google::Cloud::Storage::File
+    _(new_file.name).must_equal file_3_name
 
     mock.verify
   end
@@ -69,8 +69,8 @@ describe Google::Cloud::Storage::Bucket, :compose, :mock_storage do
     bucket.service.mocked_service = mock
 
     new_file = bucket.compose [file, file_2], file_3_name
-    new_file.must_be_kind_of Google::Cloud::Storage::File
-    new_file.name.must_equal file_3_name
+    _(new_file).must_be_kind_of Google::Cloud::Storage::File
+    _(new_file.name).must_equal file_3_name
 
     mock.verify
   end
@@ -86,8 +86,8 @@ describe Google::Cloud::Storage::Bucket, :compose, :mock_storage do
     bucket.service.mocked_service = mock
 
     new_file = bucket.compose [file, file_2], file_3_name
-    new_file.must_be_kind_of Google::Cloud::Storage::File
-    new_file.name.must_equal file_3_name
+    _(new_file).must_be_kind_of Google::Cloud::Storage::File
+    _(new_file.name).must_equal file_3_name
 
     mock.verify
   end
@@ -100,8 +100,8 @@ describe Google::Cloud::Storage::Bucket, :compose, :mock_storage do
     bucket.service.mocked_service = mock
 
     new_file = bucket.compose [file, file_2], file_3_name, acl: "private"
-    new_file.must_be_kind_of Google::Cloud::Storage::File
-    new_file.name.must_equal file_3_name
+    _(new_file).must_be_kind_of Google::Cloud::Storage::File
+    _(new_file.name).must_equal file_3_name
 
     mock.verify
   end
@@ -114,8 +114,8 @@ describe Google::Cloud::Storage::Bucket, :compose, :mock_storage do
     bucket.service.mocked_service = mock
 
     new_file = bucket.compose [file, file_2], file_3_name, acl: :public
-    new_file.must_be_kind_of Google::Cloud::Storage::File
-    new_file.name.must_equal file_3_name
+    _(new_file).must_be_kind_of Google::Cloud::Storage::File
+    _(new_file.name).must_equal file_3_name
 
     mock.verify
   end
@@ -128,9 +128,9 @@ describe Google::Cloud::Storage::Bucket, :compose, :mock_storage do
     file.service.mocked_service = mock
 
     new_file = bucket_user_project.compose [file, file_2], file_3_name
-    new_file.must_be_kind_of Google::Cloud::Storage::File
-    new_file.name.must_equal file_3_name
-    new_file.user_project.must_equal true
+    _(new_file).must_be_kind_of Google::Cloud::Storage::File
+    _(new_file.name).must_equal file_3_name
+    _(new_file.user_project).must_equal true
 
     mock.verify
   end
@@ -143,8 +143,8 @@ describe Google::Cloud::Storage::Bucket, :compose, :mock_storage do
     file.service.mocked_service = mock
 
     new_file = bucket.compose [file, file_2], file_3_name, encryption_key: encryption_key
-    new_file.must_be_kind_of Google::Cloud::Storage::File
-    new_file.name.must_equal file_3_name
+    _(new_file).must_be_kind_of Google::Cloud::Storage::File
+    _(new_file.name).must_equal file_3_name
 
     mock.verify
   end
@@ -177,8 +177,8 @@ describe Google::Cloud::Storage::Bucket, :compose, :mock_storage do
       f.storage_class = :nearline
     end
 
-    new_file.must_be_kind_of Google::Cloud::Storage::File
-    new_file.name.must_equal file_3_name
+    _(new_file).must_be_kind_of Google::Cloud::Storage::File
+    _(new_file.name).must_equal file_3_name
 
     mock.verify
   end
@@ -211,9 +211,9 @@ describe Google::Cloud::Storage::Bucket, :compose, :mock_storage do
       f.storage_class = :nearline
     end
 
-    new_file.must_be_kind_of Google::Cloud::Storage::File
-    new_file.name.must_equal file_3_name
-    new_file.user_project.must_equal true
+    _(new_file).must_be_kind_of Google::Cloud::Storage::File
+    _(new_file.name).must_equal file_3_name
+    _(new_file.user_project).must_equal true
 
     mock.verify
   end

--- a/google-cloud-storage/test/google/cloud/storage/bucket_default_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_default_acl_test.rb
@@ -31,9 +31,9 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name
-    bucket.name.must_equal bucket_name
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
 
     mock.verify
   end
@@ -48,9 +48,9 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, user_project: true
-    bucket.name.must_equal bucket_name
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
 
     mock.verify
   end
@@ -80,14 +80,14 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name
-    bucket.name.must_equal bucket_name
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
 
     bucket.default_acl.add_reader reader_entity
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
-    bucket.default_acl.readers.must_include reader_entity
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
+    _(bucket.default_acl.readers).must_include reader_entity
 
     mock.verify
   end
@@ -117,14 +117,14 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, user_project: true
-    bucket.name.must_equal bucket_name
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
 
     bucket.default_acl.add_reader reader_entity
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
-    bucket.default_acl.readers.must_include reader_entity
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
+    _(bucket.default_acl.readers).must_include reader_entity
 
     mock.verify
   end
@@ -143,14 +143,14 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name
-    bucket.name.must_equal bucket_name
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
 
     reader_entity = bucket.default_acl.readers.first
     bucket.default_acl.delete reader_entity
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.must_be :empty?
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).must_be :empty?
 
     mock.verify
   end
@@ -169,14 +169,14 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, user_project: true
-    bucket.name.must_equal bucket_name
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
 
     reader_entity = bucket.default_acl.readers.first
     bucket.default_acl.delete reader_entity
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.must_be :empty?
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).must_be :empty?
 
     mock.verify
   end

--- a/google-cloud-storage/test/google/cloud/storage/bucket_encryption_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_encryption_test.rb
@@ -63,9 +63,9 @@ describe Google::Cloud::Storage::Bucket, :encryption, :mock_storage do
 
       mock.verify
 
-      file.name.must_equal file_name
-      file.user_project.must_be :nil?
-      file.wont_be :lazy?
+      _(file.name).must_equal file_name
+      _(file.user_project).must_be :nil?
+      _(file).wont_be :lazy?
     end
   end
 
@@ -80,11 +80,11 @@ describe Google::Cloud::Storage::Bucket, :encryption, :mock_storage do
 
       bucket.service.mocked_service = mock
 
-      bucket.default_kms_key.must_be :nil?
+      _(bucket.default_kms_key).must_be :nil?
       bucket.default_kms_key = kms_key
-      bucket.default_kms_key.wont_be :nil?
-      bucket.default_kms_key.must_be_kind_of String
-      bucket.default_kms_key.must_equal kms_key
+      _(bucket.default_kms_key).wont_be :nil?
+      _(bucket.default_kms_key).must_be_kind_of String
+      _(bucket.default_kms_key).must_equal kms_key
     end
 
     it "sets its encryption config to nil" do
@@ -98,10 +98,10 @@ describe Google::Cloud::Storage::Bucket, :encryption, :mock_storage do
 
       bucket_with_key.service.mocked_service = mock
 
-      bucket_with_key.default_kms_key.wont_be :nil?
+      _(bucket_with_key.default_kms_key).wont_be :nil?
 
       bucket_with_key.default_kms_key = nil
-      bucket_with_key.default_kms_key.must_be :nil?
+      _(bucket_with_key.default_kms_key).must_be :nil?
     end
 
     it "creates a file with the kms_key option" do

--- a/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
@@ -74,14 +74,14 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket.policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal "CAE="
-      policy.version.must_equal 1
-      policy.roles.must_be_kind_of Hash
-      policy.roles.size.must_equal 1
-      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-      policy.roles["roles/storage.objectViewer"].count.must_equal 1
-      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal "CAE="
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be_kind_of Hash
+      _(policy.roles.size).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"]).must_be_kind_of Array
+      _(policy.roles["roles/storage.objectViewer"].count).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"].first).must_equal "user:viewer@example.com"
     end
 
     it "gets the policy with requested_policy_version: 1" do
@@ -92,14 +92,14 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket.policy requested_policy_version: 1
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal "CAE="
-      policy.version.must_equal 1
-      policy.roles.must_be_kind_of Hash
-      policy.roles.size.must_equal 1
-      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-      policy.roles["roles/storage.objectViewer"].count.must_equal 1
-      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal "CAE="
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be_kind_of Hash
+      _(policy.roles.size).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"]).must_be_kind_of Array
+      _(policy.roles["roles/storage.objectViewer"].count).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"].first).must_equal "user:viewer@example.com"
     end
 
     it "gets the policy with user_project set to true" do
@@ -110,14 +110,14 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket_user_project.policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal "CAE="
-      policy.version.must_equal 1
-      policy.roles.must_be_kind_of Hash
-      policy.roles.size.must_equal 1
-      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-      policy.roles["roles/storage.objectViewer"].count.must_equal 1
-      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal "CAE="
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be_kind_of Hash
+      _(policy.roles.size).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"]).must_be_kind_of Array
+      _(policy.roles["roles/storage.objectViewer"].count).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"].first).must_equal "user:viewer@example.com"
     end
 
     it "sets the policy" do
@@ -128,15 +128,15 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 1
-      policy.roles.must_be_kind_of Hash
-      policy.roles.size.must_equal 1
-      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-      policy.roles["roles/storage.objectViewer"].count.must_equal 2
-      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be_kind_of Hash
+      _(policy.roles.size).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"]).must_be_kind_of Array
+      _(policy.roles["roles/storage.objectViewer"].count).must_equal 2
+      _(policy.roles["roles/storage.objectViewer"].first).must_equal "user:viewer@example.com"
+      _(policy.roles["roles/storage.objectViewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
     end
 
     it "sets the policy with user_project set to true" do
@@ -147,15 +147,15 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket_user_project.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 1
-      policy.roles.must_be_kind_of Hash
-      policy.roles.size.must_equal 1
-      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-      policy.roles["roles/storage.objectViewer"].count.must_equal 2
-      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be_kind_of Hash
+      _(policy.roles.size).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"]).must_be_kind_of Array
+      _(policy.roles["roles/storage.objectViewer"].count).must_equal 2
+      _(policy.roles["roles/storage.objectViewer"].first).must_equal "user:viewer@example.com"
+      _(policy.roles["roles/storage.objectViewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
     end
 
     it "sets the policy in a block" do
@@ -170,15 +170,15 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 1
-      policy.roles.must_be_kind_of Hash
-      policy.roles.size.must_equal 1
-      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-      policy.roles["roles/storage.objectViewer"].count.must_equal 2
-      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be_kind_of Hash
+      _(policy.roles.size).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"]).must_be_kind_of Array
+      _(policy.roles["roles/storage.objectViewer"].count).must_equal 2
+      _(policy.roles["roles/storage.objectViewer"].first).must_equal "user:viewer@example.com"
+      _(policy.roles["roles/storage.objectViewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
     end
 
     it "sets the policy in a block with user_project set to true" do
@@ -193,15 +193,15 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 1
-      policy.roles.must_be_kind_of Hash
-      policy.roles.size.must_equal 1
-      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-      policy.roles["roles/storage.objectViewer"].count.must_equal 2
-      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be_kind_of Hash
+      _(policy.roles.size).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"]).must_be_kind_of Array
+      _(policy.roles["roles/storage.objectViewer"].count).must_equal 2
+      _(policy.roles["roles/storage.objectViewer"].first).must_equal "user:viewer@example.com"
+      _(policy.roles["roles/storage.objectViewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
     end
   end
 
@@ -280,15 +280,15 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket.policy requested_policy_version: 3
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.etag.must_equal "CAE="
-      policy.version.must_equal 1
-      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
-      policy.bindings.to_a.count.must_equal 1
-      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
-      policy.bindings.to_a[0].condition.must_be :nil?
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.etag).must_equal "CAE="
+      _(policy.version).must_equal 1
+      _(policy.bindings).must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      _(policy.bindings.to_a.count).must_equal 1
+      _(policy.bindings.to_a[0]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[0].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[0].members).must_equal ["user:viewer@example.com"]
+      _(policy.bindings.to_a[0].condition).must_be :nil?
     end
 
     it "gets the policy with user_project set to true" do
@@ -299,15 +299,15 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket_user_project.policy requested_policy_version: 3
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.etag.must_equal "CAE="
-      policy.version.must_equal 1
-      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
-      policy.bindings.to_a.count.must_equal 1
-      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
-      policy.bindings.to_a[0].condition.must_be :nil?
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.etag).must_equal "CAE="
+      _(policy.version).must_equal 1
+      _(policy.bindings).must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      _(policy.bindings.to_a.count).must_equal 1
+      _(policy.bindings.to_a[0]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[0].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[0].members).must_equal ["user:viewer@example.com"]
+      _(policy.bindings.to_a[0].condition).must_be :nil?
     end
 
     it "sets the policy" do
@@ -318,22 +318,22 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
-      policy.bindings.to_a.count.must_equal 2
-      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
-      policy.bindings.to_a[0].condition.must_be :nil?
-      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
-      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
-      policy.bindings.to_a[1].condition.title.must_equal "always-true"
-      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
-      policy.bindings.to_a[1].condition.expression.must_equal "true"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 3
+      _(policy.bindings).must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      _(policy.bindings.to_a.count).must_equal 2
+      _(policy.bindings.to_a[0]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[0].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[0].members).must_equal ["user:viewer@example.com"]
+      _(policy.bindings.to_a[0].condition).must_be :nil?
+      _(policy.bindings.to_a[1]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[1].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[1].members).must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      _(policy.bindings.to_a[1].condition).must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      _(policy.bindings.to_a[1].condition.title).must_equal "always-true"
+      _(policy.bindings.to_a[1].condition.description).must_equal "test condition always-true"
+      _(policy.bindings.to_a[1].condition.expression).must_equal "true"
     end
 
     it "sets the policy with user_project set to true" do
@@ -344,22 +344,22 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       policy = bucket_user_project.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
-      policy.bindings.to_a.count.must_equal 2
-      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
-      policy.bindings.to_a[0].condition.must_be :nil?
-      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
-      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
-      policy.bindings.to_a[1].condition.title.must_equal "always-true"
-      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
-      policy.bindings.to_a[1].condition.expression.must_equal "true"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 3
+      _(policy.bindings).must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      _(policy.bindings.to_a.count).must_equal 2
+      _(policy.bindings.to_a[0]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[0].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[0].members).must_equal ["user:viewer@example.com"]
+      _(policy.bindings.to_a[0].condition).must_be :nil?
+      _(policy.bindings.to_a[1]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[1].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[1].members).must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      _(policy.bindings.to_a[1].condition).must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      _(policy.bindings.to_a[1].condition.title).must_equal "always-true"
+      _(policy.bindings.to_a[1].condition.description).must_equal "test condition always-true"
+      _(policy.bindings.to_a[1].condition.expression).must_equal "true"
     end
 
     it "sets the policy in a block" do
@@ -383,22 +383,22 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
-      policy.bindings.to_a.count.must_equal 2
-      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
-      policy.bindings.to_a[0].condition.must_be :nil?
-      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
-      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
-      policy.bindings.to_a[1].condition.title.must_equal "always-true"
-      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
-      policy.bindings.to_a[1].condition.expression.must_equal "true"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 3
+      _(policy.bindings).must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      _(policy.bindings.to_a.count).must_equal 2
+      _(policy.bindings.to_a[0]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[0].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[0].members).must_equal ["user:viewer@example.com"]
+      _(policy.bindings.to_a[0].condition).must_be :nil?
+      _(policy.bindings.to_a[1]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[1].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[1].members).must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      _(policy.bindings.to_a[1].condition).must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      _(policy.bindings.to_a[1].condition.title).must_equal "always-true"
+      _(policy.bindings.to_a[1].condition.description).must_equal "test condition always-true"
+      _(policy.bindings.to_a[1].condition.expression).must_equal "true"
     end
 
     it "sets the policy in a block with user_project set to true" do
@@ -422,22 +422,22 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
-      policy.bindings.to_a.count.must_equal 2
-      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
-      policy.bindings.to_a[0].condition.must_be :nil?
-      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
-      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
-      policy.bindings.to_a[1].condition.title.must_equal "always-true"
-      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
-      policy.bindings.to_a[1].condition.expression.must_equal "true"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 3
+      _(policy.bindings).must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      _(policy.bindings.to_a.count).must_equal 2
+      _(policy.bindings.to_a[0]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[0].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[0].members).must_equal ["user:viewer@example.com"]
+      _(policy.bindings.to_a[0].condition).must_be :nil?
+      _(policy.bindings.to_a[1]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[1].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[1].members).must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      _(policy.bindings.to_a[1].condition).must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      _(policy.bindings.to_a[1].condition.title).must_equal "always-true"
+      _(policy.bindings.to_a[1].condition.description).must_equal "test condition always-true"
+      _(policy.bindings.to_a[1].condition.expression).must_equal "true"
     end
   end
 
@@ -451,7 +451,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
                                            "storage.buckets.delete"
     mock.verify
 
-    permissions.must_equal ["storage.buckets.get"]
+    _(permissions).must_equal ["storage.buckets.get"]
   end
 
   it "tests the permissions available with user_project set to true" do
@@ -464,6 +464,6 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
                                            "storage.buckets.delete"
     mock.verify
 
-    permissions.must_equal ["storage.buckets.get"]
+    _(permissions).must_equal ["storage.buckets.get"]
   end
 end

--- a/google-cloud-storage/test/google/cloud/storage/bucket_lock_retention_policy_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_lock_retention_policy_test.rb
@@ -41,10 +41,10 @@ describe Google::Cloud::Storage::Bucket, :lock_retention_policy, :mock_storage d
   let(:bucket_with_retention_policy) { Google::Cloud::Storage::Bucket.from_gapi bucket_with_retention_policy_gapi, storage.service }
 
   it "knows its retention policy attributes" do
-    bucket_with_retention_policy.retention_period.must_equal bucket_retention_period
-    bucket_with_retention_policy.retention_effective_at.must_be_within_delta bucket_retention_effective_at
-    bucket_with_retention_policy.retention_policy_locked?.must_equal true
-    bucket_with_retention_policy.default_event_based_hold?.must_equal true
+    _(bucket_with_retention_policy.retention_period).must_equal bucket_retention_period
+    _(bucket_with_retention_policy.retention_effective_at).must_be_within_delta bucket_retention_effective_at
+    _(bucket_with_retention_policy.retention_policy_locked?).must_equal true
+    _(bucket_with_retention_policy.default_event_based_hold?).must_equal true
   end
 
   it "updates its retention_period" do
@@ -55,12 +55,12 @@ describe Google::Cloud::Storage::Bucket, :lock_retention_policy, :mock_storage d
                 [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     bucket.service.mocked_service = mock
 
-    bucket.retention_period.must_be :nil?
+    _(bucket.retention_period).must_be :nil?
 
     bucket.retention_period = bucket_retention_period
 
-    bucket.retention_period.must_equal bucket_retention_period
-    bucket.retention_effective_at.must_be_within_delta bucket_retention_effective_at
+    _(bucket.retention_period).must_equal bucket_retention_period
+    _(bucket.retention_effective_at).must_be_within_delta bucket_retention_effective_at
 
     mock.verify
   end
@@ -72,11 +72,11 @@ describe Google::Cloud::Storage::Bucket, :lock_retention_policy, :mock_storage d
                 [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     bucket.service.mocked_service = mock
 
-    bucket.default_event_based_hold?.must_equal false
+    _(bucket.default_event_based_hold?).must_equal false
 
     bucket.default_event_based_hold = true
 
-    bucket.default_event_based_hold?.must_equal true
+    _(bucket.default_event_based_hold?).must_equal true
 
     mock.verify
   end
@@ -91,7 +91,7 @@ describe Google::Cloud::Storage::Bucket, :lock_retention_policy, :mock_storage d
 
     mock.verify
 
-    bucket.location_type.must_equal "multi-region"
+    _(bucket.location_type).must_equal "multi-region"
   end
 
   it "locks its retention policy with user_project set to true" do

--- a/google-cloud-storage/test/google/cloud/storage/bucket_notification_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_notification_test.rb
@@ -44,14 +44,14 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
 
     mock.verify
 
-    notification.wont_be_nil
-    notification.id.must_equal notification_id
-    notification.custom_attrs.must_equal custom_attrs
-    notification.event_types.must_equal event_types
-    notification.prefix.must_equal filename_prefix
-    notification.payload.must_equal payload
-    notification.topic.must_equal topic_name_full_path
-    notification.user_project.must_be :nil?
+    _(notification).wont_be_nil
+    _(notification.id).must_equal notification_id
+    _(notification.custom_attrs).must_equal custom_attrs
+    _(notification.event_types).must_equal event_types
+    _(notification.prefix).must_equal filename_prefix
+    _(notification.payload).must_equal payload
+    _(notification.topic).must_equal topic_name_full_path
+    _(notification.user_project).must_be :nil?
   end
 
   it "creates a notification with a boolean payload" do
@@ -68,7 +68,7 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
 
     mock.verify
 
-    notification.payload.must_equal "JSON_API_V1"
+    _(notification.payload).must_equal "JSON_API_V1"
   end
 
   it "creates a notification with a array of symbols event type" do
@@ -85,7 +85,7 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
 
     mock.verify
 
-    notification.event_types.must_equal event_types
+    _(notification.event_types).must_equal event_types
   end
 
   it "creates a notification with a single symbol event type" do
@@ -102,7 +102,7 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
 
     mock.verify
 
-    notification.event_types.must_equal event_types
+    _(notification.event_types).must_equal event_types
   end
 
   it "creates a notification with new_notification alias" do
@@ -128,7 +128,7 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
 
     mock.verify
 
-    notification.user_project.must_equal true
+    _(notification.user_project).must_equal true
   end
 
   it "lists notifications" do
@@ -144,10 +144,10 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
 
     mock.verify
 
-    notifications.size.must_equal num_notifications
+    _(notifications.size).must_equal num_notifications
     notifications.each do |notification|
-      notification.must_be_kind_of Google::Cloud::Storage::Notification
-      notification.user_project.must_be :nil?
+      _(notification).must_be_kind_of Google::Cloud::Storage::Notification
+      _(notification.user_project).must_be :nil?
     end
   end
 
@@ -175,10 +175,10 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
 
     mock.verify
 
-    notifications.size.must_equal num_notifications
+    _(notifications.size).must_equal num_notifications
     notifications.each do |notification|
-      notification.must_be_kind_of Google::Cloud::Storage::Notification
-      notification.user_project.must_equal true
+      _(notification).must_be_kind_of Google::Cloud::Storage::Notification
+      _(notification.user_project).must_equal true
     end
   end
 
@@ -195,13 +195,13 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
 
     mock.verify
 
-    notification.id.must_equal notification_id
-    notification.custom_attrs.must_equal custom_attrs
-    notification.event_types.must_equal event_types
-    notification.prefix.must_equal filename_prefix
-    notification.payload.must_equal payload
-    notification.topic.must_equal topic_name_full_path
-    notification.user_project.must_be :nil?
+    _(notification.id).must_equal notification_id
+    _(notification.custom_attrs).must_equal custom_attrs
+    _(notification.event_types).must_equal event_types
+    _(notification.prefix).must_equal filename_prefix
+    _(notification.payload).must_equal payload
+    _(notification.topic).must_equal topic_name_full_path
+    _(notification.user_project).must_be :nil?
   end
 
   it "finds a notification with find_notification alias" do
@@ -231,7 +231,7 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
 
     mock.verify
 
-    notification.user_project.must_equal true
+    _(notification.user_project).must_equal true
   end
 
   def minimal_notification_gapi

--- a/google-cloud-storage/test/google/cloud/storage/bucket_post_object_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_post_object_test.rb
@@ -45,10 +45,10 @@ describe Google::Cloud::Storage::Bucket, :post_object, :mock_storage do
 
       signed_post = bucket.post_object file_path, policy: policy
 
-      signed_post.url.must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
-      signed_post.fields[:GoogleAccessId].must_equal "native_client_email"
-      signed_post.fields[:signature].must_equal Base64.strict_encode64("native-signature").delete("\n")
-      signed_post.fields[:key].must_equal [bucket_name, file_path_encoded].join("/")
+      _(signed_post.url).must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
+      _(signed_post.fields[:GoogleAccessId]).must_equal "native_client_email"
+      _(signed_post.fields[:signature]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+      _(signed_post.fields[:key]).must_equal [bucket_name, file_path_encoded].join("/")
 
       signing_key_mock.verify
     end
@@ -65,10 +65,10 @@ describe Google::Cloud::Storage::Bucket, :post_object, :mock_storage do
 
     signed_post = bucket.post_object file_path
 
-    signed_post.url.must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
-    signed_post.fields[:GoogleAccessId].must_equal "native_client_email"
-    signed_post.fields[:signature].must_equal Base64.strict_encode64("native-signature").delete("\n")
-    signed_post.fields[:key].must_equal [bucket_name, file_path_encoded].join("/")
+    _(signed_post.url).must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
+    _(signed_post.fields[:GoogleAccessId]).must_equal "native_client_email"
+    _(signed_post.fields[:signature]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+    _(signed_post.fields[:key]).must_equal [bucket_name, file_path_encoded].join("/")
 
     signing_key_mock.verify
   end
@@ -86,10 +86,10 @@ describe Google::Cloud::Storage::Bucket, :post_object, :mock_storage do
 
     signed_post = bucket.post_object file_path_special_variable
 
-    signed_post.url.must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
-    signed_post.fields[:GoogleAccessId].must_equal "native_client_email"
-    signed_post.fields[:signature].must_equal Base64.strict_encode64("native-signature").delete("\n")
-    signed_post.fields[:key].must_equal [bucket_name, file_path_special_variable].join("/")
+    _(signed_post.url).must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
+    _(signed_post.fields[:GoogleAccessId]).must_equal "native_client_email"
+    _(signed_post.fields[:signature]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+    _(signed_post.fields[:key]).must_equal [bucket_name, file_path_special_variable].join("/")
 
     signing_key_mock.verify
   end

--- a/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v2_test.rb
@@ -31,10 +31,10 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
       signed_url = bucket.signed_url
 
       signed_uri = URI(signed_url)
-      signed_uri.path.must_equal "/bucket/"
+      _(signed_uri.path).must_equal "/bucket/"
       signed_url_params = CGI::parse(signed_uri.query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -50,8 +50,8 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
       signed_url = bucket.signed_url file_path
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -69,8 +69,8 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
                                                 signing_key: signing_key_mock
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["option_issuer"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["option_issuer"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -90,8 +90,8 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
                                                   private_key: "option_private_key"
 
         signed_url_params = CGI::parse(URI(signed_url).query)
-        signed_url_params["GoogleAccessId"].must_equal ["option_client_email"]
-        signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+        _(signed_url_params["GoogleAccessId"]).must_equal ["option_client_email"]
+        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
 
       end
 
@@ -110,8 +110,8 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
                                                            "X-Goog-ACL" => "public-read" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -148,11 +148,11 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
         signed_url = bucket.signed_url file_path
 
         signed_uri = URI signed_url
-        signed_uri.path.must_equal "/bucket/hello%20world.txt"
+        _(signed_uri.path).must_equal "/bucket/hello%20world.txt"
 
         signed_url_params = CGI::parse signed_uri.query
-        signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-        signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+        _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
         signing_key_mock.verify
       end
@@ -170,9 +170,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
                                      query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      signed_url_params["response-content-disposition"].must_equal ["attachment; filename=\"google-cloud.png\""]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"google-cloud.png\""]
 
       signing_key_mock.verify
     end
@@ -189,9 +189,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
                                       query: { disposition: :inline }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      signed_url_params["disposition"].must_equal ["inline"]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["disposition"]).must_equal ["inline"]
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v4_test.rb
@@ -31,14 +31,14 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
       signed_url = bucket.signed_url version: :v4
 
       signed_uri = URI(signed_url)
-      signed_uri.path.must_equal "/bucket"
+      _(signed_uri.path).must_equal "/bucket"
       signed_url_params = CGI::parse(signed_uri.query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -54,12 +54,12 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
       signed_url = bucket.signed_url file_path, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -78,12 +78,12 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
                                      signing_key: signing_key_mock, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6f7074696f6e2d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -104,12 +104,12 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
                                        private_key: "option_private_key", version: :v4
 
         signed_url_params = CGI::parse(URI(signed_url).query)
-        signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-        signed_url_params["X-Goog-Credential"].must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
-        signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-        signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-        signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-        signed_url_params["X-Goog-Signature"].must_equal  ["6f7074696f6e2d7369676e6174757265"]
+        _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+        _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
+        _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+        _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+        _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
 
       end
 
@@ -129,12 +129,12 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
                                                 "X-Goog-ACL" => "public-read" }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -169,12 +169,12 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
                                      query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
       signing_key_mock.verify
     end
   end
@@ -190,12 +190,12 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
                                      query: { disposition: :inline }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -52,42 +52,42 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   let(:bucket_complete) { Google::Cloud::Storage::Bucket.from_gapi bucket_complete_gapi, storage.service }
 
   it "knows its attributes" do
-    bucket_complete.id.must_equal bucket_complete_hash["id"]
-    bucket_complete.name.must_equal bucket_name
-    bucket_complete.created_at.must_be_within_delta bucket_complete_hash["timeCreated"].to_datetime
-    bucket_complete.api_url.must_equal bucket_url
-    bucket_complete.location.must_equal bucket_location
-    bucket_complete.location_type.must_equal bucket_location_type
-    bucket_complete.logging_bucket.must_equal bucket_logging_bucket
-    bucket_complete.logging_prefix.must_equal bucket_logging_prefix
-    bucket_complete.storage_class.must_equal bucket_storage_class
-    bucket_complete.versioning?.must_equal bucket_versioning
-    bucket_complete.website_main.must_equal bucket_website_main
-    bucket_complete.website_404.must_equal bucket_website_404
-    bucket_complete.requester_pays.must_equal bucket_requester_pays
+    _(bucket_complete.id).must_equal bucket_complete_hash["id"]
+    _(bucket_complete.name).must_equal bucket_name
+    _(bucket_complete.created_at).must_be_within_delta bucket_complete_hash["timeCreated"].to_datetime
+    _(bucket_complete.api_url).must_equal bucket_url
+    _(bucket_complete.location).must_equal bucket_location
+    _(bucket_complete.location_type).must_equal bucket_location_type
+    _(bucket_complete.logging_bucket).must_equal bucket_logging_bucket
+    _(bucket_complete.logging_prefix).must_equal bucket_logging_prefix
+    _(bucket_complete.storage_class).must_equal bucket_storage_class
+    _(bucket_complete.versioning?).must_equal bucket_versioning
+    _(bucket_complete.website_main).must_equal bucket_website_main
+    _(bucket_complete.website_404).must_equal bucket_website_404
+    _(bucket_complete.requester_pays).must_equal bucket_requester_pays
   end
 
   it "knows its labels" do
     # mostly emtpy bucket has a labels hash
-    bucket.labels.must_equal Hash.new
+    _(bucket.labels).must_equal Hash.new
     # a complete bucket has a labels hash with the correct values
-    bucket_complete.labels.must_equal bucket_labels
+    _(bucket_complete.labels).must_equal bucket_labels
   end
 
   it "returns frozen cors" do
     bucket_complete.cors.each do |cors|
-      cors.must_be_kind_of Google::Cloud::Storage::Bucket::Cors::Rule
-      cors.frozen?.must_equal true
+      _(cors).must_be_kind_of Google::Cloud::Storage::Bucket::Cors::Rule
+      _(cors.frozen?).must_equal true
     end
-    bucket_complete.cors.frozen?.must_equal true
+    _(bucket_complete.cors.frozen?).must_equal true
   end
 
   it "returns frozen lifecycle (Object Lifecycle Management)" do
     bucket_complete.lifecycle.each do |r|
-      r.must_be_kind_of Google::Cloud::Storage::Bucket::Lifecycle::Rule
-      r.frozen?.must_equal true
+      _(r).must_be_kind_of Google::Cloud::Storage::Bucket::Lifecycle::Rule
+      _(r.frozen?).must_equal true
     end
-    bucket_complete.lifecycle.frozen?.must_equal true
+    _(bucket_complete.lifecycle.frozen?).must_equal true
   end
 
   it "can delete itself" do
@@ -188,7 +188,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     new_file_contents = StringIO.new "Hello world"
 
     err = expect { bucket.create_file new_file_contents }.must_raise ArgumentError
-    err.message.must_equal "must provide path"
+    _(err.message).must_equal "must provide path"
   end
 
   it "creates a file with predefined acl" do
@@ -371,7 +371,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
       bucket_user_project.service.mocked_service = mock
 
       created = bucket_user_project.create_file tmpfile, new_file_name
-      created.user_project.must_equal true
+      _(created.user_project).must_equal true
 
       mock.verify
     end
@@ -385,7 +385,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     err = expect {
       bucket.create_file bad_file_path
     }.must_raise ArgumentError
-    err.message.must_match bad_file_path
+    _(err.message).must_match bad_file_path
   end
 
   it "lists files" do
@@ -401,10 +401,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.size.must_equal num_files
+    _(files.size).must_equal num_files
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -421,10 +421,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.size.must_equal num_files
+    _(files.size).must_equal num_files
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -439,13 +439,13 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 3
-    files.prefixes.wont_be :empty?
-    files.prefixes.must_include "/prefix/path1/"
-    files.prefixes.must_include "/prefix/path2/"
+    _(files.count).must_equal 3
+    _(files.prefixes).wont_be :empty?
+    _(files.prefixes).must_include "/prefix/path1/"
+    _(files.prefixes).must_include "/prefix/path2/"
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -460,13 +460,13 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 3
-    files.prefixes.wont_be :empty?
-    files.prefixes.must_include "/prefix/path1/"
-    files.prefixes.must_include "/prefix/path2/"
+    _(files.count).must_equal 3
+    _(files.prefixes).wont_be :empty?
+    _(files.prefixes).must_include "/prefix/path1/"
+    _(files.prefixes).must_include "/prefix/path2/"
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -481,12 +481,12 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 3
-    files.token.wont_be :nil?
-    files.token.must_equal "next_page_token"
+    _(files.count).must_equal 3
+    _(files.token).wont_be :nil?
+    _(files.token).must_equal "next_page_token"
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -501,10 +501,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 3
+    _(files.count).must_equal 3
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -521,10 +521,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.size.must_equal num_files
+    _(files.size).must_equal num_files
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_equal true
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_equal true
     end
   end
 
@@ -542,19 +542,19 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    first_files.count.must_equal 3
-    first_files.token.wont_be :nil?
-    first_files.token.must_equal "next_page_token"
+    _(first_files.count).must_equal 3
+    _(first_files.token).wont_be :nil?
+    _(first_files.token).must_equal "next_page_token"
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
 
-    second_files.count.must_equal 2
-    second_files.token.must_be :nil?
+    _(second_files.count).must_equal 2
+    _(second_files.token).must_be :nil?
     second_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -572,18 +572,18 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    first_files.count.must_equal 3
-    first_files.next?.must_equal true
+    _(first_files.count).must_equal 3
+    _(first_files.next?).must_equal true
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
 
-    second_files.count.must_equal 2
-    second_files.next?.must_equal false
+    _(second_files.count).must_equal 2
+    _(second_files.next?).must_equal false
     second_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -601,18 +601,18 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    first_files.count.must_equal 3
-    first_files.next?.must_equal true
+    _(first_files.count).must_equal 3
+    _(first_files.next?).must_equal true
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
 
-    second_files.count.must_equal 2
-    second_files.next?.must_equal false
+    _(second_files.count).must_equal 2
+    _(second_files.next?).must_equal false
     second_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -630,18 +630,18 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    first_files.count.must_equal 3
-    first_files.next?.must_equal true
+    _(first_files.count).must_equal 3
+    _(first_files.next?).must_equal true
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
 
-    second_files.count.must_equal 2
-    second_files.next?.must_equal false
+    _(second_files.count).must_equal 2
+    _(second_files.next?).must_equal false
     second_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -659,18 +659,18 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    first_files.count.must_equal 3
-    first_files.next?.must_equal true
+    _(first_files.count).must_equal 3
+    _(first_files.next?).must_equal true
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
 
-    second_files.count.must_equal 2
-    second_files.next?.must_equal false
+    _(second_files.count).must_equal 2
+    _(second_files.next?).must_equal false
     second_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -688,18 +688,18 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    first_files.count.must_equal 3
-    first_files.next?.must_equal true
+    _(first_files.count).must_equal 3
+    _(first_files.next?).must_equal true
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
 
-    second_files.count.must_equal 2
-    second_files.next?.must_equal false
+    _(second_files.count).must_equal 2
+    _(second_files.next?).must_equal false
     second_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -717,19 +717,19 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    first_files.count.must_equal 3
-    first_files.token.wont_be :nil?
-    first_files.token.must_equal "next_page_token"
+    _(first_files.count).must_equal 3
+    _(first_files.token).wont_be :nil?
+    _(first_files.token).must_equal "next_page_token"
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_equal true
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_equal true
     end
 
-    second_files.count.must_equal 2
-    second_files.token.must_be :nil?
+    _(second_files.count).must_equal 2
+    _(second_files.token).must_be :nil?
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_equal true
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_equal true
     end
   end
 
@@ -746,10 +746,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 5
+    _(files.count).must_equal 5
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -766,10 +766,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 5
+    _(files.count).must_equal 5
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -786,10 +786,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 5
+    _(files.count).must_equal 5
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -806,10 +806,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 5
+    _(files.count).must_equal 5
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -826,10 +826,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 5
+    _(files.count).must_equal 5
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -846,10 +846,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 5
+    _(files.count).must_equal 5
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -866,10 +866,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 6
+    _(files.count).must_equal 6
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -886,10 +886,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 6
+    _(files.count).must_equal 6
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_equal true
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_equal true
     end
   end
 
@@ -906,9 +906,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.user_project.must_be :nil?
-    file.wont_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.user_project).must_be :nil?
+    _(file).wont_be :lazy?
   end
 
   it "finds a file with find_file alias" do
@@ -924,9 +924,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.user_project.must_be :nil?
-    file.wont_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.user_project).must_be :nil?
+    _(file).wont_be :lazy?
   end
 
   it "finds a file with generation" do
@@ -943,9 +943,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.user_project.must_be :nil?
-    file.wont_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.user_project).must_be :nil?
+    _(file).wont_be :lazy?
   end
 
   it "finds a file with user_project set to true" do
@@ -961,9 +961,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.user_project.must_equal true
-    file.wont_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.user_project).must_equal true
+    _(file).wont_be :lazy?
   end
 
   it "finds a file with skip_lookup" do
@@ -977,10 +977,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.generation.must_be :nil?
-    file.user_project.must_be :nil?
-    file.must_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.generation).must_be :nil?
+    _(file.user_project).must_be :nil?
+    _(file).must_be :lazy?
   end
 
   it "finds a file with skip_lookup and find_file alias" do
@@ -994,10 +994,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.generation.must_be :nil?
-    file.user_project.must_be :nil?
-    file.must_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.generation).must_be :nil?
+    _(file.user_project).must_be :nil?
+    _(file).must_be :lazy?
   end
 
   it "finds a file with generation and skip_lookup" do
@@ -1012,10 +1012,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.generation.must_equal generation
-    file.user_project.must_be :nil?
-    file.must_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.generation).must_equal generation
+    _(file.user_project).must_be :nil?
+    _(file).must_be :lazy?
   end
 
   it "finds a file with user_project and skip_lookup set to true" do
@@ -1029,10 +1029,10 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.generation.must_be :nil?
-    file.user_project.must_equal true
-    file.must_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.generation).must_be :nil?
+    _(file.user_project).must_equal true
+    _(file).must_be :lazy?
   end
 
   it "can reload itself" do
@@ -1048,11 +1048,11 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     bucket.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name
-    bucket.api_url.must_equal "https://www.googleapis.com/storage/v1/b/#{bucket_name}"
+    _(bucket.api_url).must_equal "https://www.googleapis.com/storage/v1/b/#{bucket_name}"
 
     bucket.reload!
 
-    bucket.api_url.must_equal "#{new_url_root}/b/#{bucket_name}"
+    _(bucket.api_url).must_equal "#{new_url_root}/b/#{bucket_name}"
     mock.verify
   end
 
@@ -1069,11 +1069,11 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     bucket_user_project.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, user_project: true
-    bucket.api_url.must_equal "https://www.googleapis.com/storage/v1/b/#{bucket_name}"
+    _(bucket.api_url).must_equal "https://www.googleapis.com/storage/v1/b/#{bucket_name}"
 
     bucket.reload!
 
-    bucket.api_url.must_equal "#{new_url_root}/b/#{bucket_name}"
+    _(bucket.api_url).must_equal "#{new_url_root}/b/#{bucket_name}"
     mock.verify
   end
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_uniform_bucket_level_access_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_uniform_bucket_level_access_test.rb
@@ -22,8 +22,8 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :mock_sto
   let(:bucket_user_project) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_project: true }
 
   it "knows its uniform_bucket_level_access attrs" do
-    bucket.uniform_bucket_level_access?.must_equal false
-    bucket.uniform_bucket_level_access_locked_at.must_be :nil?
+    _(bucket.uniform_bucket_level_access?).must_equal false
+    _(bucket.uniform_bucket_level_access_locked_at).must_be :nil?
   end
 
   it "updates its uniform_bucket_level_access" do
@@ -32,12 +32,12 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :mock_sto
                 [bucket_name, patch_bucket_gapi(uniform_bucket_level_access: true), predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     bucket.service.mocked_service = mock
 
-    bucket.uniform_bucket_level_access?.must_equal false
+    _(bucket.uniform_bucket_level_access?).must_equal false
 
     bucket.uniform_bucket_level_access = true
 
-    bucket.uniform_bucket_level_access?.must_equal true
-    bucket.uniform_bucket_level_access_locked_at.must_be_kind_of DateTime
+    _(bucket.uniform_bucket_level_access?).must_equal true
+    _(bucket.uniform_bucket_level_access_locked_at).must_be_kind_of DateTime
 
     mock.verify
   end
@@ -49,19 +49,19 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :mock_sto
 
     bucket_user_project.service.mocked_service = mock
 
-    bucket_user_project.uniform_bucket_level_access?.must_equal false
+    _(bucket_user_project.uniform_bucket_level_access?).must_equal false
 
     bucket_user_project.uniform_bucket_level_access = true
 
-    bucket_user_project.uniform_bucket_level_access?.must_equal true
-    bucket_user_project.uniform_bucket_level_access_locked_at.must_be_kind_of DateTime
+    _(bucket_user_project.uniform_bucket_level_access?).must_equal true
+    _(bucket_user_project.uniform_bucket_level_access_locked_at).must_be_kind_of DateTime
 
     mock.verify
   end
 
   it "knows its DEPRECATED policy_only attrs" do
-    bucket.policy_only?.must_equal false
-    bucket.policy_only_locked_at.must_be :nil?
+    _(bucket.policy_only?).must_equal false
+    _(bucket.policy_only_locked_at).must_be :nil?
   end
 
   it "updates its DEPRECATED policy_only" do
@@ -70,12 +70,12 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :mock_sto
                 [bucket_name, patch_bucket_gapi(uniform_bucket_level_access: true), predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     bucket.service.mocked_service = mock
 
-    bucket.policy_only?.must_equal false
+    _(bucket.policy_only?).must_equal false
 
     bucket.policy_only = true
 
-    bucket.policy_only?.must_equal true
-    bucket.policy_only_locked_at.must_be_kind_of DateTime
+    _(bucket.policy_only?).must_equal true
+    _(bucket.policy_only_locked_at).must_be_kind_of DateTime
 
     mock.verify
   end
@@ -87,12 +87,12 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :mock_sto
 
     bucket_user_project.service.mocked_service = mock
 
-    bucket_user_project.policy_only?.must_equal false
+    _(bucket_user_project.policy_only?).must_equal false
 
     bucket_user_project.policy_only = true
 
-    bucket_user_project.policy_only?.must_equal true
-    bucket_user_project.policy_only_locked_at.must_be_kind_of DateTime
+    _(bucket_user_project.policy_only?).must_equal true
+    _(bucket_user_project.policy_only_locked_at).must_be_kind_of DateTime
 
     mock.verify
   end

--- a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
@@ -63,9 +63,9 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.wont_be :versioning?
+    _(bucket).wont_be :versioning?
     bucket.versioning = true
-    bucket.must_be :versioning?
+    _(bucket).must_be :versioning?
 
     mock.verify
   end
@@ -82,9 +82,9 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     bucket.service.mocked_service = mock
     bucket.user_project = true
 
-    bucket.wont_be :versioning?
+    _(bucket).wont_be :versioning?
     bucket.versioning = true
-    bucket.must_be :versioning?
+    _(bucket).must_be :versioning?
 
     mock.verify
   end
@@ -100,9 +100,9 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.logging_bucket.must_be :nil?
+    _(bucket.logging_bucket).must_be :nil?
     bucket.logging_bucket = bucket_logging_bucket
-    bucket.logging_bucket.must_equal bucket_logging_bucket
+    _(bucket.logging_bucket).must_equal bucket_logging_bucket
 
     mock.verify
   end
@@ -118,9 +118,9 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.logging_prefix.must_be :nil?
+    _(bucket.logging_prefix).must_be :nil?
     bucket.logging_prefix = bucket_logging_prefix
-    bucket.logging_prefix.must_equal bucket_logging_prefix
+    _(bucket.logging_prefix).must_equal bucket_logging_prefix
 
     mock.verify
   end
@@ -136,17 +136,17 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.logging_bucket.must_be :nil?
-    bucket.logging_prefix.must_be :nil?
+    _(bucket.logging_bucket).must_be :nil?
+    _(bucket.logging_prefix).must_be :nil?
 
     bucket.update do |b|
       b.logging_bucket = bucket_logging_bucket
       b.logging_prefix = bucket_logging_prefix
     end
 
-    bucket.logging_bucket.must_equal bucket_logging_bucket
-    bucket.logging_prefix.must_equal bucket_logging_prefix
-    bucket.location_type.must_equal "multi-region"
+    _(bucket.logging_bucket).must_equal bucket_logging_bucket
+    _(bucket.logging_prefix).must_equal bucket_logging_prefix
+    _(bucket.location_type).must_equal "multi-region"
 
     mock.verify
   end
@@ -161,9 +161,9 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.storage_class.must_equal bucket_storage_class
+    _(bucket.storage_class).must_equal bucket_storage_class
     bucket.storage_class = :nearline
-    bucket.storage_class.must_equal "NEARLINE"
+    _(bucket.storage_class).must_equal "NEARLINE"
 
     mock.verify
   end
@@ -179,9 +179,9 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.website_main.must_be :nil?
+    _(bucket.website_main).must_be :nil?
     bucket.website_main = bucket_website_main
-    bucket.website_main.must_equal bucket_website_main
+    _(bucket.website_main).must_equal bucket_website_main
 
     mock.verify
   end
@@ -197,9 +197,9 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.website_404.must_be :nil?
+    _(bucket.website_404).must_be :nil?
     bucket.website_404 = bucket_website_404
-    bucket.website_404.must_equal bucket_website_404
+    _(bucket.website_404).must_equal bucket_website_404
 
     mock.verify
   end
@@ -215,16 +215,16 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.website_main.must_be :nil?
-    bucket.website_404.must_be :nil?
+    _(bucket.website_main).must_be :nil?
+    _(bucket.website_404).must_be :nil?
 
     bucket.update do |b|
       b.website_main = bucket_website_main
       b.website_404 = bucket_website_404
     end
 
-    bucket.website_main.must_equal bucket_website_main
-    bucket.website_404.must_equal bucket_website_404
+    _(bucket.website_main).must_equal bucket_website_main
+    _(bucket.website_404).must_equal bucket_website_404
 
     mock.verify
   end
@@ -240,15 +240,15 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.requester_pays.must_be :nil?
+    _(bucket.requester_pays).must_be :nil?
     bucket.requester_pays = bucket_requester_pays
-    bucket.requester_pays.must_equal bucket_requester_pays
+    _(bucket.requester_pays).must_equal bucket_requester_pays
 
     mock.verify
   end
 
   it "cannot modify its labels" do
-    bucket.labels.must_equal Hash.new
+    _(bucket.labels).must_equal Hash.new
     assert_raises do
       bucket.labels["foo"] = "bar"
     end
@@ -266,9 +266,9 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.labels.must_equal Hash.new
+    _(bucket.labels).must_equal Hash.new
     bucket.labels = new_labels
-    bucket.labels.must_equal new_labels
+    _(bucket.labels).must_equal new_labels
 
     mock.verify
   end
@@ -288,13 +288,13 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.wont_be :versioning?
-    bucket.logging_bucket.must_be :nil?
-    bucket.logging_prefix.must_be :nil?
-    bucket.website_main.must_be :nil?
-    bucket.website_404.must_be :nil?
-    bucket.requester_pays.must_be :nil?
-    bucket.labels.must_equal Hash.new
+    _(bucket).wont_be :versioning?
+    _(bucket.logging_bucket).must_be :nil?
+    _(bucket.logging_prefix).must_be :nil?
+    _(bucket.website_main).must_be :nil?
+    _(bucket.website_404).must_be :nil?
+    _(bucket.requester_pays).must_be :nil?
+    _(bucket.labels).must_equal Hash.new
 
     bucket.update do |b|
       b.versioning = true
@@ -307,14 +307,14 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       b.labels["env"] = "production"
     end
 
-    bucket.versioning?.must_equal true
-    bucket.logging_bucket.must_equal bucket_logging_bucket
-    bucket.logging_prefix.must_equal bucket_logging_prefix
-    bucket.storage_class.must_equal "NEARLINE"
-    bucket.website_main.must_equal bucket_website_main
-    bucket.website_404.must_equal bucket_website_404
-    bucket.requester_pays.must_equal bucket_requester_pays
-    bucket.labels.must_equal({ "env" => "production" })
+    _(bucket.versioning?).must_equal true
+    _(bucket.logging_bucket).must_equal bucket_logging_bucket
+    _(bucket.logging_prefix).must_equal bucket_logging_prefix
+    _(bucket.storage_class).must_equal "NEARLINE"
+    _(bucket.website_main).must_equal bucket_website_main
+    _(bucket.website_404).must_equal bucket_website_404
+    _(bucket.requester_pays).must_equal bucket_requester_pays
+    _(bucket.labels).must_equal({ "env" => "production" })
 
     mock.verify
   end
@@ -330,7 +330,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
         [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
       bucket.service.mocked_service = mock
 
-      bucket.cors.must_equal []
+      _(bucket.cors).must_equal []
       bucket.cors do |c|
         c.add_rule ["http://example.org", "https://example.org"],
                    "*",
@@ -345,7 +345,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       err = expect {
         bucket_with_cors.cors.first.max_age = 600
       }.must_raise RuntimeError
-      err.message.must_match "can't modify frozen"
+      _(err.message).must_match "can't modify frozen"
     end
 
     it "can update cors inside of a block" do
@@ -364,12 +364,12 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
         [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
       bucket_with_cors.service.mocked_service = mock
 
-      bucket_with_cors.cors.must_be :frozen?
-      bucket_with_cors.cors.class.must_equal Google::Cloud::Storage::Bucket::Cors
+      _(bucket_with_cors.cors).must_be :frozen?
+      _(bucket_with_cors.cors.class).must_equal Google::Cloud::Storage::Bucket::Cors
       bucket_with_cors.update do |b|
-        b.cors.wont_be :frozen?
-        b.cors.first.class.must_equal Google::Cloud::Storage::Bucket::Cors::Rule
-        b.cors.first.wont_be :frozen?
+        _(b.cors).wont_be :frozen?
+        _(b.cors.first.class).must_equal Google::Cloud::Storage::Bucket::Cors::Rule
+        _(b.cors.first).wont_be :frozen?
         b.cors.first.max_age = 600
         b.cors.first.origin << "https://example.com"
         b.cors.first.methods = ["PUT"]
@@ -446,8 +446,8 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
                    "*",
                    headers: "X-Another-Custom-Header"
       end
-      returned_cors.frozen?.must_equal true
-      returned_cors.first.frozen?.must_equal true
+      _(returned_cors.frozen?).must_equal true
+      _(returned_cors.first.frozen?).must_equal true
 
       mock.verify
     end
@@ -465,8 +465,8 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
         [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
       bucket.service.mocked_service = mock
 
-      bucket_with_cors.cors.size.must_equal 1
-      bucket_with_cors.cors[0].origin.must_equal ["http://example.org", "https://example.org"]
+      _(bucket_with_cors.cors.size).must_equal 1
+      _(bucket_with_cors.cors[0].origin).must_equal ["http://example.org", "https://example.org"]
       bucket_with_cors.cors do |c|
         c.add_rule "http://example.net", "GET"
         c.add_rule "http://example.net", "POST"
@@ -491,7 +491,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
                   [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
       bucket.service.mocked_service = mock
 
-      bucket.lifecycle.must_equal []
+      _(bucket.lifecycle).must_equal []
       lifecycle = bucket.lifecycle do |l|
         l.add_set_storage_class_rule "NEARLINE",
                                      age: 32,
@@ -505,20 +505,20 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
 
       rule = lifecycle.first
 
-      rule.action.must_equal "SetStorageClass"
-      rule.storage_class.must_equal "NEARLINE"
-      rule.age.must_equal 32
-      rule.created_before.must_equal bucket_lifecycle_created_before
-      rule.is_live.must_equal true
-      rule.matches_storage_class.must_equal ["STANDARD"]
-      rule.num_newer_versions.must_equal 3
+      _(rule.action).must_equal "SetStorageClass"
+      _(rule.storage_class).must_equal "NEARLINE"
+      _(rule.age).must_equal 32
+      _(rule.created_before).must_equal bucket_lifecycle_created_before
+      _(rule.is_live).must_equal true
+      _(rule.matches_storage_class).must_equal ["STANDARD"]
+      _(rule.num_newer_versions).must_equal 3
     end
 
     it "can't update lifecycle outside of a block" do
       err = expect {
         bucket_with_cors.lifecycle.first.age = 600
       }.must_raise RuntimeError
-      err.message.must_match "can't modify frozen"
+      _(err.message).must_match "can't modify frozen"
     end
 
     it "can update lifecycle inside of a block" do
@@ -542,12 +542,12 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
                   [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
       bucket_with_cors.service.mocked_service = mock
 
-      bucket_with_cors.lifecycle.must_be :frozen?
-      bucket_with_cors.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
+      _(bucket_with_cors.lifecycle).must_be :frozen?
+      _(bucket_with_cors.lifecycle.class).must_equal Google::Cloud::Storage::Bucket::Lifecycle
       bucket_with_cors.update do |b|
-        b.lifecycle.wont_be :frozen?
-        b.lifecycle.first.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle::Rule
-        b.lifecycle.first.wont_be :frozen?
+        _(b.lifecycle).wont_be :frozen?
+        _(b.lifecycle.first.class).must_equal Google::Cloud::Storage::Bucket::Lifecycle::Rule
+        _(b.lifecycle.first).wont_be :frozen?
         b.lifecycle.first.storage_class = "COLDLINE"
         # Add a second rule
         b.lifecycle.add_delete_rule age: 40, is_live: false
@@ -601,8 +601,8 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
                   [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
       bucket_with_cors.service.mocked_service = mock
 
-      bucket_with_cors.lifecycle.must_be :frozen?
-      bucket_with_cors.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
+      _(bucket_with_cors.lifecycle).must_be :frozen?
+      _(bucket_with_cors.lifecycle.class).must_equal Google::Cloud::Storage::Bucket::Lifecycle
       bucket_with_cors.update do |b|
         b.lifecycle.add_delete_rule age: 40, is_live: false
         b.lifecycle.add_delete_rule is_live: false, num_newer_versions: 8
@@ -632,8 +632,8 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
                   [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
       bucket_with_cors.service.mocked_service = mock
 
-      bucket_with_cors.lifecycle.must_be :frozen?
-      bucket_with_cors.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
+      _(bucket_with_cors.lifecycle).must_be :frozen?
+      _(bucket_with_cors.lifecycle.class).must_equal Google::Cloud::Storage::Bucket::Lifecycle
       bucket_with_cors.lifecycle do |l|
         l.add_set_storage_class_rule :coldline, created_before: "2013-01-15", matches_storage_class: [:STANDARD, :nearline]  # alias: set_storage_class
         l.add_delete_rule age: 40, is_live: false

--- a/google-cloud-storage/test/google/cloud/storage/file/signer_v4/escape_characters_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file/signer_v4/escape_characters_test.rb
@@ -19,51 +19,51 @@ describe Google::Cloud::Storage::File::SignerV4, :escape_characters do
 
   it "escapes special unicode character é" do
     str = signer_v4.escape_characters "é"
-    str.must_equal '\u00e9'
+    _(str).must_equal '\u00e9'
   end
 
   it "escapes a backslash" do
     str = signer_v4.escape_characters "\\"
-    str.must_equal '\\'
+    _(str).must_equal '\\'
   end
 
   it "escapes a backspace" do
     str = signer_v4.escape_characters "\b"
-    str.must_equal '\b'
+    _(str).must_equal '\b'
   end
 
   it "escapes a form feed" do
     str = signer_v4.escape_characters "\f"
-    str.must_equal '\f'
+    _(str).must_equal '\f'
   end
 
   it "escapes a new line" do
     str = signer_v4.escape_characters "\n"
-    str.must_equal '\n'
+    _(str).must_equal '\n'
   end
 
   it "escapes a carriage return" do
     str = signer_v4.escape_characters "\r"
-    str.must_equal '\r'
+    _(str).must_equal '\r'
   end
 
   it "escapes a horizontal tab" do
     str = signer_v4.escape_characters "\t"
-    str.must_equal '\t'
+    _(str).must_equal '\t'
   end
 
   it "escapes a vertical tab" do
     str = signer_v4.escape_characters "\v"
-    str.must_equal '\v'
+    _(str).must_equal '\v'
   end
 
   it "escapes a dollar symbol" do
     str = signer_v4.escape_characters "$"
-    str.must_equal '$'
+    _(str).must_equal '$'
   end
 
   it "escapes only special characters in a string" do
     str = signer_v4.escape_characters "{\"x-goog-meta\":\"$test-object-é-meta\\data\b\f\n\r\t\v\"},"
-    str.must_equal '{"x-goog-meta":"$test-object-\u00e9-meta\\data\b\f\n\r\t\v"},'
+    _(str).must_equal '{"x-goog-meta":"$test-object-\u00e9-meta\\data\b\f\n\r\t\v"},'
   end
 end

--- a/google-cloud-storage/test/google/cloud/storage/file/signer_v4/post_object_conformance_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file/signer_v4/post_object_conformance_test.rb
@@ -49,16 +49,16 @@ class PostObjectConformanceTest < MockStorage
                                          virtual_hosted_style: (input.urlStyle == :VIRTUAL_HOSTED_STYLE),
                                          bucket_bound_hostname: bucket_bound_hostname
 
-        post_object.url.must_equal output.url
-        post_object.fields["key"].must_equal output.fields["key"]
-        post_object.fields["x-goog-algorithm"].must_equal output.fields["x-goog-algorithm"]
-        post_object.fields["x-goog-credential"].must_equal output.fields["x-goog-credential"]
-        post_object.fields["x-goog-date"].must_equal output.fields["x-goog-date"]
-        post_object.fields["policy"].must_equal output.fields["policy"]
-        post_object.fields["x-goog-signature"].must_equal output.fields["x-goog-signature"]
+        _(post_object.url).must_equal output.url
+        _(post_object.fields["key"]).must_equal output.fields["key"]
+        _(post_object.fields["x-goog-algorithm"]).must_equal output.fields["x-goog-algorithm"]
+        _(post_object.fields["x-goog-credential"]).must_equal output.fields["x-goog-credential"]
+        _(post_object.fields["x-goog-date"]).must_equal output.fields["x-goog-date"]
+        _(post_object.fields["policy"]).must_equal output.fields["policy"]
+        _(post_object.fields["x-goog-signature"]).must_equal output.fields["x-goog-signature"]
 
         fields.each_pair do |k, v|
-          post_object.fields[k].must_equal v
+          _(post_object.fields[k]).must_equal v
         end
       end
     end
@@ -83,13 +83,13 @@ class PostObjectConformanceTest < MockStorage
                                                             virtual_hosted_style: (input.urlStyle == :VIRTUAL_HOSTED_STYLE),
                                                             bucket_bound_hostname: bucket_bound_hostname
 
-        post_object.url.must_equal output.url
-        post_object.fields["key"].must_equal output.fields["key"]
-        post_object.fields["x-goog-algorithm"].must_equal output.fields["x-goog-algorithm"]
-        post_object.fields["x-goog-credential"].must_equal output.fields["x-goog-credential"]
-        post_object.fields["x-goog-date"].must_equal output.fields["x-goog-date"]
-        post_object.fields["policy"].must_equal output.fields["policy"]
-        post_object.fields["x-goog-signature"].must_equal output.fields["x-goog-signature"]
+        _(post_object.url).must_equal output.url
+        _(post_object.fields["key"]).must_equal output.fields["key"]
+        _(post_object.fields["x-goog-algorithm"]).must_equal output.fields["x-goog-algorithm"]
+        _(post_object.fields["x-goog-credential"]).must_equal output.fields["x-goog-credential"]
+        _(post_object.fields["x-goog-date"]).must_equal output.fields["x-goog-date"]
+        _(post_object.fields["policy"]).must_equal output.fields["policy"]
+        _(post_object.fields["x-goog-signature"]).must_equal output.fields["x-goog-signature"]
       end
     end
   end

--- a/google-cloud-storage/test/google/cloud/storage/file/signer_v4/signed_url_conformance_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file/signer_v4/signed_url_conformance_test.rb
@@ -44,7 +44,7 @@ class SignedUrlConformanceTest < MockStorage
         # sut
         signed_url = signer.signed_url **kwargs(test)
 
-        signed_url.must_equal test.expectedUrl
+        _(signed_url).must_equal test.expectedUrl
       end
     end
   end
@@ -56,7 +56,7 @@ class SignedUrlConformanceTest < MockStorage
         # sut
         signed_url = storage.signed_url test.bucket, test.object, **kwargs(test).merge({version: :v4})
 
-        signed_url.must_equal test.expectedUrl
+        _(signed_url).must_equal test.expectedUrl
       end
     end
   end
@@ -70,7 +70,7 @@ class SignedUrlConformanceTest < MockStorage
         # sut
         signed_url = bucket.signed_url test.object, **kwargs(test).merge({version: :v4})
 
-        signed_url.must_equal test.expectedUrl
+        _(signed_url).must_equal test.expectedUrl
       end
     end
   end
@@ -86,7 +86,7 @@ class SignedUrlConformanceTest < MockStorage
         # sut
         signed_url = file.signed_url **kwargs(test).merge({version: :v4})
 
-        signed_url.must_equal test.expectedUrl
+        _(signed_url).must_equal test.expectedUrl
       end
     end
   end

--- a/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
@@ -35,9 +35,9 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket.file file_name
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     mock.verify
   end
@@ -52,9 +52,9 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket_user_project.file file_name
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     mock.verify
   end
@@ -84,14 +84,14 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket.file file_name
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     file.acl.add_reader reader_entity
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
-    file.acl.readers.must_include reader_entity
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
+    _(file.acl.readers).must_include reader_entity
 
     mock.verify
   end
@@ -122,14 +122,14 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket.file file_name
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     file.acl.add_reader reader_entity, generation: generation
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
-    file.acl.readers.must_include reader_entity
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
+    _(file.acl.readers).must_include reader_entity
 
     mock.verify
   end
@@ -159,14 +159,14 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket_user_project.file file_name
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     file.acl.add_reader reader_entity
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
-    file.acl.readers.must_include reader_entity
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
+    _(file.acl.readers).must_include reader_entity
 
     mock.verify
   end
@@ -185,14 +185,14 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket.file file_name
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     reader_entity = file.acl.readers.first
     file.acl.delete reader_entity
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.must_be :empty?
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).must_be :empty?
 
     mock.verify
   end
@@ -212,14 +212,14 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket.file file_name
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     reader_entity = file.acl.readers.first
     file.acl.delete reader_entity, generation: generation
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.must_be :empty?
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).must_be :empty?
 
     mock.verify
   end
@@ -238,14 +238,14 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket_user_project.file file_name
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     reader_entity = file.acl.readers.first
     file.acl.delete reader_entity
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.must_be :empty?
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).must_be :empty?
 
     mock.verify
   end

--- a/google-cloud-storage/test/google/cloud/storage/file_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_signed_url_v2_test.rb
@@ -33,8 +33,8 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
       signed_url = file.signed_url
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -52,8 +52,8 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
                                    signing_key: signing_key_mock
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["option_issuer"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["option_issuer"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -73,8 +73,8 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
                                      private_key: "option_private_key"
 
         signed_url_params = CGI::parse(URI(signed_url).query)
-        signed_url_params["GoogleAccessId"].must_equal ["option_client_email"]
-        signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+        _(signed_url_params["GoogleAccessId"]).must_equal ["option_client_email"]
+        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
 
       end
 
@@ -93,8 +93,8 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
                                               "X-Goog-ACL" => "public-read" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -110,9 +110,9 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
       signed_url = file.signed_url query: { "response-content-disposition" => "attachment; filename=\"test.png\"" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      signed_url_params["response-content-disposition"].must_equal ["attachment; filename=\"test.png\""]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"test.png\""]
 
       signing_key_mock.verify
     end
@@ -149,11 +149,11 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
         signed_url = file.signed_url
 
         signed_uri = URI signed_url
-        signed_uri.path.must_equal "/bucket/hello%20world.txt"
+        _(signed_uri.path).must_equal "/bucket/hello%20world.txt"
 
         signed_url_params = CGI::parse signed_uri.query
-        signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-        signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+        _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
         signing_key_mock.verify
       end
@@ -170,9 +170,9 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
       signed_url = file.signed_url query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      signed_url_params["response-content-disposition"].must_equal ["attachment; filename=\"google-cloud.png\""]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"google-cloud.png\""]
 
       signing_key_mock.verify
     end
@@ -187,9 +187,9 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
 
       signed_url = file.signed_url query: { disposition: :inline }
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      signed_url_params["disposition"].must_equal ["inline"]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["disposition"]).must_equal ["inline"]
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/file_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_signed_url_v4_test.rb
@@ -33,12 +33,12 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
       signed_url = file.signed_url version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -55,12 +55,12 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
                                    signing_key: signing_key_mock, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6f7074696f6e2d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -80,12 +80,12 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
                                      private_key: "option_private_key", version: :v4
 
         signed_url_params = CGI::parse(URI(signed_url).query)
-        signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-        signed_url_params["X-Goog-Credential"].must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
-        signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-        signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-        signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-        signed_url_params["X-Goog-Signature"].must_equal  ["6f7074696f6e2d7369676e6174757265"]
+        _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+        _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
+        _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+        _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+        _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
 
       end
 
@@ -104,12 +104,12 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
                                               "X-Goog-ACL" => "public-read" }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -143,12 +143,12 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
       signed_url = file.signed_url query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
       signing_key_mock.verify
     end
   end
@@ -163,12 +163,12 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
       signed_url = file.signed_url query: { disposition: :inline }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -171,7 +171,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile
-      _(downloaded).must_be_kind_of File
+      _(downloaded).must_be_kind_of Tempfile
       _(tmpfile.read).must_equal data
 
       mock.verify
@@ -223,7 +223,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile, skip_decompress: true
-      _(downloaded).must_be_kind_of File
+      _(downloaded).must_be_kind_of Tempfile
       _(tmpfile.read).must_equal gzipped_data
 
       mock.verify
@@ -247,7 +247,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile.path
-      _(downloaded).must_be_kind_of File
+      _(downloaded).must_be_kind_of Tempfile
 
       mock.verify
     end
@@ -270,7 +270,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file_user_project.download tmpfile
-      _(downloaded).must_be_kind_of File
+      _(downloaded).must_be_kind_of Tempfile
 
       mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -55,34 +55,34 @@ describe Google::Cloud::Storage::File, :mock_storage do
   let(:kms_key) { "path/to/encryption_key_name" }
 
   it "knows its attributes" do
-    file.id.must_equal file_hash["id"]
-    file.name.must_equal file_hash["name"]
-    file.created_at.must_be_within_delta file_hash["timeCreated"].to_datetime
-    file.api_url.must_equal file_hash["selfLink"]
-    file.media_url.must_equal file_hash["mediaLink"]
-    file.public_url.must_equal "https://storage.googleapis.com/#{file.bucket}/#{file.name}"
-    file.public_url(protocol: :http).must_equal "http://storage.googleapis.com/#{file.bucket}/#{file.name}"
-    file.url.must_equal file.public_url
+    _(file.id).must_equal file_hash["id"]
+    _(file.name).must_equal file_hash["name"]
+    _(file.created_at).must_be_within_delta file_hash["timeCreated"].to_datetime
+    _(file.api_url).must_equal file_hash["selfLink"]
+    _(file.media_url).must_equal file_hash["mediaLink"]
+    _(file.public_url).must_equal "https://storage.googleapis.com/#{file.bucket}/#{file.name}"
+    _(file.public_url(protocol: :http)).must_equal "http://storage.googleapis.com/#{file.bucket}/#{file.name}"
+    _(file.url).must_equal file.public_url
 
-    file.md5.must_equal file_hash["md5Hash"]
-    file.crc32c.must_equal file_hash["crc32c"]
-    file.etag.must_equal file_hash["etag"]
+    _(file.md5).must_equal file_hash["md5Hash"]
+    _(file.crc32c).must_equal file_hash["crc32c"]
+    _(file.etag).must_equal file_hash["etag"]
 
-    file.cache_control.must_equal "public, max-age=3600"
-    file.content_disposition.must_equal "attachment; filename=filename.ext"
-    file.content_encoding.must_equal "gzip"
-    file.content_language.must_equal "en"
-    file.content_type.must_equal "text/plain"
+    _(file.cache_control).must_equal "public, max-age=3600"
+    _(file.content_disposition).must_equal "attachment; filename=filename.ext"
+    _(file.content_encoding).must_equal "gzip"
+    _(file.content_language).must_equal "en"
+    _(file.content_type).must_equal "text/plain"
 
-    file.metadata.must_be_kind_of Hash
-    file.metadata.size.must_equal 2
-    file.metadata.frozen?.must_equal true
-    file.metadata["player"].must_equal "Alice"
-    file.metadata["score"].must_equal "101"
+    _(file.metadata).must_be_kind_of Hash
+    _(file.metadata.size).must_equal 2
+    _(file.metadata.frozen?).must_equal true
+    _(file.metadata["player"]).must_equal "Alice"
+    _(file.metadata["score"]).must_equal "101"
 
-    file.temporary_hold?.must_equal true
-    file.event_based_hold?.must_equal true
-    file.retention_expires_at.must_be_within_delta Time.now.to_datetime
+    _(file.temporary_hold?).must_equal true
+    _(file.event_based_hold?).must_equal true
+    _(file.retention_expires_at).must_be_within_delta Time.now.to_datetime
   end
 
   it "can delete itself" do
@@ -102,7 +102,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.generation.must_equal 1234567890
+    _(file.generation).must_equal 1234567890
     file.delete generation: true
 
     mock.verify
@@ -171,8 +171,8 @@ describe Google::Cloud::Storage::File, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile
-      downloaded.must_be_kind_of File
-      tmpfile.read.must_equal data
+      _(downloaded).must_be_kind_of File
+      _(tmpfile.read).must_equal data
 
       mock.verify
     end
@@ -197,8 +197,8 @@ describe Google::Cloud::Storage::File, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile
-      downloaded.must_be_kind_of File
-      tmpfile.read.must_equal data
+      _(downloaded).must_be_kind_of File
+      _(tmpfile.read).must_equal data
 
       mock.verify
     end
@@ -223,8 +223,8 @@ describe Google::Cloud::Storage::File, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile, skip_decompress: true
-      downloaded.must_be_kind_of File
-      tmpfile.read.must_equal gzipped_data
+      _(downloaded).must_be_kind_of File
+      _(tmpfile.read).must_equal gzipped_data
 
       mock.verify
     end
@@ -247,7 +247,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile.path
-      downloaded.must_be_kind_of File
+      _(downloaded).must_be_kind_of File
 
       mock.verify
     end
@@ -270,7 +270,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file_user_project.download tmpfile
-      downloaded.must_be_kind_of File
+      _(downloaded).must_be_kind_of File
 
       mock.verify
     end
@@ -290,8 +290,8 @@ describe Google::Cloud::Storage::File, :mock_storage do
     bucket.service.mocked_service = mock
 
     downloaded = file.download
-    downloaded.must_be_kind_of StringIO
-    downloaded.read.must_equal data
+    _(downloaded).must_be_kind_of StringIO
+    _(downloaded.read).must_equal data
 
     mock.verify
   end
@@ -310,8 +310,8 @@ describe Google::Cloud::Storage::File, :mock_storage do
     bucket.service.mocked_service = mock
 
     downloaded = file.download
-    downloaded.must_be_kind_of StringIO
-    downloaded.read.must_equal data
+    _(downloaded).must_be_kind_of StringIO
+    _(downloaded.read).must_equal data
 
     mock.verify
   end
@@ -330,8 +330,8 @@ describe Google::Cloud::Storage::File, :mock_storage do
     bucket.service.mocked_service = mock
 
     downloaded = file.download skip_decompress: true
-    downloaded.must_be_kind_of StringIO
-    downloaded.read.must_equal gzipped_data
+    _(downloaded).must_be_kind_of StringIO
+    _(downloaded.read).must_equal gzipped_data
 
     mock.verify
   end
@@ -350,8 +350,8 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     downloadio = StringIO.new
     downloaded = file.download downloadio
-    downloaded.must_be_kind_of StringIO
-    downloadio.must_equal downloadio # should be the same object
+    _(downloaded).must_be_kind_of StringIO
+    _(downloadio).must_equal downloadio # should be the same object
 
     mock.verify
   end
@@ -373,7 +373,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile, encryption_key: encryption_key
-      downloaded.path.must_equal tmpfile.path
+      _(downloaded.path).must_equal tmpfile.path
 
       mock.verify
     end
@@ -388,7 +388,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile, range: 3..6
-      downloaded.path.must_equal tmpfile.path
+      _(downloaded.path).must_equal tmpfile.path
 
       mock.verify
     end
@@ -403,7 +403,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile, range: 'bytes=-6'
-      downloaded.path.must_equal tmpfile.path
+      _(downloaded.path).must_equal tmpfile.path
 
       mock.verify
     end
@@ -503,8 +503,8 @@ describe Google::Cloud::Storage::File, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download verify: :crc32c
-      downloaded.must_be_kind_of StringIO
-      downloaded.read.must_equal data
+      _(downloaded).must_be_kind_of StringIO
+      _(downloaded.read).must_equal data
 
       mock.verify
     end
@@ -664,7 +664,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       file_user_project.service.mocked_service = mock
 
       copied = file_user_project.copy "new-file.ext"
-      copied.user_project.must_equal true
+      _(copied.user_project).must_equal true
 
       mock.verify
     end
@@ -769,7 +769,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       end
 
       copied = file_user_project.copy "new-file.ext"
-      copied.user_project.must_equal true
+      _(copied.user_project).must_equal true
 
       mock.verify
     end
@@ -860,7 +860,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
         f.metadata["score"] = "10"
         f.storage_class = :nearline
       end
-      copied.user_project.must_equal true
+      _(copied.user_project).must_equal true
 
       mock.verify
     end
@@ -961,7 +961,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       file_user_project.service.mocked_service = mock
 
       copied = file_user_project.copy "new-file.ext"
-      copied.user_project.must_equal true
+      _(copied.user_project).must_equal true
 
       mock.verify
     end
@@ -1068,7 +1068,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       end
 
       copied = file_user_project.copy "new-file.ext"
-      copied.user_project.must_equal true
+      _(copied.user_project).must_equal true
 
       mock.verify
     end
@@ -1159,7 +1159,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
         f.metadata["score"] = "10"
         f.storage_class = :nearline
       end
-      copied.user_project.must_equal true
+      _(copied.user_project).must_equal true
 
       mock.verify
     end
@@ -1177,7 +1177,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       file.service.mocked_service = mock
 
       updated = file.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
-      updated.name.must_equal file.name
+      _(updated.name).must_equal file.name
 
       mock.verify
     end
@@ -1193,8 +1193,8 @@ describe Google::Cloud::Storage::File, :mock_storage do
       file_user_project.service.mocked_service = mock
 
       updated = file_user_project.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
-      updated.name.must_equal file_user_project.name
-      updated.user_project.must_equal true
+      _(updated.name).must_equal file_user_project.name
+      _(updated.user_project).must_equal true
 
       mock.verify
     end
@@ -1210,7 +1210,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       file.service.mocked_service = mock
 
       updated = file.rotate new_encryption_key: encryption_key
-      updated.name.must_equal file.name
+      _(updated.name).must_equal file.name
 
       mock.verify
     end
@@ -1226,7 +1226,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       file.service.mocked_service = mock
 
       updated = file.rotate encryption_key: source_encryption_key
-      updated.name.must_equal file.name
+      _(updated.name).must_equal file.name
 
       mock.verify
     end
@@ -1241,7 +1241,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       file.service.mocked_service = mock
 
       updated = file.rotate new_kms_key: kms_key
-      updated.name.must_equal file.name
+      _(updated.name).must_equal file.name
 
       mock.verify
     end
@@ -1257,7 +1257,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       file.service.mocked_service = mock
 
       updated = file.rotate encryption_key: source_encryption_key, new_kms_key: kms_key
-      updated.name.must_equal file.name
+      _(updated.name).must_equal file.name
 
       mock.verify
     end
@@ -1281,7 +1281,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       end
 
       updated = file.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
-      updated.name.must_equal file.name
+      _(updated.name).must_equal file.name
 
       mock.verify
     end
@@ -1305,8 +1305,8 @@ describe Google::Cloud::Storage::File, :mock_storage do
       end
 
       updated = file_user_project.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
-      updated.name.must_equal file_user_project.name
-      updated.user_project.must_equal true
+      _(updated.name).must_equal file_user_project.name
+      _(updated.user_project).must_equal true
 
       mock.verify
     end
@@ -1325,9 +1325,9 @@ describe Google::Cloud::Storage::File, :mock_storage do
     file.service.mocked_service = mock
 
     file = bucket.file file_name
-    file.generation.must_equal 1234567891
+    _(file.generation).must_equal 1234567891
     file.reload!
-    file.generation.must_equal 1234567892
+    _(file.generation).must_equal 1234567892
 
     mock.verify
   end
@@ -1345,9 +1345,9 @@ describe Google::Cloud::Storage::File, :mock_storage do
     file.service.mocked_service = mock
 
     file = bucket_user_project.file file_name
-    file.generation.must_equal 1234567891
+    _(file.generation).must_equal 1234567891
     file.reload!
-    file.generation.must_equal 1234567892
+    _(file.generation).must_equal 1234567892
 
     mock.verify
   end
@@ -1370,15 +1370,15 @@ describe Google::Cloud::Storage::File, :mock_storage do
     file.service.mocked_service = mock
 
     file = bucket.file file_name
-    file.generation.must_equal 1234567894
+    _(file.generation).must_equal 1234567894
 
     generations = file.generations
-    generations.count.must_equal 4
+    _(generations.count).must_equal 4
     generations.each do |f|
-      f.must_be_kind_of Google::Cloud::Storage::File
-      f.user_project.must_be :nil?
+      _(f).must_be_kind_of Google::Cloud::Storage::File
+      _(f.user_project).must_be :nil?
     end
-    generations.map(&:generation).must_equal [1234567894, 1234567893, 1234567892, 1234567891]
+    _(generations.map(&:generation)).must_equal [1234567894, 1234567893, 1234567892, 1234567891]
 
     mock.verify
   end
@@ -1401,22 +1401,22 @@ describe Google::Cloud::Storage::File, :mock_storage do
     file.service.mocked_service = mock
 
     file = bucket_user_project.file file_name
-    file.generation.must_equal 1234567894
-    file.user_project.must_equal true
+    _(file.generation).must_equal 1234567894
+    _(file.user_project).must_equal true
 
     generations = file.generations
-    generations.count.must_equal 4
+    _(generations.count).must_equal 4
     generations.each do |f|
-      f.must_be_kind_of Google::Cloud::Storage::File
-      f.user_project.must_equal true
+      _(f).must_be_kind_of Google::Cloud::Storage::File
+      _(f.user_project).must_equal true
     end
-    generations.map(&:generation).must_equal [1234567894, 1234567893, 1234567892, 1234567891]
+    _(generations.map(&:generation)).must_equal [1234567894, 1234567893, 1234567892, 1234567891]
 
     mock.verify
   end
 
   it "knows its KMS encryption key" do
-    file.kms_key.must_equal kms_key
+    _(file.kms_key).must_equal kms_key
   end
 
   def gzip_data data

--- a/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.cache_control.must_equal "public, max-age=3600"
+    _(file.cache_control).must_equal "public, max-age=3600"
     file.cache_control = "private, max-age=0, no-cache"
 
     mock.verify
@@ -43,7 +43,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.content_disposition.must_equal "attachment; filename=filename.ext"
+    _(file.content_disposition).must_equal "attachment; filename=filename.ext"
     file.content_disposition = "inline; filename=filename.ext"
 
     mock.verify
@@ -57,7 +57,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.content_encoding.must_equal "gzip"
+    _(file.content_encoding).must_equal "gzip"
     file.content_encoding = "deflate"
 
     mock.verify
@@ -71,7 +71,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.content_language.must_equal "en"
+    _(file.content_language).must_equal "en"
     file.content_language = "de"
 
     mock.verify
@@ -85,7 +85,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.content_type.must_equal "text/plain"
+    _(file.content_type).must_equal "text/plain"
     file.content_type = "application/json"
 
     mock.verify
@@ -99,7 +99,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.metadata.must_equal({"player"=>"Alice", "score"=>"101"})
+    _(file.metadata).must_equal({"player"=>"Alice", "score"=>"101"})
     file.metadata = { "player" => "Bob", score: 10 }
 
     mock.verify
@@ -115,9 +115,9 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.storage_class.must_equal "STANDARD"
+    _(file.storage_class).must_equal "STANDARD"
     file.storage_class = :nearline
-    file.storage_class.must_equal "NEARLINE"
+    _(file.storage_class).must_equal "NEARLINE"
 
     mock.verify
   end
@@ -132,9 +132,9 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
 
     file_user_project.service.mocked_service = mock
 
-    file_user_project.storage_class.must_equal "STANDARD"
+    _(file_user_project.storage_class).must_equal "STANDARD"
     file_user_project.storage_class = :coldline
-    file_user_project.storage_class.must_equal "COLDLINE"
+    _(file_user_project.storage_class).must_equal "COLDLINE"
 
     mock.verify
   end
@@ -159,9 +159,9 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     def file.sleep *args
     end
 
-    file.storage_class.must_equal "STANDARD"
+    _(file.storage_class).must_equal "STANDARD"
     file.storage_class = :archive
-    file.storage_class.must_equal "ARCHIVE"
+    _(file.storage_class).must_equal "ARCHIVE"
 
     mock.verify
   end
@@ -186,9 +186,9 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     def file_user_project.sleep *args
     end
 
-    file_user_project.storage_class.must_equal "STANDARD"
+    _(file_user_project.storage_class).must_equal "STANDARD"
     file_user_project.storage_class = :dra
-    file_user_project.storage_class.must_equal "DURABLE_REDUCED_AVAILABILITY"
+    _(file_user_project.storage_class).must_equal "DURABLE_REDUCED_AVAILABILITY"
 
     mock.verify
   end
@@ -201,7 +201,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.temporary_hold?.must_equal true
+    _(file.temporary_hold?).must_equal true
     file.release_temporary_hold!
 
     mock.verify
@@ -215,7 +215,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.event_based_hold?.must_equal true
+    _(file.event_based_hold?).must_equal true
     file.release_event_based_hold!
 
     mock.verify

--- a/google-cloud-storage/test/google/cloud/storage/hmac_key_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/hmac_key_test.rb
@@ -46,23 +46,23 @@ describe Google::Cloud::Storage::HmacKey, :mock_storage do
   let(:hmac_key_user_project) { Google::Cloud::Storage::HmacKey.from_gapi hmac_key_gapi, storage.service, user_project: true }
 
   it "knows its attributes" do
-    hmac_key.secret.must_equal hmac_key_gapi.secret
+    _(hmac_key.secret).must_equal hmac_key_gapi.secret
 
-    hmac_key.access_id.must_equal hmac_key_metadata_gapi.access_id
-    hmac_key.api_url.must_equal hmac_key_metadata_gapi.self_link
-    hmac_key.created_at.must_equal hmac_key_metadata_gapi.time_created
-    hmac_key.etag.must_equal hmac_key_metadata_gapi.etag
-    hmac_key.id.must_equal hmac_key_metadata_gapi.id
-    hmac_key.project_id.must_equal hmac_key_metadata_gapi.project_id
-    hmac_key.service_account_email.must_equal hmac_key_metadata_gapi.service_account_email
-    hmac_key.state.must_equal hmac_key_metadata_gapi.state
-    hmac_key.updated_at.must_equal hmac_key_metadata_gapi.updated
+    _(hmac_key.access_id).must_equal hmac_key_metadata_gapi.access_id
+    _(hmac_key.api_url).must_equal hmac_key_metadata_gapi.self_link
+    _(hmac_key.created_at).must_equal hmac_key_metadata_gapi.time_created
+    _(hmac_key.etag).must_equal hmac_key_metadata_gapi.etag
+    _(hmac_key.id).must_equal hmac_key_metadata_gapi.id
+    _(hmac_key.project_id).must_equal hmac_key_metadata_gapi.project_id
+    _(hmac_key.service_account_email).must_equal hmac_key_metadata_gapi.service_account_email
+    _(hmac_key.state).must_equal hmac_key_metadata_gapi.state
+    _(hmac_key.updated_at).must_equal hmac_key_metadata_gapi.updated
   end
 
   it "exposes state query methods" do
-    hmac_key.active?.must_equal true
-    hmac_key.inactive?.must_equal false
-    hmac_key.deleted?.must_equal false
+    _(hmac_key.active?).must_equal true
+    _(hmac_key.inactive?).must_equal false
+    _(hmac_key.deleted?).must_equal false
   end
 
   it "can delete itself" do

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_acl_test.rb
@@ -27,10 +27,10 @@ describe Google::Cloud::Storage::Bucket, :acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, skip_lookup: true
-    bucket.name.must_equal bucket_name
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
 
     mock.verify
   end
@@ -44,10 +44,10 @@ describe Google::Cloud::Storage::Bucket, :acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, skip_lookup: true, user_project: true
-    bucket.name.must_equal bucket_name
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
 
     mock.verify
   end
@@ -76,16 +76,16 @@ describe Google::Cloud::Storage::Bucket, :acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, skip_lookup: true
-    bucket.name.must_equal bucket_name
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
 
     bucket.acl.add_writer writer_entity
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.wont_be :empty?
-    bucket.acl.readers.wont_be :empty?
-    bucket.acl.writers.must_include writer_entity
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).wont_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
+    _(bucket.acl.writers).must_include writer_entity
 
     mock.verify
   end
@@ -114,16 +114,16 @@ describe Google::Cloud::Storage::Bucket, :acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, skip_lookup: true, user_project: true
-    bucket.name.must_equal bucket_name
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
 
     bucket.acl.add_writer writer_entity
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.wont_be :empty?
-    bucket.acl.readers.wont_be :empty?
-    bucket.acl.writers.must_include writer_entity
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).wont_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
+    _(bucket.acl.writers).must_include writer_entity
 
     mock.verify
   end
@@ -141,16 +141,16 @@ describe Google::Cloud::Storage::Bucket, :acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, skip_lookup: true
-    bucket.name.must_equal bucket_name
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
 
     reader_entity = bucket.acl.readers.first
     bucket.acl.delete reader_entity
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.must_be :empty?
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).must_be :empty?
 
     mock.verify
   end
@@ -168,16 +168,16 @@ describe Google::Cloud::Storage::Bucket, :acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, skip_lookup: true, user_project: true
-    bucket.name.must_equal bucket_name
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).wont_be :empty?
 
     reader_entity = bucket.acl.readers.first
     bucket.acl.delete reader_entity
-    bucket.acl.owners.wont_be  :empty?
-    bucket.acl.writers.must_be :empty?
-    bucket.acl.readers.must_be :empty?
+    _(bucket.acl.owners).wont_be  :empty?
+    _(bucket.acl.writers).must_be :empty?
+    _(bucket.acl.readers).must_be :empty?
 
     mock.verify
   end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_default_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_default_acl_test.rb
@@ -27,9 +27,9 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, skip_lookup: true
-    bucket.name.must_equal bucket_name
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
 
     mock.verify
   end
@@ -43,9 +43,9 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, skip_lookup: true, user_project: true
-    bucket.name.must_equal bucket_name
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
 
     mock.verify
   end
@@ -74,14 +74,14 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, skip_lookup: true
-    bucket.name.must_equal bucket_name
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
 
     bucket.default_acl.add_reader reader_entity
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
-    bucket.default_acl.readers.must_include reader_entity
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
+    _(bucket.default_acl.readers).must_include reader_entity
 
     mock.verify
   end
@@ -110,14 +110,14 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, skip_lookup: true, user_project: true
-    bucket.name.must_equal bucket_name
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
 
     bucket.default_acl.add_reader reader_entity
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
-    bucket.default_acl.readers.must_include reader_entity
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
+    _(bucket.default_acl.readers).must_include reader_entity
 
     mock.verify
   end
@@ -135,14 +135,14 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, skip_lookup: true
-    bucket.name.must_equal bucket_name
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
 
     reader_entity = bucket.default_acl.readers.first
     bucket.default_acl.delete reader_entity
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.must_be :empty?
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).must_be :empty?
 
     mock.verify
   end
@@ -160,14 +160,14 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, skip_lookup: true, user_project: true
-    bucket.name.must_equal bucket_name
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.wont_be :empty?
+    _(bucket.name).must_equal bucket_name
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).wont_be :empty?
 
     reader_entity = bucket.default_acl.readers.first
     bucket.default_acl.delete reader_entity
-    bucket.default_acl.owners.wont_be  :empty?
-    bucket.default_acl.readers.must_be :empty?
+    _(bucket.default_acl.owners).wont_be  :empty?
+    _(bucket.default_acl.readers).must_be :empty?
 
     mock.verify
   end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
@@ -72,14 +72,14 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket.policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal "CAE="
-      policy.version.must_equal 1
-      policy.roles.must_be_kind_of Hash
-      policy.roles.size.must_equal 1
-      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-      policy.roles["roles/storage.objectViewer"].count.must_equal 1
-      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal "CAE="
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be_kind_of Hash
+      _(policy.roles.size).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"]).must_be_kind_of Array
+      _(policy.roles["roles/storage.objectViewer"].count).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"].first).must_equal "user:viewer@example.com"
     end
 
     it "gets the policy with requested_policy_version: 1" do
@@ -90,14 +90,14 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket.policy requested_policy_version: 1
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal "CAE="
-      policy.version.must_equal 1
-      policy.roles.must_be_kind_of Hash
-      policy.roles.size.must_equal 1
-      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-      policy.roles["roles/storage.objectViewer"].count.must_equal 1
-      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal "CAE="
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be_kind_of Hash
+      _(policy.roles.size).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"]).must_be_kind_of Array
+      _(policy.roles["roles/storage.objectViewer"].count).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"].first).must_equal "user:viewer@example.com"
     end
 
     it "gets the policy with user_project set to true" do
@@ -108,14 +108,14 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket_user_project.policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal "CAE="
-      policy.version.must_equal 1
-      policy.roles.must_be_kind_of Hash
-      policy.roles.size.must_equal 1
-      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-      policy.roles["roles/storage.objectViewer"].count.must_equal 1
-      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal "CAE="
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be_kind_of Hash
+      _(policy.roles.size).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"]).must_be_kind_of Array
+      _(policy.roles["roles/storage.objectViewer"].count).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"].first).must_equal "user:viewer@example.com"
     end
 
     it "sets the policy" do
@@ -126,15 +126,15 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 1
-      policy.roles.must_be_kind_of Hash
-      policy.roles.size.must_equal 1
-      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-      policy.roles["roles/storage.objectViewer"].count.must_equal 2
-      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be_kind_of Hash
+      _(policy.roles.size).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"]).must_be_kind_of Array
+      _(policy.roles["roles/storage.objectViewer"].count).must_equal 2
+      _(policy.roles["roles/storage.objectViewer"].first).must_equal "user:viewer@example.com"
+      _(policy.roles["roles/storage.objectViewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
     end
 
     it "sets the policy with user_project set to true" do
@@ -145,15 +145,15 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket_user_project.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 1
-      policy.roles.must_be_kind_of Hash
-      policy.roles.size.must_equal 1
-      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-      policy.roles["roles/storage.objectViewer"].count.must_equal 2
-      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be_kind_of Hash
+      _(policy.roles.size).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"]).must_be_kind_of Array
+      _(policy.roles["roles/storage.objectViewer"].count).must_equal 2
+      _(policy.roles["roles/storage.objectViewer"].first).must_equal "user:viewer@example.com"
+      _(policy.roles["roles/storage.objectViewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
     end
 
     it "sets the policy in a block" do
@@ -168,15 +168,15 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 1
-      policy.roles.must_be_kind_of Hash
-      policy.roles.size.must_equal 1
-      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-      policy.roles["roles/storage.objectViewer"].count.must_equal 2
-      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be_kind_of Hash
+      _(policy.roles.size).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"]).must_be_kind_of Array
+      _(policy.roles["roles/storage.objectViewer"].count).must_equal 2
+      _(policy.roles["roles/storage.objectViewer"].first).must_equal "user:viewer@example.com"
+      _(policy.roles["roles/storage.objectViewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
     end
 
     it "sets the policy in a block with user_project set to true" do
@@ -191,15 +191,15 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 1
-      policy.roles.must_be_kind_of Hash
-      policy.roles.size.must_equal 1
-      policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-      policy.roles["roles/storage.objectViewer"].count.must_equal 2
-      policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-      policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be_kind_of Hash
+      _(policy.roles.size).must_equal 1
+      _(policy.roles["roles/storage.objectViewer"]).must_be_kind_of Array
+      _(policy.roles["roles/storage.objectViewer"].count).must_equal 2
+      _(policy.roles["roles/storage.objectViewer"].first).must_equal "user:viewer@example.com"
+      _(policy.roles["roles/storage.objectViewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
     end
   end
 
@@ -278,16 +278,16 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket.policy requested_policy_version: 3
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.etag.must_equal "CAE="
-      policy.version.must_equal 1
-      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
-      policy.bindings.to_a.count.must_equal 1
-      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
-      policy.bindings.to_a[0].condition.must_be :nil?
-      policy.bindings.to_a[0].condition.must_be :nil?
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.etag).must_equal "CAE="
+      _(policy.version).must_equal 1
+      _(policy.bindings).must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      _(policy.bindings.to_a.count).must_equal 1
+      _(policy.bindings.to_a[0]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[0].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[0].members).must_equal ["user:viewer@example.com"]
+      _(policy.bindings.to_a[0].condition).must_be :nil?
+      _(policy.bindings.to_a[0].condition).must_be :nil?
     end
 
     it "gets the policy with user_project set to true" do
@@ -298,15 +298,15 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket_user_project.policy requested_policy_version: 3
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.etag.must_equal "CAE="
-      policy.version.must_equal 1
-      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
-      policy.bindings.to_a.count.must_equal 1
-      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
-      policy.bindings.to_a[0].condition.must_be :nil?
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.etag).must_equal "CAE="
+      _(policy.version).must_equal 1
+      _(policy.bindings).must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      _(policy.bindings.to_a.count).must_equal 1
+      _(policy.bindings.to_a[0]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[0].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[0].members).must_equal ["user:viewer@example.com"]
+      _(policy.bindings.to_a[0].condition).must_be :nil?
     end
 
     it "sets the policy" do
@@ -317,22 +317,22 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
-      policy.bindings.to_a.count.must_equal 2
-      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
-      policy.bindings.to_a[0].condition.must_be :nil?
-      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
-      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
-      policy.bindings.to_a[1].condition.title.must_equal "always-true"
-      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
-      policy.bindings.to_a[1].condition.expression.must_equal "true"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 3
+      _(policy.bindings).must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      _(policy.bindings.to_a.count).must_equal 2
+      _(policy.bindings.to_a[0]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[0].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[0].members).must_equal ["user:viewer@example.com"]
+      _(policy.bindings.to_a[0].condition).must_be :nil?
+      _(policy.bindings.to_a[1]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[1].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[1].members).must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      _(policy.bindings.to_a[1].condition).must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      _(policy.bindings.to_a[1].condition.title).must_equal "always-true"
+      _(policy.bindings.to_a[1].condition.description).must_equal "test condition always-true"
+      _(policy.bindings.to_a[1].condition.expression).must_equal "true"
     end
 
     it "sets the policy with user_project set to true" do
@@ -343,22 +343,22 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       policy = bucket_user_project.update_policy updated_policy
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
-      policy.bindings.to_a.count.must_equal 2
-      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
-      policy.bindings.to_a[0].condition.must_be :nil?
-      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
-      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
-      policy.bindings.to_a[1].condition.title.must_equal "always-true"
-      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
-      policy.bindings.to_a[1].condition.expression.must_equal "true"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 3
+      _(policy.bindings).must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      _(policy.bindings.to_a.count).must_equal 2
+      _(policy.bindings.to_a[0]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[0].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[0].members).must_equal ["user:viewer@example.com"]
+      _(policy.bindings.to_a[0].condition).must_be :nil?
+      _(policy.bindings.to_a[1]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[1].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[1].members).must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      _(policy.bindings.to_a[1].condition).must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      _(policy.bindings.to_a[1].condition.title).must_equal "always-true"
+      _(policy.bindings.to_a[1].condition.description).must_equal "test condition always-true"
+      _(policy.bindings.to_a[1].condition.expression).must_equal "true"
     end
 
     it "sets the policy in a block" do
@@ -382,22 +382,22 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
-      policy.bindings.to_a.count.must_equal 2
-      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
-      policy.bindings.to_a[0].condition.must_be :nil?
-      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
-      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
-      policy.bindings.to_a[1].condition.title.must_equal "always-true"
-      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
-      policy.bindings.to_a[1].condition.expression.must_equal "true"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 3
+      _(policy.bindings).must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      _(policy.bindings.to_a.count).must_equal 2
+      _(policy.bindings.to_a[0]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[0].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[0].members).must_equal ["user:viewer@example.com"]
+      _(policy.bindings.to_a[0].condition).must_be :nil?
+      _(policy.bindings.to_a[1]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[1].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[1].members).must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      _(policy.bindings.to_a[1].condition).must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      _(policy.bindings.to_a[1].condition.title).must_equal "always-true"
+      _(policy.bindings.to_a[1].condition.description).must_equal "test condition always-true"
+      _(policy.bindings.to_a[1].condition.expression).must_equal "true"
     end
 
     it "sets the policy in a block with user_project set to true" do
@@ -421,22 +421,22 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       end
       mock.verify
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.etag.must_equal "CAF="
-      policy.version.must_equal 3
-      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
-      policy.bindings.to_a.count.must_equal 2
-      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
-      policy.bindings.to_a[0].condition.must_be :nil?
-      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
-      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
-      policy.bindings.to_a[1].condition.title.must_equal "always-true"
-      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
-      policy.bindings.to_a[1].condition.expression.must_equal "true"
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.etag).must_equal "CAF="
+      _(policy.version).must_equal 3
+      _(policy.bindings).must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      _(policy.bindings.to_a.count).must_equal 2
+      _(policy.bindings.to_a[0]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[0].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[0].members).must_equal ["user:viewer@example.com"]
+      _(policy.bindings.to_a[0].condition).must_be :nil?
+      _(policy.bindings.to_a[1]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[1].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[1].members).must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      _(policy.bindings.to_a[1].condition).must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      _(policy.bindings.to_a[1].condition.title).must_equal "always-true"
+      _(policy.bindings.to_a[1].condition.description).must_equal "test condition always-true"
+      _(policy.bindings.to_a[1].condition.expression).must_equal "true"
     end
   end
 
@@ -450,7 +450,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
                                            "storage.buckets.delete"
     mock.verify
 
-    permissions.must_equal ["storage.buckets.get"]
+    _(permissions).must_equal ["storage.buckets.get"]
   end
 
   it "tests the permissions available with user_project set to true" do
@@ -463,6 +463,6 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
                                            "storage.buckets.delete"
     mock.verify
 
-    permissions.must_equal ["storage.buckets.get"]
+    _(permissions).must_equal ["storage.buckets.get"]
   end
 end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_post_object_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_post_object_test.rb
@@ -44,10 +44,10 @@ describe Google::Cloud::Storage::Bucket, :post_object, :lazy, :mock_storage do
 
       signed_post = bucket.post_object file_path, policy: policy
 
-      signed_post.url.must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
-      signed_post.fields[:GoogleAccessId].must_equal "native_client_email"
-      signed_post.fields[:signature].must_equal Base64.strict_encode64("native-signature").delete("\n")
-      signed_post.fields[:key].must_equal [bucket_name, file_path_encoded].join("/")
+      _(signed_post.url).must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
+      _(signed_post.fields[:GoogleAccessId]).must_equal "native_client_email"
+      _(signed_post.fields[:signature]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+      _(signed_post.fields[:key]).must_equal [bucket_name, file_path_encoded].join("/")
 
       signing_key_mock.verify
     end
@@ -64,10 +64,10 @@ describe Google::Cloud::Storage::Bucket, :post_object, :lazy, :mock_storage do
 
     signed_post = bucket.post_object file_path
 
-    signed_post.url.must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
-    signed_post.fields[:GoogleAccessId].must_equal "native_client_email"
-    signed_post.fields[:signature].must_equal Base64.strict_encode64("native-signature").delete("\n")
-    signed_post.fields[:key].must_equal [bucket_name, file_path_encoded].join("/")
+    _(signed_post.url).must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
+    _(signed_post.fields[:GoogleAccessId]).must_equal "native_client_email"
+    _(signed_post.fields[:signature]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+    _(signed_post.fields[:key]).must_equal [bucket_name, file_path_encoded].join("/")
 
     signing_key_mock.verify
   end
@@ -85,10 +85,10 @@ describe Google::Cloud::Storage::Bucket, :post_object, :lazy, :mock_storage do
 
     signed_post = bucket.post_object file_path_special_variable
 
-    signed_post.url.must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
-    signed_post.fields[:GoogleAccessId].must_equal "native_client_email"
-    signed_post.fields[:signature].must_equal Base64.strict_encode64("native-signature").delete("\n")
-    signed_post.fields[:key].must_equal [bucket_name, file_path_special_variable].join("/")
+    _(signed_post.url).must_equal Google::Cloud::Storage::GOOGLEAPIS_URL
+    _(signed_post.fields[:GoogleAccessId]).must_equal "native_client_email"
+    _(signed_post.fields[:signature]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+    _(signed_post.fields[:key]).must_equal [bucket_name, file_path_special_variable].join("/")
 
     signing_key_mock.verify
   end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v2_test.rb
@@ -30,8 +30,8 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v2, :lazy, :mock_storage 
       signed_url = bucket.signed_url file_path
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -49,8 +49,8 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v2, :lazy, :mock_storage 
                                                 signing_key: signing_key_mock
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["option_issuer"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["option_issuer"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -70,8 +70,8 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v2, :lazy, :mock_storage 
                                                   private_key: "option_private_key"
 
         signed_url_params = CGI::parse(URI(signed_url).query)
-        signed_url_params["GoogleAccessId"].must_equal ["option_client_email"]
-        signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+        _(signed_url_params["GoogleAccessId"]).must_equal ["option_client_email"]
+        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
 
       end
 
@@ -90,8 +90,8 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v2, :lazy, :mock_storage 
                                                            "X-Goog-ACL" => "public-read" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -128,11 +128,11 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v2, :lazy, :mock_storage 
         signed_url = bucket.signed_url file_path
 
         signed_uri = URI signed_url
-        signed_uri.path.must_equal "/bucket/hello%20world.txt"
+        _(signed_uri.path).must_equal "/bucket/hello%20world.txt"
 
         signed_url_params = CGI::parse signed_uri.query
-        signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-        signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+        _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
         signing_key_mock.verify
       end
@@ -150,9 +150,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v2, :lazy, :mock_storage 
                                      query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      signed_url_params["response-content-disposition"].must_equal ["attachment; filename=\"google-cloud.png\""]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"google-cloud.png\""]
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v4_test.rb
@@ -30,12 +30,12 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
       signed_url = bucket.signed_url file_path, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -54,12 +54,12 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
                                      signing_key: signing_key_mock, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6f7074696f6e2d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -80,12 +80,12 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
                                        private_key: "option_private_key", version: :v4
 
         signed_url_params = CGI::parse(URI(signed_url).query)
-        signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-        signed_url_params["X-Goog-Credential"].must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
-        signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-        signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-        signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-        signed_url_params["X-Goog-Signature"].must_equal  ["6f7074696f6e2d7369676e6174757265"]
+        _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+        _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
+        _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+        _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+        _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
 
       end
 
@@ -105,12 +105,12 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
                                                 "X-Goog-ACL" => "public-read" }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -145,12 +145,12 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
                                      query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
       signing_key_mock.verify
     end
   end
@@ -166,12 +166,12 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
                                      query: { disposition: :inline }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
@@ -143,7 +143,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
     new_file_contents = StringIO.new "Hello world"
 
     err = expect { bucket.create_file new_file_contents }.must_raise ArgumentError
-    err.message.must_equal "must provide path"
+    _(err.message).must_equal "must provide path"
   end
 
   it "creates a file with predefined acl" do
@@ -307,7 +307,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
       bucket_user_project.service.mocked_service = mock
 
       created = bucket_user_project.create_file tmpfile, new_file_name
-      created.user_project.must_equal true
+      _(created.user_project).must_equal true
 
       mock.verify
     end
@@ -321,7 +321,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
     err = expect {
       bucket.create_file bad_file_path
     }.must_raise ArgumentError
-    err.message.must_match bad_file_path
+    _(err.message).must_match bad_file_path
   end
 
   it "lists files" do
@@ -337,10 +337,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.size.must_equal num_files
+    _(files.size).must_equal num_files
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -357,10 +357,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.size.must_equal num_files
+    _(files.size).must_equal num_files
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -375,13 +375,13 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 3
-    files.prefixes.wont_be :empty?
-    files.prefixes.must_include "/prefix/path1/"
-    files.prefixes.must_include "/prefix/path2/"
+    _(files.count).must_equal 3
+    _(files.prefixes).wont_be :empty?
+    _(files.prefixes).must_include "/prefix/path1/"
+    _(files.prefixes).must_include "/prefix/path2/"
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -396,13 +396,13 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 3
-    files.prefixes.wont_be :empty?
-    files.prefixes.must_include "/prefix/path1/"
-    files.prefixes.must_include "/prefix/path2/"
+    _(files.count).must_equal 3
+    _(files.prefixes).wont_be :empty?
+    _(files.prefixes).must_include "/prefix/path1/"
+    _(files.prefixes).must_include "/prefix/path2/"
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -417,12 +417,12 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 3
-    files.token.wont_be :nil?
-    files.token.must_equal "next_page_token"
+    _(files.count).must_equal 3
+    _(files.token).wont_be :nil?
+    _(files.token).must_equal "next_page_token"
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -437,10 +437,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 3
+    _(files.count).must_equal 3
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -457,10 +457,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.size.must_equal num_files
+    _(files.size).must_equal num_files
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_equal true
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_equal true
     end
   end
 
@@ -478,19 +478,19 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    first_files.count.must_equal 3
-    first_files.token.wont_be :nil?
-    first_files.token.must_equal "next_page_token"
+    _(first_files.count).must_equal 3
+    _(first_files.token).wont_be :nil?
+    _(first_files.token).must_equal "next_page_token"
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
 
-    second_files.count.must_equal 2
-    second_files.token.must_be :nil?
+    _(second_files.count).must_equal 2
+    _(second_files.token).must_be :nil?
     second_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -508,18 +508,18 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    first_files.count.must_equal 3
-    first_files.next?.must_equal true
+    _(first_files.count).must_equal 3
+    _(first_files.next?).must_equal true
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
 
-    second_files.count.must_equal 2
-    second_files.next?.must_equal false
+    _(second_files.count).must_equal 2
+    _(second_files.next?).must_equal false
     second_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -537,18 +537,18 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    first_files.count.must_equal 3
-    first_files.next?.must_equal true
+    _(first_files.count).must_equal 3
+    _(first_files.next?).must_equal true
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
 
-    second_files.count.must_equal 2
-    second_files.next?.must_equal false
+    _(second_files.count).must_equal 2
+    _(second_files.next?).must_equal false
     second_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -566,18 +566,18 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    first_files.count.must_equal 3
-    first_files.next?.must_equal true
+    _(first_files.count).must_equal 3
+    _(first_files.next?).must_equal true
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
 
-    second_files.count.must_equal 2
-    second_files.next?.must_equal false
+    _(second_files.count).must_equal 2
+    _(second_files.next?).must_equal false
     second_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -595,18 +595,18 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    first_files.count.must_equal 3
-    first_files.next?.must_equal true
+    _(first_files.count).must_equal 3
+    _(first_files.next?).must_equal true
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
 
-    second_files.count.must_equal 2
-    second_files.next?.must_equal false
+    _(second_files.count).must_equal 2
+    _(second_files.next?).must_equal false
     second_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -624,18 +624,18 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    first_files.count.must_equal 3
-    first_files.next?.must_equal true
+    _(first_files.count).must_equal 3
+    _(first_files.next?).must_equal true
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
 
-    second_files.count.must_equal 2
-    second_files.next?.must_equal false
+    _(second_files.count).must_equal 2
+    _(second_files.next?).must_equal false
     second_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -653,19 +653,19 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    first_files.count.must_equal 3
-    first_files.token.wont_be :nil?
-    first_files.token.must_equal "next_page_token"
+    _(first_files.count).must_equal 3
+    _(first_files.token).wont_be :nil?
+    _(first_files.token).must_equal "next_page_token"
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_equal true
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_equal true
     end
 
-    second_files.count.must_equal 2
-    second_files.token.must_be :nil?
+    _(second_files.count).must_equal 2
+    _(second_files.token).must_be :nil?
     first_files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_equal true
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_equal true
     end
   end
 
@@ -682,10 +682,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 5
+    _(files.count).must_equal 5
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -702,10 +702,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 5
+    _(files.count).must_equal 5
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -722,10 +722,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 5
+    _(files.count).must_equal 5
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -742,10 +742,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 5
+    _(files.count).must_equal 5
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -762,10 +762,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 5
+    _(files.count).must_equal 5
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -782,10 +782,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 5
+    _(files.count).must_equal 5
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -802,10 +802,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 6
+    _(files.count).must_equal 6
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -822,10 +822,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    files.count.must_equal 6
+    _(files.count).must_equal 6
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_equal true
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_equal true
     end
   end
 
@@ -842,9 +842,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.user_project.must_be :nil?
-    file.wont_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.user_project).must_be :nil?
+    _(file).wont_be :lazy?
   end
 
   it "finds a file with find_file alias" do
@@ -860,9 +860,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.user_project.must_be :nil?
-    file.wont_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.user_project).must_be :nil?
+    _(file).wont_be :lazy?
   end
 
   it "finds a file with generation" do
@@ -879,9 +879,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.user_project.must_be :nil?
-    file.wont_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.user_project).must_be :nil?
+    _(file).wont_be :lazy?
   end
 
   it "finds a file with customer-supplied encryption key" do
@@ -897,9 +897,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.user_project.must_be :nil?
-    file.wont_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.user_project).must_be :nil?
+    _(file).wont_be :lazy?
   end
 
   it "finds a file with user_project set to true" do
@@ -915,9 +915,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.user_project.must_equal true
-    file.wont_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.user_project).must_equal true
+    _(file).wont_be :lazy?
   end
 
   it "finds a file with skip_lookup" do
@@ -931,10 +931,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.generation.must_be :nil?
-    file.user_project.must_be :nil?
-    file.must_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.generation).must_be :nil?
+    _(file.user_project).must_be :nil?
+    _(file).must_be :lazy?
   end
 
   it "finds a file with skip_lookup and find_file alias" do
@@ -948,10 +948,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.generation.must_be :nil?
-    file.user_project.must_be :nil?
-    file.must_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.generation).must_be :nil?
+    _(file.user_project).must_be :nil?
+    _(file).must_be :lazy?
   end
 
   it "finds a file with generation and skip_lookup" do
@@ -966,10 +966,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.generation.must_equal generation
-    file.user_project.must_be :nil?
-    file.must_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.generation).must_equal generation
+    _(file.user_project).must_be :nil?
+    _(file).must_be :lazy?
   end
 
   it "finds a file with user_project and skip_lookupset to true" do
@@ -983,10 +983,10 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.generation.must_be :nil?
-    file.user_project.must_equal true
-    file.must_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.generation).must_be :nil?
+    _(file.user_project).must_equal true
+    _(file).must_be :lazy?
   end
 
   it "can reload itself" do
@@ -1002,11 +1002,11 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
     bucket.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name
-    bucket.api_url.must_equal "https://www.googleapis.com/storage/v1/b/#{bucket_name}"
+    _(bucket.api_url).must_equal "https://www.googleapis.com/storage/v1/b/#{bucket_name}"
 
     bucket.reload!
 
-    bucket.api_url.must_equal "#{new_url_root}/b/#{bucket_name}"
+    _(bucket.api_url).must_equal "#{new_url_root}/b/#{bucket_name}"
     mock.verify
   end
 
@@ -1023,11 +1023,11 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
     bucket_user_project.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name, user_project: true
-    bucket.api_url.must_equal "https://www.googleapis.com/storage/v1/b/#{bucket_name}"
+    _(bucket.api_url).must_equal "https://www.googleapis.com/storage/v1/b/#{bucket_name}"
 
     bucket.reload!
 
-    bucket.api_url.must_equal "#{new_url_root}/b/#{bucket_name}"
+    _(bucket.api_url).must_equal "#{new_url_root}/b/#{bucket_name}"
     mock.verify
   end
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_update_test.rb
@@ -47,9 +47,9 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.wont_be :versioning?
+    _(bucket).wont_be :versioning?
     bucket.versioning = true
-    bucket.must_be :versioning?
+    _(bucket).must_be :versioning?
 
     mock.verify
   end
@@ -66,9 +66,9 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
     bucket.service.mocked_service = mock
     bucket.user_project = true
 
-    bucket.wont_be :versioning?
+    _(bucket).wont_be :versioning?
     bucket.versioning = true
-    bucket.must_be :versioning?
+    _(bucket).must_be :versioning?
 
     mock.verify
   end
@@ -84,9 +84,9 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.logging_bucket.must_be :nil?
+    _(bucket.logging_bucket).must_be :nil?
     bucket.logging_bucket = bucket_logging_bucket
-    bucket.logging_bucket.must_equal bucket_logging_bucket
+    _(bucket.logging_bucket).must_equal bucket_logging_bucket
 
     mock.verify
   end
@@ -102,9 +102,9 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.logging_prefix.must_be :nil?
+    _(bucket.logging_prefix).must_be :nil?
     bucket.logging_prefix = bucket_logging_prefix
-    bucket.logging_prefix.must_equal bucket_logging_prefix
+    _(bucket.logging_prefix).must_equal bucket_logging_prefix
 
     mock.verify
   end
@@ -120,16 +120,16 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.logging_bucket.must_be :nil?
-    bucket.logging_prefix.must_be :nil?
+    _(bucket.logging_bucket).must_be :nil?
+    _(bucket.logging_prefix).must_be :nil?
 
     bucket.update do |b|
       b.logging_bucket = bucket_logging_bucket
       b.logging_prefix = bucket_logging_prefix
     end
 
-    bucket.logging_bucket.must_equal bucket_logging_bucket
-    bucket.logging_prefix.must_equal bucket_logging_prefix
+    _(bucket.logging_bucket).must_equal bucket_logging_bucket
+    _(bucket.logging_prefix).must_equal bucket_logging_prefix
 
     mock.verify
   end
@@ -144,9 +144,9 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.storage_class.must_be :nil?
+    _(bucket.storage_class).must_be :nil?
     bucket.storage_class = :nearline
-    bucket.storage_class.must_equal "NEARLINE"
+    _(bucket.storage_class).must_equal "NEARLINE"
 
     mock.verify
   end
@@ -162,9 +162,9 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.website_main.must_be :nil?
+    _(bucket.website_main).must_be :nil?
     bucket.website_main = bucket_website_main
-    bucket.website_main.must_equal bucket_website_main
+    _(bucket.website_main).must_equal bucket_website_main
 
     mock.verify
   end
@@ -180,9 +180,9 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.website_404.must_be :nil?
+    _(bucket.website_404).must_be :nil?
     bucket.website_404 = bucket_website_404
-    bucket.website_404.must_equal bucket_website_404
+    _(bucket.website_404).must_equal bucket_website_404
 
     mock.verify
   end
@@ -198,16 +198,16 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.website_main.must_be :nil?
-    bucket.website_404.must_be :nil?
+    _(bucket.website_main).must_be :nil?
+    _(bucket.website_404).must_be :nil?
 
     bucket.update do |b|
       b.website_main = bucket_website_main
       b.website_404 = bucket_website_404
     end
 
-    bucket.website_main.must_equal bucket_website_main
-    bucket.website_404.must_equal bucket_website_404
+    _(bucket.website_main).must_equal bucket_website_main
+    _(bucket.website_404).must_equal bucket_website_404
 
     mock.verify
   end
@@ -223,15 +223,15 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.requester_pays.must_be :nil?
+    _(bucket.requester_pays).must_be :nil?
     bucket.requester_pays = bucket_requester_pays
-    bucket.requester_pays.must_equal bucket_requester_pays
+    _(bucket.requester_pays).must_equal bucket_requester_pays
 
     mock.verify
   end
 
   it "cannot modify its labels" do
-    bucket.labels.must_equal Hash.new
+    _(bucket.labels).must_equal Hash.new
     assert_raises do
       bucket.labels["foo"] = "bar"
     end
@@ -249,9 +249,9 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.labels.must_equal Hash.new
+    _(bucket.labels).must_equal Hash.new
     bucket.labels = new_labels
-    bucket.labels.must_equal new_labels
+    _(bucket.labels).must_equal new_labels
 
     mock.verify
   end
@@ -271,13 +271,13 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
 
     bucket.service.mocked_service = mock
 
-    bucket.wont_be :versioning?
-    bucket.logging_bucket.must_be :nil?
-    bucket.logging_prefix.must_be :nil?
-    bucket.website_main.must_be :nil?
-    bucket.website_404.must_be :nil?
-    bucket.requester_pays.must_be :nil?
-    bucket.labels.must_equal Hash.new
+    _(bucket).wont_be :versioning?
+    _(bucket.logging_bucket).must_be :nil?
+    _(bucket.logging_prefix).must_be :nil?
+    _(bucket.website_main).must_be :nil?
+    _(bucket.website_404).must_be :nil?
+    _(bucket.requester_pays).must_be :nil?
+    _(bucket.labels).must_equal Hash.new
 
     bucket.update do |b|
       b.versioning = true
@@ -290,14 +290,14 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
       b.labels["env"] = "production"
     end
 
-    bucket.versioning?.must_equal true
-    bucket.logging_bucket.must_equal bucket_logging_bucket
-    bucket.logging_prefix.must_equal bucket_logging_prefix
-    bucket.storage_class.must_equal "NEARLINE"
-    bucket.website_main.must_equal bucket_website_main
-    bucket.website_404.must_equal bucket_website_404
-    bucket.requester_pays.must_equal bucket_requester_pays
-    bucket.labels.must_equal({ "env" => "production" })
+    _(bucket.versioning?).must_equal true
+    _(bucket.logging_bucket).must_equal bucket_logging_bucket
+    _(bucket.logging_prefix).must_equal bucket_logging_prefix
+    _(bucket.storage_class).must_equal "NEARLINE"
+    _(bucket.website_main).must_equal bucket_website_main
+    _(bucket.website_404).must_equal bucket_website_404
+    _(bucket.requester_pays).must_equal bucket_requester_pays
+    _(bucket.labels).must_equal({ "env" => "production" })
 
     mock.verify
   end
@@ -313,7 +313,7 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
         [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
       bucket.service.mocked_service = mock
 
-      bucket.cors.must_equal []
+      _(bucket.cors).must_equal []
       bucket.cors do |c|
         c.add_rule ["http://example.org", "https://example.org"],
                    "*",
@@ -331,7 +331,7 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
                               headers: ["X-My-Custom-Header"],
                               max_age: 300
       }.must_raise RuntimeError
-      err.message.must_match "can't modify frozen"
+      _(err.message).must_match "can't modify frozen"
     end
 
     it "can update cors inside of a block" do
@@ -350,11 +350,11 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
         [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
       bucket.service.mocked_service = mock
 
-      bucket.cors.must_be :frozen?
-      bucket.cors.class.must_equal Google::Cloud::Storage::Bucket::Cors
+      _(bucket.cors).must_be :frozen?
+      _(bucket.cors.class).must_equal Google::Cloud::Storage::Bucket::Cors
       bucket.update do |b|
-        b.cors.wont_be :frozen?
-        b.cors.must_be :empty?
+        _(b.cors).wont_be :frozen?
+        _(b.cors).must_be :empty?
         b.cors.add_rule ["http://example.org", "https://example.org", "https://example.com"],
                          "PUT",
                          headers: ["X-My-Custom-Header", "X-Another-Custom-Header"],
@@ -431,8 +431,8 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
                    "*",
                    headers: "X-Another-Custom-Header"
       end
-      returned_cors.frozen?.must_equal true
-      returned_cors.first.frozen?.must_equal true
+      _(returned_cors.frozen?).must_equal true
+      _(returned_cors.first.frozen?).must_equal true
 
       mock.verify
     end
@@ -453,7 +453,7 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
                   [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
       bucket.service.mocked_service = mock
 
-      bucket.lifecycle.must_equal []
+      _(bucket.lifecycle).must_equal []
       bucket.lifecycle do |l|
         l.add_set_storage_class_rule "NEARLINE", age: 32
       end
@@ -465,7 +465,7 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
       err = expect {
         bucket.lifecycle.add_set_storage_class_rule "NEARLINE", age: 32
       }.must_raise RuntimeError
-      err.message.must_match "can't modify frozen"
+      _(err.message).must_match "can't modify frozen"
     end
 
     it "can update lifecycle inside of a block" do
@@ -481,11 +481,11 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
                   [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
       bucket.service.mocked_service = mock
 
-      bucket.lifecycle.must_be :frozen?
-      bucket.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
+      _(bucket.lifecycle).must_be :frozen?
+      _(bucket.lifecycle.class).must_equal Google::Cloud::Storage::Bucket::Lifecycle
       bucket.update do |b|
-        b.lifecycle.wont_be :frozen?
-        b.lifecycle.must_be :empty?
+        _(b.lifecycle).wont_be :frozen?
+        _(b.lifecycle).must_be :empty?
         b.lifecycle.add_delete_rule age: 40, is_live: false
       end
 
@@ -530,8 +530,8 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
                   [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
       bucket.service.mocked_service = mock
 
-      bucket.lifecycle.must_be :frozen?
-      bucket.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
+      _(bucket.lifecycle).must_be :frozen?
+      _(bucket.lifecycle.class).must_equal Google::Cloud::Storage::Bucket::Lifecycle
       bucket.update do |b|
         b.lifecycle.add_delete_rule age: 40, is_live: false
         b.lifecycle.add_delete_rule is_live: false, num_newer_versions: 8
@@ -554,8 +554,8 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
                   [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
       bucket.service.mocked_service = mock
 
-      bucket.lifecycle.must_be :frozen?
-      bucket.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
+      _(bucket.lifecycle).must_be :frozen?
+      _(bucket.lifecycle.class).must_equal Google::Cloud::Storage::Bucket::Lifecycle
       bucket.lifecycle do |l|
         l.add_set_storage_class_rule "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["STANDARD", "NEARLINE"]
         l.add_delete_rule age: 40, is_live: false

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_acl_test.rb
@@ -33,9 +33,9 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket.file file_name, skip_lookup: true
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     mock.verify
   end
@@ -50,9 +50,9 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket_user_project.file file_name, skip_lookup: true
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     mock.verify
   end
@@ -82,14 +82,14 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket.file file_name, skip_lookup: true
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     file.acl.add_reader reader_entity
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
-    file.acl.readers.must_include reader_entity
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
+    _(file.acl.readers).must_include reader_entity
 
     mock.verify
   end
@@ -120,14 +120,14 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket.file file_name, skip_lookup: true
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     file.acl.add_reader reader_entity, generation: generation
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
-    file.acl.readers.must_include reader_entity
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
+    _(file.acl.readers).must_include reader_entity
 
     mock.verify
   end
@@ -157,14 +157,14 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket_user_project.file file_name, skip_lookup: true
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     file.acl.add_reader reader_entity
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
-    file.acl.readers.must_include reader_entity
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
+    _(file.acl.readers).must_include reader_entity
 
     mock.verify
   end
@@ -183,14 +183,14 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket.file file_name, skip_lookup: true
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     reader_entity = file.acl.readers.first
     file.acl.delete reader_entity
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.must_be :empty?
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).must_be :empty?
 
     mock.verify
   end
@@ -210,14 +210,14 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket.file file_name, skip_lookup: true
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     reader_entity = file.acl.readers.first
     file.acl.delete reader_entity, generation: generation
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.must_be :empty?
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).must_be :empty?
 
     mock.verify
   end
@@ -236,14 +236,14 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
     storage.service.mocked_service = mock
 
     file = bucket_user_project.file file_name, skip_lookup: true
-    file.name.must_equal file_name
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.wont_be :empty?
+    _(file.name).must_equal file_name
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).wont_be :empty?
 
     reader_entity = file.acl.readers.first
     file.acl.delete reader_entity
-    file.acl.owners.wont_be  :empty?
-    file.acl.readers.must_be :empty?
+    _(file.acl.owners).wont_be  :empty?
+    _(file.acl.readers).must_be :empty?
 
     mock.verify
   end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v2_test.rb
@@ -32,8 +32,8 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
       signed_url = file.signed_url
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -51,8 +51,8 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
                                    signing_key: signing_key_mock
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["option_issuer"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["option_issuer"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -72,8 +72,8 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
                                      private_key: "option_private_key"
 
         signed_url_params = CGI::parse(URI(signed_url).query)
-        signed_url_params["GoogleAccessId"].must_equal ["option_client_email"]
-        signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+        _(signed_url_params["GoogleAccessId"]).must_equal ["option_client_email"]
+        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
 
       end
 
@@ -92,8 +92,8 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
                                               "X-Goog-ACL" => "public-read" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -109,9 +109,9 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
       signed_url = file.signed_url query: { "response-content-disposition" => "attachment; filename=\"test.png\"" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      signed_url_params["response-content-disposition"].must_equal ["attachment; filename=\"test.png\""]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"test.png\""]
 
       signing_key_mock.verify
     end
@@ -148,11 +148,11 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
         signed_url = file.signed_url
 
         signed_uri = URI signed_url
-        signed_uri.path.must_equal "/bucket/hello%20world.txt"
+        _(signed_uri.path).must_equal "/bucket/hello%20world.txt"
 
         signed_url_params = CGI::parse signed_uri.query
-        signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-        signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+        _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
         signing_key_mock.verify
       end
@@ -169,9 +169,9 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
       signed_url = file.signed_url query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      signed_url_params["response-content-disposition"].must_equal ["attachment; filename=\"google-cloud.png\""]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"google-cloud.png\""]
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v4_test.rb
@@ -32,12 +32,12 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
       signed_url = file.signed_url version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -55,12 +55,12 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
                                    signing_key: signing_key_mock, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6f7074696f6e2d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -80,12 +80,12 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
                                      private_key: "option_private_key", version: :v4
 
         signed_url_params = CGI::parse(URI(signed_url).query)
-        signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-        signed_url_params["X-Goog-Credential"].must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
-        signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-        signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-        signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-        signed_url_params["X-Goog-Signature"].must_equal  ["6f7074696f6e2d7369676e6174757265"]
+        _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+        _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
+        _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+        _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+        _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
 
       end
 
@@ -104,12 +104,12 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
                                               "X-Goog-ACL" => "public-read" }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -143,12 +143,12 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
       signed_url = file.signed_url query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
       signing_key_mock.verify
     end
   end
@@ -163,12 +163,12 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
       signed_url = file.signed_url query: { disposition: :inline }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
@@ -62,27 +62,27 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
   it "knows its attributes" do
     file_hash = {}
-    file.id.must_be :nil?
-    file.name.must_equal file_name
-    file.created_at.must_be :nil?
-    file.api_url.must_be :nil?
-    file.media_url.must_be :nil?
-    file.public_url.must_equal "https://storage.googleapis.com/#{bucket_name}/#{file_name}"
-    file.public_url(protocol: :http).must_equal "http://storage.googleapis.com/#{file.bucket}/#{file.name}"
-    file.url.must_equal file.public_url
+    _(file.id).must_be :nil?
+    _(file.name).must_equal file_name
+    _(file.created_at).must_be :nil?
+    _(file.api_url).must_be :nil?
+    _(file.media_url).must_be :nil?
+    _(file.public_url).must_equal "https://storage.googleapis.com/#{bucket_name}/#{file_name}"
+    _(file.public_url(protocol: :http)).must_equal "http://storage.googleapis.com/#{file.bucket}/#{file.name}"
+    _(file.url).must_equal file.public_url
 
-    file.md5.must_be :nil?
-    file.crc32c.must_be :nil?
-    file.etag.must_be :nil?
+    _(file.md5).must_be :nil?
+    _(file.crc32c).must_be :nil?
+    _(file.etag).must_be :nil?
 
-    file.cache_control.must_be :nil?
-    file.content_disposition.must_be :nil?
-    file.content_encoding.must_be :nil?
-    file.content_language.must_be :nil?
-    file.content_type.must_be :nil?
+    _(file.cache_control).must_be :nil?
+    _(file.content_disposition).must_be :nil?
+    _(file.content_encoding).must_be :nil?
+    _(file.content_language).must_be :nil?
+    _(file.content_type).must_be :nil?
 
-    file.metadata.must_be_kind_of Hash
-    file.metadata.must_be :empty?
+    _(file.metadata).must_be_kind_of Hash
+    _(file.metadata).must_be :empty?
   end
 
   it "can delete itself" do
@@ -102,7 +102,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.generation.must_be :nil?
+    _(file.generation).must_be :nil?
     file.delete generation: true
 
     mock.verify
@@ -115,7 +115,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     file.service.mocked_service = mock
 
     file.gapi.generation = 1234567892
-    file.generation.must_equal 1234567892
+    _(file.generation).must_equal 1234567892
     file.delete generation: true
 
     mock.verify
@@ -149,7 +149,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
     file_user_project.service.mocked_service = mock
 
-    file_user_project.generation.must_be :nil?
+    _(file_user_project.generation).must_be :nil?
     file_user_project.delete generation: true
 
     mock.verify
@@ -162,7 +162,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     file_user_project.service.mocked_service = mock
 
     file_user_project.gapi.generation = 1234567893
-    file_user_project.generation.must_equal 1234567893
+    _(file_user_project.generation).must_equal 1234567893
     file_user_project.delete generation: true
 
     mock.verify
@@ -196,7 +196,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile
-      downloaded.must_be_kind_of File
+      _(downloaded).must_be_kind_of File
 
       mock.verify
     end
@@ -219,7 +219,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile.path
-      downloaded.must_be_kind_of File
+      _(downloaded).must_be_kind_of File
 
       mock.verify
     end
@@ -242,7 +242,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file_user_project.download tmpfile
-      downloaded.must_be_kind_of File
+      _(downloaded).must_be_kind_of File
 
       mock.verify
     end
@@ -261,7 +261,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     bucket.service.mocked_service = mock
 
     downloaded = file.download
-    downloaded.must_be_kind_of StringIO
+    _(downloaded).must_be_kind_of StringIO
 
     mock.verify
   end
@@ -280,8 +280,8 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
     downloadio = StringIO.new
     downloaded = file.download downloadio
-    downloaded.must_be_kind_of StringIO
-    downloadio.must_equal downloadio # should be the same object
+    _(downloaded).must_be_kind_of StringIO
+    _(downloadio).must_equal downloadio # should be the same object
 
     mock.verify
   end
@@ -303,7 +303,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile, encryption_key: encryption_key
-      downloaded.path.must_equal tmpfile.path
+      _(downloaded.path).must_equal tmpfile.path
 
       mock.verify
     end
@@ -545,7 +545,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     file_user_project.service.mocked_service = mock
 
     copied = file_user_project.copy "new-file.ext"
-    copied.user_project.must_equal true
+    _(copied.user_project).must_equal true
 
     mock.verify
   end
@@ -650,7 +650,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     end
 
     copied = file_user_project.copy "new-file.ext"
-    copied.user_project.must_equal true
+    _(copied.user_project).must_equal true
 
     mock.verify
   end
@@ -741,7 +741,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
       f.metadata["score"] = "10"
       f.storage_class = :nearline
     end
-    copied.user_project.must_equal true
+    _(copied.user_project).must_equal true
 
     mock.verify
   end
@@ -757,7 +757,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     file.service.mocked_service = mock
 
     updated = file.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
-    updated.name.must_equal file.name
+    _(updated.name).must_equal file.name
 
     mock.verify
   end
@@ -773,8 +773,8 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     file_user_project.service.mocked_service = mock
 
     updated = file_user_project.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
-    updated.name.must_equal file_user_project.name
-    updated.user_project.must_equal true
+    _(updated.name).must_equal file_user_project.name
+    _(updated.user_project).must_equal true
 
     mock.verify
   end
@@ -790,7 +790,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     file.service.mocked_service = mock
 
     updated = file.rotate new_encryption_key: encryption_key
-    updated.name.must_equal file.name
+    _(updated.name).must_equal file.name
 
     mock.verify
   end
@@ -806,7 +806,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     file.service.mocked_service = mock
 
     updated = file.rotate encryption_key: source_encryption_key
-    updated.name.must_equal file.name
+    _(updated.name).must_equal file.name
 
     mock.verify
   end
@@ -830,7 +830,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     end
 
     updated = file.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
-    updated.name.must_equal file.name
+    _(updated.name).must_equal file.name
 
     mock.verify
   end
@@ -854,8 +854,8 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     end
 
     updated = file_user_project.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
-    updated.name.must_equal file_user_project.name
-    updated.user_project.must_equal true
+    _(updated.name).must_equal file_user_project.name
+    _(updated.user_project).must_equal true
 
     mock.verify
   end
@@ -873,9 +873,9 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     file.service.mocked_service = mock
 
     file = bucket.file file_name
-    file.generation.must_equal 1234567891
+    _(file.generation).must_equal 1234567891
     file.reload!
-    file.generation.must_equal 1234567892
+    _(file.generation).must_equal 1234567892
 
     mock.verify
   end
@@ -893,9 +893,9 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     file.service.mocked_service = mock
 
     file = bucket_user_project.file file_name
-    file.generation.must_equal 1234567891
+    _(file.generation).must_equal 1234567891
     file.reload!
-    file.generation.must_equal 1234567892
+    _(file.generation).must_equal 1234567892
 
     mock.verify
   end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
@@ -196,7 +196,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile
-      _(downloaded).must_be_kind_of File
+      _(downloaded).must_be_kind_of Tempfile
 
       mock.verify
     end
@@ -219,7 +219,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile.path
-      _(downloaded).must_be_kind_of File
+      _(downloaded).must_be_kind_of Tempfile
 
       mock.verify
     end
@@ -242,7 +242,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file_user_project.download tmpfile
-      _(downloaded).must_be_kind_of File
+      _(downloaded).must_be_kind_of Tempfile
 
       mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_update_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.cache_control.must_be :nil?
+    _(file.cache_control).must_be :nil?
     file.cache_control = "private, max-age=0, no-cache"
 
     mock.verify
@@ -42,7 +42,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.content_disposition.must_be :nil?
+    _(file.content_disposition).must_be :nil?
     file.content_disposition = "inline; filename=filename.ext"
 
     mock.verify
@@ -56,7 +56,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.content_encoding.must_be :nil?
+    _(file.content_encoding).must_be :nil?
     file.content_encoding = "deflate"
 
     mock.verify
@@ -70,7 +70,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.content_language.must_be :nil?
+    _(file.content_language).must_be :nil?
     file.content_language = "de"
 
     mock.verify
@@ -84,7 +84,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.content_type.must_be :nil?
+    _(file.content_type).must_be :nil?
     file.content_type = "application/json"
 
     mock.verify
@@ -98,7 +98,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.metadata.must_be :empty?
+    _(file.metadata).must_be :empty?
     file.metadata = { "player" => "Bob", score: 10 }
 
     mock.verify
@@ -114,9 +114,9 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
 
     file.service.mocked_service = mock
 
-    file.storage_class.must_be :nil?
+    _(file.storage_class).must_be :nil?
     file.storage_class = :dra
-    file.storage_class.must_equal "DURABLE_REDUCED_AVAILABILITY"
+    _(file.storage_class).must_equal "DURABLE_REDUCED_AVAILABILITY"
 
     mock.verify
   end
@@ -131,9 +131,9 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
 
     file_user_project.service.mocked_service = mock
 
-    file_user_project.storage_class.must_be :nil?
+    _(file_user_project.storage_class).must_be :nil?
     file_user_project.storage_class = :dra
-    file_user_project.storage_class.must_equal "DURABLE_REDUCED_AVAILABILITY"
+    _(file_user_project.storage_class).must_equal "DURABLE_REDUCED_AVAILABILITY"
 
     mock.verify
   end
@@ -158,9 +158,9 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     def file.sleep *args
     end
 
-    file.storage_class.must_be :nil?
+    _(file.storage_class).must_be :nil?
     file.storage_class = :dra
-    file.storage_class.must_equal "DURABLE_REDUCED_AVAILABILITY"
+    _(file.storage_class).must_equal "DURABLE_REDUCED_AVAILABILITY"
 
     mock.verify
   end
@@ -185,9 +185,9 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     def file_user_project.sleep *args
     end
 
-    file_user_project.storage_class.must_be :nil?
+    _(file_user_project.storage_class).must_be :nil?
     file_user_project.storage_class = :dra
-    file_user_project.storage_class.must_equal "DURABLE_REDUCED_AVAILABILITY"
+    _(file_user_project.storage_class).must_equal "DURABLE_REDUCED_AVAILABILITY"
 
     mock.verify
   end

--- a/google-cloud-storage/test/google/cloud/storage/notification_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/notification_test.rb
@@ -26,12 +26,12 @@ describe Google::Cloud::Storage::Notification, :mock_storage do
 
 
   it "knows its attributes" do
-    notification.id.must_equal "1"
-    notification.custom_attrs.must_equal({ "foo" => "bar" })
-    notification.event_types.must_equal ["OBJECT_FINALIZE"]
-    notification.prefix.must_equal "my-prefix"
-    notification.payload.must_equal "NONE"
-    notification.topic.must_equal "//pubsub.googleapis.com/projects/#{project}/topics/#{topic_name}"
+    _(notification.id).must_equal "1"
+    _(notification.custom_attrs).must_equal({ "foo" => "bar" })
+    _(notification.event_types).must_equal ["OBJECT_FINALIZE"]
+    _(notification.prefix).must_equal "my-prefix"
+    _(notification.payload).must_equal "NONE"
+    _(notification.topic).must_equal "//pubsub.googleapis.com/projects/#{project}/topics/#{topic_name}"
   end
 
   it "can delete itself" do

--- a/google-cloud-storage/test/google/cloud/storage/policy_binding_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_binding_test.rb
@@ -40,18 +40,18 @@ describe Google::Cloud::Storage::Policy::Binding do
   let(:complex_binding) { Google::Cloud::Storage::Policy::Binding.new **complex_hash }
 
   it "knows itself" do
-    simple_binding.must_be_kind_of Google::Cloud::Storage::Policy::Binding
-    simple_binding.role.must_equal "roles/storage.objectViewer"
-    simple_binding.members.must_equal ["user:viewer@example.com"]
-    simple_binding.condition.must_be :nil?
+    _(simple_binding).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+    _(simple_binding.role).must_equal "roles/storage.objectViewer"
+    _(simple_binding.members).must_equal ["user:viewer@example.com"]
+    _(simple_binding.condition).must_be :nil?
 
-    complex_binding.must_be_kind_of Google::Cloud::Storage::Policy::Binding
-    complex_binding.role.must_equal "roles/storage.objectViewer"
-    complex_binding.members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
-    complex_binding.condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
-    complex_binding.condition.title.must_equal "always-true"
-    complex_binding.condition.description.must_equal "test condition always-true"
-    complex_binding.condition.expression.must_equal "true"
+    _(complex_binding).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+    _(complex_binding.role).must_equal "roles/storage.objectViewer"
+    _(complex_binding.members).must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+    _(complex_binding.condition).must_be_kind_of Google::Cloud::Storage::Policy::Condition
+    _(complex_binding.condition.title).must_equal "always-true"
+    _(complex_binding.condition.description).must_equal "test condition always-true"
+    _(complex_binding.condition.expression).must_equal "true"
   end
 
   it "can be changed" do
@@ -63,22 +63,22 @@ describe Google::Cloud::Storage::Policy::Binding do
       expression: "false"
     }
 
-    simple_binding.must_be_kind_of Google::Cloud::Storage::Policy::Binding
-    simple_binding.role.must_equal "roles/storage.objectOwner"
-    simple_binding.members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
-    simple_binding.condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
-    simple_binding.condition.title.must_equal "always-false"
-    simple_binding.condition.description.must_equal "test condition always-false"
-    simple_binding.condition.expression.must_equal "false"
+    _(simple_binding).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+    _(simple_binding.role).must_equal "roles/storage.objectOwner"
+    _(simple_binding.members).must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+    _(simple_binding.condition).must_be_kind_of Google::Cloud::Storage::Policy::Condition
+    _(simple_binding.condition.title).must_equal "always-false"
+    _(simple_binding.condition.description).must_equal "test condition always-false"
+    _(simple_binding.condition.expression).must_equal "false"
 
     simple_binding.role = "roles/storage.objectAdmin"
     simple_binding.members = ["user:admin@example.com"]
     simple_binding.condition = nil
 
-    simple_binding.must_be_kind_of Google::Cloud::Storage::Policy::Binding
-    simple_binding.role.must_equal "roles/storage.objectAdmin"
-    simple_binding.members.must_equal ["user:admin@example.com"]
-    simple_binding.condition.must_be :nil?
+    _(simple_binding).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+    _(simple_binding.role).must_equal "roles/storage.objectAdmin"
+    _(simple_binding.members).must_equal ["user:admin@example.com"]
+    _(simple_binding.condition).must_be :nil?
 
     new_condition = Google::Cloud::Storage::Policy::Condition.new(
       title: "always-true",
@@ -88,9 +88,9 @@ describe Google::Cloud::Storage::Policy::Binding do
 
     simple_binding.condition = new_condition
 
-    simple_binding.condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
-    simple_binding.condition.title.must_equal "always-true"
-    simple_binding.condition.description.must_equal "test condition always-true"
-    simple_binding.condition.expression.must_equal "true"
+    _(simple_binding.condition).must_be_kind_of Google::Cloud::Storage::Policy::Condition
+    _(simple_binding.condition.title).must_equal "always-true"
+    _(simple_binding.condition.description).must_equal "test condition always-true"
+    _(simple_binding.condition.expression).must_equal "true"
   end
 end

--- a/google-cloud-storage/test/google/cloud/storage/policy_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_test.rb
@@ -35,21 +35,21 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
     let(:policy) { Google::Cloud::Storage::PolicyV1.from_gapi policy_gapi_v1 }
 
     it "knows its attributes" do
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_equal etag
-      policy.version.must_equal 1
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_equal etag
+      _(policy.version).must_equal 1
     end
 
     it "knows its roles" do
-      policy.roles.keys.sort.must_equal ["roles/viewer"]
-      policy.roles.values.sort.must_equal [["allUsers"]]
+      _(policy.roles.keys.sort).must_equal ["roles/viewer"]
+      _(policy.roles.values.sort).must_equal [["allUsers"]]
     end
 
     it "returns an empty array for missing role" do
       role = policy.role "roles/does-not-exist"
-      role.must_be_kind_of Array
-      role.must_be :empty?
-      role.frozen?.must_equal false
+      _(role).must_be_kind_of Array
+      _(role).must_be :empty?
+      _(role.frozen?).must_equal false
     end
 
     it "raises for unsupported method calls" do
@@ -63,10 +63,10 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
 
       gapi_policy = policy.to_gapi
 
-      gapi_policy.class.must_equal Google::Apis::StorageV1::Policy
-      gapi_policy.bindings.size.must_equal policy.roles.size
+      _(gapi_policy.class).must_equal Google::Apis::StorageV1::Policy
+      _(gapi_policy.bindings.size).must_equal policy.roles.size
       gapi_policy.bindings.each do |binding|
-        binding.members.sort.must_equal policy.roles[binding.role].uniq.sort
+        _(binding.members.sort).must_equal policy.roles[binding.role].uniq.sort
       end
     end
 
@@ -75,10 +75,10 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
 
       policy = Google::Cloud::Storage::PolicyV1.from_gapi gapi
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-      policy.etag.must_be :nil?
-      policy.version.must_equal 1
-      policy.roles.must_be :empty?
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+      _(policy.etag).must_be :nil?
+      _(policy.version).must_equal 1
+      _(policy.roles).must_be :empty?
     end
   end
 
@@ -111,25 +111,25 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
     let(:policy) { Google::Cloud::Storage::PolicyV3.from_gapi policy_gapi_v3 }
 
     it "knows its attributes" do
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.etag.must_equal etag
-      policy.version.must_equal 3
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.etag).must_equal etag
+      _(policy.version).must_equal 3
     end
 
     it "knows its bindings" do
-      policy.bindings.must_be_kind_of Google::Cloud::Storage::Policy::Bindings
-      policy.bindings.to_a.count.must_equal 2
-      policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
-      policy.bindings.to_a[0].condition.must_be :nil?
-      policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::Policy::Binding
-      policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
-      policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
-      policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::Policy::Condition
-      policy.bindings.to_a[1].condition.title.must_equal "always-true"
-      policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
-      policy.bindings.to_a[1].condition.expression.must_equal "true"
+      _(policy.bindings).must_be_kind_of Google::Cloud::Storage::Policy::Bindings
+      _(policy.bindings.to_a.count).must_equal 2
+      _(policy.bindings.to_a[0]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[0].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[0].members).must_equal ["user:viewer@example.com"]
+      _(policy.bindings.to_a[0].condition).must_be :nil?
+      _(policy.bindings.to_a[1]).must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(policy.bindings.to_a[1].role).must_equal "roles/storage.objectViewer"
+      _(policy.bindings.to_a[1].members).must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+      _(policy.bindings.to_a[1].condition).must_be_kind_of Google::Cloud::Storage::Policy::Condition
+      _(policy.bindings.to_a[1].condition.title).must_equal "always-true"
+      _(policy.bindings.to_a[1].condition.description).must_equal "test condition always-true"
+      _(policy.bindings.to_a[1].condition.expression).must_equal "true"
     end
 
     it "raises for unsupported method calls" do
@@ -145,10 +145,10 @@ describe Google::Cloud::Storage::Policy, :mock_storage do
 
       policy = Google::Cloud::Storage::PolicyV3.from_gapi gapi
 
-      policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-      policy.etag.must_be :nil?
-      policy.version.must_equal 3
-      policy.bindings.to_a.must_be :empty?
+      _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+      _(policy.etag).must_be :nil?
+      _(policy.version).must_equal 3
+      _(policy.bindings.to_a).must_be :empty?
     end
   end
 end

--- a/google-cloud-storage/test/google/cloud/storage/policy_v1_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_v1_test.rb
@@ -34,21 +34,21 @@ describe Google::Cloud::Storage::PolicyV1, :mock_storage do
   let(:policy) { Google::Cloud::Storage::PolicyV1.from_gapi policy_gapi_v1 }
 
   it "knows its attributes" do
-    policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-    policy.etag.must_equal etag
-    policy.version.must_equal 1
+    _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+    _(policy.etag).must_equal etag
+    _(policy.version).must_equal 1
   end
 
   it "knows its roles" do
-    policy.roles.keys.sort.must_equal ["roles/viewer"]
-    policy.roles.values.sort.must_equal [["allUsers"]]
+    _(policy.roles.keys.sort).must_equal ["roles/viewer"]
+    _(policy.roles.values.sort).must_equal [["allUsers"]]
   end
 
   it "returns an empty array for missing role" do
     role = policy.role "roles/does-not-exist"
-    role.must_be_kind_of Array
-    role.must_be :empty?
-    role.frozen?.must_equal false
+    _(role).must_be_kind_of Array
+    _(role).must_be :empty?
+    _(role.frozen?).must_equal false
   end
 
   it "creates from an empty Google::Apis::StorageV1::Policy object" do
@@ -56,9 +56,9 @@ describe Google::Cloud::Storage::PolicyV1, :mock_storage do
 
     policy = Google::Cloud::Storage::PolicyV1.from_gapi gapi
 
-    policy.must_be_kind_of Google::Cloud::Storage::PolicyV1
-    policy.etag.must_be :nil?
-    policy.version.must_equal 1
-    policy.roles.must_be :empty?
+    _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV1
+    _(policy.etag).must_be :nil?
+    _(policy.version).must_equal 1
+    _(policy.roles).must_be :empty?
   end
 end

--- a/google-cloud-storage/test/google/cloud/storage/policy_v3_bindings_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_v3_bindings_test.rb
@@ -41,58 +41,58 @@ describe Google::Cloud::Storage::PolicyV3, :bindings do
   let(:complex_binding) { Google::Cloud::Storage::Policy::Binding.new **complex_hash }
 
   it "bindings can be added, iterated and removed" do
-    policy.bindings.to_a.count.must_equal 0
+    _(policy.bindings.to_a.count).must_equal 0
     policy.bindings.insert simple_binding
-    policy.bindings.to_a.count.must_equal 1
+    _(policy.bindings.to_a.count).must_equal 1
     policy.bindings.insert complex_binding
-    policy.bindings.to_a.count.must_equal 2
+    _(policy.bindings.to_a.count).must_equal 2
 
     idx = 0
     policy.bindings.each do |binding|
-      binding.must_be_kind_of Google::Cloud::Storage::Policy::Binding
+      _(binding).must_be_kind_of Google::Cloud::Storage::Policy::Binding
       idx += 1
     end
-    idx.must_equal 2
+    _(idx).must_equal 2
 
     enumerator = policy.bindings.each
-    enumerator.next.must_equal simple_binding
-    enumerator.next.must_equal complex_binding
+    _(enumerator.next).must_equal simple_binding
+    _(enumerator.next).must_equal complex_binding
 
     policy.bindings.remove complex_binding
-    policy.bindings.to_a.count.must_equal 1
+    _(policy.bindings.to_a.count).must_equal 1
     policy.bindings.remove simple_binding
-    policy.bindings.to_a.count.must_equal 0
+    _(policy.bindings.to_a.count).must_equal 0
   end
 
   it "multiple bindings can be added and removed in a single call" do
-    policy.bindings.to_a.count.must_equal 0
+    _(policy.bindings.to_a.count).must_equal 0
     policy.bindings.insert simple_binding, complex_binding
-    policy.bindings.to_a.count.must_equal 2
+    _(policy.bindings.to_a.count).must_equal 2
 
     policy.bindings.remove complex_binding, simple_binding
-    policy.bindings.to_a.count.must_equal 0
+    _(policy.bindings.to_a.count).must_equal 0
   end
 
   it "bindings can be added and removed using hashes" do
-    policy.bindings.to_a.count.must_equal 0
+    _(policy.bindings.to_a.count).must_equal 0
     policy.bindings.insert simple_hash
-    policy.bindings.to_a.count.must_equal 1
+    _(policy.bindings.to_a.count).must_equal 1
     policy.bindings.insert complex_hash
-    policy.bindings.to_a.count.must_equal 2
+    _(policy.bindings.to_a.count).must_equal 2
 
     policy.bindings.remove complex_hash
-    policy.bindings.to_a.count.must_equal 1
+    _(policy.bindings.to_a.count).must_equal 1
     policy.bindings.remove simple_hash
-    policy.bindings.to_a.count.must_equal 0
+    _(policy.bindings.to_a.count).must_equal 0
   end
 
   it "multiple bindings can be added and removed using hashes in a single call" do
-    policy.bindings.to_a.count.must_equal 0
+    _(policy.bindings.to_a.count).must_equal 0
     policy.bindings.insert simple_hash, complex_hash
-    policy.bindings.to_a.count.must_equal 2
+    _(policy.bindings.to_a.count).must_equal 2
 
     policy.bindings.remove complex_hash, simple_hash
-    policy.bindings.to_a.count.must_equal 0
+    _(policy.bindings.to_a.count).must_equal 0
   end
 
   it "bindings can be changed to create duplicates and all duplicates removed" do
@@ -114,23 +114,23 @@ describe Google::Cloud::Storage::PolicyV3, :bindings do
       }
     }
 
-    policy.bindings.to_a.count.must_equal 0
+    _(policy.bindings.to_a.count).must_equal 0
     policy.bindings.insert simple_hash, simple_owner_hash
-    policy.bindings.to_a.count.must_equal 2
+    _(policy.bindings.to_a.count).must_equal 2
     policy.bindings.insert complex_hash, complex_owner_hash
-    policy.bindings.to_a.count.must_equal 4
+    _(policy.bindings.to_a.count).must_equal 4
 
     simple_owner_binding = policy.bindings.find { |b| b.role == simple_owner_hash[:role] && b.members == simple_owner_hash[:members] }
-    simple_owner_binding.must_be_kind_of Google::Cloud::Storage::PolicyV3::Binding
-    simple_owner_binding.role.must_equal "roles/storage.objectOwner"
-    simple_owner_binding.members.must_equal ["user:owner@example.com"]
-    simple_owner_binding.condition.must_be :nil?
+    _(simple_owner_binding).must_be_kind_of Google::Cloud::Storage::PolicyV3::Binding
+    _(simple_owner_binding.role).must_equal "roles/storage.objectOwner"
+    _(simple_owner_binding.members).must_equal ["user:owner@example.com"]
+    _(simple_owner_binding.condition).must_be :nil?
 
     complex_owner_binding = policy.bindings.find { |b| b.role == complex_owner_hash[:role] && b.members == complex_owner_hash[:members] }
-    complex_owner_binding.must_be_kind_of Google::Cloud::Storage::PolicyV3::Binding
-    complex_owner_binding.role.must_equal "roles/storage.objectOwner"
-    complex_owner_binding.members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
-    complex_owner_binding.condition.must_be_kind_of Google::Cloud::Storage::PolicyV3::Condition
+    _(complex_owner_binding).must_be_kind_of Google::Cloud::Storage::PolicyV3::Binding
+    _(complex_owner_binding.role).must_equal "roles/storage.objectOwner"
+    _(complex_owner_binding.members).must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+    _(complex_owner_binding.condition).must_be_kind_of Google::Cloud::Storage::PolicyV3::Condition
 
     # change the binding to be the same as the simple binding
     simple_owner_binding.role = simple_hash[:role]
@@ -141,10 +141,10 @@ describe Google::Cloud::Storage::PolicyV3, :bindings do
     complex_owner_binding.condition = complex_hash[:condition]
 
     # remove the now duplicate values by specifying only one binding value
-    policy.bindings.to_a.count.must_equal 4
+    _(policy.bindings.to_a.count).must_equal 4
     policy.bindings.remove simple_hash
-    policy.bindings.to_a.count.must_equal 2
+    _(policy.bindings.to_a.count).must_equal 2
     policy.bindings.remove complex_hash
-    policy.bindings.to_a.count.must_equal 0
+    _(policy.bindings.to_a.count).must_equal 0
   end
 end

--- a/google-cloud-storage/test/google/cloud/storage/policy_v3_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_v3_test.rb
@@ -44,25 +44,25 @@ describe Google::Cloud::Storage::PolicyV3, :mock_storage do
   let(:policy) { Google::Cloud::Storage::PolicyV3.from_gapi policy_gapi_v3 }
 
   it "knows its attributes" do
-    policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-    policy.etag.must_equal etag
-    policy.version.must_equal 3
+    _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+    _(policy.etag).must_equal etag
+    _(policy.version).must_equal 3
   end
 
   it "knows its bindings" do
-    policy.bindings.must_be_kind_of Google::Cloud::Storage::PolicyV3::Bindings
-    policy.bindings.to_a.count.must_equal 2
-    policy.bindings.to_a[0].must_be_kind_of Google::Cloud::Storage::PolicyV3::Binding
-    policy.bindings.to_a[0].role.must_equal "roles/storage.objectViewer"
-    policy.bindings.to_a[0].members.must_equal ["user:viewer@example.com"]
-    policy.bindings.to_a[0].condition.must_be :nil?
-    policy.bindings.to_a[1].must_be_kind_of Google::Cloud::Storage::PolicyV3::Binding
-    policy.bindings.to_a[1].role.must_equal "roles/storage.objectViewer"
-    policy.bindings.to_a[1].members.must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
-    policy.bindings.to_a[1].condition.must_be_kind_of Google::Cloud::Storage::PolicyV3::Condition
-    policy.bindings.to_a[1].condition.title.must_equal "always-true"
-    policy.bindings.to_a[1].condition.description.must_equal "test condition always-true"
-    policy.bindings.to_a[1].condition.expression.must_equal "true"
+    _(policy.bindings).must_be_kind_of Google::Cloud::Storage::PolicyV3::Bindings
+    _(policy.bindings.to_a.count).must_equal 2
+    _(policy.bindings.to_a[0]).must_be_kind_of Google::Cloud::Storage::PolicyV3::Binding
+    _(policy.bindings.to_a[0].role).must_equal "roles/storage.objectViewer"
+    _(policy.bindings.to_a[0].members).must_equal ["user:viewer@example.com"]
+    _(policy.bindings.to_a[0].condition).must_be :nil?
+    _(policy.bindings.to_a[1]).must_be_kind_of Google::Cloud::Storage::PolicyV3::Binding
+    _(policy.bindings.to_a[1].role).must_equal "roles/storage.objectViewer"
+    _(policy.bindings.to_a[1].members).must_equal ["serviceAccount:1234567890@developer.gserviceaccount.com"]
+    _(policy.bindings.to_a[1].condition).must_be_kind_of Google::Cloud::Storage::PolicyV3::Condition
+    _(policy.bindings.to_a[1].condition.title).must_equal "always-true"
+    _(policy.bindings.to_a[1].condition.description).must_equal "test condition always-true"
+    _(policy.bindings.to_a[1].condition.expression).must_equal "true"
   end
 
   it "creates from an empty Google::Apis::StorageV1::Policy object" do
@@ -70,9 +70,9 @@ describe Google::Cloud::Storage::PolicyV3, :mock_storage do
 
     policy = Google::Cloud::Storage::PolicyV3.from_gapi gapi
 
-    policy.must_be_kind_of Google::Cloud::Storage::PolicyV3
-    policy.etag.must_be :nil?
-    policy.version.must_equal 3
-    policy.bindings.to_a.must_be :empty?
+    _(policy).must_be_kind_of Google::Cloud::Storage::PolicyV3
+    _(policy.etag).must_be :nil?
+    _(policy.version).must_equal 3
+    _(policy.bindings.to_a).must_be :empty?
   end
 end

--- a/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
   let(:anonymous_storage) { Google::Cloud::Storage.anonymous }
 
   it "raises when creating a bucket without authentication" do
-    stub = Object.new
+    stub = self
     def stub.insert_bucket *args
       _(args.first).must_be_nil # project
       raise Google::Apis::AuthorizationError.new("unauthorized", status_code: 401)
@@ -31,7 +31,7 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
   end
 
   it "raises when listing buckets without authentication" do
-    stub = Object.new
+    stub = self
     def stub.list_buckets *args
       _(args.first).must_be_nil # project
       raise Google::Apis::AuthorizationError.new("unauthorized", status_code: 401)

--- a/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
@@ -122,7 +122,7 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
       end
 
       downloaded = file.download tmpfile
-      _(downloaded).must_be_kind_of File
+      _(downloaded).must_be_kind_of Tempfile
 
       mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
   it "raises when creating a bucket without authentication" do
     stub = Object.new
     def stub.insert_bucket *args
-      args.first.must_be_nil # project
+      _(args.first).must_be_nil # project
       raise Google::Apis::AuthorizationError.new("unauthorized", status_code: 401)
     end
     anonymous_storage.service.mocked_service = stub
@@ -33,7 +33,7 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
   it "raises when listing buckets without authentication" do
     stub = Object.new
     def stub.list_buckets *args
-      args.first.must_be_nil # project
+      _(args.first).must_be_nil # project
       raise Google::Apis::AuthorizationError.new("unauthorized", status_code: 401)
     end
     anonymous_storage.service.mocked_service = stub
@@ -53,8 +53,8 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
 
     mock.verify
 
-    bucket.name.must_equal bucket_name
-    bucket.wont_be :lazy?
+    _(bucket.name).must_equal bucket_name
+    _(bucket).wont_be :lazy?
   end
 
   it "lists public files" do
@@ -71,10 +71,10 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
 
     mock.verify
 
-    files.size.must_equal num_files
+    _(files.size).must_equal num_files
     files.each do |file|
-      file.must_be_kind_of Google::Cloud::Storage::File
-      file.user_project.must_be :nil?
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
     end
   end
 
@@ -93,9 +93,9 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
 
     mock.verify
 
-    file.name.must_equal file_name
-    file.user_project.must_be :nil?
-    file.wont_be :lazy?
+    _(file.name).must_equal file_name
+    _(file.user_project).must_be :nil?
+    _(file).wont_be :lazy?
   end
 
   it "downloads a public file" do
@@ -122,7 +122,7 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
       end
 
       downloaded = file.download tmpfile
-      downloaded.must_be_kind_of File
+      _(downloaded).must_be_kind_of File
 
       mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/project_hmac_keys_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_hmac_keys_test.rb
@@ -46,8 +46,8 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
     mock.verify
 
-    hmac_key.must_be_kind_of Google::Cloud::Storage::HmacKey
-    hmac_key.service_account_email.must_equal service_account_email
+    _(hmac_key).must_be_kind_of Google::Cloud::Storage::HmacKey
+    _(hmac_key.service_account_email).must_equal service_account_email
   end
 
   it "creates an HMAC key with project_id set to another project ID" do
@@ -60,8 +60,8 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
     mock.verify
 
-    hmac_key.must_be_kind_of Google::Cloud::Storage::HmacKey
-    hmac_key.project_id.must_equal other_project_id
+    _(hmac_key).must_be_kind_of Google::Cloud::Storage::HmacKey
+    _(hmac_key.project_id).must_equal other_project_id
   end
 
   it "creates an HMAC key with user_project set to another project ID" do
@@ -73,8 +73,8 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
     mock.verify
 
-    hmac_key.must_be_kind_of Google::Cloud::Storage::HmacKey
-    hmac_key.user_project.must_equal other_project_id
+    _(hmac_key).must_be_kind_of Google::Cloud::Storage::HmacKey
+    _(hmac_key.user_project).must_equal other_project_id
   end
 
   it "lists HMAC keys" do
@@ -86,7 +86,7 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
     mock.verify
 
-    hmac_keys.size.must_equal 3
+    _(hmac_keys.size).must_equal 3
   end
 
   it "lists HMAC keys with project_id set to another project ID" do
@@ -98,7 +98,7 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
     mock.verify
 
-    hmac_keys.size.must_equal 3
+    _(hmac_keys.size).must_equal 3
   end
 
   it "lists HMAC keys with service_account_email, show_deleted_keys and user_project options" do
@@ -110,7 +110,7 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
     mock.verify
 
-    hmac_keys.size.must_equal 3
+    _(hmac_keys.size).must_equal 3
   end
 
   it "paginates HMAC keys with token and max" do
@@ -126,12 +126,12 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
     mock.verify
 
-    hmac_keys_1.size.must_equal 3
-    hmac_keys_1.token.wont_be :nil?
-    hmac_keys_1.token.must_equal "next_page_token"
+    _(hmac_keys_1.size).must_equal 3
+    _(hmac_keys_1.token).wont_be :nil?
+    _(hmac_keys_1.token).must_equal "next_page_token"
 
-    hmac_keys_2.count.must_equal 3
-    hmac_keys_2.token.must_be :nil?
+    _(hmac_keys_2.count).must_equal 3
+    _(hmac_keys_2.token).must_be :nil?
   end
 
   it "paginates HMAC keys with next? and next" do
@@ -147,13 +147,13 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
     mock.verify
 
-    hmac_keys_1.size.must_equal 3
-    hmac_keys_1.next?.must_equal true
-    hmac_keys_1.token.must_equal "next_page_token"
+    _(hmac_keys_1.size).must_equal 3
+    _(hmac_keys_1.next?).must_equal true
+    _(hmac_keys_1.token).must_equal "next_page_token"
 
-    hmac_keys_2.count.must_equal 3
-    hmac_keys_2.token.must_be :nil?
-    hmac_keys_2.next?.must_equal false
+    _(hmac_keys_2.count).must_equal 3
+    _(hmac_keys_2.token).must_be :nil?
+    _(hmac_keys_2.next?).must_equal false
   end
 
   it "paginates HMAC keys with all" do
@@ -168,7 +168,7 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
     mock.verify
 
-    hmac_keys.size.must_equal 6
+    _(hmac_keys.size).must_equal 6
   end
 
   it "iterates HMAC keys with all using Enumerator" do
@@ -183,7 +183,7 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
     mock.verify
 
-    hmac_keys.size.must_equal 5
+    _(hmac_keys.size).must_equal 5
   end
 
   it "iterates HMAC keys with all and request_limit and user_project set to another project ID" do
@@ -198,7 +198,7 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
     mock.verify
 
-    hmac_keys.size.must_equal 6
+    _(hmac_keys.size).must_equal 6
   end
 
   it "finds an HMAC key" do
@@ -210,7 +210,7 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
     mock.verify
 
-    hmac_key.access_id.must_equal access_id
+    _(hmac_key.access_id).must_equal access_id
   end
 
   it "finds an HMAC key with project_id set to another project ID" do
@@ -223,7 +223,7 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
     mock.verify
 
-    hmac_key.project_id.must_equal other_project_id
+    _(hmac_key.project_id).must_equal other_project_id
   end
 
   it "finds an HMAC key with user_project set to another project ID" do
@@ -235,6 +235,6 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
     mock.verify
 
-    hmac_key.user_project.must_equal other_project_id
+    _(hmac_key.user_project).must_equal other_project_id
   end
 end

--- a/google-cloud-storage/test/google/cloud/storage/project_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_signed_url_v2_test.rb
@@ -28,8 +28,8 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
       signed_url = storage.signed_url bucket_name, file_path
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -48,8 +48,8 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
                                       signing_key: signing_key_mock
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["option_issuer"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["option_issuer"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -70,8 +70,8 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
                                         private_key: "option_private_key"
 
         signed_url_params = CGI::parse(URI(signed_url).query)
-        signed_url_params["GoogleAccessId"].must_equal ["option_client_email"]
-        signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+        _(signed_url_params["GoogleAccessId"]).must_equal ["option_client_email"]
+        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
 
       end
 
@@ -91,8 +91,8 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
                                                  "X-Goog-ACL" => "public-read" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
       signing_key_mock.verify
     end
@@ -108,9 +108,9 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
       signed_url = storage.signed_url bucket_name, file_path, query: { "response-content-disposition" => "attachment; filename=\"test.png\"" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      signed_url_params["response-content-disposition"].must_equal ["attachment; filename=\"test.png\""]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"test.png\""]
 
       signing_key_mock.verify
     end
@@ -147,11 +147,11 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
         signed_url = storage.signed_url bucket_name, file_path
 
         signed_uri = URI signed_url
-        signed_uri.path.must_equal "/bucket/hello%20world.txt"
+        _(signed_uri.path).must_equal "/bucket/hello%20world.txt"
 
         signed_url_params = CGI::parse signed_uri.query
-        signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-        signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+        _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
 
         signing_key_mock.verify
       end
@@ -169,9 +169,9 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
                                       query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      signed_url_params["response-content-disposition"].must_equal ["attachment; filename=\"google-cloud.png\""]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"google-cloud.png\""]
 
       signing_key_mock.verify
     end
@@ -188,9 +188,9 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
                                       query: { disposition: :inline }
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      signed_url_params["disposition"].must_equal ["inline"]
+      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
+      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      _(signed_url_params["disposition"]).must_equal ["inline"]
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/project_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_signed_url_v4_test.rb
@@ -28,12 +28,12 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
       signed_url = storage.signed_url bucket_name, file_path, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -52,12 +52,12 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
                                       signing_key: signing_key_mock, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6f7074696f6e2d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -78,12 +78,12 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
                                         private_key: "option_private_key", version: :v4
 
         signed_url_params = CGI::parse(URI(signed_url).query)
-        signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-        signed_url_params["X-Goog-Credential"].must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
-        signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-        signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-        signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-        signed_url_params["X-Goog-Signature"].must_equal  ["6f7074696f6e2d7369676e6174757265"]
+        _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+        _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
+        _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+        _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+        _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
 
       end
 
@@ -103,12 +103,12 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
                                                  "X-Goog-ACL" => "public-read" }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end
@@ -143,12 +143,12 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
                                       query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
       signing_key_mock.verify
     end
   end
@@ -164,12 +164,12 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
                                       query: { disposition: :inline }, version: :v4
 
       signed_url_params = CGI::parse(URI(signed_url).query)
-      signed_url_params["X-Goog-Algorithm"].must_equal  ["GOOG4-RSA-SHA256"]
-      signed_url_params["X-Goog-Credential"].must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      signed_url_params["X-Goog-Date"].must_equal  ["20120101T000000Z"]
-      signed_url_params["X-Goog-Expires"].must_equal  ["604800"]
-      signed_url_params["X-Goog-SignedHeaders"].must_equal  ["host"]
-      signed_url_params["X-Goog-Signature"].must_equal  ["6e61746976652d7369676e6174757265"]
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
+      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
+      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
+      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
+      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/project_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_test.rb
@@ -42,8 +42,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     mock.expect :get_project_service_account, service_account_resp, [project]
     storage.service.mocked_service = mock
 
-    storage.service_account_email.must_equal email
-    storage.service_account_email.must_equal email # memoized, no request
+    _(storage.service_account_email).must_equal email
+    _(storage.service_account_email).must_equal email # memoized, no request
 
     mock.verify
   end
@@ -59,9 +59,9 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
-    bucket.location_type.must_equal bucket_location_type
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
+    _(bucket.location_type).must_equal bucket_location_type
   end
 
   it "creates a bucket with location" do
@@ -75,10 +75,10 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
-    bucket.location.must_equal bucket_location
-    bucket.location_type.must_equal bucket_location_type
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
+    _(bucket.location).must_equal bucket_location
+    _(bucket.location_type).must_equal bucket_location_type
   end
 
   it "creates a bucket with storage_class" do
@@ -92,9 +92,9 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
-    bucket.storage_class.must_equal bucket_storage_class
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
+    _(bucket.storage_class).must_equal bucket_storage_class
   end
 
   it "creates a bucket with versioning" do
@@ -108,9 +108,9 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
-    bucket.versioning?.must_equal true
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
+    _(bucket.versioning?).must_equal true
   end
 
   it "creates a bucket with logging bucket and prefix" do
@@ -124,10 +124,10 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
-    bucket.logging_bucket.must_equal bucket_logging_bucket
-    bucket.logging_prefix.must_equal bucket_logging_prefix
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
+    _(bucket.logging_bucket).must_equal bucket_logging_bucket
+    _(bucket.logging_prefix).must_equal bucket_logging_prefix
   end
 
   it "creates a bucket with website main and 404" do
@@ -141,10 +141,10 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
-    bucket.website_main.must_equal bucket_website_main
-    bucket.website_404.must_equal bucket_website_404
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
+    _(bucket.website_main).must_equal bucket_website_main
+    _(bucket.website_404).must_equal bucket_website_404
   end
 
   it "creates a bucket with requester pays" do
@@ -160,9 +160,9 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
-    bucket.requester_pays.must_equal bucket_requester_pays
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
+    _(bucket.requester_pays).must_equal bucket_requester_pays
   end
 
   it "creates a bucket with requester pays and user_project set to true" do
@@ -178,10 +178,10 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
-    bucket.requester_pays.must_equal bucket_requester_pays
-    bucket.user_project.must_equal true
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
+    _(bucket.requester_pays).must_equal bucket_requester_pays
+    _(bucket.user_project).must_equal true
   end
 
   it "creates a bucket with requester pays and user_project set to another project ID" do
@@ -197,10 +197,10 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
-    bucket.requester_pays.must_equal bucket_requester_pays
-    bucket.user_project.must_equal "my-other-project"
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
+    _(bucket.requester_pays).must_equal bucket_requester_pays
+    _(bucket.user_project).must_equal "my-other-project"
   end
 
   it "creates a bucket with block CORS" do
@@ -220,9 +220,9 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
-    bucket.cors.class.must_equal Google::Cloud::Storage::Bucket::Cors
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
+    _(bucket.cors.class).must_equal Google::Cloud::Storage::Bucket::Cors
   end
 
   it "creates a bucket with block lifecycle (Object Lifecycle Management)" do
@@ -239,9 +239,9 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
-    bucket.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
+    _(bucket.lifecycle.class).must_equal Google::Cloud::Storage::Bucket::Lifecycle
   end
 
   it "creates a bucket with block labels" do
@@ -254,16 +254,16 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     storage.service.mocked_service = mock
 
     bucket = storage.create_bucket bucket_name do |b|
-      b.labels.must_equal Hash.new
+      _(b.labels).must_equal Hash.new
       b.labels = { "env" => "production" }
       b.labels["foo"] = "bar"
     end
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
-    bucket.cors.class.must_equal Google::Cloud::Storage::Bucket::Cors
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
+    _(bucket.cors.class).must_equal Google::Cloud::Storage::Bucket::Cors
   end
 
   it "creates a bucket with block encryption" do
@@ -281,10 +281,10 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.default_kms_key.wont_be :nil?
-    bucket.default_kms_key.must_be_kind_of String
-    bucket.default_kms_key.must_equal kms_key
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.default_kms_key).wont_be :nil?
+    _(bucket.default_kms_key).must_be_kind_of String
+    _(bucket.default_kms_key).must_equal kms_key
   end
 
   it "creates a bucket with predefined acl" do
@@ -298,8 +298,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
   end
 
   it "creates a bucket with predefined acl alias" do
@@ -313,8 +313,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
   end
 
   it "creates a bucket with predefined default acl" do
@@ -328,8 +328,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
   end
 
   it "creates a bucket with predefined default acl alias" do
@@ -343,8 +343,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.name.must_equal bucket_name
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.name).must_equal bucket_name
   end
 
   it "creates a bucket with retention_period" do
@@ -370,10 +370,10 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.retention_period.must_equal bucket_retention_period
-    bucket.retention_effective_at.must_be_within_delta bucket_retention_effective_at
-    bucket.retention_policy_locked?.must_equal false
-    bucket.default_event_based_hold?.must_equal false
+    _(bucket.retention_period).must_equal bucket_retention_period
+    _(bucket.retention_effective_at).must_be_within_delta bucket_retention_effective_at
+    _(bucket.retention_policy_locked?).must_equal false
+    _(bucket.default_event_based_hold?).must_equal false
   end
 
   it "creates a bucket with default_event_based_hold" do
@@ -391,10 +391,10 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.retention_period.must_be :nil?
-    bucket.retention_effective_at.must_be :nil?
-    bucket.retention_policy_locked?.must_equal false
-    bucket.default_event_based_hold?.must_equal true
+    _(bucket.retention_period).must_be :nil?
+    _(bucket.retention_effective_at).must_be :nil?
+    _(bucket.retention_policy_locked?).must_equal false
+    _(bucket.default_event_based_hold?).must_equal true
   end
 
   it "raises when creating a bucket with a blank name" do
@@ -423,10 +423,10 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    buckets.size.must_equal num_buckets
+    _(buckets.size).must_equal num_buckets
     bucket = buckets.first
-    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
-    bucket.location_type.must_equal "multi-region"
+    _(bucket).must_be_kind_of Google::Cloud::Storage::Bucket
+    _(bucket.location_type).must_equal "multi-region"
   end
 
   it "lists buckets with find_buckets alias" do
@@ -441,7 +441,7 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    buckets.size.must_equal num_buckets
+    _(buckets.size).must_equal num_buckets
   end
 
   it "paginates buckets" do
@@ -456,12 +456,12 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    first_buckets.count.must_equal 3
-    first_buckets.token.wont_be :nil?
-    first_buckets.token.must_equal "next_page_token"
+    _(first_buckets.count).must_equal 3
+    _(first_buckets.token).wont_be :nil?
+    _(first_buckets.token).must_equal "next_page_token"
 
-    second_buckets.count.must_equal 2
-    second_buckets.token.must_be :nil?
+    _(second_buckets.count).must_equal 2
+    _(second_buckets.token).must_be :nil?
   end
 
   it "paginates buckets with max set" do
@@ -476,12 +476,12 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    first_buckets.count.must_equal 3
-    first_buckets.token.wont_be :nil?
-    first_buckets.token.must_equal "next_page_token"
+    _(first_buckets.count).must_equal 3
+    _(first_buckets.token).wont_be :nil?
+    _(first_buckets.token).must_equal "next_page_token"
 
-    second_buckets.count.must_equal 2
-    second_buckets.token.must_be :nil?
+    _(second_buckets.count).must_equal 2
+    _(second_buckets.token).must_be :nil?
   end
 
   it "paginates buckets without max set" do
@@ -496,11 +496,11 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    buckets.size.must_equal num_buckets
+    _(buckets.size).must_equal num_buckets
 
-    buckets.count.must_equal 3
-    buckets.token.wont_be :nil?
-    buckets.token.must_equal "next_page_token"
+    _(buckets.count).must_equal 3
+    _(buckets.token).wont_be :nil?
+    _(buckets.token).must_equal "next_page_token"
   end
 
   it "paginates buckets with next? and next" do
@@ -515,11 +515,11 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    first_buckets.count.must_equal 3
-    first_buckets.next?.must_equal true
+    _(first_buckets.count).must_equal 3
+    _(first_buckets.next?).must_equal true
 
-    second_buckets.count.must_equal 2
-    second_buckets.next?.must_equal false
+    _(second_buckets.count).must_equal 2
+    _(second_buckets.next?).must_equal false
   end
 
   it "paginates buckets with next? and next and max set" do
@@ -534,11 +534,11 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    first_buckets.count.must_equal 3
-    first_buckets.next?.must_equal true
+    _(first_buckets.count).must_equal 3
+    _(first_buckets.next?).must_equal true
 
-    second_buckets.count.must_equal 2
-    second_buckets.next?.must_equal false
+    _(second_buckets.count).must_equal 2
+    _(second_buckets.next?).must_equal false
   end
 
   it "paginates buckets with all" do
@@ -552,7 +552,7 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    buckets.count.must_equal 5
+    _(buckets.count).must_equal 5
   end
 
   it "paginates buckets with all and max set" do
@@ -566,7 +566,7 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    buckets.count.must_equal 5
+    _(buckets.count).must_equal 5
   end
 
   it "iterates buckets with all using Enumerator" do
@@ -580,7 +580,7 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    buckets.count.must_equal 5
+    _(buckets.count).must_equal 5
   end
 
   it "iterates buckets with all and request_limit set" do
@@ -594,7 +594,7 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    buckets.count.must_equal 6
+    _(buckets.count).must_equal 6
   end
 
   it "iterates buckets with all and user_project set to true" do
@@ -608,8 +608,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    buckets.count.must_equal 6
-    buckets.first.user_project.must_equal true
+    _(buckets.count).must_equal 6
+    _(buckets.first.user_project).must_equal true
   end
 
   it "iterates buckets with all and user_project set to another project ID" do
@@ -623,8 +623,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    buckets.count.must_equal 6
-    buckets.first.user_project.must_equal "my-other-project"
+    _(buckets.count).must_equal 6
+    _(buckets.first.user_project).must_equal "my-other-project"
   end
 
   it "finds a bucket" do
@@ -639,8 +639,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.name.must_equal bucket_name
-    bucket.wont_be :lazy?
+    _(bucket.name).must_equal bucket_name
+    _(bucket).wont_be :lazy?
   end
 
   it "finds a bucket with find_bucket alias" do
@@ -655,8 +655,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.name.must_equal bucket_name
-    bucket.wont_be :lazy?
+    _(bucket.name).must_equal bucket_name
+    _(bucket).wont_be :lazy?
   end
 
   it "finds a bucket with user_project set to true" do
@@ -671,8 +671,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.name.must_equal bucket_name
-    bucket.wont_be :lazy?
+    _(bucket.name).must_equal bucket_name
+    _(bucket).wont_be :lazy?
   end
 
   it "finds a bucket with user_project set to another project ID" do
@@ -687,8 +687,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.name.must_equal bucket_name
-    bucket.wont_be :lazy?
+    _(bucket.name).must_equal bucket_name
+    _(bucket).wont_be :lazy?
   end
 
   it "returns a lazy bucket" do
@@ -702,8 +702,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.name.must_equal bucket_name
-    bucket.must_be :lazy?
+    _(bucket.name).must_equal bucket_name
+    _(bucket).must_be :lazy?
   end
 
   it "returns a lazy bucket with find_bucket alias" do
@@ -717,8 +717,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.name.must_equal bucket_name
-    bucket.must_be :lazy?
+    _(bucket.name).must_equal bucket_name
+    _(bucket).must_be :lazy?
   end
 
   it "returns a lazy bucket with user_project set to true" do
@@ -732,8 +732,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.name.must_equal bucket_name
-    bucket.must_be :lazy?
+    _(bucket.name).must_equal bucket_name
+    _(bucket).must_be :lazy?
   end
 
   it "returns a lazy bucket with user_project set to another project ID" do
@@ -747,8 +747,8 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     mock.verify
 
-    bucket.name.must_equal bucket_name
-    bucket.must_be :lazy?
+    _(bucket.name).must_equal bucket_name
+    _(bucket).must_be :lazy?
   end
 
   def bucket_with_location created_bucket

--- a/google-cloud-storage/test/google/cloud/storage/verifier_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/verifier_test.rb
@@ -39,7 +39,7 @@ describe Google::Cloud::Storage::File::Verifier, :mock_storage do
     Tempfile.open "google-cloud" do |tmpfile|
       tmpfile.write file_contents
       digest = Google::Cloud::Storage::File::Verifier.md5_for tmpfile
-      digest.must_equal md5_digest
+      _(digest).must_equal md5_digest
     end
   end
 
@@ -47,7 +47,7 @@ describe Google::Cloud::Storage::File::Verifier, :mock_storage do
     Tempfile.open "google-cloud" do |tmpfile|
       tmpfile.write file_contents
       digest = Google::Cloud::Storage::File::Verifier.crc32c_for tmpfile
-      digest.must_equal crc32c_digest
+      _(digest).must_equal crc32c_digest
     end
   end
 

--- a/google-cloud-storage/test/google/cloud/storage_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage_test.rb
@@ -20,51 +20,51 @@ describe Google::Cloud do
     it "calls out to Google::Cloud.storage" do
       gcloud = Google::Cloud.new
       stubbed_storage = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, host: nil) {
-        project.must_be :nil?
-        keyfile.must_be :nil?
-        scope.must_be :nil?
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_be :nil?
+        _(keyfile).must_be :nil?
+        _(scope).must_be :nil?
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         "storage-project-object-empty"
       }
       Google::Cloud.stub :storage, stubbed_storage do
         project = gcloud.storage
-        project.must_equal "storage-project-object-empty"
+        _(project).must_equal "storage-project-object-empty"
       end
     end
 
     it "passes project and keyfile to Google::Cloud.storage" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_storage = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_be :nil?
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_be :nil?
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         "storage-project-object"
       }
       Google::Cloud.stub :storage, stubbed_storage do
         project = gcloud.storage
-        project.must_equal "storage-project-object"
+        _(project).must_equal "storage-project-object"
       end
     end
 
     it "passes project and keyfile and options to Google::Cloud.storage" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_storage = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_equal "http://example.com/scope"
-        retries.must_equal 5
-        timeout.must_equal 60
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_equal "http://example.com/scope"
+        _(retries).must_equal 5
+        _(timeout).must_equal 60
+        _(host).must_be :nil?
         "storage-project-object-scoped"
       }
       Google::Cloud.stub :storage, stubbed_storage do
         project = gcloud.storage scope: "http://example.com/scope", retries: 5, timeout: 60
-        project.must_equal "storage-project-object-scoped"
+        _(project).must_equal "storage-project-object-scoped"
       end
     end
   end
@@ -86,9 +86,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Storage::Credentials.stub :default, default_credentials do
             storage = Google::Cloud.storage
-            storage.must_be_kind_of Google::Cloud::Storage::Project
-            storage.project.must_equal "project-id"
-            storage.service.credentials.must_equal default_credentials
+            _(storage).must_be_kind_of Google::Cloud::Storage::Project
+            _(storage.project).must_equal "project-id"
+            _(storage.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -96,17 +96,17 @@ describe Google::Cloud do
 
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "storage-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "storage-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "storage-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
         # TODO: Remove once discovery document is updated.
-        host.must_equal "https://storage.googleapis.com/"
+        _(host).must_equal "https://storage.googleapis.com/"
         OpenStruct.new project: project
       }
 
@@ -117,9 +117,9 @@ describe Google::Cloud do
             Google::Cloud::Storage::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Storage::Service.stub :new, stubbed_service do
                 storage = Google::Cloud.storage "project-id", "path/to/keyfile.json"
-                storage.must_be_kind_of Google::Cloud::Storage::Project
-                storage.project.must_equal "project-id"
-                storage.service.must_be_kind_of OpenStruct
+                _(storage).must_be_kind_of Google::Cloud::Storage::Project
+                _(storage.project).must_equal "project-id"
+                _(storage.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -131,20 +131,20 @@ describe Google::Cloud do
   describe "Storage.anonymous" do
     it "uses provided options" do
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_be :nil?
-        credentials.must_be :nil?
-        retries.must_equal 5
-        timeout.must_equal 60
-        host.must_equal "storage-endpoint2.example.com"
+        _(project).must_be :nil?
+        _(credentials).must_be :nil?
+        _(retries).must_equal 5
+        _(timeout).must_equal 60
+        _(host).must_equal "storage-endpoint2.example.com"
         OpenStruct.new project: project
       }
       # Clear all environment variables
       ENV.stub :[], nil do
         Google::Cloud::Storage::Service.stub :new, stubbed_service do
           storage = Google::Cloud::Storage.anonymous retries: 5, timeout: 60, endpoint: "storage-endpoint2.example.com"
-          storage.must_be_kind_of Google::Cloud::Storage::Project
-          storage.project.must_be :nil?
-          storage.service.credentials.must_be :nil?
+          _(storage).must_be_kind_of Google::Cloud::Storage::Project
+          _(storage.project).must_be :nil?
+          _(storage.service.credentials).must_be :nil?
         end
       end
     end
@@ -167,9 +167,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Storage::Credentials.stub :default, default_credentials do
             storage = Google::Cloud::Storage.new
-            storage.must_be_kind_of Google::Cloud::Storage::Project
-            storage.project.must_equal "project-id"
-            storage.service.credentials.must_equal default_credentials
+            _(storage).must_be_kind_of Google::Cloud::Storage::Project
+            _(storage.project).must_equal "project-id"
+            _(storage.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -177,11 +177,11 @@ describe Google::Cloud do
 
     it "uses provided endpoint" do
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal default_credentials
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_equal "storage-endpoint2.example.com"
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_equal "storage-endpoint2.example.com"
         OpenStruct.new project: project
       }
 
@@ -190,9 +190,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Storage::Service.stub :new, stubbed_service do
             storage = Google::Cloud::Storage.new credentials: default_credentials, endpoint: "storage-endpoint2.example.com"
-            storage.must_be_kind_of Google::Cloud::Storage::Project
-            storage.project.must_equal "project-id"
-            storage.service.must_be_kind_of OpenStruct
+            _(storage).must_be_kind_of Google::Cloud::Storage::Project
+            _(storage.project).must_equal "project-id"
+            _(storage.service).must_be_kind_of OpenStruct
           end
         end
       end
@@ -200,17 +200,17 @@ describe Google::Cloud do
 
     it "uses provided project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "storage-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "storage-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "storage-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
         # TODO: Remove once discovery document is updated.
-        host.must_equal "https://storage.googleapis.com/"
+        _(host).must_equal "https://storage.googleapis.com/"
         OpenStruct.new project: project
       }
 
@@ -221,9 +221,9 @@ describe Google::Cloud do
             Google::Cloud::Storage::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Storage::Service.stub :new, stubbed_service do
                 storage = Google::Cloud::Storage.new project_id: "project-id", credentials: "path/to/keyfile.json"
-                storage.must_be_kind_of Google::Cloud::Storage::Project
-                storage.project.must_equal "project-id"
-                storage.service.must_be_kind_of OpenStruct
+                _(storage).must_be_kind_of Google::Cloud::Storage::Project
+                _(storage.project).must_equal "project-id"
+                _(storage.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -233,17 +233,17 @@ describe Google::Cloud do
 
     it "uses provided project and keyfile aliases" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "storage-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "storage-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "storage-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
         # TODO: Remove once discovery document is updated.
-        host.must_equal "https://storage.googleapis.com/"
+        _(host).must_equal "https://storage.googleapis.com/"
         OpenStruct.new project: project
       }
 
@@ -254,9 +254,9 @@ describe Google::Cloud do
             Google::Cloud::Storage::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Storage::Service.stub :new, stubbed_service do
                 storage = Google::Cloud::Storage.new project: "project-id", keyfile: "path/to/keyfile.json"
-                storage.must_be_kind_of Google::Cloud::Storage::Project
-                storage.project.must_equal "project-id"
-                storage.service.must_be_kind_of OpenStruct
+                _(storage).must_be_kind_of Google::Cloud::Storage::Project
+                _(storage.project).must_equal "project-id"
+                _(storage.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -266,18 +266,18 @@ describe Google::Cloud do
 
     it "gets project_id from credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         OpenStruct.new project_id: "project-id"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_be_kind_of OpenStruct
-        credentials.project_id.must_equal "project-id"
-        retries.must_be :nil?
-        timeout.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_be_kind_of OpenStruct
+        _(credentials.project_id).must_equal "project-id"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
         # TODO: Remove once discovery document is updated.
-        host.must_equal "https://storage.googleapis.com/"
+        _(host).must_equal "https://storage.googleapis.com/"
         OpenStruct.new project: project
       }
       empty_env = OpenStruct.new
@@ -290,9 +290,9 @@ describe Google::Cloud do
               Google::Cloud::Storage::Credentials.stub :new, stubbed_credentials do
                 Google::Cloud::Storage::Service.stub :new, stubbed_service do
                   storage = Google::Cloud::Storage.new credentials: "path/to/keyfile.json"
-                  storage.must_be_kind_of Google::Cloud::Storage::Project
-                  storage.project.must_equal "project-id"
-                  storage.service.must_be_kind_of OpenStruct
+                  _(storage).must_be_kind_of Google::Cloud::Storage::Project
+                  _(storage.project).must_equal "project-id"
+                  _(storage.service).must_be_kind_of OpenStruct
                 end
               end
             end
@@ -311,17 +311,17 @@ describe Google::Cloud do
 
     it "uses shared config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "storage-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "storage-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "storage-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
         # TODO: Remove once discovery document is updated.
-        host.must_equal "https://storage.googleapis.com/"
+        _(host).must_equal "https://storage.googleapis.com/"
         OpenStruct.new project: project
       }
 
@@ -338,9 +338,9 @@ describe Google::Cloud do
             Google::Cloud::Storage::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Storage::Service.stub :new, stubbed_service do
                 storage = Google::Cloud::Storage.new
-                storage.must_be_kind_of Google::Cloud::Storage::Project
-                storage.project.must_equal "project-id"
-                storage.service.must_be_kind_of OpenStruct
+                _(storage).must_be_kind_of Google::Cloud::Storage::Project
+                _(storage.project).must_equal "project-id"
+                _(storage.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -350,17 +350,17 @@ describe Google::Cloud do
 
     it "uses shared config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "storage-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "storage-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "storage-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
         # TODO: Remove once discovery document is updated.
-        host.must_equal "https://storage.googleapis.com/"
+        _(host).must_equal "https://storage.googleapis.com/"
         OpenStruct.new project: project
       }
 
@@ -377,9 +377,9 @@ describe Google::Cloud do
             Google::Cloud::Storage::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Storage::Service.stub :new, stubbed_service do
                 storage = Google::Cloud::Storage.new
-                storage.must_be_kind_of Google::Cloud::Storage::Project
-                storage.project.must_equal "project-id"
-                storage.service.must_be_kind_of OpenStruct
+                _(storage).must_be_kind_of Google::Cloud::Storage::Project
+                _(storage.project).must_equal "project-id"
+                _(storage.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -389,17 +389,17 @@ describe Google::Cloud do
 
     it "uses storage config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "storage-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "storage-credentials"
-        retries.must_equal 3
-        timeout.must_equal 42
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "storage-credentials"
+        _(retries).must_equal 3
+        _(timeout).must_equal 42
         # TODO: Remove once discovery document is updated.
-        host.must_equal "https://storage.googleapis.com/"
+        _(host).must_equal "https://storage.googleapis.com/"
         OpenStruct.new project: project
       }
 
@@ -418,9 +418,9 @@ describe Google::Cloud do
             Google::Cloud::Storage::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Storage::Service.stub :new, stubbed_service do
                 storage = Google::Cloud::Storage.new
-                storage.must_be_kind_of Google::Cloud::Storage::Project
-                storage.project.must_equal "project-id"
-                storage.service.must_be_kind_of OpenStruct
+                _(storage).must_be_kind_of Google::Cloud::Storage::Project
+                _(storage.project).must_equal "project-id"
+                _(storage.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -430,15 +430,15 @@ describe Google::Cloud do
 
     it "uses storage config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "storage-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "storage-credentials"
-        retries.must_equal 3
-        timeout.must_equal 42
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "storage-credentials"
+        _(retries).must_equal 3
+        _(timeout).must_equal 42
         OpenStruct.new project: project
       }
 
@@ -457,9 +457,9 @@ describe Google::Cloud do
             Google::Cloud::Storage::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Storage::Service.stub :new, stubbed_service do
                 storage = Google::Cloud::Storage.new
-                storage.must_be_kind_of Google::Cloud::Storage::Project
-                storage.project.must_equal "project-id"
-                storage.service.must_be_kind_of OpenStruct
+                _(storage).must_be_kind_of Google::Cloud::Storage::Project
+                _(storage.project).must_equal "project-id"
+                _(storage.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -469,16 +469,16 @@ describe Google::Cloud do
 
     it "uses storage config for endpoint" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "storage-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "storage-credentials"
-        retries.must_equal 3
-        timeout.must_equal 42
-        host.must_equal "storage-endpoint2.example.com"
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "storage-credentials"
+        _(retries).must_equal 3
+        _(timeout).must_equal 42
+        _(host).must_equal "storage-endpoint2.example.com"
         OpenStruct.new project: project
       }
 
@@ -498,9 +498,9 @@ describe Google::Cloud do
             Google::Cloud::Storage::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Storage::Service.stub :new, stubbed_service do
                 storage = Google::Cloud::Storage.new
-                storage.must_be_kind_of Google::Cloud::Storage::Project
-                storage.project.must_equal "project-id"
-                storage.service.must_be_kind_of OpenStruct
+                _(storage).must_be_kind_of Google::Cloud::Storage::Project
+                _(storage.project).must_equal "project-id"
+                _(storage.service).must_be_kind_of OpenStruct
               end
             end
           end


### PR DESCRIPTION
This pull request bumps the minitest version of google-cloud-storage because #4884 finds newer version of minitest is necessary to support Ruby 2.8 keyword arguments.

Summary of changes:
* Bump minitest of google-cloud-storage version to the latest
* https://github.com/rubocop-hq/rubocop-minitest supports auto-corrections for minitest global expectations warnings
* Most of (kind of) false positives are corrected and restored manually.

Follow up #4884 Related to #4110