### PR TITLE
chore: use image with node for presubmits

### DIFF
--- a/.kokoro/presubmit/linux/common.cfg
+++ b/.kokoro/presubmit/linux/common.cfg
@@ -34,7 +34,7 @@ env_vars: {
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi"
+    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi-node"
 }
 
 env_vars: {


### PR DESCRIPTION
Fixes issue where checking docs links fails due to no npx: https://source.cloud.google.com/results/invocations/7e9312c3-1cff-4b21-b582-761ace83e24e/targets/cloud-devrel%2Fclient-libraries%2Fgoogle-cloud-ruby%2Fpresubmit-linux/log