### PR TITLE
chore: restore namespace compatibility for OsLogin, PhishingProtection, and RecaptchaEnterprise

### DIFF
--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -253,3 +253,21 @@ s.replace(
     'github.io/google-cloud-ruby/#/docs/google-cloud-os_login/latest/.*$',
     'dev/ruby/google-cloud-os_login/latest'
 )
+
+# https://github.com/googleapis/gapic-generator/issues/2525
+s.replace(
+    'lib/google/cloud/os_login/v*/**/*.rb',
+    'Google::Cloud::Oslogin',
+    'Google::Cloud::OsLogin')
+s.replace(
+    'lib/google/cloud/os_login/v*/doc/google/cloud/oslogin/**/*.rb',
+    '\n    module Oslogin\n',
+    '\n    module OsLogin\n'
+)
+
+# https://github.com/protocolbuffers/protobuf/issues/5584
+s.replace(
+    'lib/google/cloud/oslogin/*/*_pb.rb',
+    '\nmodule Google::Cloud::OsLogin::V(\\w+)\n',
+    '\nmodule Google\n  module Cloud\n    module OsLogin\n    end\n    Oslogin = OsLogin unless const_defined? :Oslogin\n  end\nend\nmodule Google::Cloud::OsLogin::V\\1\n',
+)

--- a/google-cloud-phishing_protection/synth.py
+++ b/google-cloud-phishing_protection/synth.py
@@ -283,5 +283,23 @@ s.replace(
     'https://cloud.google.com/phishing-protection'
 )
 
+# https://github.com/googleapis/gapic-generator/issues/2525
+s.replace(
+    'lib/google/cloud/phishing_protection/v*/**/*.rb',
+    'Google::Cloud::Phishingprotection',
+    'Google::Cloud::PhishingProtection')
+s.replace(
+    'lib/google/cloud/phishing_protection/v*/doc/google/cloud/phishingprotection/**/*.rb',
+    '\n    module Phishingprotection\n',
+    '\n    module PhishingProtection\n'
+)
+
+# https://github.com/protocolbuffers/protobuf/issues/5584
+s.replace(
+    'lib/google/cloud/phishingprotection/v*/*_pb.rb',
+    '\nmodule Google::Cloud::PhishingProtection::V(\\w+)\n',
+    '\nmodule Google\n  module Cloud\n    module PhishingProtection\n    end\n    Phishingprotection = PhishingProtection unless const_defined? :Phishingprotection\n  end\nend\nmodule Google::Cloud::PhishingProtection::V\\1\n',
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)

--- a/google-cloud-recaptcha_enterprise/synth.py
+++ b/google-cloud-recaptcha_enterprise/synth.py
@@ -282,5 +282,23 @@ s.replace(
     'https://cloud.google.com/recaptcha-enterprise'
 )
 
+# https://github.com/googleapis/gapic-generator/issues/2525
+s.replace(
+    'lib/google/cloud/recaptcha_enterprise/v*/**/*.rb',
+    'Google::Cloud::Recaptchaenterprise',
+    'Google::Cloud::RecaptchaEnterprise')
+s.replace(
+    'lib/google/cloud/recaptcha_enterprise/v*/doc/google/cloud/recaptchaenterprise/**/*.rb',
+    '\n    module Recaptchaenterprise\n',
+    '\n    module RecaptchaEnterprise\n'
+)
+
+# https://github.com/protocolbuffers/protobuf/issues/5584
+s.replace(
+    'lib/google/cloud/recaptchaenterprise/v*/*_pb.rb',
+    '\nmodule Google::Cloud::RecaptchaEnterprise::V(\\w+)\n',
+    '\nmodule Google\n  module Cloud\n    module RecaptchaEnterprise\n    end\n    Recaptchaenterprise = RecaptchaEnterprise unless const_defined? :Recaptchaenterprise\n  end\nend\nmodule Google::Cloud::RecaptchaEnterprise::V\\1\n',
+)
+
 # Generate the helper methods
 call('bundle update && bundle exec rake generate_partials', shell=True)


### PR DESCRIPTION
We are in the process of updating protos upstream to generate to the correct Ruby namespaces for the microgenerator (i.e. setting the `ruby_package` option). Unfortunately, this causes us to run into a bug in the monolith where it doesn't recognize `ruby_package` and tries to reference the wrong namespace for proto types (https://github.com/googleapis/gapic-generator/issues/2525). We first encountered this problem when we updated `VideoIntelligence` to use `ruby_package`, and worked around it with a synth hack. We need to replicate this hack for each library as we fix their `ruby_package`, if we still want the monolith to work for those libraries.

This PR applies the hack to OsLogin, PhishingProtection, and RecaptchaEnterprise, and should fix the failed synths in #5324, #5325, and #5327. ~~(Note: OsLogin still has an issue where `ruby_package` is not properly applied in the common proto types; an upstream fix for that should be landing shortly, but until then, OsLogin will not build. The current synth hack in this PR assumes the upstream fix is already in place.)~~ The additional OsLogin upstream fix is now done.