### PR TITLE
feat(bigquery): Add logging for errors that result in request retries

### DIFF
--- a/google-cloud-bigquery/LOGGING.md
+++ b/google-cloud-bigquery/LOGGING.md
@@ -1,24 +1,27 @@
 # Enabling Logging
 
-To enable general logging for this library, set the logger for the underlying [Google
-API
+The [google-cloud-bigquery](https://github.com/googleapis/google-cloud-ruby/tree/master/google-cloud-bigquery)
+library uses the [Google API
 Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging)
-library. The logger that you set may be a Ruby stdlib
+library to perform RPC calls, but also rescues API errors and retries requests itself.
+Therefore, it may be necessary to enable logging in both libraries.
+
+# Enabling Logging in Google API Client
+
+To enable general logging for google-cloud-bigquery, set the logger for the underlying [Google
+API Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging)
+library. The logger that you provide may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
 [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Stackdriver
+that will write logs to [Cloud
 Logging](https://cloud.google.com/logging/).
-
-You may also pass the same logger (or a different one) when you call
-{Google::Cloud::Bigquery.new}. Logging in the higher-level {Google::Cloud::Bigquery}
-client is currently limited to logging errors that result in request retries.
 
 If you do not set the logger explicitly and your application is running in a
 Rails environment, it will default to `Rails.logger`. Otherwise, if you do not
 set the logger and you are not using Rails, logging is disabled by default.
 
-Configuring a Ruby stdlib logger:
+Configuring a Ruby stdlib logger for Google API Client:
 
 ```ruby
 require "logger"
@@ -28,6 +31,32 @@ my_logger.level = Logger::WARN
 
 # Set the Google API Client logger
 Google::Apis.logger = my_logger
+```
+
+# Enabling Logging in google-cloud-bigquery
+
+You may also pass the same logger (or a different one) when you call
+{Google::Cloud::Bigquery.new} to instantiate a google-cloud-bigquery client.
+
+Logging in the higher-level {Google::Cloud::Bigquery}
+library is currently limited to logging errors that result in request retries.
+
+Currently, log entries in google-cloud-bigquery use the following levels:
+
+* `WARN` - Entries contain only the class name of a rescued error, in order
+  to protect potentially sensitive user data.
+* `DEBUG` - Entries contain all details of the rescued error, in order to
+  facilitate debugging. ATTENTION: `DEBUG`-level logging should be used only
+  in a carefully-controlled environment due to the possibility of logging
+  sensitive user data.
+
+Configuring a Ruby stdlib logger for google-cloud-bigquery:
+
+```ruby
+require "logger"
+
+my_logger = Logger.new $stderr
+my_logger.level = Logger::WARN
 
 # Set the Google::Cloud::Bigquery logger for logging
 # errors that result in request retries.

--- a/google-cloud-bigquery/LOGGING.md
+++ b/google-cloud-bigquery/LOGGING.md
@@ -1,6 +1,6 @@
 # Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [Google
+To enable general logging for this library, set the logger for the underlying [Google
 API
 Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging)
 library. The logger that you set may be a Ruby stdlib
@@ -9,6 +9,10 @@ shown below, or a
 [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver
 Logging](https://cloud.google.com/logging/).
+
+You may also pass the same logger (or a different one) when you call
+{Google::Cloud::Bigquery.new}. Logging in the higher-level {Google::Cloud::Bigquery}
+client is currently limited to logging errors that result in request retries.
 
 If you do not set the logger explicitly and your application is running in a
 Rails environment, it will default to `Rails.logger`. Otherwise, if you do not
@@ -24,4 +28,8 @@ my_logger.level = Logger::WARN
 
 # Set the Google API Client logger
 Google::Apis.logger = my_logger
+
+# Set the Google::Cloud::Bigquery logger for logging
+# errors that result in request retries.
+bigquery = Google::Cloud::Bigquery.new logger: my_logger
 ```

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -18,6 +18,7 @@ gem "minitest"
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"
+require "logger"
 require "google/cloud/bigquery"
 require "google/cloud/storage"
 
@@ -27,8 +28,12 @@ if ENV["GCLOUD_TEST_GENERATE_XML_REPORT"]
   Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::JUnitReporter.new]
 end
 
+# Create a stdlib logger for retry attempts
+logger = Logger.new $stderr
+logger.level = Logger::WARN
+
 # Create shared bigquery object so we don't create new for each test
-$bigquery = Google::Cloud::Bigquery.new retries: 10
+$bigquery = Google::Cloud::Bigquery.new retries: 10, logger: logger
 
 # Create shared storage object so we don't create new for each test
 $storage = Google::Cloud::Storage.new

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -56,6 +56,12 @@ module Google
       # @param [String] project Alias for the `project_id` argument. Deprecated.
       # @param [String] keyfile Alias for the `credentials` argument.
       #   Deprecated.
+      # @param [Logger, Google::Cloud::Logging::Logger, nil] logger A logger for
+      #   logging errors that result in request retries. May be a Ruby stdlib
+      #   [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html)
+      #   or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
+      #   that will write logs to [Cloud Logging](https://cloud.google.com/logging/).
+      #   Optional.
       #
       # @return [Google::Cloud::Bigquery::Project]
       #
@@ -67,7 +73,7 @@ module Google
       #   table = dataset.table "my_table"
       #
       def self.new project_id: nil, credentials: nil, scope: nil, retries: nil, timeout: nil, endpoint: nil,
-                   project: nil, keyfile: nil
+                   project: nil, keyfile: nil, logger: nil
         scope       ||= configure.scope
         retries     ||= configure.retries
         timeout     ||= configure.timeout
@@ -84,7 +90,7 @@ module Google
         Bigquery::Project.new(
           Bigquery::Service.new(
             project_id, credentials,
-            retries: retries, timeout: timeout, host: endpoint
+            retries: retries, timeout: timeout, host: endpoint, logger: logger
           )
         )
       end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -1582,7 +1582,8 @@ module Google
           project_service = Service.new gapi.project_reference.project_id,
                                         service.credentials,
                                         retries: service.retries,
-                                        timeout: service.timeout
+                                        timeout: service.timeout,
+                                        logger:  service.logger
           new(project_service).tap do |p|
             p.instance_variable_set :@name, gapi.friendly_name
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -43,7 +43,10 @@ module Google
         attr_accessor :logger
 
         # @private
-        attr_reader :retries, :timeout, :host
+        attr_accessor :retries
+
+        # @private
+        attr_reader :timeout, :host
 
         ##
         # Creates a new Service instance.
@@ -590,9 +593,8 @@ module Google
           protected
 
           def retry? err, current_retries #:nodoc:
-            return true if err.is_a? JSON::ParserError # See #5180
             if current_retries < @retries
-              return true if retry_error_reason? err.body
+              return true if err.is_a?(JSON::ParserError) || retry_error_reason?(err.body) # See #5180 re: JSON
             end
             false
           end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -39,16 +39,20 @@ module Google
         attr_accessor :credentials
 
         # @private
+        attr_accessor :logger
+
+        # @private
         attr_reader :retries, :timeout, :host
 
         ##
         # Creates a new Service instance.
-        def initialize project, credentials, retries: nil, timeout: nil, host: nil
+        def initialize project, credentials, retries: nil, timeout: nil, host: nil, logger: nil
           @project = project
           @credentials = credentials
           @retries = retries
           @timeout = timeout
           @host = host
+          @logger = logger
         end
 
         def service
@@ -80,7 +84,7 @@ module Google
         # been granted the READER dataset role.
         def list_datasets all: nil, filter: nil, max: nil, token: nil
           # The list operation is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.list_datasets @project, all: all, filter: filter, max_results: max, page_token: token
           end
         end
@@ -89,7 +93,7 @@ module Google
         # Returns the dataset specified by datasetID.
         def get_dataset dataset_id
           # The get operation is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.get_dataset @project, dataset_id
           end
         end
@@ -111,7 +115,7 @@ module Google
             # The patch with etag operation is considered idempotent
             patch_with_backoff = true
           end
-          execute backoff: patch_with_backoff do
+          execute backoff: patch_with_backoff, logger_component: fm(__method__) do
             service.patch_dataset @project, dataset_id, patched_dataset_gapi, options: options
           end
         end
@@ -133,14 +137,14 @@ module Google
         # Requires the READER dataset role.
         def list_tables dataset_id, max: nil, token: nil
           # The list operation is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.list_tables @project, dataset_id, max_results: max, page_token: token
           end
         end
 
         def get_project_table project_id, dataset_id, table_id
           # The get operation is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.get_table project_id, dataset_id, table_id
           end
         end
@@ -152,7 +156,7 @@ module Google
         # which describes the structure of this table.
         def get_table dataset_id, table_id
           # The get operation is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             get_project_table @project, dataset_id, table_id
           end
         end
@@ -174,7 +178,7 @@ module Google
             # The patch with etag operation is considered idempotent
             patch_with_backoff = true
           end
-          execute backoff: patch_with_backoff do
+          execute backoff: patch_with_backoff, logger_component: fm(__method__) do
             service.patch_table @project, dataset_id, table_id, patched_table_gapi, options: options
           end
         end
@@ -190,7 +194,7 @@ module Google
         # Retrieves data from the table.
         def list_tabledata dataset_id, table_id, max: nil, token: nil, start: nil
           # The list operation is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             json_txt = service.list_table_data \
               @project, dataset_id, table_id,
               max_results: max,
@@ -230,7 +234,7 @@ module Google
           }.to_json
 
           # The insertAll with insertId operation is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.insert_all_table_data(
               @project, dataset_id, table_id, insert_req,
               options: { skip_serialization: true }
@@ -244,7 +248,7 @@ module Google
         def list_models dataset_id, max: nil, token: nil
           options = { skip_deserialization: true }
           # The list operation is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             json_txt = service.list_models @project, dataset_id, max_results: max, page_token: token, options: options
             JSON.parse json_txt, symbolize_names: true
           end
@@ -256,7 +260,7 @@ module Google
         # which describes the structure of this model.
         def get_model dataset_id, model_id
           # The get operation is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             json_txt = service.get_model @project, dataset_id, model_id, options: { skip_deserialization: true }
             JSON.parse json_txt, symbolize_names: true
           end
@@ -273,7 +277,7 @@ module Google
             # The patch with etag operation is considered idempotent
             patch_with_backoff = true
           end
-          execute backoff: patch_with_backoff do
+          execute backoff: patch_with_backoff, logger_component: fm(__method__) do
             json_txt = service.patch_model @project, dataset_id, model_id, patched_model_gapi, options: options
             JSON.parse json_txt, symbolize_names: true
           end
@@ -299,7 +303,7 @@ module Google
         #   etag, projectId, datasetId, routineId, routineType, creationTime, lastModifiedTime, and language.
         def list_routines dataset_id, max: nil, token: nil, filter: nil
           # The list operation is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.list_routines @project, dataset_id, max_results: max,
                                                         page_token:  token,
                                                         filter:      filter
@@ -310,7 +314,7 @@ module Google
         # Gets the specified routine resource by routine ID.
         def get_routine dataset_id, routine_id
           # The get operation is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.get_routine @project, dataset_id, routine_id
           end
         end
@@ -325,7 +329,7 @@ module Google
             # The update with etag operation is considered idempotent
             update_with_backoff = true
           end
-          execute backoff: update_with_backoff do
+          execute backoff: update_with_backoff, logger_component: fm(__method__) do
             service.update_routine @project, dataset_id, routine_id, new_routine_gapi, options: options
           end
         end
@@ -344,7 +348,7 @@ module Google
           # The list operation is considered idempotent
           min_creation_time = Convert.time_to_millis min_created_at
           max_creation_time = Convert.time_to_millis max_created_at
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.list_jobs @project, all_users: all, max_results: max,
                                         page_token: token, projection: "full", state_filter: filter,
                                         min_creation_time: min_creation_time, max_creation_time: max_creation_time,
@@ -356,7 +360,7 @@ module Google
         # Cancel the job specified by jobId.
         def cancel_job job_id, location: nil
           # The BigQuery team has told us cancelling is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.cancel_job @project, job_id, location: location
           end
         end
@@ -365,7 +369,7 @@ module Google
         # Returns the job specified by jobID.
         def get_job job_id, location: nil
           # The get operation is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.get_job @project, job_id, location: location
           end
         end
@@ -373,13 +377,13 @@ module Google
         def insert_job config, location: nil
           job_object = API::Job.new job_reference: job_ref_from(nil, nil, location: location), configuration: config
           # Jobs have generated id, so this operation is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.insert_job @project, job_object
           end
         end
 
         def query_job query_job_gapi
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.insert_job @project, query_job_gapi
           end
         end
@@ -388,7 +392,7 @@ module Google
         # Returns the query data for the job
         def job_query_results job_id, location: nil, max: nil, token: nil, start: nil, timeout: nil
           # The get operation is considered idempotent
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.get_job_query_results @project, job_id,
                                           location:    location,
                                           max_results: max,
@@ -399,25 +403,25 @@ module Google
         end
 
         def copy_table copy_job_gapi
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.insert_job @project, copy_job_gapi
           end
         end
 
         def extract_table extract_job_gapi
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.insert_job @project, extract_job_gapi
           end
         end
 
         def load_table_gs_url load_job_gapi
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.insert_job @project, load_job_gapi
           end
         end
 
         def load_table_file file, load_job_gapi
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.insert_job @project, load_job_gapi, upload_source: file, content_type: mime_type_for(file)
           end
         end
@@ -463,7 +467,7 @@ module Google
         ##
         # Lists all projects to which you have been granted any project role.
         def list_projects max: nil, token: nil
-          execute backoff: true do
+          execute backoff: true, logger_component: fm(__method__) do
             service.list_projects max_results: max, page_token: token
           end
         end
@@ -502,6 +506,11 @@ module Google
 
         protected
 
+        # Format the method name for the logger_component string passed to execute backoff.
+        def fm method
+          "#{self.class}##{method}"
+        end
+
         # Generate a random string similar to the BigQuery service job IDs.
         def generate_id
           SecureRandom.urlsafe_base64 21
@@ -515,9 +524,9 @@ module Google
           nil
         end
 
-        def execute backoff: nil
+        def execute backoff: nil, logger_component: nil
           if backoff
-            Backoff.new(retries: retries).execute { yield }
+            Backoff.new(retries: retries, logger: logger, logger_component: logger_component).execute { yield }
           else
             yield
           end
@@ -542,10 +551,12 @@ module Google
             sleep delay
           end
 
-          def initialize retries: nil, reasons: nil, backoff: nil
+          def initialize retries: nil, reasons: nil, backoff: nil, logger: nil, logger_component: nil
             @retries = (retries || Backoff.retries).to_i
             @reasons = (reasons || Backoff.reasons).to_a
             @backoff = backoff || Backoff.backoff
+            @logger = logger
+            @logger_component = logger_component
           end
 
           def execute
@@ -555,6 +566,12 @@ module Google
                 return yield
               rescue Google::Apis::Error => e
                 raise e unless retry? e.body, current_retries
+
+                if @logger
+                  msg = ["Attempting retry #{current_retries + 1} because of retryable error: #{e.inspect}"]
+                  msg.unshift @logger_component if @logger_component
+                  @logger.warn msg.join(": ")
+                end
 
                 @backoff.call current_retries
                 current_retries += 1

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -569,9 +569,16 @@ module Google
                 raise e unless retry? e, current_retries
 
                 if @logger
-                  msg = ["Attempting retry #{current_retries + 1} because of retryable error: #{e.inspect}"]
-                  msg.unshift @logger_component if @logger_component
-                  @logger.warn msg.join(": ")
+                  msg = []
+                  msg << @logger_component if @logger_component
+                  if @logger.debug?
+                    # May contain sensitive user information if JSON::ParserError, see #5552.
+                    msg << ["Attempting retry #{current_retries + 1} because of retryable error: #{e.inspect}"]
+                    @logger.debug msg.join(": ")
+                  else
+                    msg << ["Attempting retry #{current_retries + 1} because of retryable error: #{e.class}"]
+                    @logger.warn msg.join(": ")
+                  end
                 end
 
                 @backoff.call current_retries

--- a/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
@@ -366,7 +366,56 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
     bigquery.service.mocked_service = stub
 
     mock_logger = Minitest::Mock.new
-    mock_logger.expect :warn, nil, ["Google::Cloud::Bigquery::Service#get_dataset: Attempting retry 1 because of retryable error: #<Google::Apis::Error: notfound status_code: 400 body: \"{\\\"error\\\":{\\\"errors\\\":[{\\\"reason\\\":\\\"backendError\\\"}]}}\">"]
+    mock_logger.expect :debug?, false, []
+    mock_logger.expect :warn, nil, ["Google::Cloud::Bigquery::Service#get_dataset: Attempting retry 1 because of retryable error: Google::Apis::Error"]
+    bigquery.service.logger = mock_logger
+
+    Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
+      dataset = bigquery.dataset dataset_id
+
+      dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+      dataset.dataset_id.must_equal dataset_id
+    end
+
+    mock.verify
+    mock_logger.verify
+  end
+
+  it "logs a retryable error at debug level if a logger is provided" do
+    mock = Minitest::Mock.new
+    mock.expect :retry, nil, [0]
+
+    mocked_backoff = lambda { |i| mock.retry i }
+
+    stub = Object.new # mocked_service
+
+    def stub.get_dataset *args
+      @tries ||= 0
+      @tries += 1
+      if @tries == 1
+        # raise Google::Apis::Error.new "notfound", status_code: 400, body: backenderror_body
+        raise Google::Apis::Error.new "notfound",
+          status_code: 400,
+          body: { "error" => { "errors" => [{ "reason" => "backendError" }] } }.to_json
+      end
+
+      random_dataset_hash = {
+        "kind" => "bigquery#dataset",
+        "etag" => "etag123456789",
+        "id" => "id",
+        "datasetReference" => {
+          "datasetId" => "my_dataset",
+          "projectId" => "test"
+        },
+        "friendlyName" => "My Dataset",
+      }
+      Google::Apis::BigqueryV2::Dataset.from_json random_dataset_hash.to_json
+    end
+    bigquery.service.mocked_service = stub
+
+    mock_logger = Minitest::Mock.new
+    mock_logger.expect :debug?, true, []
+    mock_logger.expect :debug, nil, ["Google::Cloud::Bigquery::Service#get_dataset: Attempting retry 1 because of retryable error: #<Google::Apis::Error: notfound status_code: 400 body: \"{\\\"error\\\":{\\\"errors\\\":[{\\\"reason\\\":\\\"backendError\\\"}]}}\">"]
     bigquery.service.logger = mock_logger
 
     Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
@@ -293,6 +293,53 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
     err.message.must_equal "nope"
   end
 
+  it "logs a retryable error at warn level if a logger is provided" do
+    mock = Minitest::Mock.new
+    mock.expect :retry, nil, [0]
+
+    mocked_backoff = lambda { |i| mock.retry i }
+
+    stub = Object.new # mocked_service
+
+    def stub.get_dataset *args
+      @tries ||= 0
+      @tries += 1
+      if @tries == 1
+        # raise Google::Apis::Error.new "notfound", status_code: 400, body: backenderror_body
+        raise Google::Apis::Error.new "notfound",
+          status_code: 400,
+          body: { "error" => { "errors" => [{ "reason" => "backendError" }] } }.to_json
+      end
+
+      random_dataset_hash = {
+        "kind" => "bigquery#dataset",
+        "etag" => "etag123456789",
+        "id" => "id",
+        "datasetReference" => {
+          "datasetId" => "my_dataset",
+          "projectId" => "test"
+        },
+        "friendlyName" => "My Dataset",
+      }
+      Google::Apis::BigqueryV2::Dataset.from_json random_dataset_hash.to_json
+    end
+    bigquery.service.mocked_service = stub
+
+    mock_logger = Minitest::Mock.new
+    mock_logger.expect :warn, nil, ["Google::Cloud::Bigquery::Service#get_dataset: Attempting retry 1 because of retryable error: #<Google::Apis::Error: notfound status_code: 400 body: \"{\\\"error\\\":{\\\"errors\\\":[{\\\"reason\\\":\\\"backendError\\\"}]}}\">"]
+    bigquery.service.logger = mock_logger
+
+    Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
+      dataset = bigquery.dataset dataset_id
+
+      dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+      dataset.dataset_id.must_equal dataset_id
+    end
+
+    mock.verify
+    mock_logger.verify
+  end
+
   def find_dataset_gapi id
     Google::Apis::BigqueryV2::Dataset.from_json random_dataset_hash(id).to_json
   end


### PR DESCRIPTION
- [x] Add `logger` param to `Google::Cloud::Bigquery.new` and logging for errors that result in request retries.
- [x] Add `JSON::ParserError` to retryable error types.

closes: #5180

Example of real-world `DEBUG`-level logging output:

```
W, [2020-04-13T15:28:59.748917 #15888]  WARN -- : Google::Cloud::Bigquery::Service#patch_dataset: Attempting retry 1 because of retryable error: #<Google::Apis::RateLimitError: rateLimitExceeded: Exceeded rate limits: too many dataset metadata update operations for this dataset. For more information, see https://cloud.google.com/bigquery/troubleshooting-errors status_code: 403 header: #<HTTP::Message::Headers:0x00007fa54a299c70 @http_version="1.1", @body_size=0, @chunked=false, @request_method="PATCH", @request_uri=#<Addressable::URI:0x3fd2a5145ca0 URI:https://bigquery.googleapis.com/bigquery/v2/projects/bustling-kayak-91516/datasets/gcloud_ruby_acceptance_2020_04_13t21_18_46z_72954f3c_dataset?>, @request_query=nil, @request_absolute_uri=nil, @status_code=403, @reason_phrase="Forbidden", @body_type=nil, @body_charset=nil, @body_date=nil, @body_encoding=#<Encoding:UTF-8>, @is_request=false, @header_item=[["ETag", "d89IZbp6cpg6UH1TBM8IfA=="], ["Vary", "Origin"], ["Vary", "X-Origin"], ["Vary", "Referer"], ["Content-Type", "application/json; charset=UTF-8"], ["Content-Encoding", "gzip"], ["Date", "Mon, 13 Apr 2020 21:28:59 GMT"], ["Server", "ESF"], ["Cache-Control", "private"], ["X-XSS-Protection", "0"], ["X-Frame-Options", "SAMEORIGIN"], ["X-Content-Type-Options", "nosniff"], ["Alt-Svc", "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,h3-T050=\":443\"; ma=2592000"], ["Transfer-Encoding", "chunked"]], @dumped=false> body: "{\n  \"error\": {\n    \"code\": 403,\n    \"message\": \"Exceeded rate limits: too many dataset metadata update operations for this dataset. For more information, see https://cloud.google.com/bigquery/troubleshooting-errors\",\n    \"errors\": [\n      {\n        \"message\": \"Exceeded rate limits: too many dataset metadata update operations for this dataset. For more information, see https://cloud.google.com/bigquery/troubleshooting-errors\",\n        \"domain\": \"usageLimits\",\n        \"reason\": \"rateLimitExceeded\"\n      }\n    ],\n    \"status\": \"PERMISSION_DENIED\"\n  }\n}\n">
```