### PR TITLE
chore: Restore namespace compatibility for WebRisk, Container, and Bigquery-DataTransfer

### DIFF
--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -236,3 +236,21 @@ s.replace(
     'github.io/google-cloud-ruby/#/docs/google-cloud-bigquery-data_transfer/latest/.*$',
     'dev/ruby/google-cloud-bigquery-data_transfer/latest'
 )
+
+# https://github.com/googleapis/gapic-generator/issues/2525
+s.replace(
+    'lib/google/cloud/bigquery/data_transfer/v1/**/*.rb',
+    'Google::Cloud::Bigquery::Datatransfer',
+    'Google::Cloud::Bigquery::DataTransfer')
+s.replace(
+    'lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/**/*.rb',
+    '\n      module Datatransfer\n',
+    '\n      module DataTransfer\n'
+)
+
+# https://github.com/protocolbuffers/protobuf/issues/5584
+s.replace(
+    'lib/google/cloud/bigquery/datatransfer/*/*_pb.rb',
+    '\nmodule Google::Cloud::Bigquery::DataTransfer::V1\n',
+    '\nmodule Google\n  module Cloud\n    module Bigquery\n      module DataTransfer\n      end\n      Datatransfer = DataTransfer unless const_defined? :Datatransfer\n    end\n  end\nend\nmodule Google::Cloud::Bigquery::DataTransfer::V1\n',
+)

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -238,3 +238,10 @@ s.replace(
     'github.io/google-cloud-ruby/#/docs/google-cloud-container/latest/.*$',
     'dev/ruby/google-cloud-container/latest'
 )
+
+# https://github.com/googleapis/gapic-generator/issues/2525
+s.replace(
+    'lib/google/container/*/*_pb.rb',
+    '\nmodule Google::Cloud::Container::V(\\w+)\n',
+    '\nmodule Google\n  module Cloud\n    module Container\n    end\n  end\n  Container = Cloud::Container unless const_defined? :Container\nend\nmodule Google::Cloud::Container::V\\1\n',
+)

--- a/google-cloud-webrisk/synth.py
+++ b/google-cloud-webrisk/synth.py
@@ -203,3 +203,12 @@ s.replace(
     'github.io/google-cloud-ruby/#/docs/google-cloud-webrisk/latest/.*$',
     'dev/ruby/google-cloud-webrisk/latest'
 )
+
+# For this library, undo the effect of ruby_package and keep things in the
+# module Google::Cloud::Webrisk. When we move to the microgenerator, we will
+# deprecate this entire library and create google-cloud-web_risk instead.
+s.replace(
+    'lib/google/cloud/webrisk/v1beta1/*_pb.rb',
+    '\nmodule Google::Cloud::WebRisk::V1beta1\n',
+    '\nmodule Google::Cloud::Webrisk::V1beta1\n',
+)


### PR DESCRIPTION
We are in the process of updating protos upstream to generate to the correct Ruby namespaces for the microgenerator (i.e. setting the `ruby_package` option). Unfortunately, this causes us to run into a bug in the monolith where it doesn't recognize `ruby_package` and tries to reference the wrong namespace for proto types (googleapis/gapic-generator#2525). We first encountered this problem when we updated `VideoIntelligence` to use `ruby_package`, and worked around it with a synth hack. We need to replicate this hack for each library as we fix their `ruby_package`, if we still want the monolith to work for those libraries.

This PR applies the hack to container and bigquery-data_transfer. (See also #5332 which applied this for several other libraries.)

For webrisk, we do something a bit different. We are going to rename the entire library (from `google-cloud-webrisk` to `google-cloud-web_risk`). This is because the product is emphatically branded as "Web Risk" rather than "Webrisk", and also because "webrisk" looks a bit too similar to "webrick" which is in the Ruby standard library. Therefore, for the now legacy `google-cloud-webrisk`, we are "undoing" the effect of `ruby_package` and changing the module back to `Google::Cloud::Webrisk` to retain the current usage. We will update the module name to `WebRisk` (and create the new gem `google-cloud-web_risk`) when we migrate this library to the microgenerator (which I expect to be in the next few weeks).