### PR TITLE
chore(container_analysis): restore path helpers for gapic v2 generation

### DIFF
--- a/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/helpers.rb
+++ b/google-cloud-container_analysis/lib/google/cloud/container_analysis/v1/helpers.rb
@@ -1,0 +1,40 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module ContainerAnalysis
+      module V1
+        class ContainerAnalysisClient
+          # Returns a fully-qualified note resource name string.
+          # @param project [String]
+          # @param note [String]
+          # @return [String]
+          def self.note_path project, note
+            "projects/#{project}/notes/#{note}"
+          end
+
+          # Returns a fully-qualified occurrence resource name string.
+          # @param project [String]
+          # @param occurrence [String]
+          # @return [String]
+          def self.occurrence_path project, occurrence
+            "projects/#{project}/occurrences/#{occurrence}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-container_analysis/synth.py
+++ b/google-cloud-container_analysis/synth.py
@@ -247,3 +247,10 @@ s.replace(
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
     'https://googleapis.dev/ruby/google-cloud-container_analysis/latest/file.AUTHENTICATION.html'
 )
+
+# Require helper methods
+s.replace(
+    'lib/google/cloud/container_analysis/v1.rb',
+    'require "google/cloud/container_analysis/v1/container_analysis_client"\n\n',
+    'require "google/cloud/container_analysis/v1/container_analysis_client"\nrequire "google/cloud/container_analysis/v1/helpers"\n\n'
+)


### PR DESCRIPTION
Fixes #5304 by re-adding the helpers using a partial gapic.