### PR TITLE
chore(asset): add needed dependencies on accesscontextmanager

### DIFF
--- a/google-cloud-asset-v1/synth.py
+++ b/google-cloud-asset-v1/synth.py
@@ -28,6 +28,10 @@ library = gapic.ruby_library(
     extra_proto_files=[
         "google/cloud/common_resources.proto",
         "google/cloud/orgpolicy/v1/orgpolicy.proto",
+        "google/identity/accesscontextmanager/type/device_resources.proto",
+        "google/identity/accesscontextmanager/v1/access_level.proto",
+        "google/identity/accesscontextmanager/v1/access_policy.proto",
+        "google/identity/accesscontextmanager/v1/service_perimeter.proto",
     ],
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-asset-v1",

--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -24,6 +24,14 @@ logging.basicConfig(level=logging.DEBUG)
 gapic = gcp.GAPICMicrogenerator()
 library = gapic.ruby_library(
     "asset", "v1",
+    extra_proto_files=[
+        "google/cloud/common_resources.proto",
+        "google/cloud/orgpolicy/v1/orgpolicy.proto",
+        "google/identity/accesscontextmanager/type/device_resources.proto",
+        "google/identity/accesscontextmanager/v1/access_level.proto",
+        "google/identity/accesscontextmanager/v1/access_policy.proto",
+        "google/identity/accesscontextmanager/v1/service_perimeter.proto",
+    ],
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-asset",
         "ruby-cloud-title": "Cloud Asset",


### PR DESCRIPTION
Fixes #5205. Fixes #5206.

Asset has picked up some dependencies on protos from accesscontextmanager and orgpolicy. (This is a rare case, for protos in one API to depend on protos from another.)