### PR TITLE
chore(secret_manager-v1): reenable context-aware-commits

### DIFF
--- a/google-cloud-secret_manager-v1/synth.py
+++ b/google-cloud-secret_manager-v1/synth.py
@@ -19,6 +19,8 @@ import synthtool.gcp as gcp
 import synthtool.languages.ruby as ruby
 import logging
 
+AUTOSYNTH_MULTIPLE_COMMITS = True
+
 logging.basicConfig(level=logging.DEBUG)
 
 gapic = gcp.GAPICMicrogenerator()


### PR DESCRIPTION
I have reason to believe that recent changes to autosynth have fixed
the issues manifest in
https://github.com/googleapis/google-cloud-ruby/pull/5248

Specifically, look at these 3 good PRs generated with context-aware
commits enabled:
https://github.com/googleapis/google-cloud-ruby/pull/5398
https://github.com/googleapis/google-cloud-ruby/pull/5399
https://github.com/googleapis/google-cloud-ruby/pull/5400

This reverts commit 7099cb3afe7778e6c024bdad5b367e5aa5ee3ac8.