### PR TITLE
Release google-cloud-data_catalog 0.1.0

### DIFF
--- a/google-cloud-data_catalog/CHANGELOG.md
+++ b/google-cloud-data_catalog/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-04-06
+
+* Initial release
+

--- a/google-cloud-data_catalog/lib/google/cloud/data_catalog/version.rb
+++ b/google-cloud-data_catalog/lib/google/cloud/data_catalog/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module DataCatalog
-      VERSION = "0.0.1"
+      VERSION = "0.1.0"
     end
   end
 end


### PR DESCRIPTION
* Initial release

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-data_catalog/CHANGELOG.md b/google-cloud-data_catalog/CHANGELOG.md
index 575f12aa6..f88957a62 100644
--- a/google-cloud-data_catalog/CHANGELOG.md
+++ b/google-cloud-data_catalog/CHANGELOG.md
@@ -1,6 +1,2 @@
 # Release History
 
-### 0.1.0 / 2020-04-06
-
-* Initial release
-
diff --git a/google-cloud-data_catalog/lib/google/cloud/data_catalog/version.rb b/google-cloud-data_catalog/lib/google/cloud/data_catalog/version.rb
index e614f451c..1ef8dab83 100644
--- a/google-cloud-data_catalog/lib/google/cloud/data_catalog/version.rb
+++ b/google-cloud-data_catalog/lib/google/cloud/data_catalog/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module DataCatalog
-      VERSION = "0.1.0"
+      VERSION = "0.0.1"
     end
   end
 end

```

</details>

This pull request was generated using releasetool.