### PR TITLE
chore(datastore): Update minitest to 5.14

### DIFF
--- a/google-cloud-datastore/.rubocop.yml
+++ b/google-cloud-datastore/.rubocop.yml
@@ -1,15 +1,15 @@
+require: rubocop-minitest
+
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
     - "google-cloud-datastore.gemspec"
     - "lib/google/datastore/**/*"
     - "lib/google/cloud/datastore/v1/**/*"
     - "Rakefile"
     - "support/**/*"
-    - "test/**/*"
 
 Documentation:
   Enabled: false

--- a/google-cloud-datastore/.rubocop.yml
+++ b/google-cloud-datastore/.rubocop.yml
@@ -1,15 +1,15 @@
-require: rubocop-minitest
-
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
+    - "acceptance/**/*"
     - "google-cloud-datastore.gemspec"
     - "lib/google/datastore/**/*"
     - "lib/google/cloud/datastore/v1/**/*"
     - "Rakefile"
     - "support/**/*"
+    - "test/**/*"
 
 Documentation:
   Enabled: false

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -10,4 +10,4 @@ gem "rake"
 
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"
+gem "minitest"

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -11,3 +11,4 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest"
+gem "rubocop-minitest"

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -11,4 +11,3 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest"
-gem "rubocop-minitest"

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -7,7 +7,3 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "rake"
-
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest"

--- a/google-cloud-datastore/acceptance/datastore/datastore_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/datastore_test.rb
@@ -21,12 +21,12 @@ describe "Datastore", :datastore do
 
   it "should allocate IDs" do
     incomplete_key = Google::Cloud::Datastore::Key.new "Kind"
-    incomplete_key.wont_be :complete?
+    _(incomplete_key).wont_be :complete?
 
     keys = dataset.allocate_ids incomplete_key, 10
 
-    keys.count.must_equal 10
-    keys.each { |key| key.must_be :complete? }
+    _(keys.count).must_equal 10
+    keys.each { |key| _(key).must_be :complete? }
   end
 
   describe "create, retrieve and delete" do
@@ -59,23 +59,23 @@ describe "Datastore", :datastore do
       post.key = Google::Cloud::Datastore::Key.new "Post", "#{prefix}_post1"
       post.exclude_from_indexes! "author", true
       # Verify the index excludes are set properly
-      post.exclude_from_indexes?("title").must_equal false
-      post.exclude_from_indexes?("author").must_equal true
+      _(post.exclude_from_indexes?("title")).must_equal false
+      _(post.exclude_from_indexes?("author")).must_equal true
 
       dataset.save post
 
       refresh = dataset.find post.key
-      refresh.key.kind.must_equal        post.key.kind
-      refresh.key.id.must_be :nil?
-      refresh.key.name.must_equal        post.key.name
-      refresh.properties.to_h.must_equal post.properties.to_h
+      _(refresh.key.kind).must_equal        post.key.kind
+      _(refresh.key.id).must_be :nil?
+      _(refresh.key.name).must_equal        post.key.name
+      _(refresh.properties.to_h).must_equal post.properties.to_h
       # Verify the index excludes are retrieved properly
-      refresh.exclude_from_indexes?("title").must_equal false
-      refresh.exclude_from_indexes?("author").must_equal true
+      _(refresh.exclude_from_indexes?("title")).must_equal false
+      _(refresh.exclude_from_indexes?("author")).must_equal true
 
       dataset.delete post
       refresh = dataset.find post.key
-      refresh.must_be :nil?
+      _(refresh).must_be :nil?
     end
 
     it "should save/find with a key name and delete with a key" do
@@ -83,14 +83,14 @@ describe "Datastore", :datastore do
       dataset.save post
 
       refresh = dataset.find post.key
-      refresh.key.kind.must_equal        post.key.kind
-      refresh.key.id.must_be :nil?
-      refresh.key.name.must_equal        post.key.name
-      refresh.properties.to_h.must_equal post.properties.to_h
+      _(refresh.key.kind).must_equal        post.key.kind
+      _(refresh.key.id).must_be :nil?
+      _(refresh.key.name).must_equal        post.key.name
+      _(refresh.properties.to_h).must_equal post.properties.to_h
 
       dataset.delete post.key
       refresh = dataset.find post.key
-      refresh.must_be :nil?
+      _(refresh).must_be :nil?
     end
 
     it "should save/find/delete with a numeric key id" do
@@ -98,81 +98,81 @@ describe "Datastore", :datastore do
       dataset.save post
 
       refresh = dataset.find post.key
-      refresh.key.kind.must_equal        post.key.kind
-      refresh.key.id.must_equal          post.key.id
-      refresh.key.name.must_be :nil?
-      refresh.properties.to_h.must_equal post.properties.to_h
+      _(refresh.key.kind).must_equal        post.key.kind
+      _(refresh.key.id).must_equal          post.key.id
+      _(refresh.key.name).must_be :nil?
+      _(refresh.properties.to_h).must_equal post.properties.to_h
 
       dataset.delete post
       refresh = dataset.find post.key
-      refresh.must_be :nil?
+      _(refresh).must_be :nil?
     end
 
     it "should save/find/delete with a generated key id" do
       post.key = Google::Cloud::Datastore::Key.new "Post"
 
-      post.key.id.must_be :nil?
+      _(post.key.id).must_be :nil?
 
       dataset.save post
 
-      post.key.id.wont_be :nil?
+      _(post.key.id).wont_be :nil?
 
       refresh = dataset.find "Post",     post.key.id
-      refresh.key.kind.must_equal        post.key.kind
-      refresh.key.id.must_equal          post.key.id
-      refresh.key.name.must_be :nil?
-      refresh.properties.to_h.must_equal post.properties.to_h
+      _(refresh.key.kind).must_equal        post.key.kind
+      _(refresh.key.id).must_equal          post.key.id
+      _(refresh.key.name).must_be :nil?
+      _(refresh.properties.to_h).must_equal post.properties.to_h
 
       dataset.delete post
       refresh = dataset.find post.key
-      refresh.must_be :nil?
+      _(refresh).must_be :nil?
     end
 
     it "should save/find/delete multiple entities at once" do
       post.key  = Google::Cloud::Datastore::Key.new "Post"
       post2.key = Google::Cloud::Datastore::Key.new "Post"
 
-      post.key.must_be :incomplete?
-      post2.key.must_be :incomplete?
+      _(post.key).must_be :incomplete?
+      _(post2.key).must_be :incomplete?
 
       dataset.save post, post2
 
-      post.key.wont_be :incomplete?
-      post2.key.wont_be :incomplete?
+      _(post.key).wont_be :incomplete?
+      _(post2.key).wont_be :incomplete?
 
       entities = dataset.find_all post.key, post2.key
-      entities.count.must_equal 2
+      _(entities.count).must_equal 2
 
       dataset.delete post, post2
 
       entities = dataset.find_all post.key, post2.key
-      entities.count.must_equal 0
+      _(entities.count).must_equal 0
     end
 
     it "should save/find/delete multiple entities with commit" do
       post.key  = Google::Cloud::Datastore::Key.new "Post"
       post2.key = Google::Cloud::Datastore::Key.new "Post"
 
-      post.key.must_be :incomplete?
-      post2.key.must_be :incomplete?
+      _(post.key).must_be :incomplete?
+      _(post2.key).must_be :incomplete?
 
       dataset.save post
 
-      post.key.must_be :complete?
-      post2.key.must_be :incomplete?
+      _(post.key).must_be :complete?
+      _(post2.key).must_be :incomplete?
 
       dataset.commit do |c|
         c.delete post
         c.save post2
       end
 
-      post.key.must_be :complete?
-      post2.key.must_be :complete?
+      _(post.key).must_be :complete?
+      _(post2.key).must_be :complete?
 
       dataset.delete post2
 
       entities = dataset.find_all post.key, post2.key
-      entities.count.must_equal 0
+      _(entities.count).must_equal 0
     end
 
     it "entities retrieved from datastore have immutable keys" do
@@ -180,8 +180,8 @@ describe "Datastore", :datastore do
       dataset.save post
 
       refresh = dataset.find post.key
-      refresh.must_be :persisted?
-      refresh.key.must_be :frozen?
+      _(refresh).must_be :persisted?
+      _(refresh.key).must_be :frozen?
 
       assert_raises RuntimeError do
         refresh.key = Google::Cloud::Datastore::Key.new "User", 456789
@@ -207,8 +207,8 @@ describe "Datastore", :datastore do
       # Rewind not needed because the StringIO poistion is always at the beginning whe retrieved from Datastore.
       # entity["avatar"].rewind
       post["avatar"].rewind
-      entity["avatar"].size.must_equal post["avatar"].size
-      entity["avatar"].read.must_equal post["avatar"].read
+      _(entity["avatar"].size).must_equal post["avatar"].size
+      _(entity["avatar"].read).must_equal post["avatar"].read
 
       Tempfile.open ["avatar", "png"] do |tmpfile|
         tmpfile.binmode
@@ -217,8 +217,8 @@ describe "Datastore", :datastore do
 
         tmpfile.rewind
         avatar.rewind
-        tmpfile.size.must_equal avatar.size
-        tmpfile.read.must_equal avatar.read
+        _(tmpfile.size).must_equal avatar.size
+        _(tmpfile.read).must_equal avatar.read
       end
 
       dataset.delete post
@@ -232,15 +232,15 @@ describe "Datastore", :datastore do
       sleep 1
 
       refresh = dataset.find post.key, consistency: :eventual
-      refresh.wont_be :nil?
-      refresh.key.kind.must_equal        post.key.kind
-      refresh.key.id.must_be :nil?
-      refresh.key.name.must_equal        post.key.name
-      refresh.properties.to_h.must_equal post.properties.to_h
+      _(refresh).wont_be :nil?
+      _(refresh.key.kind).must_equal        post.key.kind
+      _(refresh.key.id).must_be :nil?
+      _(refresh.key.name).must_equal        post.key.name
+      _(refresh.properties.to_h).must_equal post.properties.to_h
 
       dataset.delete post.key
       refresh = dataset.find post.key
-      refresh.must_be :nil?
+      _(refresh).must_be :nil?
     end
 
     it "allows embedded entities and keys" do
@@ -249,21 +249,21 @@ describe "Datastore", :datastore do
       post["embedded_entity"]["embedded_name"] = "hello!"
       post["embedded_key"] = dataset.entity "EmbeddedKey", "#{prefix}_will_be_pesisted"
 
-      post["embedded_entity"].wont_be :nil?
-      post["embedded_entity"].key.wont_be :nil?
-      post["embedded_entity"]["embedded_name"].must_equal "hello!"
-      post["embedded_key"].wont_be :nil?
+      _(post["embedded_entity"]).wont_be :nil?
+      _(post["embedded_entity"].key).wont_be :nil?
+      _(post["embedded_entity"]["embedded_name"]).must_equal "hello!"
+      _(post["embedded_key"]).wont_be :nil?
 
       dataset.save post
 
       refresh = dataset.find post.key
 
-      refresh["embedded_entity"].wont_be :nil?
-      refresh["embedded_entity"].key.must_be :nil?
-      refresh["embedded_entity"]["embedded_name"].must_equal "hello!"
-      refresh["embedded_entity"].to_grpc.properties.must_equal post["embedded_entity"].to_grpc.properties
-      refresh["embedded_key"].wont_be :nil?
-      refresh["embedded_key"].to_grpc.must_equal post["embedded_key"].to_grpc
+      _(refresh["embedded_entity"]).wont_be :nil?
+      _(refresh["embedded_entity"].key).must_be :nil?
+      _(refresh["embedded_entity"]["embedded_name"]).must_equal "hello!"
+      _(refresh["embedded_entity"].to_grpc.properties).must_equal post["embedded_entity"].to_grpc.properties
+      _(refresh["embedded_key"]).wont_be :nil?
+      _(refresh["embedded_key"].to_grpc).must_equal post["embedded_key"].to_grpc
 
       dataset.delete post
     end
@@ -282,13 +282,13 @@ describe "Datastore", :datastore do
     try_with_backoff "query by key" do
       entities = dataset.run query
       fail "retry query by key" unless entities.count == 1
-      entities.count.must_equal 1
+      _(entities.count).must_equal 1
 
       entity = entities.first
-      entity["fullName"].must_equal      person["fullName"]
-      entity["linkedTo"].kind.must_equal person["linkedTo"].kind
-      entity["linkedTo"].id.must_be :nil?
-      entity["linkedTo"].name.must_equal person["linkedTo"].name
+      _(entity["fullName"]).must_equal      person["fullName"]
+      _(entity["linkedTo"].kind).must_equal person["linkedTo"].kind
+      _(entity["linkedTo"].id).must_be :nil?
+      _(entity["linkedTo"].name).must_equal person["linkedTo"].name
     end
   end
 
@@ -411,17 +411,17 @@ describe "Datastore", :datastore do
       query = Google::Cloud::Datastore::Query.new.
         kind("Character").ancestor(book).limit(5)
       entities = dataset.run query
-      entities.count.must_equal 5
+      _(entities.count).must_equal 5
 
       # second page
       query.offset 5
       entities = dataset.run query
-      entities.count.must_equal 3
+      _(entities.count).must_equal 3
 
       # third page
       query.offset 10
       entities = dataset.run query
-      entities.count.must_equal 0
+      _(entities.count).must_equal 0
     end
 
     it "should filter queries with simple indexes" do
@@ -429,7 +429,7 @@ describe "Datastore", :datastore do
         kind("Character").ancestor(book).
         where("appearances", ">=", 20)
       entities = dataset.run query
-      entities.count.must_equal 6
+      _(entities.count).must_equal 6
     end
 
     it "should filter queries with defined indexes" do
@@ -438,21 +438,21 @@ describe "Datastore", :datastore do
         where("family", "=", "Stark").
         where("appearances", ">=", 20)
       entities = dataset.run query
-      entities.count.must_equal 6
+      _(entities.count).must_equal 6
     end
 
     it "should filter by ancestor key" do
       query = Google::Cloud::Datastore::Query.new.
         kind("Character").ancestor(book.key)
       entities = dataset.run query
-      entities.count.must_equal 8
+      _(entities.count).must_equal 8
     end
 
     it "should filter by ancestor entity" do
       query = Google::Cloud::Datastore::Query.new.
         kind("Character").ancestor(book)
       entities = dataset.run query
-      entities.count.must_equal 8
+      _(entities.count).must_equal 8
     end
 
     it "should filter by key" do
@@ -460,7 +460,7 @@ describe "Datastore", :datastore do
         kind("Character").ancestor(book).
         where("__key__", "=", rickard.key)
       entities = dataset.run query
-      entities.count.must_equal 1
+      _(entities.count).must_equal 1
     end
 
     it "should order queries" do
@@ -468,9 +468,9 @@ describe "Datastore", :datastore do
         kind("Character").ancestor(book).
         order("appearances")
       entities = dataset.run query
-      entities.count.must_equal      characters.count
-      entities[0]["name"].must_equal rickard["name"]
-      entities[7]["name"].must_equal arya["name"]
+      _(entities.count).must_equal      characters.count
+      _(entities[0]["name"]).must_equal rickard["name"]
+      _(entities[7]["name"]).must_equal arya["name"]
     end
 
     it "should select projections" do
@@ -479,9 +479,9 @@ describe "Datastore", :datastore do
         select("name", "family")
       entities = dataset.run query
       entities.each do |entity|
-        entity.properties.to_h.keys.count.must_equal 2
-        entity.properties["name"].wont_be :nil?
-        entity.properties["family"].wont_be :nil?
+        _(entity.properties.to_h.keys.count).must_equal 2
+        _(entity.properties["name"]).wont_be :nil?
+        _(entity.properties["family"]).wont_be :nil?
       end
     end
 
@@ -490,16 +490,16 @@ describe "Datastore", :datastore do
         kind("Character").ancestor(book).
         limit(3).offset(2).order("appearances")
       entities = dataset.run query
-      entities.count.must_equal 3
-      entities[0]["name"].must_equal robb["name"]
-      entities[2]["name"].must_equal catelyn["name"]
+      _(entities.count).must_equal 3
+      _(entities[0]["name"]).must_equal robb["name"]
+      _(entities[2]["name"]).must_equal catelyn["name"]
 
       # next page
       query.offset(5)
       entities = dataset.run query
-      entities.count.must_equal 3
-      entities[0]["name"].must_equal sansa["name"]
-      entities[2]["name"].must_equal arya["name"]
+      _(entities.count).must_equal 3
+      _(entities[0]["name"]).must_equal sansa["name"]
+      _(entities[2]["name"]).must_equal arya["name"]
     end
 
     it "should paginate with all" do
@@ -507,9 +507,9 @@ describe "Datastore", :datastore do
         kind("Character").ancestor(book).
         order("appearances")
       entities = dataset.run(query).all.to_a
-      entities.count.must_equal 8
-      entities[0]["name"].must_equal rickard["name"]
-      entities[5]["name"].must_equal sansa["name"]
+      _(entities.count).must_equal 8
+      _(entities[0]["name"]).must_equal rickard["name"]
+      _(entities[5]["name"]).must_equal sansa["name"]
     end
 
     it "should resume from a start cursor" do
@@ -517,31 +517,31 @@ describe "Datastore", :datastore do
         kind("Character").ancestor(book).
         limit(3).order("appearances")
       entities = dataset.run query
-      entities.count.must_equal 3
-      entities[0]["name"].must_equal rickard["name"]
-      entities[2]["name"].must_equal robb["name"]
+      _(entities.count).must_equal 3
+      _(entities[0]["name"]).must_equal rickard["name"]
+      _(entities[2]["name"]).must_equal robb["name"]
 
       next_cursor = entities.cursor
-      next_cursor.wont_be :nil?
+      _(next_cursor).wont_be :nil?
       next_query = Google::Cloud::Datastore::Query.new.
         kind("Character").ancestor(book).
         limit(3).order("appearances").
         cursor(next_cursor)
       next_entities = dataset.run next_query
-      next_entities.count.must_equal 3
-      next_entities[0]["name"].must_equal bran["name"]
-      next_entities[2]["name"].must_equal sansa["name"]
+      _(next_entities.count).must_equal 3
+      _(next_entities[0]["name"]).must_equal bran["name"]
+      _(next_entities[2]["name"]).must_equal sansa["name"]
 
       last_cursor = next_entities.cursor
-      last_cursor.wont_be :nil?
+      _(last_cursor).wont_be :nil?
       last_query = Google::Cloud::Datastore::Query.new.
         kind("Character").ancestor(book).
         limit(3).order("appearances").
         cursor(last_cursor)
       last_entities = dataset.run last_query
-      last_entities.count.must_equal 2
-      last_entities[0]["name"].must_equal jonsnow["name"]
-      last_entities[1]["name"].must_equal arya["name"]
+      _(last_entities.count).must_equal 2
+      _(last_entities[0]["name"]).must_equal jonsnow["name"]
+      _(last_entities[1]["name"]).must_equal arya["name"]
     end
 
     it "should group queries" do
@@ -549,42 +549,42 @@ describe "Datastore", :datastore do
         kind("Character").ancestor(book).
         group_by("alive")
       entities = dataset.run query
-      entities.count.must_equal 2
+      _(entities.count).must_equal 2
     end
 
     it "should filter queries with simple indexes using GQL and named bindings" do
       gql = dataset.gql "SELECT * FROM Character WHERE __key__ HAS ANCESTOR @bookKey AND appearances >= @appearanceCount",
                         bookKey: book.key, appearanceCount: 20
       entities = dataset.run gql
-      entities.count.must_equal 6
+      _(entities.count).must_equal 6
     end
 
     it "should filter queries with simple indexes using GQL and positional bindings" do
       gql = dataset.gql "SELECT * FROM Character WHERE __key__ HAS ANCESTOR @1 AND appearances >= @2"
       gql.positional_bindings = [book.key, 20]
       entities = dataset.run gql
-      entities.count.must_equal 6
+      _(entities.count).must_equal 6
     end
 
     it "should filter queries with defined indexes using GQL and named bindings" do
       gql = dataset.gql "SELECT * FROM Character WHERE __key__ HAS ANCESTOR @bookKey AND family = @familyName AND appearances >= @appearanceCount",
                         bookKey: book.key, familyName: "Stark", appearanceCount: 20
       entities = dataset.run gql
-      entities.count.must_equal 6
+      _(entities.count).must_equal 6
     end
 
     it "should filter queries with defined indexes using GQL and positional bindings" do
       gql = dataset.gql "SELECT * FROM Character WHERE __key__ HAS ANCESTOR @1 AND family = @2 AND appearances >= @3"
       gql.positional_bindings = [book.key, "Stark", 20]
       entities = dataset.run gql
-      entities.count.must_equal 6
+      _(entities.count).must_equal 6
     end
 
     it "should filter queries with defined indexes using GQL and literal values" do
       gql = dataset.gql "SELECT * FROM Character WHERE __key__ HAS ANCESTOR Key(Book, '#{prefix}_GoT') AND family = 'Stark' AND appearances >= 20"
       gql.allow_literals = true
       entities = dataset.run gql
-      entities.count.must_equal 6
+      _(entities.count).must_equal 6
     end
 
     it "should specify consistency" do
@@ -593,7 +593,7 @@ describe "Datastore", :datastore do
         where("family", "=", "Stark").
         where("appearances", ">=", 20)
       entities = dataset.run query, consistency: :strong
-      entities.count.must_equal 6
+      _(entities.count).must_equal 6
     end
 
     it "should find and run query in a read-only transaction" do
@@ -605,7 +605,7 @@ describe "Datastore", :datastore do
         fresh = tx.find book.key
         entities = tx.run query
       end
-      entities.count.must_equal 8
+      _(entities.count).must_equal 8
     end
 
     after do
@@ -628,11 +628,11 @@ describe "Datastore", :datastore do
       end
 
       entity = dataset.find obj.key
-      entity.wont_be :nil?
-      entity.key.kind.must_equal        obj.key.kind
-      entity.key.id.must_be :nil?
-      entity.key.name.must_equal        obj.key.name
-      entity.properties.to_h.must_equal obj.properties.to_h
+      _(entity).wont_be :nil?
+      _(entity.key.kind).must_equal        obj.key.kind
+      _(entity.key.id).must_be :nil?
+      _(entity.key.name).must_equal        obj.key.name
+      _(entity.properties.to_h).must_equal obj.properties.to_h
       dataset.delete entity
     end
 
@@ -642,7 +642,7 @@ describe "Datastore", :datastore do
       obj["url"] = "www.google.com"
 
       tx = dataset.transaction
-      tx.id.wont_be :nil?
+      _(tx.id).wont_be :nil?
 
       if tx.find(obj.key).nil?
         tx.save obj
@@ -651,11 +651,11 @@ describe "Datastore", :datastore do
       tx.commit
 
       entity = dataset.find obj.key
-      entity.wont_be :nil?
-      entity.key.kind.must_equal        obj.key.kind
-      entity.key.id.must_be :nil?
-      entity.key.name.must_equal        obj.key.name
-      entity.properties.to_h.must_equal obj.properties.to_h
+      _(entity).wont_be :nil?
+      _(entity.key.kind).must_equal        obj.key.kind
+      _(entity.key.id).must_be :nil?
+      _(entity.key.name).must_equal        obj.key.name
+      _(entity.properties.to_h).must_equal obj.properties.to_h
       dataset.delete entity
     end
 
@@ -666,7 +666,7 @@ describe "Datastore", :datastore do
       dataset.save obj
 
       tx = dataset.transaction
-      tx.id.wont_be :nil?
+      _(tx.id).wont_be :nil?
 
       obj2 = tx.find obj.key
 
@@ -686,10 +686,10 @@ describe "Datastore", :datastore do
         tx2.commit
       end
 
-      retried.must_equal true
+      _(retried).must_equal true
       entity = dataset.find obj.key
-      entity.wont_be :nil?
-      entity["url"].must_equal "2.google.com"
+      _(entity).wont_be :nil?
+      _(entity["url"]).must_equal "2.google.com"
       dataset.delete entity
     end
 
@@ -702,7 +702,7 @@ describe "Datastore", :datastore do
       end
 
       refresh = dataset.find "Post", "#{prefix}_post5"
-      refresh.must_be :nil?
+      _(refresh).must_be :nil?
     end
   end
 end

--- a/google-cloud-datastore/google-cloud-datastore.gemspec
+++ b/google-cloud-datastore/google-cloud-datastore.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
-  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"

--- a/google-cloud-datastore/test/google/cloud/datastore/convert/struct_to_hash_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/convert/struct_to_hash_test.rb
@@ -29,19 +29,19 @@ describe Google::Cloud::Datastore::Convert, :struct_to_hash do
 
   it "converts empty struct" do
     hash = Google::Cloud::Datastore::Convert.struct_to_hash Google::Protobuf::Struct.new
-    hash.must_be_kind_of Hash
-    hash.must_be :empty?
+    _(hash).must_be_kind_of Hash
+    _(hash).must_be :empty?
   end
 
   it "converts complex struct" do
     hash = Google::Cloud::Datastore::Convert.struct_to_hash struct
-    hash.must_be_kind_of Hash
-    hash.wont_be :empty?
-    hash["foo"].must_be :nil?
-    hash["bar"].must_equal true
-    hash["baz"].must_equal "bif"
-    hash["pi"].must_equal 3.14
-    hash["meta"].must_equal({ "foo" => "bar" })
-    hash["msg"].must_equal ["hello", "world"]
+    _(hash).must_be_kind_of Hash
+    _(hash).wont_be :empty?
+    _(hash["foo"]).must_be :nil?
+    _(hash["bar"]).must_equal true
+    _(hash["baz"]).must_equal "bif"
+    _(hash["pi"]).must_equal 3.14
+    _(hash["meta"]).must_equal({ "foo" => "bar" })
+    _(hash["msg"]).must_equal ["hello", "world"]
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore/convert/value_to_object_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/convert/value_to_object_test.rb
@@ -25,31 +25,31 @@ describe Google::Cloud::Datastore::Convert, :value_to_object do
 
   it "converts nil value" do
     obj = Google::Cloud::Datastore::Convert.value_to_object nil_value
-    obj.must_be :nil?
+    _(obj).must_be :nil?
   end
 
   it "converts true value" do
     obj = Google::Cloud::Datastore::Convert.value_to_object true_value
-    obj.must_equal true
+    _(obj).must_equal true
   end
 
   it "converts string value" do
     obj = Google::Cloud::Datastore::Convert.value_to_object string_value
-    obj.must_equal "bif"
+    _(obj).must_equal "bif"
   end
 
   it "converts num value" do
     obj = Google::Cloud::Datastore::Convert.value_to_object num_value
-    obj.must_equal 3.14
+    _(obj).must_equal 3.14
   end
 
   it "converts struct value" do
     obj = Google::Cloud::Datastore::Convert.value_to_object struct_value
-    obj.must_equal({ "foo" => "bar" })
+    _(obj).must_equal({ "foo" => "bar" })
   end
 
   it "converts list value" do
     obj = Google::Cloud::Datastore::Convert.value_to_object list_value
-    obj.must_equal ["hello", "world"]
+    _(obj).must_equal ["hello", "world"]
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
@@ -86,16 +86,16 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     dataset.service.mocked_service.expect :allocate_ids, allocate_res, [project, keys, options: default_options]
 
     incomplete_key = Google::Cloud::Datastore::Key.new "ds-test"
-    incomplete_key.must_be :incomplete?
+    _(incomplete_key).must_be :incomplete?
     returned_keys = dataset.allocate_ids incomplete_key
-    returned_keys.count.must_equal 1
-    returned_keys.first.must_be_kind_of Google::Cloud::Datastore::Key
-    returned_keys.first.must_be :complete?
+    _(returned_keys.count).must_equal 1
+    _(returned_keys.first).must_be_kind_of Google::Cloud::Datastore::Key
+    _(returned_keys.first).must_be :complete?
   end
 
   it "allocate_ids raises when not given an incomplete key" do
     complete_key = Google::Cloud::Datastore::Key.new "ds-test", 789
-    complete_key.must_be :complete?
+    _(complete_key).must_be :complete?
     assert_raises Google::Cloud::Datastore::KeyError do
       dataset.allocate_ids complete_key
     end
@@ -118,11 +118,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e["name"] = "thingamajig"
     end
 
-    entity.key.must_be :complete?
-    entity.wont_be :persisted?
+    _(entity.key).must_be :complete?
+    _(entity).wont_be :persisted?
     dataset.save entity
-    entity.key.must_be :complete?
-    entity.must_be :persisted?
+    _(entity.key).must_be :complete?
+    _(entity).must_be :persisted?
   end
 
   it "save will persist incomplete entities" do
@@ -140,11 +140,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
       e["name"] = "thingamajig"
     end
-    entity.key.wont_be :complete?
-    entity.wont_be :persisted?
+    _(entity.key).wont_be :complete?
+    _(entity).wont_be :persisted?
     dataset.save entity
-    entity.key.must_be :complete?
-    entity.must_be :persisted?
+    _(entity.key).must_be :complete?
+    _(entity).must_be :persisted?
   end
 
   it "save will persist complete entities with upsert alias" do
@@ -164,11 +164,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
     end
-    entity.key.must_be :complete?
-    entity.wont_be :persisted?
+    _(entity.key).must_be :complete?
+    _(entity).wont_be :persisted?
     dataset.upsert entity
-    entity.key.must_be :complete?
-    entity.must_be :persisted?
+    _(entity.key).must_be :complete?
+    _(entity).must_be :persisted?
   end
 
   it "save will persist incomplete entities with upsert alias" do
@@ -186,11 +186,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
       e["name"] = "thingamajig"
     end
-    entity.key.wont_be :complete?
-    entity.wont_be :persisted?
+    _(entity.key).wont_be :complete?
+    _(entity).wont_be :persisted?
     dataset.upsert entity
-    entity.key.must_be :complete?
-    entity.must_be :persisted?
+    _(entity.key).must_be :complete?
+    _(entity).must_be :persisted?
   end
 
   it "save will persist multiple entities" do
@@ -217,11 +217,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thangie"
       e["name"] = "thungamajig"
     end
-    entity1.wont_be :persisted?
-    entity2.wont_be :persisted?
+    _(entity1).wont_be :persisted?
+    _(entity2).wont_be :persisted?
     dataset.save entity1, entity2
-    entity1.must_be :persisted?
-    entity2.must_be :persisted?
+    _(entity1).must_be :persisted?
+    _(entity2).must_be :persisted?
   end
 
   it "save will persist multiple entities in an array" do
@@ -248,11 +248,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thangie"
       e["name"] = "thungamajig"
     end
-    entity1.wont_be :persisted?
-    entity2.wont_be :persisted?
+    _(entity1).wont_be :persisted?
+    _(entity2).wont_be :persisted?
     dataset.save [entity1, entity2]
-    entity1.must_be :persisted?
-    entity2.must_be :persisted?
+    _(entity1).must_be :persisted?
+    _(entity2).must_be :persisted?
   end
 
   it "insert will persist complete entities" do
@@ -272,11 +272,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
     end
-    entity.key.must_be :complete?
-    entity.wont_be :persisted?
+    _(entity.key).must_be :complete?
+    _(entity).wont_be :persisted?
     dataset.insert entity
-    entity.key.must_be :complete?
-    entity.must_be :persisted?
+    _(entity.key).must_be :complete?
+    _(entity).must_be :persisted?
   end
 
   it "insert will persist incomplete entities" do
@@ -294,11 +294,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
       e["name"] = "thingamajig"
     end
-    entity.key.wont_be :complete?
-    entity.wont_be :persisted?
+    _(entity.key).wont_be :complete?
+    _(entity).wont_be :persisted?
     dataset.insert entity
-    entity.key.must_be :complete?
-    entity.must_be :persisted?
+    _(entity.key).must_be :complete?
+    _(entity).must_be :persisted?
   end
 
   it "insert will persist multiple entities" do
@@ -326,11 +326,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thangie"
       e["name"] = "thungamajig"
     end
-    entity1.wont_be :persisted?
-    entity2.wont_be :persisted?
+    _(entity1).wont_be :persisted?
+    _(entity2).wont_be :persisted?
     dataset.insert entity1, entity2
-    entity1.must_be :persisted?
-    entity2.must_be :persisted?
+    _(entity1).must_be :persisted?
+    _(entity2).must_be :persisted?
   end
 
   it "insert will persist multiple entities in an array" do
@@ -358,11 +358,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thangie"
       e["name"] = "thungamajig"
     end
-    entity1.wont_be :persisted?
-    entity2.wont_be :persisted?
+    _(entity1).wont_be :persisted?
+    _(entity2).wont_be :persisted?
     dataset.insert [entity1, entity2]
-    entity1.must_be :persisted?
-    entity2.must_be :persisted?
+    _(entity1).must_be :persisted?
+    _(entity2).must_be :persisted?
   end
 
   it "update will persist entities" do
@@ -381,11 +381,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
     end
-    entity.key.must_be :complete?
-    entity.wont_be :persisted?
+    _(entity.key).must_be :complete?
+    _(entity).wont_be :persisted?
     dataset.update entity
-    entity.key.must_be :complete?
-    entity.must_be :persisted?
+    _(entity.key).must_be :complete?
+    _(entity).must_be :persisted?
   end
 
   it "update will persist multiple entities" do
@@ -414,11 +414,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thangie"
       e["name"] = "thungamajig"
     end
-    entity1.wont_be :persisted?
-    entity2.wont_be :persisted?
+    _(entity1).wont_be :persisted?
+    _(entity2).wont_be :persisted?
     dataset.update entity1, entity2
-    entity1.must_be :persisted?
-    entity2.must_be :persisted?
+    _(entity1).must_be :persisted?
+    _(entity2).must_be :persisted?
   end
 
   it "update will persist multiple entities in an array" do
@@ -447,11 +447,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thangie"
       e["name"] = "thungamajig"
     end
-    entity1.wont_be :persisted?
-    entity2.wont_be :persisted?
+    _(entity1).wont_be :persisted?
+    _(entity2).wont_be :persisted?
     dataset.update [entity1, entity2]
-    entity1.must_be :persisted?
-    entity2.must_be :persisted?
+    _(entity1).must_be :persisted?
+    _(entity2).must_be :persisted?
   end
 
   it "find can take a kind and id" do
@@ -459,7 +459,7 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     dataset.service.mocked_service.expect :lookup, lookup_res, [project, keys, read_options: nil, options: default_options]
 
     entity = dataset.find "ds-test", 123
-    entity.must_be_kind_of Google::Cloud::Datastore::Entity
+    _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
   end
 
   it "find can take a kind and name" do
@@ -467,7 +467,7 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     dataset.service.mocked_service.expect :lookup, lookup_res, [project, keys, read_options: nil, options: default_options]
 
     entity = dataset.find "ds-test", "thingie"
-    entity.must_be_kind_of Google::Cloud::Datastore::Entity
+    _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
   end
 
   it "find can take a key" do
@@ -476,7 +476,7 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
 
     key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
     entity = dataset.find key
-    entity.must_be_kind_of Google::Cloud::Datastore::Entity
+    _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
   end
 
   it "find is aliased to get" do
@@ -484,7 +484,7 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     dataset.service.mocked_service.expect :lookup, lookup_res, [project, keys, read_options: nil, options: default_options]
 
     entity = dataset.get "ds-test", 123
-    entity.must_be_kind_of Google::Cloud::Datastore::Entity
+    _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
   end
 
   it "find can specify consistency" do
@@ -493,14 +493,14 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     dataset.service.mocked_service.expect :lookup, lookup_res, [project, keys, read_options: read_options, options: default_options]
 
     entity = dataset.find "ds-test", 123, consistency: :eventual
-    entity.must_be_kind_of Google::Cloud::Datastore::Entity
+    _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
   end
 
   it "find raises if consistency is a bad value" do
     error = expect do
       dataset.find "ds-test", 123, consistency: "foobar"
     end.must_raise ArgumentError
-    error.message.must_equal "Consistency must be :eventual or :strong, not \"foobar\"."
+    _(error.message).must_equal "Consistency must be :eventual or :strong, not \"foobar\"."
   end
 
   it "find_all takes several keys" do
@@ -511,11 +511,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
     key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
     entities = dataset.find_all key1, key2
-    entities.count.must_equal 2
-    entities.deferred.count.must_equal 0
-    entities.missing.count.must_equal 0
+    _(entities.count).must_equal 2
+    _(entities.deferred.count).must_equal 0
+    _(entities.missing.count).must_equal 0
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
@@ -527,11 +527,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
     key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
     entities = dataset.lookup key1, key2
-    entities.count.must_equal 2
-    entities.deferred.count.must_equal 0
-    entities.missing.count.must_equal 0
+    _(entities.count).must_equal 2
+    _(entities.deferred.count).must_equal 0
+    _(entities.missing.count).must_equal 0
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
@@ -544,11 +544,11 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
     key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
     entities = dataset.lookup key1, key2, consistency: :eventual
-    entities.count.must_equal 2
-    entities.deferred.count.must_equal 0
-    entities.missing.count.must_equal 0
+    _(entities.count).must_equal 2
+    _(entities.deferred.count).must_equal 0
+    _(entities.missing.count).must_equal 0
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
@@ -557,7 +557,7 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       entities = dataset.lookup key, key, consistency: "foobar"
     end.must_raise ArgumentError
-    error.message.must_equal "Consistency must be :eventual or :strong, not \"foobar\"."
+    _(error.message).must_equal "Consistency must be :eventual or :strong, not \"foobar\"."
   end
 
   describe "find_all result object" do
@@ -590,14 +590,14 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
       key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
       entities = dataset.find_all key1, key2
-      entities.count.must_equal 2
-      entities.deferred.count.must_equal 2
-      entities.missing.count.must_equal 0
+      _(entities.count).must_equal 2
+      _(entities.deferred.count).must_equal 2
+      _(entities.missing.count).must_equal 0
       entities.each do |entity|
-        entity.must_be_kind_of Google::Cloud::Datastore::Entity
+        _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
       end
       entities.deferred.each do |deferred_key|
-        deferred_key.must_be_kind_of Google::Cloud::Datastore::Key
+        _(deferred_key).must_be_kind_of Google::Cloud::Datastore::Key
       end
     end
 
@@ -609,14 +609,14 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
       key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
       entities = dataset.find_all key1, key2
-      entities.count.must_equal 2
-      entities.deferred.count.must_equal 0
-      entities.missing.count.must_equal 2
+      _(entities.count).must_equal 2
+      _(entities.deferred.count).must_equal 0
+      _(entities.missing.count).must_equal 2
       entities.each do |entity|
-        entity.must_be_kind_of Google::Cloud::Datastore::Entity
+        _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
       end
       entities.missing.each do |entity|
-        entity.must_be_kind_of Google::Cloud::Datastore::Entity
+        _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
       end
     end
   end
@@ -736,26 +736,26 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     dataset.service.mocked_service.expect :run_query, run_query_res, [project, partition_id: nil, read_options: nil, query: query.to_grpc, gql_query: nil, options: default_options]
 
     entities = dataset.run query
-    entities.count.must_equal 2
+    _(entities.count).must_equal 2
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    entities.cursor_for(entities.first).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
-    entities.cursor_for(entities.last).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
+    _(entities.cursor_for(entities.first)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
+    _(entities.cursor_for(entities.last)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
     entities.each_with_cursor do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
     # can use the enumerator without passing a block...
     entities.each_with_cursor.map do |entity, cursor|
       [entity.key, cursor]
     end.each do |result, cursor|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
-    entities.cursor.must_equal query_cursor
-    entities.end_cursor.must_equal query_cursor
-    entities.more_results.must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
+    _(entities.cursor).must_equal query_cursor
+    _(entities.end_cursor).must_equal query_cursor
+    _(entities.more_results).must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
     refute entities.not_finished?
     refute entities.more_after_limit?
     refute entities.more_after_cursor?
@@ -782,37 +782,37 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e["name"] = "Gonna be deleted"
     end
 
-    entity_to_be_saved.wont_be :persisted?
+    _(entity_to_be_saved).wont_be :persisted?
     dataset.commit do |c|
       c.save entity_to_be_saved
       c.delete entity_to_be_deleted
     end
-    entity_to_be_saved.must_be :persisted?
+    _(entity_to_be_saved).must_be :persisted?
   end
 
   it "run_query will fulfill a query" do
     dataset.service.mocked_service.expect :run_query, run_query_res, [project, partition_id: nil, read_options: nil, query: query.to_grpc, gql_query: nil, options: default_options]
 
     entities = dataset.run_query query
-    entities.count.must_equal 2
+    _(entities.count).must_equal 2
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    entities.cursor_for(entities.first).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
-    entities.cursor_for(entities.last).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
+    _(entities.cursor_for(entities.first)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
+    _(entities.cursor_for(entities.last)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
     entities.each_with_cursor do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
     # can use the enumerator without passing a block...
     entities.each_with_cursor.map do |entity, cursor|
       [entity.key, cursor]
     end.each do |result, cursor|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
-    entities.cursor.must_equal query_cursor
-    entities.more_results.must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
+    _(entities.cursor).must_equal query_cursor
+    _(entities.more_results).must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
     refute entities.not_finished?
     refute entities.more_after_limit?
     refute entities.more_after_cursor?
@@ -824,25 +824,25 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     dataset.service.mocked_service.expect :run_query, run_query_res, [project, partition_id: partition_id, read_options: nil, query: query.to_grpc, gql_query: nil, options: default_options]
 
     entities = dataset.run_query query, namespace: "foobar"
-    entities.count.must_equal 2
+    _(entities.count).must_equal 2
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    entities.cursor_for(entities.first).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
-    entities.cursor_for(entities.last).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
+    _(entities.cursor_for(entities.first)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
+    _(entities.cursor_for(entities.last)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
     entities.each_with_cursor do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
     # can use the enumerator without passing a block...
     entities.each_with_cursor.map do |entity, cursor|
       [entity.key, cursor]
     end.each do |result, cursor|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
-    entities.cursor.must_equal query_cursor
-    entities.more_results.must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
+    _(entities.cursor).must_equal query_cursor
+    _(entities.more_results).must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
     refute entities.not_finished?
     refute entities.more_after_limit?
     refute entities.more_after_cursor?
@@ -854,26 +854,26 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
 
     gql = dataset.gql "SELECT * FROM Task"
     entities = dataset.run gql
-    entities.count.must_equal 2
+    _(entities.count).must_equal 2
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    entities.cursor_for(entities.first).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
-    entities.cursor_for(entities.last).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
+    _(entities.cursor_for(entities.first)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
+    _(entities.cursor_for(entities.last)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
     entities.each_with_cursor do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
     # can use the enumerator without passing a block...
     entities.each_with_cursor.map do |entity, cursor|
       [entity.key, cursor]
     end.each do |result, cursor|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
-    entities.cursor.must_equal query_cursor
-    entities.end_cursor.must_equal query_cursor
-    entities.more_results.must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
+    _(entities.cursor).must_equal query_cursor
+    _(entities.end_cursor).must_equal query_cursor
+    _(entities.more_results).must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
     refute entities.not_finished?
     refute entities.more_after_limit?
     refute entities.more_after_cursor?
@@ -886,26 +886,26 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
 
     gql = dataset.gql "SELECT * FROM Task"
     entities = dataset.run gql, namespace: "foobar"
-    entities.count.must_equal 2
+    _(entities.count).must_equal 2
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    entities.cursor_for(entities.first).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
-    entities.cursor_for(entities.last).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
+    _(entities.cursor_for(entities.first)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
+    _(entities.cursor_for(entities.last)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
     entities.each_with_cursor do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
     # can use the enumerator without passing a block...
     entities.each_with_cursor.map do |entity, cursor|
       [entity.key, cursor]
     end.each do |result, cursor|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
-    entities.cursor.must_equal query_cursor
-    entities.end_cursor.must_equal query_cursor
-    entities.more_results.must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
+    _(entities.cursor).must_equal query_cursor
+    _(entities.end_cursor).must_equal query_cursor
+    _(entities.more_results).must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
     refute entities.not_finished?
     refute entities.more_after_limit?
     refute entities.more_after_cursor?
@@ -917,26 +917,26 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
 
     gql = dataset.gql "SELECT * FROM Task"
     entities = dataset.run_query gql
-    entities.count.must_equal 2
+    _(entities.count).must_equal 2
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    entities.cursor_for(entities.first).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
-    entities.cursor_for(entities.last).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
+    _(entities.cursor_for(entities.first)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
+    _(entities.cursor_for(entities.last)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
     entities.each_with_cursor do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
     # can use the enumerator without passing a block...
     entities.each_with_cursor.map do |entity, cursor|
       [entity.key, cursor]
     end.each do |result, cursor|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
-    entities.cursor.must_equal query_cursor
-    entities.end_cursor.must_equal query_cursor
-    entities.more_results.must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
+    _(entities.cursor).must_equal query_cursor
+    _(entities.end_cursor).must_equal query_cursor
+    _(entities.more_results).must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
     refute entities.not_finished?
     refute entities.more_after_limit?
     refute entities.more_after_cursor?
@@ -949,26 +949,26 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
 
     gql = dataset.gql "SELECT * FROM Task"
     entities = dataset.run_query gql, namespace: "foobar"
-    entities.count.must_equal 2
+    _(entities.count).must_equal 2
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    entities.cursor_for(entities.first).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
-    entities.cursor_for(entities.last).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
+    _(entities.cursor_for(entities.first)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
+    _(entities.cursor_for(entities.last)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
     entities.each_with_cursor do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
     # can use the enumerator without passing a block...
     entities.each_with_cursor.map do |entity, cursor|
       [entity.key, cursor]
     end.each do |result, cursor|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
-    entities.cursor.must_equal query_cursor
-    entities.end_cursor.must_equal query_cursor
-    entities.more_results.must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
+    _(entities.cursor).must_equal query_cursor
+    _(entities.end_cursor).must_equal query_cursor
+    _(entities.more_results).must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
     refute entities.not_finished?
     refute entities.more_after_limit?
     refute entities.more_after_cursor?
@@ -983,124 +983,124 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
 
   it "query returns a Query instance" do
     query = dataset.query "Task"
-    query.must_be_kind_of Google::Cloud::Datastore::Query
+    _(query).must_be_kind_of Google::Cloud::Datastore::Query
 
     grpc = query.to_grpc
-    grpc.kind.map(&:name).must_include "Task"
-    grpc.kind.map(&:name).wont_include "User"
+    _(grpc.kind.map(&:name)).must_include "Task"
+    _(grpc.kind.map(&:name)).wont_include "User"
 
     # Add a second kind to the query
     query.kind "User"
 
     grpc = query.to_grpc
-    grpc.kind.map(&:name).must_include "Task"
-    grpc.kind.map(&:name).must_include "User"
+    _(grpc.kind.map(&:name)).must_include "Task"
+    _(grpc.kind.map(&:name)).must_include "User"
   end
 
   it "key returns a Key instance" do
     key = dataset.key "ThisThing", 1234
-    key.must_be_kind_of Google::Cloud::Datastore::Key
-    key.kind.must_equal "ThisThing"
-    key.id.must_equal 1234
-    key.name.must_be :nil?
+    _(key).must_be_kind_of Google::Cloud::Datastore::Key
+    _(key.kind).must_equal "ThisThing"
+    _(key.id).must_equal 1234
+    _(key.name).must_be :nil?
 
     key = dataset.key "ThisThing", "charlie"
-    key.must_be_kind_of Google::Cloud::Datastore::Key
-    key.kind.must_equal "ThisThing"
-    key.id.must_be :nil?
-    key.name.must_equal "charlie"
+    _(key).must_be_kind_of Google::Cloud::Datastore::Key
+    _(key.kind).must_equal "ThisThing"
+    _(key.id).must_be :nil?
+    _(key.name).must_equal "charlie"
   end
 
   it "key sets a parent and grandparent in the constructor" do
     path = [["OtherThing", "root"], ["ThatThing", 6789], ["ThisThing", 1234]]
     key = dataset.key path, project: "custom-ds", namespace: "custom-ns"
-    key.kind.must_equal "ThisThing"
-    key.id.must_equal 1234
-    key.name.must_be :nil?
-    key.path.must_equal [["OtherThing", "root"], ["ThatThing", 6789], ["ThisThing", 1234]]
-    key.project.must_equal "custom-ds"
-    key.namespace.must_equal "custom-ns"
+    _(key.kind).must_equal "ThisThing"
+    _(key.id).must_equal 1234
+    _(key.name).must_be :nil?
+    _(key.path).must_equal [["OtherThing", "root"], ["ThatThing", 6789], ["ThisThing", 1234]]
+    _(key.project).must_equal "custom-ds"
+    _(key.namespace).must_equal "custom-ns"
 
-    key.parent.wont_be :nil?
-    key.parent.kind.must_equal "ThatThing"
-    key.parent.id.must_equal 6789
-    key.parent.name.must_be :nil?
-    key.parent.path.must_equal [["OtherThing", "root"], ["ThatThing", 6789]]
-    key.parent.project.must_equal "custom-ds"
-    key.parent.namespace.must_equal "custom-ns"
+    _(key.parent).wont_be :nil?
+    _(key.parent.kind).must_equal "ThatThing"
+    _(key.parent.id).must_equal 6789
+    _(key.parent.name).must_be :nil?
+    _(key.parent.path).must_equal [["OtherThing", "root"], ["ThatThing", 6789]]
+    _(key.parent.project).must_equal "custom-ds"
+    _(key.parent.namespace).must_equal "custom-ns"
 
-    key.parent.parent.wont_be :nil?
-    key.parent.parent.kind.must_equal "OtherThing"
-    key.parent.parent.id.must_be :nil?
-    key.parent.parent.name.must_equal "root"
-    key.parent.parent.path.must_equal [["OtherThing", "root"]]
-    key.parent.parent.project.must_equal "custom-ds"
-    key.parent.parent.namespace.must_equal "custom-ns"
+    _(key.parent.parent).wont_be :nil?
+    _(key.parent.parent.kind).must_equal "OtherThing"
+    _(key.parent.parent.id).must_be :nil?
+    _(key.parent.parent.name).must_equal "root"
+    _(key.parent.parent.path).must_equal [["OtherThing", "root"]]
+    _(key.parent.parent.project).must_equal "custom-ds"
+    _(key.parent.parent.namespace).must_equal "custom-ns"
   end
 
   it "entity returns an Entity instance" do
     entity = dataset.entity
-    entity.must_be_kind_of Google::Cloud::Datastore::Entity
+    _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
   end
 
   it "entity sets the Key's kind for the new Entity" do
     entity = dataset.entity "User"
-    entity.must_be_kind_of Google::Cloud::Datastore::Entity
-    entity.key.kind.must_equal "User"
-    entity.key.id.must_be :nil?
-    entity.key.name.must_be :nil?
+    _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+    _(entity.key.kind).must_equal "User"
+    _(entity.key.id).must_be :nil?
+    _(entity.key.name).must_be :nil?
   end
 
   it "entity sets the Key's kind and id for the new Entity" do
     entity = dataset.entity "User", 123
-    entity.must_be_kind_of Google::Cloud::Datastore::Entity
-    entity.key.kind.must_equal "User"
-    entity.key.id.must_equal 123
-    entity.key.name.must_be :nil?
+    _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+    _(entity.key.kind).must_equal "User"
+    _(entity.key.id).must_equal 123
+    _(entity.key.name).must_be :nil?
   end
 
   it "entity sets the Key's kind and name for the new Entity" do
     entity = dataset.entity "User", "username"
-    entity.must_be_kind_of Google::Cloud::Datastore::Entity
-    entity.key.kind.must_equal "User"
-    entity.key.id.must_be :nil?
-    entity.key.name.must_equal "username"
+    _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+    _(entity.key.kind).must_equal "User"
+    _(entity.key.id).must_be :nil?
+    _(entity.key.name).must_equal "username"
   end
 
   it "entity sets the Key object for the new Entity" do
     key = dataset.key "User", "username"
     entity = dataset.entity key
-    entity.must_be_kind_of Google::Cloud::Datastore::Entity
-    entity.key.kind.must_equal "User"
-    entity.key.id.must_be :nil?
-    entity.key.name.must_equal "username"
+    _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+    _(entity.key.kind).must_equal "User"
+    _(entity.key.id).must_be :nil?
+    _(entity.key.name).must_equal "username"
   end
 
   it "entity sets a key's parent and grandparent" do
     path = [["OtherThing", "root"], ["ThatThing", 6789], ["ThisThing", 1234]]
     entity = dataset.entity path, project: "custom-ds", namespace: "custom-ns"
-    entity.key.kind.must_equal "ThisThing"
-    entity.key.id.must_equal 1234
-    entity.key.name.must_be :nil?
-    entity.key.path.must_equal [["OtherThing", "root"], ["ThatThing", 6789], ["ThisThing", 1234]]
-    entity.key.project.must_equal "custom-ds"
-    entity.key.namespace.must_equal "custom-ns"
+    _(entity.key.kind).must_equal "ThisThing"
+    _(entity.key.id).must_equal 1234
+    _(entity.key.name).must_be :nil?
+    _(entity.key.path).must_equal [["OtherThing", "root"], ["ThatThing", 6789], ["ThisThing", 1234]]
+    _(entity.key.project).must_equal "custom-ds"
+    _(entity.key.namespace).must_equal "custom-ns"
 
-    entity.key.parent.wont_be :nil?
-    entity.key.parent.kind.must_equal "ThatThing"
-    entity.key.parent.id.must_equal 6789
-    entity.key.parent.name.must_be :nil?
-    entity.key.parent.path.must_equal [["OtherThing", "root"], ["ThatThing", 6789]]
-    entity.key.parent.project.must_equal "custom-ds"
-    entity.key.parent.namespace.must_equal "custom-ns"
+    _(entity.key.parent).wont_be :nil?
+    _(entity.key.parent.kind).must_equal "ThatThing"
+    _(entity.key.parent.id).must_equal 6789
+    _(entity.key.parent.name).must_be :nil?
+    _(entity.key.parent.path).must_equal [["OtherThing", "root"], ["ThatThing", 6789]]
+    _(entity.key.parent.project).must_equal "custom-ds"
+    _(entity.key.parent.namespace).must_equal "custom-ns"
 
-    entity.key.parent.parent.wont_be :nil?
-    entity.key.parent.parent.kind.must_equal "OtherThing"
-    entity.key.parent.parent.id.must_be :nil?
-    entity.key.parent.parent.name.must_equal "root"
-    entity.key.parent.parent.path.must_equal [["OtherThing", "root"]]
-    entity.key.parent.parent.project.must_equal "custom-ds"
-    entity.key.parent.parent.namespace.must_equal "custom-ns"
+    _(entity.key.parent.parent).wont_be :nil?
+    _(entity.key.parent.parent.kind).must_equal "OtherThing"
+    _(entity.key.parent.parent.id).must_be :nil?
+    _(entity.key.parent.parent.name).must_equal "root"
+    _(entity.key.parent.parent.path).must_equal [["OtherThing", "root"]]
+    _(entity.key.parent.parent.project).must_equal "custom-ds"
+    _(entity.key.parent.parent.namespace).must_equal "custom-ns"
   end
 
   it "entity can configure the new Entity using a block" do
@@ -1108,12 +1108,12 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       e["name"] = "User McUser"
       e["email"] = "user@example.net"
     end
-    entity.must_be_kind_of Google::Cloud::Datastore::Entity
-    entity.key.kind.must_equal "User"
-    entity.key.id.must_be :nil?
-    entity.key.name.must_equal "username"
-    entity.properties["name"].must_equal "User McUser"
-    entity.properties["email"].must_equal "user@example.net"
+    _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+    _(entity.key.kind).must_equal "User"
+    _(entity.key.id).must_be :nil?
+    _(entity.key.name).must_equal "username"
+    _(entity.properties["name"]).must_equal "User McUser"
+    _(entity.properties["email"]).must_equal "user@example.net"
   end
 
   it "transaction will return a Transaction" do
@@ -1122,8 +1122,8 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project, transaction_options: nil]
 
     tx = dataset.transaction
-    tx.must_be_kind_of Google::Cloud::Datastore::Transaction
-    tx.id.must_equal "giterdone"
+    _(tx).must_be_kind_of Google::Cloud::Datastore::Transaction
+    _(tx.id).must_equal "giterdone"
   end
 
   it "transaction will return a Transaction with previous_transaction" do
@@ -1137,8 +1137,8 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project, transaction_options: tx_options]
 
     tx = dataset.transaction previous_transaction: previous_transaction_id
-    tx.must_be_kind_of Google::Cloud::Datastore::Transaction
-    tx.id.must_equal "giterdone"
+    _(tx).must_be_kind_of Google::Cloud::Datastore::Transaction
+    _(tx.id).must_equal "giterdone"
   end
 
   it "read_only_transaction will return a read-only Transaction" do
@@ -1151,7 +1151,7 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project, transaction_options: tx_options]
 
     tx = dataset.read_only_transaction
-    tx.must_be_kind_of Google::Cloud::Datastore::ReadOnlyTransaction
+    _(tx).must_be_kind_of Google::Cloud::Datastore::ReadOnlyTransaction
   end
 
   it "snapshot will return a read-only Transaction" do
@@ -1164,7 +1164,7 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project, transaction_options: tx_options]
 
     tx = dataset.snapshot
-    tx.must_be_kind_of Google::Cloud::Datastore::ReadOnlyTransaction
+    _(tx).must_be_kind_of Google::Cloud::Datastore::ReadOnlyTransaction
   end
 
   it "transaction will commit with a block" do
@@ -1205,10 +1205,10 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       end
     end
 
-    error.wont_be :nil?
-    error.message.must_equal "Transaction failed to commit."
-    error.cause.wont_be :nil?
-    error.cause.message.must_equal "This error should be wrapped by TransactionError."
+    _(error).wont_be :nil?
+    _(error.message).must_equal "Transaction failed to commit."
+    _(error.cause).wont_be :nil?
+    _(error.cause.message).must_equal "This error should be wrapped by TransactionError."
   end
 
   it "transaction will wrap errors for both commit and rollback" do
@@ -1218,7 +1218,7 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       tx_id = "giterdone".encode("ASCII-8BIT")
       begin_tx_res = Google::Datastore::V1::BeginTransactionResponse.new(transaction: tx_id)
 
-      stub = Object.new
+      stub = self
       stub.instance_variable_set :@response, begin_tx_res
       def stub.begin_transaction read_only: nil, previous_transaction: nil
         @response
@@ -1243,15 +1243,15 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
         end
       end
 
-      error.wont_be :nil?
-      error.must_be_kind_of Google::Cloud::Datastore::TransactionError
-      error.message.must_equal "Transaction failed to commit and rollback."
-      error.cause.wont_be :nil?
-      error.cause.must_be_kind_of RuntimeError
-      error.cause.message.must_equal "rollback error"
+      _(error).wont_be :nil?
+      _(error).must_be_kind_of Google::Cloud::Datastore::TransactionError
+      _(error.message).must_equal "Transaction failed to commit and rollback."
+      _(error.cause).wont_be :nil?
+      _(error.cause).must_be_kind_of RuntimeError
+      _(error.cause.message).must_equal "rollback error"
       if error.cause.respond_to? :cause # RuntimeError#cause not on Ruby 2.0
-        error.cause.cause.must_be_kind_of RuntimeError
-        error.cause.cause.message.must_equal "commit error"
+        _(error.cause.cause).must_be_kind_of RuntimeError
+        _(error.cause.cause.message).must_equal "commit error"
       end
     ensure
       # Reset mocked service so the call to verify works.
@@ -1321,9 +1321,9 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
           tx.save entity
         end
       end.must_raise Google::Cloud::Datastore::TransactionError
-      error.message.must_equal "Transaction failed to commit."
-      error.cause.must_be_kind_of StandardError
-      error.cause.message.must_equal "unsupported"
+      _(error.message).must_equal "Transaction failed to commit."
+      _(error.cause).must_be_kind_of StandardError
+      _(error.cause.message).must_equal "unsupported"
     end
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore/entity_exclude_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/entity_exclude_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::Datastore::Entity, :exclude_from_indexes, :mock_datastor
     grpc.properties["name"] = Google::Cloud::Datastore::Convert.to_value "User McNumber"
 
     entity_from_grpc = Google::Cloud::Datastore::Entity.from_grpc grpc
-    entity_from_grpc.exclude_from_indexes?("name").must_equal false
+    _(entity_from_grpc.exclude_from_indexes?("name")).must_equal false
   end
 
   it "converts indexed list to not excluded from a GRPC object" do
@@ -41,7 +41,7 @@ describe Google::Cloud::Datastore::Entity, :exclude_from_indexes, :mock_datastor
     grpc.properties["tags"] = Google::Cloud::Datastore::Convert.to_value ["ruby", "code"]
 
     entity_from_grpc = Google::Cloud::Datastore::Entity.from_grpc grpc
-    entity_from_grpc.exclude_from_indexes?("tags").must_equal [false, false]
+    _(entity_from_grpc.exclude_from_indexes?("tags")).must_equal [false, false]
   end
 
   it "doesn't exclude from indexes by default" do
@@ -50,19 +50,19 @@ describe Google::Cloud::Datastore::Entity, :exclude_from_indexes, :mock_datastor
 
     grpc = entity.to_grpc
 
-    grpc.properties["name"].exclude_from_indexes.must_equal false
-    grpc.properties["email"].exclude_from_indexes.must_equal false
+    _(grpc.properties["name"].exclude_from_indexes).must_equal false
+    _(grpc.properties["email"].exclude_from_indexes).must_equal false
   end
 
   it "excludes when setting a boolean" do
     entity["age"] = 21
     entity.exclude_from_indexes! "age", true
 
-    entity.exclude_from_indexes?("age").must_equal true
+    _(entity.exclude_from_indexes?("age")).must_equal true
 
     grpc = entity.to_grpc
 
-    grpc.properties["age"].exclude_from_indexes.must_equal true
+    _(grpc.properties["age"].exclude_from_indexes).must_equal true
   end
 
   it "excludes when setting a Proc" do
@@ -71,11 +71,11 @@ describe Google::Cloud::Datastore::Entity, :exclude_from_indexes, :mock_datastor
       age > 18
     end
 
-    entity.exclude_from_indexes?("age").must_equal true
+    _(entity.exclude_from_indexes?("age")).must_equal true
 
     grpc = entity.to_grpc
 
-    grpc.properties["age"].exclude_from_indexes.must_equal true
+    _(grpc.properties["age"].exclude_from_indexes).must_equal true
 
     # And now the inverse, the Proc evaluates to false
 
@@ -83,58 +83,58 @@ describe Google::Cloud::Datastore::Entity, :exclude_from_indexes, :mock_datastor
       age < 18
     end
 
-    entity.exclude_from_indexes?("age").must_equal false
+    _(entity.exclude_from_indexes?("age")).must_equal false
 
     grpc = entity.to_grpc
 
-    grpc.properties["age"].exclude_from_indexes.must_equal false
+    _(grpc.properties["age"].exclude_from_indexes).must_equal false
   end
 
   it "excludes when setting an Array on a non array value" do
     entity["age"] = 21
     entity.exclude_from_indexes! "age", [true, false, true, false]
 
-    entity.exclude_from_indexes?("age").must_equal true
+    _(entity.exclude_from_indexes?("age")).must_equal true
 
     grpc = entity.to_grpc
 
-    grpc.properties["age"].exclude_from_indexes.must_equal true
+    _(grpc.properties["age"].exclude_from_indexes).must_equal true
 
     # And now the inverse, the first value is false
 
     entity.exclude_from_indexes! "age", [false, true, false, true]
 
-    entity.exclude_from_indexes?("age").must_equal false
+    _(entity.exclude_from_indexes?("age")).must_equal false
 
     grpc = entity.to_grpc
 
-    grpc.properties["age"].exclude_from_indexes.must_equal false
+    _(grpc.properties["age"].exclude_from_indexes).must_equal false
   end
 
   describe Array do
     it "doesn't exclude Array values from indexes by default" do
       entity["tags"] = ["ruby", "code"]
 
-      entity.exclude_from_indexes?("tags").must_equal [false, false]
+      _(entity.exclude_from_indexes?("tags")).must_equal [false, false]
 
       grpc = entity.to_grpc
 
       tag_grpc = grpc.properties["tags"]
-      tag_grpc.exclude_from_indexes.must_equal false
-        tag_grpc.array_value.values.map(&:exclude_from_indexes).must_equal [false, false]
+      _(tag_grpc.exclude_from_indexes).must_equal false
+        _(tag_grpc.array_value.values.map(&:exclude_from_indexes)).must_equal [false, false]
     end
 
     it "excludes an Array when setting a boolean" do
       entity["tags"] = ["ruby", "code"]
       entity.exclude_from_indexes! "tags", true
 
-      entity.exclude_from_indexes?("tags").must_equal [true, true]
+      _(entity.exclude_from_indexes?("tags")).must_equal [true, true]
 
       grpc = entity.to_grpc
 
       tag_grpc = grpc.properties["tags"]
-      tag_grpc.exclude_from_indexes.must_equal false
-      tag_grpc.array_value.values.map(&:exclude_from_indexes).must_equal [true, true]
+      _(tag_grpc.exclude_from_indexes).must_equal false
+      _(tag_grpc.array_value.values.map(&:exclude_from_indexes)).must_equal [true, true]
     end
 
     it "excludes an Array when setting a Proc" do
@@ -143,13 +143,13 @@ describe Google::Cloud::Datastore::Entity, :exclude_from_indexes, :mock_datastor
         tag =~ /r/
       end
 
-      entity.exclude_from_indexes?("tags").must_equal [true, false]
+      _(entity.exclude_from_indexes?("tags")).must_equal [true, false]
 
       grpc = entity.to_grpc
 
       tag_grpc = grpc.properties["tags"]
-      tag_grpc.exclude_from_indexes.must_equal false
-      tag_grpc.array_value.values.map(&:exclude_from_indexes).must_equal [true, false]
+      _(tag_grpc.exclude_from_indexes).must_equal false
+      _(tag_grpc.array_value.values.map(&:exclude_from_indexes)).must_equal [true, false]
 
       # And now the inverse, the Proc evaluates to false
 
@@ -158,26 +158,26 @@ describe Google::Cloud::Datastore::Entity, :exclude_from_indexes, :mock_datastor
         tag =~ /c/
       end
 
-      entity.exclude_from_indexes?("tags").must_equal [false, true]
+      _(entity.exclude_from_indexes?("tags")).must_equal [false, true]
 
       grpc = entity.to_grpc
 
       tag_grpc = grpc.properties["tags"]
-      tag_grpc.exclude_from_indexes.must_equal false
-      tag_grpc.array_value.values.map(&:exclude_from_indexes).must_equal [false, true]
+      _(tag_grpc.exclude_from_indexes).must_equal false
+      _(tag_grpc.array_value.values.map(&:exclude_from_indexes)).must_equal [false, true]
     end
 
     it "excludes an Array when setting an Array" do
       entity["tags"] = ["ruby", "code"]
       entity.exclude_from_indexes! "tags", [true, false]
 
-      entity.exclude_from_indexes?("tags").must_equal [true, false]
+      _(entity.exclude_from_indexes?("tags")).must_equal [true, false]
 
       grpc = entity.to_grpc
 
       tag_grpc = grpc.properties["tags"]
-      tag_grpc.exclude_from_indexes.must_equal false
-      tag_grpc.array_value.values.map(&:exclude_from_indexes).must_equal [true, false]
+      _(tag_grpc.exclude_from_indexes).must_equal false
+      _(tag_grpc.array_value.values.map(&:exclude_from_indexes)).must_equal [true, false]
     end
 
     it "excludes an Array when setting an Array that is too small" do
@@ -185,38 +185,38 @@ describe Google::Cloud::Datastore::Entity, :exclude_from_indexes, :mock_datastor
       entity.exclude_from_indexes! "tags", [true, false]
 
       # the default is to not exclude when the array is too small
-      entity.exclude_from_indexes?("tags").must_equal [true, false, false, false]
+      _(entity.exclude_from_indexes?("tags")).must_equal [true, false, false, false]
 
       grpc = entity.to_grpc
 
       tag_grpc = grpc.properties["tags"]
-      tag_grpc.exclude_from_indexes.must_equal false
-      tag_grpc.array_value.values.map(&:exclude_from_indexes).must_equal [true, false, false, false]
+      _(tag_grpc.exclude_from_indexes).must_equal false
+      _(tag_grpc.array_value.values.map(&:exclude_from_indexes)).must_equal [true, false, false, false]
     end
 
     it "excludes an Array when setting an Array that is too big" do
       entity["tags"] = ["ruby", "code"]
       entity.exclude_from_indexes! "tags", [true, false, true, false, true, false]
 
-      entity.exclude_from_indexes?("tags").must_equal [true, false]
+      _(entity.exclude_from_indexes?("tags")).must_equal [true, false]
 
       grpc = entity.to_grpc
 
       tag_grpc = grpc.properties["tags"]
-      tag_grpc.exclude_from_indexes.must_equal false
-      tag_grpc.array_value.values.map(&:exclude_from_indexes).must_equal [true, false]
+      _(tag_grpc.exclude_from_indexes).must_equal false
+      _(tag_grpc.array_value.values.map(&:exclude_from_indexes)).must_equal [true, false]
 
       # Now add to the entity and get the previously stored exclude values
 
       entity["tags"] = ["ruby", "code", "google", "cloud"]
 
-      entity.exclude_from_indexes?("tags").must_equal [true, false, true, false]
+      _(entity.exclude_from_indexes?("tags")).must_equal [true, false, true, false]
 
       grpc = entity.to_grpc
 
       tag_grpc = grpc.properties["tags"]
-      tag_grpc.exclude_from_indexes.must_equal false
-      tag_grpc.array_value.values.map(&:exclude_from_indexes).must_equal [true, false, true, false]
+      _(tag_grpc.exclude_from_indexes).must_equal false
+      _(tag_grpc.array_value.values.map(&:exclude_from_indexes)).must_equal [true, false, true, false]
     end
   end
 
@@ -224,21 +224,21 @@ describe Google::Cloud::Datastore::Entity, :exclude_from_indexes, :mock_datastor
     it "recalculates when changing from a single value to an array" do
       entity["tags"] = "ruby"
 
-      entity.exclude_from_indexes?("tags").must_equal false
+      _(entity.exclude_from_indexes?("tags")).must_equal false
 
       entity.exclude_from_indexes! "tags", true
 
-      entity.exclude_from_indexes?("tags").must_equal true
+      _(entity.exclude_from_indexes?("tags")).must_equal true
 
       entity["tags"] = ["ruby", "code"]
 
-      entity.exclude_from_indexes?("tags").must_equal [true, true]
+      _(entity.exclude_from_indexes?("tags")).must_equal [true, true]
 
       entity.exclude_from_indexes! "tags", [false, false]
 
       entity["tags"] = "ruby"
 
-      entity.exclude_from_indexes?("tags").must_equal false
+      _(entity.exclude_from_indexes?("tags")).must_equal false
     end
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore/entity_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/entity_test.rb
@@ -26,38 +26,38 @@ describe Google::Cloud::Datastore::Entity, :mock_datastore do
 
   it "creates instances with .new" do
     # Calling entity here creates by calling new
-    entity.wont_be :nil?
-    entity.properties["name"].must_equal "User McUser"
-    entity.properties["email"].must_equal "user@example.net"
+    _(entity).wont_be :nil?
+    _(entity.properties["name"]).must_equal "User McUser"
+    _(entity.properties["email"]).must_equal "user@example.net"
   end
 
   it "allows properties to be accessed by strings or symbols" do
     # Calling entity here creates by calling new
-    entity.wont_be :nil?
-    entity.properties["name"].must_equal "User McUser"
-    entity.properties["email"].must_equal "user@example.net"
+    _(entity).wont_be :nil?
+    _(entity.properties["name"]).must_equal "User McUser"
+    _(entity.properties["email"]).must_equal "user@example.net"
 
-    entity.properties[:name].must_equal "User McUser"
-    entity.properties[:email].must_equal "user@example.net"
+    _(entity.properties[:name]).must_equal "User McUser"
+    _(entity.properties[:email]).must_equal "user@example.net"
 
     entity[:age] = 29
-    entity.properties[:age].must_equal 29
-    entity.properties["age"].must_equal 29
+    _(entity.properties[:age]).must_equal 29
+    _(entity.properties["age"]).must_equal 29
   end
 
   it "returns a correct GRPC object" do
     grpc = entity.to_grpc
 
     # Key values
-    grpc.key.path.count.must_equal 1
-    grpc.key.path.last.kind.must_equal "User"
-    grpc.key.path.last.id_type.must_equal :name
-    grpc.key.path.last.name.must_equal "username"
+    _(grpc.key.path.count).must_equal 1
+    _(grpc.key.path.last.kind).must_equal "User"
+    _(grpc.key.path.last.id_type).must_equal :name
+    _(grpc.key.path.last.name).must_equal "username"
 
     # Property values
-    grpc.properties.count.must_equal 2
-    grpc.properties["name"].string_value.must_equal entity["name"]
-    grpc.properties["email"].string_value.must_equal entity["email"]
+    _(grpc.properties.count).must_equal 2
+    _(grpc.properties["name"].string_value).must_equal entity["name"]
+    _(grpc.properties["email"].string_value).must_equal entity["email"]
   end
 
   it "returns a correct GRPC object when key is nil" do
@@ -66,12 +66,12 @@ describe Google::Cloud::Datastore::Entity, :mock_datastore do
     grpc = entity.to_grpc
 
     # Key values
-    grpc.key.must_be :nil?
+    _(grpc.key).must_be :nil?
 
     # Property values
-    grpc.properties.count.must_equal 2
-    grpc.properties["name"].string_value.must_equal entity["name"]
-    grpc.properties["email"].string_value.must_equal entity["email"]
+    _(grpc.properties.count).must_equal 2
+    _(grpc.properties["name"].string_value).must_equal entity["name"]
+    _(grpc.properties["email"].string_value).must_equal entity["email"]
   end
 
   it "can be created with a GRPC object" do
@@ -86,13 +86,13 @@ describe Google::Cloud::Datastore::Entity, :mock_datastore do
 
     entity_from_grpc = Google::Cloud::Datastore::Entity.from_grpc grpc
 
-    entity_from_grpc.key.kind.must_equal "User"
-    entity_from_grpc.key.id.must_equal 123456
-    entity_from_grpc.key.name.must_be :nil?
-    entity_from_grpc.properties["name"].must_equal "User McNumber"
-    entity_from_grpc.properties["email"].must_equal "number@example.net"
-    entity_from_grpc.properties.exist?("avatar").must_equal true
-    entity_from_grpc.properties["avatar"].must_be :nil?
+    _(entity_from_grpc.key.kind).must_equal "User"
+    _(entity_from_grpc.key.id).must_equal 123456
+    _(entity_from_grpc.key.name).must_be :nil?
+    _(entity_from_grpc.properties["name"]).must_equal "User McNumber"
+    _(entity_from_grpc.properties["email"]).must_equal "number@example.net"
+    _(entity_from_grpc.properties.exist?("avatar")).must_equal true
+    _(entity_from_grpc.properties["avatar"]).must_be :nil?
   end
 
   it "can store other entities as properties" do
@@ -111,16 +111,16 @@ describe Google::Cloud::Datastore::Entity, :mock_datastore do
     grpc = entity.to_grpc
 
     task_property = grpc.properties["tasks"]
-    task_property.array_value.values.wont_be :empty?
-    task_property.array_value.values.count.must_equal 2
+    _(task_property.array_value.values).wont_be :empty?
+    _(task_property.array_value.values.count).must_equal 2
     grpc_task_1 = task_property.array_value.values.first
     grpc_task_2 = task_property.array_value.values.last
-    grpc_task_1.wont_be :nil?
-    grpc_task_2.wont_be :nil?
-    grpc_task_1.entity_value.wont_be :nil?
-    grpc_task_2.entity_value.wont_be :nil?
-    grpc_task_1.entity_value.properties["description"].string_value.must_equal "can persist entities"
-    grpc_task_2.entity_value.properties["description"].string_value.must_equal "can persist lists"
+    _(grpc_task_1).wont_be :nil?
+    _(grpc_task_2).wont_be :nil?
+    _(grpc_task_1.entity_value).wont_be :nil?
+    _(grpc_task_2.entity_value).wont_be :nil?
+    _(grpc_task_1.entity_value.properties["description"].string_value).must_equal "can persist entities"
+    _(grpc_task_2.entity_value.properties["description"].string_value).must_equal "can persist lists"
   end
 
   it "can store keys as properties" do
@@ -143,19 +143,19 @@ describe Google::Cloud::Datastore::Entity, :mock_datastore do
     key_property = grpc.properties["head"]
 
     key_value = key_property.key_value
-    key_value.wont_be :nil?
-    key_value.must_equal                    key1.to_grpc
-    key_value.path.first.kind.must_equal    key1.to_grpc.path.last.kind
-    key_value.path.first.id_type.must_equal key1.to_grpc.path.last.id_type
-    key_value.path.first.name.must_equal    key1.to_grpc.path.last.name
-    key_value.path.first.id.must_equal      key1.to_grpc.path.last.id
+    _(key_value).wont_be :nil?
+    _(key_value).must_equal                    key1.to_grpc
+    _(key_value.path.first.kind).must_equal    key1.to_grpc.path.last.kind
+    _(key_value.path.first.id_type).must_equal key1.to_grpc.path.last.id_type
+    _(key_value.path.first.name).must_equal    key1.to_grpc.path.last.name
+    _(key_value.path.first.id).must_equal      key1.to_grpc.path.last.id
   end
 
   it "raises when setting an unsupported property type" do
     error = assert_raises Google::Cloud::Datastore::PropertyError do
       entity["thing"] = OpenStruct.new
     end
-    error.message.must_equal "A property of type OpenStruct is not supported."
+    _(error.message).must_equal "A property of type OpenStruct is not supported."
   end
 
   it "raises when setting a key when persisted" do
@@ -167,8 +167,8 @@ describe Google::Cloud::Datastore::Entity, :mock_datastore do
 
     entity_from_grpc = Google::Cloud::Datastore::Entity.from_grpc grpc
 
-    entity_from_grpc.must_be :persisted?
-    entity_from_grpc.key.must_be :frozen?
+    _(entity_from_grpc).must_be :persisted?
+    _(entity_from_grpc.key).must_be :frozen?
 
     assert_raises RuntimeError do
       entity_from_grpc.key = Google::Cloud::Datastore::Key.new "User", 456789
@@ -181,6 +181,6 @@ describe Google::Cloud::Datastore::Entity, :mock_datastore do
 
   it "knows its serialized side" do
     # Don't care about the exact value, just want a number and no error
-    entity.serialized_size.must_be_kind_of Integer
+    _(entity.serialized_size).must_be_kind_of Integer
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore/gql_query_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/gql_query_test.rb
@@ -20,15 +20,15 @@ describe Google::Cloud::Datastore::GqlQuery, :mock_datastore do
     gql.query_string = "SELECT * FROM Task WHERE completed = @completed"
     gql.named_bindings = {completed: true}
 
-    gql.query_string.must_equal "SELECT * FROM Task WHERE completed = @completed"
-    gql.named_bindings.must_equal({"completed" => true})
+    _(gql.query_string).must_equal "SELECT * FROM Task WHERE completed = @completed"
+    _(gql.named_bindings).must_equal({"completed" => true})
 
     grpc = gql.to_grpc
-    grpc.must_be_kind_of Google::Datastore::V1::GqlQuery
+    _(grpc).must_be_kind_of Google::Datastore::V1::GqlQuery
 
-    grpc.query_string.must_equal gql.query_string
-    grpc.named_bindings.count.must_equal 1
-    grpc.named_bindings["completed"].value.boolean_value.must_equal true
+    _(grpc.query_string).must_equal gql.query_string
+    _(grpc.named_bindings.count).must_equal 1
+    _(grpc.named_bindings["completed"].value.boolean_value).must_equal true
   end
 
   it "can't modify named_bindings" do
@@ -42,15 +42,15 @@ describe Google::Cloud::Datastore::GqlQuery, :mock_datastore do
     gql.query_string = "SELECT * FROM Task WHERE completed = @1"
     gql.positional_bindings = [true]
 
-    gql.query_string.must_equal "SELECT * FROM Task WHERE completed = @1"
-    gql.positional_bindings.must_equal [true]
+    _(gql.query_string).must_equal "SELECT * FROM Task WHERE completed = @1"
+    _(gql.positional_bindings).must_equal [true]
 
     grpc = gql.to_grpc
-    grpc.must_be_kind_of Google::Datastore::V1::GqlQuery
+    _(grpc).must_be_kind_of Google::Datastore::V1::GqlQuery
 
-    grpc.query_string.must_equal gql.query_string
-    grpc.positional_bindings.count.must_equal 1
-    grpc.positional_bindings.first.value.boolean_value.must_equal true
+    _(grpc.query_string).must_equal gql.query_string
+    _(grpc.positional_bindings.count).must_equal 1
+    _(grpc.positional_bindings.first.value.boolean_value).must_equal true
   end
 
   it "can't modify positional_bindings" do
@@ -62,18 +62,18 @@ describe Google::Cloud::Datastore::GqlQuery, :mock_datastore do
   it "can set and modify allow_literals" do
     gql = Google::Cloud::Datastore::GqlQuery.new
     gql.query_string = "SELECT * FROM Task WHERE completed = true"
-    gql.allow_literals.must_equal false #default
+    _(gql.allow_literals).must_equal false #default
 
     gql.allow_literals = true
 
-    gql.query_string.must_equal "SELECT * FROM Task WHERE completed = true"
-    gql.allow_literals.must_equal true
+    _(gql.query_string).must_equal "SELECT * FROM Task WHERE completed = true"
+    _(gql.allow_literals).must_equal true
 
     grpc = gql.to_grpc
-    grpc.must_be_kind_of Google::Datastore::V1::GqlQuery
+    _(grpc).must_be_kind_of Google::Datastore::V1::GqlQuery
 
-    grpc.query_string.must_equal gql.query_string
-    grpc.allow_literals.must_equal true
+    _(grpc.query_string).must_equal gql.query_string
+    _(grpc.allow_literals).must_equal true
   end
 
   it "can set a Cursor as a named binding" do
@@ -82,11 +82,11 @@ describe Google::Cloud::Datastore::GqlQuery, :mock_datastore do
     gql.named_bindings = {startCursor: Google::Cloud::Datastore::Cursor.new("c3VwZXJhd2Vzb21lIQ==")}
 
     grpc = gql.to_grpc
-    grpc.must_be_kind_of Google::Datastore::V1::GqlQuery
+    _(grpc).must_be_kind_of Google::Datastore::V1::GqlQuery
 
-    grpc.query_string.must_equal gql.query_string
-    grpc.named_bindings.count.must_equal 1
-    grpc.named_bindings["startCursor"].cursor.must_equal "superawesome!"
+    _(grpc.query_string).must_equal gql.query_string
+    _(grpc.named_bindings.count).must_equal 1
+    _(grpc.named_bindings["startCursor"].cursor).must_equal "superawesome!"
   end
 
   it "will break if setting a cursor that is not a Cursor object" do
@@ -95,11 +95,11 @@ describe Google::Cloud::Datastore::GqlQuery, :mock_datastore do
     gql.named_bindings = {startCursor: "c3VwZXJhd2Vzb21lIQ=="}
 
     grpc = gql.to_grpc
-    grpc.must_be_kind_of Google::Datastore::V1::GqlQuery
+    _(grpc).must_be_kind_of Google::Datastore::V1::GqlQuery
 
-    grpc.query_string.must_equal gql.query_string
-    grpc.named_bindings.count.must_equal 1
+    _(grpc.query_string).must_equal gql.query_string
+    _(grpc.named_bindings.count).must_equal 1
     # This is bad. The cursor value is not set properly. Query will fail.
-    grpc.named_bindings["startCursor"].value.string_value.must_equal "c3VwZXJhd2Vzb21lIQ=="
+    _(grpc.named_bindings["startCursor"].value.string_value).must_equal "c3VwZXJhd2Vzb21lIQ=="
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore/key_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/key_test.rb
@@ -18,167 +18,167 @@ describe Google::Cloud::Datastore::Key, :mock_datastore do
 
   it "behaves correctly when empty" do
     key = Google::Cloud::Datastore::Key.new
-    key.kind.must_be :nil?
-    key.id.must_be :nil?
-    key.name.must_be :nil?
-    key.project.must_be :nil?
-    key.namespace.must_be :nil?
+    _(key.kind).must_be :nil?
+    _(key.id).must_be :nil?
+    _(key.name).must_be :nil?
+    _(key.project).must_be :nil?
+    _(key.namespace).must_be :nil?
   end
 
   it "creates instances with .new" do
     key = Google::Cloud::Datastore::Key.new "ThisThing", 1234
-    key.kind.must_equal "ThisThing"
-    key.id.must_equal 1234
-    key.name.must_be :nil?
+    _(key.kind).must_equal "ThisThing"
+    _(key.id).must_equal 1234
+    _(key.name).must_be :nil?
 
     key = Google::Cloud::Datastore::Key.new "ThisThing", "charlie"
-    key.kind.must_equal "ThisThing"
-    key.id.must_be :nil?
-    key.name.must_equal "charlie"
+    _(key.kind).must_equal "ThisThing"
+    _(key.id).must_be :nil?
+    _(key.name).must_equal "charlie"
   end
 
   it "can set a parent" do
     key = Google::Cloud::Datastore::Key.new "ThisThing", 1234
-    key.kind.must_equal "ThisThing"
-    key.id.must_equal 1234
-    key.name.must_be :nil?
+    _(key.kind).must_equal "ThisThing"
+    _(key.id).must_equal 1234
+    _(key.name).must_be :nil?
 
-    key.parent.must_be :nil?
+    _(key.parent).must_be :nil?
     key.parent = Google::Cloud::Datastore::Key.new "ThatThing", 6789
-    key.parent.wont_be :nil?
-    key.parent.kind.must_equal "ThatThing"
-    key.parent.id.must_equal 6789
-    key.parent.name.must_be :nil?
+    _(key.parent).wont_be :nil?
+    _(key.parent.kind).must_equal "ThatThing"
+    _(key.parent.id).must_equal 6789
+    _(key.parent.name).must_be :nil?
   end
 
   it "can set a project" do
     key = Google::Cloud::Datastore::Key.new "ThisThing", 1234
-    key.kind.must_equal "ThisThing"
-    key.id.must_equal 1234
-    key.name.must_be :nil?
+    _(key.kind).must_equal "ThisThing"
+    _(key.id).must_equal 1234
+    _(key.name).must_be :nil?
 
-    key.project.must_be :nil?
+    _(key.project).must_be :nil?
     key.project = "custom-ds"
-    key.project.wont_be :nil?
-    key.project.must_equal "custom-ds"
+    _(key.project).wont_be :nil?
+    _(key.project).must_equal "custom-ds"
   end
 
   it "can set a dataset_id as an alias of project" do
     key = Google::Cloud::Datastore::Key.new "ThisThing", 1234
-    key.kind.must_equal "ThisThing"
-    key.id.must_equal 1234
-    key.name.must_be :nil?
+    _(key.kind).must_equal "ThisThing"
+    _(key.id).must_equal 1234
+    _(key.name).must_be :nil?
 
-    key.project.must_be :nil?
-    key.dataset_id.must_be :nil?
+    _(key.project).must_be :nil?
+    _(key.dataset_id).must_be :nil?
     key.dataset_id = "custom-ds"
-    key.dataset_id.wont_be :nil?
-    key.project.wont_be :nil?
-    key.dataset_id.must_equal "custom-ds"
-    key.project.must_equal "custom-ds"
+    _(key.dataset_id).wont_be :nil?
+    _(key.project).wont_be :nil?
+    _(key.dataset_id).must_equal "custom-ds"
+    _(key.project).must_equal "custom-ds"
   end
 
   it "can set a namespace" do
     key = Google::Cloud::Datastore::Key.new "ThisThing", 1234
-    key.kind.must_equal "ThisThing"
-    key.id.must_equal 1234
-    key.name.must_be :nil?
+    _(key.kind).must_equal "ThisThing"
+    _(key.id).must_equal 1234
+    _(key.name).must_be :nil?
 
-    key.namespace.must_be :nil?
+    _(key.namespace).must_be :nil?
     key.namespace = "custom-ns"
-    key.namespace.wont_be :nil?
-    key.namespace.must_equal "custom-ns"
+    _(key.namespace).wont_be :nil?
+    _(key.namespace).must_equal "custom-ns"
   end
 
   describe "path" do
     it "returns kind and id" do
       key = Google::Cloud::Datastore::Key.new "Task", 123456
-      key.path.must_equal [["Task", 123456]]
+      _(key.path).must_equal [["Task", 123456]]
     end
     it "returns kind and name" do
       key = Google::Cloud::Datastore::Key.new "Task", "todos"
-      key.path.must_equal [["Task", "todos"]]
+      _(key.path).must_equal [["Task", "todos"]]
     end
     it "returns parent when present" do
       key = Google::Cloud::Datastore::Key.new "Task", "todos"
       key.parent = Google::Cloud::Datastore::Key.new "User", "username"
-      key.path.must_equal [["User", "username"], ["Task", "todos"]]
+      _(key.path).must_equal [["User", "username"], ["Task", "todos"]]
     end
     it "returns all parents using references" do
       key = Google::Cloud::Datastore::Key.new "Task", "todos"
       key.parent = Google::Cloud::Datastore::Key.new "User", "username"
       key.parent.parent = Google::Cloud::Datastore::Key.new "Org", "company"
-      key.path.must_equal [["Org", "company"], ["User", "username"], ["Task", "todos"]]
+      _(key.path).must_equal [["Org", "company"], ["User", "username"], ["Task", "todos"]]
     end
   end
 
   it "knows if it is complete or not" do
     key = Google::Cloud::Datastore::Key.new "Task"
-    key.id.must_be :nil?
-    key.name.must_be :nil?
-    key.wont_be :complete?
-    key.must_be :incomplete?
+    _(key.id).must_be :nil?
+    _(key.name).must_be :nil?
+    _(key).wont_be :complete?
+    _(key).must_be :incomplete?
 
     key.id = 123455
-    key.id.wont_be :nil?
-    key.name.must_be :nil?
-    key.must_be :complete?
-    key.wont_be :incomplete?
+    _(key.id).wont_be :nil?
+    _(key.name).must_be :nil?
+    _(key).must_be :complete?
+    _(key).wont_be :incomplete?
 
     key.name = "description"
-    key.id.must_be :nil?
-    key.name.wont_be :nil?
-    key.must_be :complete?
-    key.wont_be :incomplete?
+    _(key.id).must_be :nil?
+    _(key.name).wont_be :nil?
+    _(key).must_be :complete?
+    _(key).wont_be :incomplete?
   end
 
   it "isn't complete is missing kind" do
     key = Google::Cloud::Datastore::Key.new "Task"
     key.kind = nil
-    key.kind.must_be :nil?
-    key.id.must_be :nil?
-    key.name.must_be :nil?
-    key.wont_be :complete?
-    key.must_be :incomplete?
+    _(key.kind).must_be :nil?
+    _(key.id).must_be :nil?
+    _(key.name).must_be :nil?
+    _(key).wont_be :complete?
+    _(key).must_be :incomplete?
 
     key.id = 123455
-    key.kind.must_be :nil?
-    key.id.wont_be :nil?
-    key.name.must_be :nil?
-    key.wont_be :complete?
-    key.must_be :incomplete?
+    _(key.kind).must_be :nil?
+    _(key.id).wont_be :nil?
+    _(key.name).must_be :nil?
+    _(key).wont_be :complete?
+    _(key).must_be :incomplete?
 
     key.name = "description"
-    key.kind.must_be :nil?
-    key.id.must_be :nil?
-    key.name.wont_be :nil?
-    key.wont_be :complete?
-    key.must_be :incomplete?
+    _(key.kind).must_be :nil?
+    _(key.id).must_be :nil?
+    _(key.name).wont_be :nil?
+    _(key).wont_be :complete?
+    _(key).must_be :incomplete?
   end
 
   it "returns a correct GRPC object" do
     key = Google::Cloud::Datastore::Key.new "ThisThing", 1234
     grpc = key.to_grpc
-    grpc.path.count.must_equal 1
-    grpc.path.last.kind.must_equal "ThisThing"
-    grpc.path.last.id_type.must_equal :id
-    grpc.path.last.id.must_equal 1234
-    grpc.partition_id.must_be :nil?
+    _(grpc.path.count).must_equal 1
+    _(grpc.path.last.kind).must_equal "ThisThing"
+    _(grpc.path.last.id_type).must_equal :id
+    _(grpc.path.last.id).must_equal 1234
+    _(grpc.partition_id).must_be :nil?
 
     key = Google::Cloud::Datastore::Key.new "ThisThing", "charlie"
     key.parent = Google::Cloud::Datastore::Key.new "ThatThing", "henry"
     key.project = "custom-ds"
     key.namespace = "custom-ns"
     grpc = key.to_grpc
-    grpc.path.count.must_equal 2
-    grpc.path.first.kind.must_equal "ThatThing"
-    grpc.path.first.id_type.must_equal :name
-    grpc.path.first.name.must_equal "henry"
-    grpc.path.last.kind.must_equal "ThisThing"
-    grpc.path.last.id_type.must_equal :name
-    grpc.path.last.name.must_equal "charlie"
-    grpc.partition_id.project_id.must_equal "custom-ds"
-    grpc.partition_id.namespace_id.must_equal "custom-ns"
+    _(grpc.path.count).must_equal 2
+    _(grpc.path.first.kind).must_equal "ThatThing"
+    _(grpc.path.first.id_type).must_equal :name
+    _(grpc.path.first.name).must_equal "henry"
+    _(grpc.path.last.kind).must_equal "ThisThing"
+    _(grpc.path.last.id_type).must_equal :name
+    _(grpc.path.last.name).must_equal "charlie"
+    _(grpc.partition_id.project_id).must_equal "custom-ds"
+    _(grpc.partition_id.namespace_id).must_equal "custom-ns"
   end
 
   it "can be created with a GRPC object" do
@@ -191,13 +191,13 @@ describe Google::Cloud::Datastore::Key, :mock_datastore do
     )
     key = Google::Cloud::Datastore::Key.from_grpc grpc
 
-    key.wont_be :nil?
-    key.kind.must_equal "AnotherThing"
-    key.id.must_equal 56789
-    key.name.must_be :nil?
-    key.project.must_equal "custom-ds"
-    key.namespace.must_equal "custom-ns"
-    key.must_be :frozen?
+    _(key).wont_be :nil?
+    _(key.kind).must_equal "AnotherThing"
+    _(key.id).must_equal 56789
+    _(key.name).must_be :nil?
+    _(key.project).must_equal "custom-ds"
+    _(key.namespace).must_equal "custom-ns"
+    _(key).must_be :frozen?
   end
 
   it "returns nil when the GRPC object is nil" do
@@ -205,12 +205,12 @@ describe Google::Cloud::Datastore::Key, :mock_datastore do
     grpc = nil
     key = Google::Cloud::Datastore::Key.from_grpc grpc
 
-    key.must_be :nil?
+    _(key).must_be :nil?
   end
 
   it "knows its serialized side" do
     # Don't care about the exact value, just want a number and no error
     key = Google::Cloud::Datastore::Key.new "ThisThing", 1234
-    key.serialized_size.must_be_kind_of Integer
+    _(key.serialized_size).must_be_kind_of Integer
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore/lookup_results/find_all_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/lookup_results/find_all_test.rb
@@ -76,25 +76,25 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
     dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, second_keys, read_options: nil, options: default_options]
 
     first_entities = dataset.find_all keys
-    first_entities.count.must_equal 2
-    first_entities.deferred.count.must_equal 2
-    first_entities.missing.count.must_equal 2
+    _(first_entities.count).must_equal 2
+    _(first_entities.deferred.count).must_equal 2
+    _(first_entities.missing.count).must_equal 2
     first_entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
     first_entities.deferred.each do |deferred_key|
-      deferred_key.must_be_kind_of Google::Cloud::Datastore::Key
+      _(deferred_key).must_be_kind_of Google::Cloud::Datastore::Key
     end
     first_entities.missing.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
 
     second_entities = dataset.find_all first_entities.deferred
-    second_entities.count.must_equal 2
-    second_entities.deferred.count.must_equal 0
-    second_entities.missing.count.must_equal 0
+    _(second_entities.count).must_equal 2
+    _(second_entities.deferred.count).must_equal 0
+    _(second_entities.missing.count).must_equal 0
     second_entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
@@ -104,25 +104,25 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
     dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, second_keys, read_options: read_options, options: default_options]
 
     first_entities = dataset.find_all keys, consistency: :eventual
-    first_entities.count.must_equal 2
-    first_entities.deferred.count.must_equal 2
-    first_entities.missing.count.must_equal 2
+    _(first_entities.count).must_equal 2
+    _(first_entities.deferred.count).must_equal 2
+    _(first_entities.missing.count).must_equal 2
     first_entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
     first_entities.deferred.each do |deferred_key|
-      deferred_key.must_be_kind_of Google::Cloud::Datastore::Key
+      _(deferred_key).must_be_kind_of Google::Cloud::Datastore::Key
     end
     first_entities.missing.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
 
     second_entities = dataset.find_all first_entities.deferred, consistency: :eventual
-    second_entities.count.must_equal 2
-    second_entities.deferred.count.must_equal 0
-    second_entities.missing.count.must_equal 0
+    _(second_entities.count).must_equal 2
+    _(second_entities.deferred.count).must_equal 0
+    _(second_entities.missing.count).must_equal 0
     second_entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
@@ -142,25 +142,25 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
 
     dataset.transaction do |tx|
       first_entities = tx.find_all keys
-      first_entities.count.must_equal 2
-      first_entities.deferred.count.must_equal 2
-      first_entities.missing.count.must_equal 2
+      _(first_entities.count).must_equal 2
+      _(first_entities.deferred.count).must_equal 2
+      _(first_entities.missing.count).must_equal 2
       first_entities.each do |entity|
-        entity.must_be_kind_of Google::Cloud::Datastore::Entity
+        _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
       end
       first_entities.deferred.each do |deferred_key|
-        deferred_key.must_be_kind_of Google::Cloud::Datastore::Key
+        _(deferred_key).must_be_kind_of Google::Cloud::Datastore::Key
       end
       first_entities.missing.each do |entity|
-        entity.must_be_kind_of Google::Cloud::Datastore::Entity
+        _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
       end
 
       second_entities = tx.find_all first_entities.deferred
-      second_entities.count.must_equal 2
-      second_entities.deferred.count.must_equal 0
-      second_entities.missing.count.must_equal 0
+      _(second_entities.count).must_equal 2
+      _(second_entities.deferred.count).must_equal 0
+      _(second_entities.missing.count).must_equal 0
       second_entities.each do |entity|
-        entity.must_be_kind_of Google::Cloud::Datastore::Entity
+        _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
       end
     end
   end
@@ -170,27 +170,27 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
     dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, second_keys, read_options: nil, options: default_options]
 
     first_entities = dataset.find_all keys
-    first_entities.next?.must_equal true
-    first_entities.count.must_equal 2
-    first_entities.deferred.count.must_equal 2
-    first_entities.missing.count.must_equal 2
+    _(first_entities.next?).must_equal true
+    _(first_entities.count).must_equal 2
+    _(first_entities.deferred.count).must_equal 2
+    _(first_entities.missing.count).must_equal 2
     first_entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
     first_entities.deferred.each do |deferred_key|
-      deferred_key.must_be_kind_of Google::Cloud::Datastore::Key
+      _(deferred_key).must_be_kind_of Google::Cloud::Datastore::Key
     end
     first_entities.missing.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
 
     second_entities = first_entities.next
-    second_entities.next?.must_equal false
-    second_entities.count.must_equal 2
-    second_entities.deferred.count.must_equal 0
-    second_entities.missing.count.must_equal 0
+    _(second_entities.next?).must_equal false
+    _(second_entities.count).must_equal 2
+    _(second_entities.deferred.count).must_equal 0
+    _(second_entities.missing.count).must_equal 0
     second_entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
@@ -200,27 +200,27 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
     dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, second_keys, read_options: read_options, options: default_options]
 
     first_entities = dataset.find_all keys, consistency: :eventual
-    first_entities.next?.must_equal true
-    first_entities.count.must_equal 2
-    first_entities.deferred.count.must_equal 2
-    first_entities.missing.count.must_equal 2
+    _(first_entities.next?).must_equal true
+    _(first_entities.count).must_equal 2
+    _(first_entities.deferred.count).must_equal 2
+    _(first_entities.missing.count).must_equal 2
     first_entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
     first_entities.deferred.each do |deferred_key|
-      deferred_key.must_be_kind_of Google::Cloud::Datastore::Key
+      _(deferred_key).must_be_kind_of Google::Cloud::Datastore::Key
     end
     first_entities.missing.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
 
     second_entities = first_entities.next
-    second_entities.next?.must_equal false
-    second_entities.count.must_equal 2
-    second_entities.deferred.count.must_equal 0
-    second_entities.missing.count.must_equal 0
+    _(second_entities.next?).must_equal false
+    _(second_entities.count).must_equal 2
+    _(second_entities.deferred.count).must_equal 0
+    _(second_entities.missing.count).must_equal 0
     second_entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
@@ -240,27 +240,27 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
 
     dataset.transaction do |tx|
       first_entities = tx.find_all keys
-      first_entities.next?.must_equal true
-      first_entities.count.must_equal 2
-      first_entities.deferred.count.must_equal 2
-      first_entities.missing.count.must_equal 2
+      _(first_entities.next?).must_equal true
+      _(first_entities.count).must_equal 2
+      _(first_entities.deferred.count).must_equal 2
+      _(first_entities.missing.count).must_equal 2
       first_entities.each do |entity|
-        entity.must_be_kind_of Google::Cloud::Datastore::Entity
+        _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
       end
       first_entities.deferred.each do |deferred_key|
-        deferred_key.must_be_kind_of Google::Cloud::Datastore::Key
+        _(deferred_key).must_be_kind_of Google::Cloud::Datastore::Key
       end
       first_entities.missing.each do |entity|
-        entity.must_be_kind_of Google::Cloud::Datastore::Entity
+        _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
       end
 
       second_entities = first_entities.next
-      second_entities.next?.must_equal false
-      second_entities.count.must_equal 2
-      second_entities.deferred.count.must_equal 0
-      second_entities.missing.count.must_equal 0
+      _(second_entities.next?).must_equal false
+      _(second_entities.count).must_equal 2
+      _(second_entities.deferred.count).must_equal 0
+      _(second_entities.missing.count).must_equal 0
       second_entities.each do |entity|
-        entity.must_be_kind_of Google::Cloud::Datastore::Entity
+        _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
       end
     end
   end
@@ -270,9 +270,9 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
     dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, second_keys, read_options: nil, options: default_options]
 
     entities = dataset.find_all(keys).all.to_a
-    entities.count.must_equal 4
+    _(entities.count).must_equal 4
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
@@ -282,9 +282,9 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
     dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, second_keys, read_options: read_options, options: default_options]
 
     entities = dataset.find_all(keys, consistency: :eventual).all.to_a
-    entities.count.must_equal 4
+    _(entities.count).must_equal 4
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
@@ -304,9 +304,9 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
 
     dataset.transaction do |tx|
       entities = tx.find_all(keys).all.to_a
-      entities.count.must_equal 4
+      _(entities.count).must_equal 4
       entities.each do |entity|
-        entity.must_be_kind_of Google::Cloud::Datastore::Entity
+        _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
       end
     end
   end
@@ -316,9 +316,9 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
     dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, second_keys, read_options: nil, options: default_options]
 
     entities = dataset.find_all(keys).all.take(3)
-    entities.count.must_equal 3
+    _(entities.count).must_equal 3
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
@@ -329,9 +329,9 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
     # This test is a bit handwavy, as there aren't more results to lookup.
     # But if you reduce the limit it will not make additional call.
     entities = dataset.find_all(keys).all(request_limit: 1).to_a
-    entities.count.must_equal 4
+    _(entities.count).must_equal 4
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore/properties_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/properties_test.rb
@@ -29,14 +29,14 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
   it "decodes empty value" do
     value = Google::Datastore::V1::Value.new
     raw = Google::Cloud::Datastore::Convert.from_value value
-    raw.must_be :nil?
+    _(raw).must_be :nil?
   end
 
   it "encodes a string" do
     raw = "hello, i am a string"
     value = Google::Cloud::Datastore::Convert.to_value raw
-    value.value_type.must_equal :string_value
-    value.string_value.must_equal raw
+    _(value.value_type).must_equal :string_value
+    _(value.string_value).must_equal raw
   end
 
   it "decodes a string" do
@@ -44,53 +44,53 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     value = Google::Datastore::V1::Value.new
     value.string_value = str
     raw = Google::Cloud::Datastore::Convert.from_value value
-    raw.must_equal str
+    _(raw).must_equal str
   end
 
   it "encodes nil" do
     value = Google::Cloud::Datastore::Convert.to_value nil
-    value.value_type.must_equal :null_value
-    value.null_value.must_equal :NULL_VALUE
+    _(value.value_type).must_equal :null_value
+    _(value.null_value).must_equal :NULL_VALUE
   end
 
   it "decodes NULL" do
     value = Google::Datastore::V1::Value.new
     value.null_value = :NULL_VALUE
     raw = Google::Cloud::Datastore::Convert.from_value value
-    raw.must_be :nil?
+    _(raw).must_be :nil?
   end
 
   it "encodes true" do
     value = Google::Cloud::Datastore::Convert.to_value true
-    value.value_type.must_equal :boolean_value
-    value.boolean_value.must_equal true
+    _(value.value_type).must_equal :boolean_value
+    _(value.boolean_value).must_equal true
   end
 
   it "decodes true" do
     value = Google::Datastore::V1::Value.new
     value.boolean_value = true
     raw = Google::Cloud::Datastore::Convert.from_value value
-    raw.must_equal true
+    _(raw).must_equal true
   end
 
   it "encodes false" do
     value = Google::Cloud::Datastore::Convert.to_value false
-    value.value_type.must_equal :boolean_value
-    value.boolean_value.must_equal false
+    _(value.value_type).must_equal :boolean_value
+    _(value.boolean_value).must_equal false
   end
 
   it "decodes false" do
     value = Google::Datastore::V1::Value.new
     value.boolean_value = false
     raw = Google::Cloud::Datastore::Convert.from_value value
-    raw.must_equal false
+    _(raw).must_equal false
   end
 
   it "encodes integer" do
     raw = 1234
     value = Google::Cloud::Datastore::Convert.to_value raw
-    value.value_type.must_equal :integer_value
-    value.integer_value.must_equal raw
+    _(value.value_type).must_equal :integer_value
+    _(value.integer_value).must_equal raw
   end
 
   it "decodes integer" do
@@ -98,14 +98,14 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     value = Google::Datastore::V1::Value.new
     value.integer_value = num
     raw = Google::Cloud::Datastore::Convert.from_value value
-    raw.must_equal num
+    _(raw).must_equal num
   end
 
   it "encodes float" do
     raw = 12.34
     value = Google::Cloud::Datastore::Convert.to_value raw
-    value.value_type.must_equal :double_value
-    value.double_value.must_equal raw
+    _(value.value_type).must_equal :double_value
+    _(value.double_value).must_equal raw
   end
 
   it "decodes float" do
@@ -113,14 +113,14 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     value = Google::Datastore::V1::Value.new
     value.double_value = num
     raw = Google::Cloud::Datastore::Convert.from_value value
-    raw.must_equal num
+    _(raw).must_equal num
   end
 
   it "encodes Key" do
     key = Google::Cloud::Datastore::Key.new "Thing", 123
     value = Google::Cloud::Datastore::Convert.to_value key
-    value.value_type.must_equal :key_value
-    value.key_value.must_equal key.to_grpc
+    _(value.value_type).must_equal :key_value
+    _(value.key_value).must_equal key.to_grpc
   end
 
   it "decodes Key" do
@@ -130,7 +130,7 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     raw = Google::Cloud::Datastore::Convert.from_value value
     assert_kind_of Google::Cloud::Datastore::Key, raw
     refute_kind_of Google::Datastore::V1::Key, raw
-    raw.to_grpc.must_equal key.to_grpc
+    _(raw.to_grpc).must_equal key.to_grpc
   end
 
   it "encodes Entity" do
@@ -138,9 +138,9 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     entity.key = Google::Cloud::Datastore::Key.new "Thing", 123
     entity["name"] = "Thing 1"
     value = Google::Cloud::Datastore::Convert.to_value entity
-    value.value_type.must_equal :entity_value
-    value.entity_value.properties.must_equal entity.to_grpc.properties
-    value.entity_value.key.must_be :nil? # embedded entities can't have keys
+    _(value.value_type).must_equal :entity_value
+    _(value.entity_value.properties).must_equal entity.to_grpc.properties
+    _(value.entity_value.key).must_be :nil? # embedded entities can't have keys
   end
 
   it "decodes Entity" do
@@ -154,14 +154,14 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     refute_kind_of Google::Datastore::V1::Entity, raw
     raw_grpc = raw.to_grpc
     entity_grpc = entity.to_grpc
-    raw_grpc.must_equal entity_grpc
+    _(raw_grpc).must_equal entity_grpc
   end
 
   it "encodes Array" do
     array = ["string", 123, true]
     value = Google::Cloud::Datastore::Convert.to_value array
-    value.value_type.must_equal :array_value
-    value.array_value.must_equal Google::Datastore::V1::ArrayValue.new(
+    _(value.value_type).must_equal :array_value
+    _(value.array_value).must_equal Google::Datastore::V1::ArrayValue.new(
       values: [Google::Datastore::V1::Value.new(string_value: "string"),
                Google::Datastore::V1::Value.new(integer_value: 123),
                Google::Datastore::V1::Value.new(boolean_value: true)]
@@ -177,51 +177,51 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     )
     raw = Google::Cloud::Datastore::Convert.from_value value
     assert_kind_of Array, raw
-    raw.count.must_equal 3
-    raw[0].must_equal "string"
-    raw[1].must_equal 123
-    raw[2].must_equal true
+    _(raw.count).must_equal 3
+    _(raw[0]).must_equal "string"
+    _(raw[1]).must_equal 123
+    _(raw[2]).must_equal true
   end
 
   it "encodes Time" do
     value = Google::Cloud::Datastore::Convert.to_value time_obj
-    value.value_type.must_equal :timestamp_value
-    value.timestamp_value.must_equal time_grpc
+    _(value.value_type).must_equal :timestamp_value
+    _(value.timestamp_value).must_equal time_grpc
   end
 
   it "encodes Date" do
     date_obj = time_obj.to_date
     value = Google::Cloud::Datastore::Convert.to_value date_obj
-    value.value_type.must_equal :timestamp_value
-    value.timestamp_value.must_equal Google::Protobuf::Timestamp.new(seconds: date_obj.to_time.to_i)
+    _(value.value_type).must_equal :timestamp_value
+    _(value.timestamp_value).must_equal Google::Protobuf::Timestamp.new(seconds: date_obj.to_time.to_i)
   end
 
   it "encodes DateTime" do
     datetime_obj = time_obj.to_datetime
     value = Google::Cloud::Datastore::Convert.to_value datetime_obj
-    value.value_type.must_equal :timestamp_value
-    value.timestamp_value.must_equal time_grpc
+    _(value.value_type).must_equal :timestamp_value
+    _(value.timestamp_value).must_equal time_grpc
   end
 
   it "decodes timestamp" do
     value = Google::Datastore::V1::Value.new
     value.timestamp_value = time_grpc
     raw = Google::Cloud::Datastore::Convert.from_value value
-    raw.must_equal time_obj
+    _(raw).must_equal time_obj
   end
 
   it "encodes IO as blob" do
     raw = File.open "acceptance/data/CloudPlatform_128px_Retina.png", "rb"
     value = Google::Cloud::Datastore::Convert.to_value raw
-    value.value_type.must_equal :blob_value
-    value.blob_value.must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
+    _(value.value_type).must_equal :blob_value
+    _(value.blob_value).must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
   end
 
   it "encodes StringIO as blob" do
     raw = StringIO.new(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
     value = Google::Cloud::Datastore::Convert.to_value raw
-    value.value_type.must_equal :blob_value
-    value.blob_value.must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
+    _(value.value_type).must_equal :blob_value
+    _(value.blob_value).must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
   end
 
   it "encodes Temfile as blob" do
@@ -230,29 +230,29 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     raw.write(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
     raw.rewind
     value = Google::Cloud::Datastore::Convert.to_value raw
-    value.value_type.must_equal :blob_value
-    value.blob_value.must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
+    _(value.value_type).must_equal :blob_value
+    _(value.blob_value).must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
   end
 
   it "decodes blob to StringIO" do
     value = Google::Datastore::V1::Value.new
     value.blob_value = File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
     raw = Google::Cloud::Datastore::Convert.from_value value
-    raw.must_be_kind_of StringIO
-    raw.read.must_equal StringIO.new(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb")).read
+    _(raw).must_be_kind_of StringIO
+    _(raw.read).must_equal StringIO.new(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb")).read
   end
 
   it "encodes location hash" do
     latlng_obj = {latitude: 37.4220041, longitude: -122.0862462}
     value = Google::Cloud::Datastore::Convert.to_value latlng_obj
-    value.value_type.must_equal :geo_point_value
-    value.geo_point_value.must_equal Google::Type::LatLng.new(latitude: 37.4220041, longitude: -122.0862462)
+    _(value.value_type).must_equal :geo_point_value
+    _(value.geo_point_value).must_equal Google::Type::LatLng.new(latitude: 37.4220041, longitude: -122.0862462)
   end
 
   it "decodes geo_point" do
     value = Google::Datastore::V1::Value.new
     value.geo_point_value = Google::Type::LatLng.new(latitude: 37.4220041, longitude: -122.0862462)
     raw = Google::Cloud::Datastore::Convert.from_value value
-    raw.must_equal({latitude: 37.4220041, longitude: -122.0862462})
+    _(raw).must_equal({latitude: 37.4220041, longitude: -122.0862462})
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results/all_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results/all_test.rb
@@ -70,26 +70,26 @@ describe Google::Cloud::Datastore::Dataset, :all, :mock_datastore do
   it "run will fulfill a query and return an object that can paginate" do
     first_entities = dataset.run dataset.query("Task")
 
-    first_entities.count.must_equal 25
+    _(first_entities.count).must_equal 25
     first_entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    first_entities.cursor_for(first_entities.first).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1-0")
-    first_entities.cursor_for(first_entities.last).must_equal  Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1-24")
+    _(first_entities.cursor_for(first_entities.first)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1-0")
+    _(first_entities.cursor_for(first_entities.last)).must_equal  Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1-24")
     first_entities.each_with_cursor do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
     # can use the enumerator without passing a block...
     first_entities.each_with_cursor.map do |entity, cursor|
       [entity.key, cursor]
     end.each do |result, cursor|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
-    first_entities.cursor.must_equal     Google::Cloud::Datastore::Cursor.from_grpc("second-page-cursor")
-    first_entities.end_cursor.must_equal Google::Cloud::Datastore::Cursor.from_grpc("second-page-cursor")
-    first_entities.more_results.must_equal :NOT_FINISHED
+    _(first_entities.cursor).must_equal     Google::Cloud::Datastore::Cursor.from_grpc("second-page-cursor")
+    _(first_entities.end_cursor).must_equal Google::Cloud::Datastore::Cursor.from_grpc("second-page-cursor")
+    _(first_entities.more_results).must_equal :NOT_FINISHED
     assert first_entities.not_finished?
     refute first_entities.more_after_limit?
     refute first_entities.more_after_cursor?
@@ -99,24 +99,24 @@ describe Google::Cloud::Datastore::Dataset, :all, :mock_datastore do
     next_entities = first_entities.next
 
     next_entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    next_entities.cursor_for(next_entities.first).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-2-0")
-    next_entities.cursor_for(next_entities.last).must_equal  Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-2-24")
+    _(next_entities.cursor_for(next_entities.first)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-2-0")
+    _(next_entities.cursor_for(next_entities.last)).must_equal  Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-2-24")
     next_entities.each_with_cursor do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
     # can use the enumerator without passing a block...
     next_entities.each_with_cursor.map do |entity, cursor|
       [entity.key, cursor]
     end.each do |result, cursor|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
-    next_entities.cursor.must_be     :nil?
-    next_entities.end_cursor.must_be :nil?
-    next_entities.more_results.must_equal :NO_MORE_RESULTS
+    _(next_entities.cursor).must_be     :nil?
+    _(next_entities.end_cursor).must_be :nil?
+    _(next_entities.more_results).must_equal :NO_MORE_RESULTS
     refute next_entities.not_finished?
     refute next_entities.more_after_limit?
     refute next_entities.more_after_cursor?
@@ -128,27 +128,27 @@ describe Google::Cloud::Datastore::Dataset, :all, :mock_datastore do
   it "run will fulfill a query and return an object that can paginate with all" do
     entities = dataset.run dataset.query("Task")
     entities.all.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
   it "run will fulfill a query and can use the all enumerator to get count" do
     entities = dataset.run dataset.query("Task")
-    entities.all.count.must_equal 50
+    _(entities.all.count).must_equal 50
   end
 
   it "run will fulfill a query and can use the all enumerator to map results" do
     entities = dataset.run dataset.query("Task")
     entities.all.map(&:key).each do |result|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
     end
   end
 
   it "run will fulfill a query and return an object that can paginate with all_with_cursor" do
     entities = dataset.run dataset.query("Task")
     entities.all_with_cursor.each do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_more_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_more_test.rb
@@ -72,28 +72,28 @@ describe Google::Cloud::Datastore::Dataset, :all_with_more, :mock_datastore do
     entities = dataset.run dataset.query("Task")
     # set request_limit to 1 to only make one more request
     entities.all(request_limit: 1) do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
   it "run will fulfill a query and can use the all as a lazy enumerator" do
     entities = dataset.run dataset.query("Task")
     # no request_limit set, enumerator should only make 2 total requests though
-    entities.all.lazy.take(30).count.must_equal 30
+    _(entities.all.lazy.take(30).count).must_equal 30
   end
 
   it "run will fulfill a query and can use the all_with_cursor and limit api calls" do
     entities = dataset.run dataset.query("Task")
     # set request_limit to 1 to only make one more request
     entities.all_with_cursor(request_limit: 1) do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
   end
 
   it "run will fulfill a query and can use the all_with_cursor as a lazy enumerator" do
     entities = dataset.run dataset.query("Task")
     # no request_limit set, enumerator should only make 2 total requests though
-    entities.all_with_cursor.lazy.take(30).count.must_equal 30
+    _(entities.all_with_cursor.lazy.take(30).count).must_equal 30
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_offset_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_offset_test.rb
@@ -72,28 +72,28 @@ describe Google::Cloud::Datastore::Dataset, :all_with_offset, :mock_datastore do
     entities = dataset.run dataset.query("Task").offset(5)
     # set request_limit to 1 to only make one more request
     entities.all(request_limit: 1) do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
   it "run will fulfill a query and can use the all as a lazy enumerator" do
     entities = dataset.run dataset.query("Task").offset(5)
     # no request_limit set, enumerator should only make 2 total requests though
-    entities.all.lazy.take(30).count.must_equal 30
+    _(entities.all.lazy.take(30).count).must_equal 30
   end
 
   it "run will fulfill a query and can use the all_with_cursor and limit api calls" do
     entities = dataset.run dataset.query("Task").offset(5)
     # set request_limit to 1 to only make one more request
     entities.all_with_cursor(request_limit: 1) do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
   end
 
   it "run will fulfill a query and can use the all_with_cursor as a lazy enumerator" do
     entities = dataset.run dataset.query("Task").offset(5)
     # no request_limit set, enumerator should only make 2 total requests though
-    entities.all_with_cursor.take(30).count.must_equal 30
+    _(entities.all_with_cursor.take(30).count).must_equal 30
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results_test.rb
@@ -71,25 +71,25 @@ describe Google::Cloud::Datastore::Dataset::QueryResults, :mock_datastore do
     dataset.service.mocked_service.expect :run_query, run_query_res_not_finished, [project, partition_id: nil, read_options: nil, query: query.to_grpc, gql_query: nil, options: default_options]
 
     entities = dataset.run query
-    entities.count.must_equal 2
+    _(entities.count).must_equal 2
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    entities.cursor_for(entities.first).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
-    entities.cursor_for(entities.last).must_equal  Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
+    _(entities.cursor_for(entities.first)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
+    _(entities.cursor_for(entities.last)).must_equal  Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
     entities.each_with_cursor do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
     # can use the enumerator without passing a block...
     entities.each_with_cursor.map do |entity, cursor|
       [entity.key, cursor]
     end.each do |result, cursor|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
-    entities.cursor.must_equal query_cursor
-    entities.more_results.must_equal :NOT_FINISHED
+    _(entities.cursor).must_equal query_cursor
+    _(entities.more_results).must_equal :NOT_FINISHED
     assert entities.not_finished?
     refute entities.more_after_limit?
     refute entities.more_after_cursor?
@@ -100,25 +100,25 @@ describe Google::Cloud::Datastore::Dataset::QueryResults, :mock_datastore do
     dataset.service.mocked_service.expect :run_query, run_query_res_more_after_limit, [project, partition_id: nil, read_options: nil, query: query.to_grpc, gql_query: nil, options: default_options]
 
     entities = dataset.run query
-    entities.count.must_equal 2
+    _(entities.count).must_equal 2
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    entities.cursor_for(entities.first).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
-    entities.cursor_for(entities.last).must_equal  Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
+    _(entities.cursor_for(entities.first)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
+    _(entities.cursor_for(entities.last)).must_equal  Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
     entities.each_with_cursor do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
     # can use the enumerator without passing a block...
     entities.each_with_cursor.map do |entity, cursor|
       [entity.key, cursor]
     end.each do |result, cursor|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
-    entities.cursor.must_equal query_cursor
-    entities.more_results.must_equal :MORE_RESULTS_AFTER_LIMIT
+    _(entities.cursor).must_equal query_cursor
+    _(entities.more_results).must_equal :MORE_RESULTS_AFTER_LIMIT
     refute entities.not_finished?
     assert entities.more_after_limit?
     refute entities.more_after_cursor?
@@ -129,25 +129,25 @@ describe Google::Cloud::Datastore::Dataset::QueryResults, :mock_datastore do
     dataset.service.mocked_service.expect :run_query, run_query_res_more_after_cursor, [project, partition_id: nil, read_options: nil, query: query.to_grpc, gql_query: nil, options: default_options]
 
     entities = dataset.run query
-    entities.count.must_equal 2
+    _(entities.count).must_equal 2
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    entities.cursor_for(entities.first).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
-    entities.cursor_for(entities.last).must_equal  Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
+    _(entities.cursor_for(entities.first)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
+    _(entities.cursor_for(entities.last)).must_equal  Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
     entities.each_with_cursor do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
     # can use the enumerator without passing a block...
     entities.each_with_cursor.map do |entity, cursor|
       [entity.key, cursor]
     end.each do |result, cursor|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
-    entities.cursor.must_equal query_cursor
-    entities.more_results.must_equal :MORE_RESULTS_AFTER_CURSOR
+    _(entities.cursor).must_equal query_cursor
+    _(entities.more_results).must_equal :MORE_RESULTS_AFTER_CURSOR
     refute entities.not_finished?
     refute entities.more_after_limit?
     assert entities.more_after_cursor?
@@ -158,25 +158,25 @@ describe Google::Cloud::Datastore::Dataset::QueryResults, :mock_datastore do
     dataset.service.mocked_service.expect :run_query, run_query_res_no_more, [project, partition_id: nil, read_options: nil, query: query.to_grpc, gql_query: nil, options: default_options]
 
     entities = dataset.run query
-    entities.count.must_equal 2
+    _(entities.count).must_equal 2
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    entities.cursor_for(entities.first).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
-    entities.cursor_for(entities.last).must_equal  Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
+    _(entities.cursor_for(entities.first)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
+    _(entities.cursor_for(entities.last)).must_equal  Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
     entities.each_with_cursor do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
     # can use the enumerator without passing a block...
     entities.each_with_cursor.map do |entity, cursor|
       [entity.key, cursor]
     end.each do |result, cursor|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
-    entities.cursor.must_equal query_cursor
-    entities.more_results.must_equal :NO_MORE_RESULTS
+    _(entities.cursor).must_equal query_cursor
+    _(entities.more_results).must_equal :NO_MORE_RESULTS
     refute entities.not_finished?
     refute entities.more_after_limit?
     refute entities.more_after_cursor?

--- a/google-cloud-datastore/test/google/cloud/datastore/query_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_test.rb
@@ -20,15 +20,15 @@ describe Google::Cloud::Datastore::Query, :mock_datastore do
     query.kind "Task"
 
     grpc = query.to_grpc
-    grpc.kind.map(&:name).must_include "Task"
-    grpc.kind.map(&:name).wont_include "User"
+    _(grpc.kind.map(&:name)).must_include "Task"
+    _(grpc.kind.map(&:name)).wont_include "User"
 
     # Add a second kind to the query
     query.kind "User"
 
     grpc = query.to_grpc
-    grpc.kind.map(&:name).must_include "Task"
-    grpc.kind.map(&:name).must_include "User"
+    _(grpc.kind.map(&:name)).must_include "Task"
+    _(grpc.kind.map(&:name)).must_include "User"
   end
 
   it "can filter properties" do
@@ -36,37 +36,37 @@ describe Google::Cloud::Datastore::Query, :mock_datastore do
     query.where "completed", "=", true
 
     grpc = query.to_grpc
-    grpc.filter.wont_be :nil?
-    grpc.filter.filter_type.must_equal :composite_filter
-    grpc.filter.property_filter.must_be :nil?
-    grpc.filter.composite_filter.wont_be :nil?
-    grpc.filter.composite_filter.op.must_equal :AND
-    grpc.filter.composite_filter.filters.count.must_equal 1
+    _(grpc.filter).wont_be :nil?
+    _(grpc.filter.filter_type).must_equal :composite_filter
+    _(grpc.filter.property_filter).must_be :nil?
+    _(grpc.filter.composite_filter).wont_be :nil?
+    _(grpc.filter.composite_filter.op).must_equal :AND
+    _(grpc.filter.composite_filter.filters.count).must_equal 1
 
     new_filter = grpc.filter.composite_filter.filters.first
-    new_filter.property_filter.property.name.must_equal "completed"
-    new_filter.property_filter.op.must_equal :EQUAL
-    Google::Cloud::Datastore::Convert.from_value(new_filter.property_filter.value).must_equal true
+    _(new_filter.property_filter.property.name).must_equal "completed"
+    _(new_filter.property_filter.op).must_equal :EQUAL
+    _(Google::Cloud::Datastore::Convert.from_value(new_filter.property_filter.value)).must_equal true
 
     # Add a second filter and generate new grpcbuf
     # Use the filter alias to add the second filter
     query.filter "due", :>, Time.new(2014, 1, 1, 0, 0, 0, 0)
     grpc = query.to_grpc
-    grpc.filter.composite_filter.filters.count.must_equal 2
+    _(grpc.filter.composite_filter.filters.count).must_equal 2
 
     first_filter = grpc.filter.composite_filter.filters.first
-    first_filter.property_filter.wont_be :nil?
-    first_filter.composite_filter.must_be :nil?
-    first_filter.property_filter.property.name.must_equal "completed"
-    first_filter.property_filter.op.must_equal :EQUAL
-    Google::Cloud::Datastore::Convert.from_value(first_filter.property_filter.value).must_equal true
+    _(first_filter.property_filter).wont_be :nil?
+    _(first_filter.composite_filter).must_be :nil?
+    _(first_filter.property_filter.property.name).must_equal "completed"
+    _(first_filter.property_filter.op).must_equal :EQUAL
+    _(Google::Cloud::Datastore::Convert.from_value(first_filter.property_filter.value)).must_equal true
 
     second_filter = grpc.filter.composite_filter.filters.last
-    second_filter.property_filter.wont_be :nil?
-    second_filter.composite_filter.must_be :nil?
-    second_filter.property_filter.property.name.must_equal "due"
-    second_filter.property_filter.op.must_equal :GREATER_THAN
-    Google::Cloud::Datastore::Convert.from_value(second_filter.property_filter.value).must_equal Time.new(2014, 1, 1, 0, 0, 0, 0)
+    _(second_filter.property_filter).wont_be :nil?
+    _(second_filter.composite_filter).must_be :nil?
+    _(second_filter.property_filter.property.name).must_equal "due"
+    _(second_filter.property_filter.op).must_equal :GREATER_THAN
+    _(Google::Cloud::Datastore::Convert.from_value(second_filter.property_filter.value)).must_equal Time.new(2014, 1, 1, 0, 0, 0, 0)
   end
 
   it "can order results" do
@@ -75,16 +75,16 @@ describe Google::Cloud::Datastore::Query, :mock_datastore do
 
     grpc = query.to_grpc
     order = order_as_arrays grpc
-    order.must_include [ "due",       :ASCENDING ]
-    order.wont_include [ "completed", :DESCENDING ]
+    _(order).must_include [ "due",       :ASCENDING ]
+    _(order).wont_include [ "completed", :DESCENDING ]
 
     # Add a second kind to the query
     query.order "completed", :desc
 
     grpc = query.to_grpc
     order = order_as_arrays grpc
-    order.must_include [ "due",       :ASCENDING ]
-    order.must_include [ "completed", :DESCENDING ]
+    _(order).must_include [ "due",       :ASCENDING ]
+    _(order).must_include [ "completed", :DESCENDING ]
   end
 
   it "accepts any string that starts with 'd' for DESCENDING" do
@@ -94,26 +94,26 @@ describe Google::Cloud::Datastore::Query, :mock_datastore do
     grpc = query.to_grpc
     order = order_as_arrays grpc
 
-    order.must_include [ "completed", :DESCENDING ]
+    _(order).must_include [ "completed", :DESCENDING ]
   end
 
   it "can limit and offset" do
     query.kind "Task"
 
     grpc = query.to_grpc
-    grpc.limit.must_be :nil?
+    _(grpc.limit).must_be :nil?
 
     query.limit 10
 
     grpc = query.to_grpc
-    grpc.limit.must_equal Google::Protobuf::Int32Value.new(value: 10)
+    _(grpc.limit).must_equal Google::Protobuf::Int32Value.new(value: 10)
 
-    grpc.offset.must_equal 0
+    _(grpc.offset).must_equal 0
 
     query.offset 20
 
     grpc = query.to_grpc
-    grpc.offset.must_equal 20
+    _(grpc.offset).must_equal 20
   end
 
   it "can specify a cursor" do
@@ -123,69 +123,69 @@ describe Google::Cloud::Datastore::Query, :mock_datastore do
     query.kind "Task"
 
     grpc = query.to_grpc
-    grpc.start_cursor.must_be :empty?
+    _(grpc.start_cursor).must_be :empty?
 
     query.cursor encoded_cursor
 
     grpc = query.to_grpc
-    grpc.start_cursor.must_equal raw_cursor
+    _(grpc.start_cursor).must_equal raw_cursor
   end
 
   it "can select the properties to return" do
     query.kind "Task"
 
     grpc = query.to_grpc
-    grpc.projection.must_be :empty?
+    _(grpc.projection).must_be :empty?
 
     query.select "completed"
 
     grpc = query.to_grpc
-    grpc.projection.wont_be :empty?
-    grpc.projection.count.must_equal 1
-    grpc.projection.first.property.name.must_equal "completed"
+    _(grpc.projection).wont_be :empty?
+    _(grpc.projection.count).must_equal 1
+    _(grpc.projection.first.property.name).must_equal "completed"
   end
 
   it "can select the properties using projection alias" do
     query.kind "Task"
 
     grpc = query.to_grpc
-    grpc.projection.must_be :empty?
+    _(grpc.projection).must_be :empty?
 
     # Use projection instead of select
     query.projection "completed"
 
     grpc = query.to_grpc
-    grpc.projection.wont_be :empty?
-    grpc.projection.count.must_equal 1
-    grpc.projection.first.property.name.must_equal "completed"
+    _(grpc.projection).wont_be :empty?
+    _(grpc.projection.count).must_equal 1
+    _(grpc.projection.first.property.name).must_equal "completed"
   end
 
   it "can group on properties" do
     query.kind "Task"
 
     grpc = query.to_grpc
-    grpc.distinct_on.must_be :empty?
+    _(grpc.distinct_on).must_be :empty?
 
     query.group_by "completed"
 
     grpc = query.to_grpc
-    grpc.distinct_on.wont_be :empty?
-    grpc.distinct_on.count.must_equal 1
-    grpc.distinct_on.first.name.must_equal "completed"
+    _(grpc.distinct_on).wont_be :empty?
+    _(grpc.distinct_on.count).must_equal 1
+    _(grpc.distinct_on.first.name).must_equal "completed"
   end
 
   it "can group on properties using distinct_on" do
     query.kind "Task"
 
     grpc = query.to_grpc
-    grpc.distinct_on.must_be :empty?
+    _(grpc.distinct_on).must_be :empty?
 
     query.distinct_on "completed"
 
     grpc = query.to_grpc
-    grpc.distinct_on.wont_be :empty?
-    grpc.distinct_on.count.must_equal 1
-    grpc.distinct_on.first.name.must_equal "completed"
+    _(grpc.distinct_on).wont_be :empty?
+    _(grpc.distinct_on.count).must_equal 1
+    _(grpc.distinct_on.first.name).must_equal "completed"
   end
 
   it "can query ancestor" do
@@ -195,15 +195,15 @@ describe Google::Cloud::Datastore::Query, :mock_datastore do
 
     grpc = query.to_grpc
 
-    grpc.filter.composite_filter.filters.count.must_equal 1
+    _(grpc.filter.composite_filter.filters.count).must_equal 1
 
     ancestor_filter = grpc.filter.composite_filter.filters.first
-    ancestor_filter.property_filter.property.name.must_equal "__key__"
-    ancestor_filter.property_filter.op.must_equal :HAS_ANCESTOR
+    _(ancestor_filter.property_filter.property.name).must_equal "__key__"
+    _(ancestor_filter.property_filter.op).must_equal :HAS_ANCESTOR
     key = Google::Cloud::Datastore::Convert.from_value(ancestor_filter.property_filter.value)
-    key.kind.must_equal ancestor_key.kind
-    key.id.must_be :nil?
-    key.name.must_equal ancestor_key.name
+    _(key.kind).must_equal ancestor_key.kind
+    _(key.id).must_be :nil?
+    _(key.name).must_equal ancestor_key.name
   end
 
   it "can manually filter on ancestor" do
@@ -213,15 +213,15 @@ describe Google::Cloud::Datastore::Query, :mock_datastore do
 
     grpc = query.to_grpc
 
-    grpc.filter.composite_filter.filters.count.must_equal 1
+    _(grpc.filter.composite_filter.filters.count).must_equal 1
 
     ancestor_filter = grpc.filter.composite_filter.filters.first
-    ancestor_filter.property_filter.property.name.must_equal "__key__"
-    ancestor_filter.property_filter.op.must_equal :HAS_ANCESTOR
+    _(ancestor_filter.property_filter.property.name).must_equal "__key__"
+    _(ancestor_filter.property_filter.op).must_equal :HAS_ANCESTOR
     key = Google::Cloud::Datastore::Convert.from_value(ancestor_filter.property_filter.value)
-    key.kind.must_equal ancestor_key.kind
-    key.id.must_be :nil?
-    key.name.must_equal ancestor_key.name
+    _(key.kind).must_equal ancestor_key.kind
+    _(key.id).must_be :nil?
+    _(key.name).must_equal ancestor_key.name
   end
 
   it "can chain query methods" do
@@ -229,33 +229,33 @@ describe Google::Cloud::Datastore::Query, :mock_datastore do
       where("completed", "=", true).group_by("completed").
       order("due", :desc).limit(10).offset(20)
 
-    q2.must_equal query
-    q2.to_grpc.must_equal query.to_grpc
+    _(q2).must_equal query
+    _(q2.to_grpc).must_equal query.to_grpc
 
     grpc = query.to_grpc
 
-    grpc.kind.map(&:name).must_include "Task"
+    _(grpc.kind.map(&:name)).must_include "Task"
 
-    grpc.projection.wont_be :nil?
-    grpc.projection.count.must_equal 2
-    grpc.projection.first.property.name.must_equal "due"
-    grpc.projection.last.property.name.must_equal "completed"
+    _(grpc.projection).wont_be :nil?
+    _(grpc.projection.count).must_equal 2
+    _(grpc.projection.first.property.name).must_equal "due"
+    _(grpc.projection.last.property.name).must_equal "completed"
 
     filter = grpc.filter.composite_filter.filters.first
-    filter.property_filter.property.name.must_equal "completed"
-    filter.property_filter.op.must_equal :EQUAL
-    Google::Cloud::Datastore::Convert.from_value(filter.property_filter.value).must_equal true
+    _(filter.property_filter.property.name).must_equal "completed"
+    _(filter.property_filter.op).must_equal :EQUAL
+    _(Google::Cloud::Datastore::Convert.from_value(filter.property_filter.value)).must_equal true
 
-    grpc.distinct_on.wont_be :empty?
-    grpc.distinct_on.count.must_equal 1
-    grpc.distinct_on.first.name.must_equal "completed"
+    _(grpc.distinct_on).wont_be :empty?
+    _(grpc.distinct_on.count).must_equal 1
+    _(grpc.distinct_on.first.name).must_equal "completed"
 
     order = order_as_arrays grpc
-    order.must_include [ "due", :DESCENDING ]
+    _(order).must_include [ "due", :DESCENDING ]
 
-    grpc.limit.must_equal Google::Protobuf::Int32Value.new(value: 10)
+    _(grpc.limit).must_equal Google::Protobuf::Int32Value.new(value: 10)
 
-    grpc.offset.must_equal 20
+    _(grpc.offset).must_equal 20
   end
 
   def order_as_arrays grpc

--- a/google-cloud-datastore/test/google/cloud/datastore/read_only_transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/read_only_transaction_test.rb
@@ -75,7 +75,7 @@ describe Google::Cloud::Datastore::ReadOnlyTransaction, :mock_datastore do
 
     key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
     entity = transaction.find key
-    entity.must_be_kind_of Google::Cloud::Datastore::Entity
+    _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
   end
 
   it "find_all takes several keys" do
@@ -87,11 +87,11 @@ describe Google::Cloud::Datastore::ReadOnlyTransaction, :mock_datastore do
     key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
     key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
     entities = transaction.find_all key1, key2
-    entities.count.must_equal 2
-    entities.deferred.count.must_equal 0
-    entities.missing.count.must_equal 0
+    _(entities.count).must_equal 2
+    _(entities.deferred.count).must_equal 0
+    _(entities.missing.count).must_equal 0
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
@@ -101,13 +101,13 @@ describe Google::Cloud::Datastore::ReadOnlyTransaction, :mock_datastore do
 
     query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = transaction.run query
-    entities.count.must_equal 2
+    _(entities.count).must_equal 2
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    entities.cursor.must_equal query_cursor
-    entities.end_cursor.must_equal query_cursor
-    entities.more_results.must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
+    _(entities.cursor).must_equal query_cursor
+    _(entities.end_cursor).must_equal query_cursor
+    _(entities.more_results).must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
     refute entities.not_finished?
     refute entities.more_after_limit?
     refute entities.more_after_cursor?
@@ -119,26 +119,26 @@ describe Google::Cloud::Datastore::ReadOnlyTransaction, :mock_datastore do
 
     gql = transaction.gql "SELECT * FROM Task"
     entities = transaction.run gql
-    entities.count.must_equal 2
+    _(entities.count).must_equal 2
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    entities.cursor_for(entities.first).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
-    entities.cursor_for(entities.last).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
+    _(entities.cursor_for(entities.first)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-0")
+    _(entities.cursor_for(entities.last)).must_equal Google::Cloud::Datastore::Cursor.from_grpc("result-cursor-1")
     entities.each_with_cursor do |entity, cursor|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
     # can use the enumerator without passing a block...
     entities.each_with_cursor.map do |entity, cursor|
       [entity.key, cursor]
     end.each do |result, cursor|
-      result.must_be_kind_of Google::Cloud::Datastore::Key
-      cursor.must_be_kind_of Google::Cloud::Datastore::Cursor
+      _(result).must_be_kind_of Google::Cloud::Datastore::Key
+      _(cursor).must_be_kind_of Google::Cloud::Datastore::Cursor
     end
-    entities.cursor.must_equal query_cursor
-    entities.end_cursor.must_equal query_cursor
-    entities.more_results.must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
+    _(entities.cursor).must_equal query_cursor
+    _(entities.end_cursor).must_equal query_cursor
+    _(entities.more_results).must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
     refute entities.not_finished?
     refute entities.more_after_limit?
     refute entities.more_after_cursor?
@@ -147,91 +147,91 @@ describe Google::Cloud::Datastore::ReadOnlyTransaction, :mock_datastore do
 
   describe "error handling" do
     it "start will raise if transaction is already open" do
-      transaction.id.wont_be :nil?
+      _(transaction.id).wont_be :nil?
       error = assert_raises Google::Cloud::Datastore::TransactionError do
         transaction.start
       end
-      error.wont_be :nil?
-      error.message.must_equal "Transaction already opened."
+      _(error).wont_be :nil?
+      _(error.message).must_equal "Transaction already opened."
     end
 
     it "commit will raise if transaction is not open" do
-      transaction.id.wont_be :nil?
+      _(transaction.id).wont_be :nil?
       transaction.reset!
-      transaction.id.must_be :nil?
+      _(transaction.id).must_be :nil?
       error = assert_raises Google::Cloud::Datastore::TransactionError do
         transaction.commit
       end
-      error.wont_be :nil?
-      error.message.must_equal "Cannot commit when not in a transaction."
+      _(error).wont_be :nil?
+      _(error.message).must_equal "Cannot commit when not in a transaction."
     end
 
     it "transaction will raise if transaction is not open" do
-      transaction.id.wont_be :nil?
+      _(transaction.id).wont_be :nil?
       transaction.reset!
-      transaction.id.must_be :nil?
+      _(transaction.id).must_be :nil?
       error = assert_raises Google::Cloud::Datastore::TransactionError do
         transaction.rollback
       end
-      error.wont_be :nil?
-      error.message.must_equal "Cannot rollback when not in a transaction."
+      _(error).wont_be :nil?
+      _(error.message).must_equal "Cannot rollback when not in a transaction."
     end
   end
 
   it "query returns a Query instance" do
     query = transaction.query "Task"
-    query.must_be_kind_of Google::Cloud::Datastore::Query
+    _(query).must_be_kind_of Google::Cloud::Datastore::Query
 
     grpc = query.to_grpc
-    grpc.kind.map(&:name).must_include "Task"
-    grpc.kind.map(&:name).wont_include "User"
+    _(grpc.kind.map(&:name)).must_include "Task"
+    _(grpc.kind.map(&:name)).wont_include "User"
 
     # Add a second kind to the query
     query.kind "User"
 
     grpc = query.to_grpc
-    grpc.kind.map(&:name).must_include "Task"
-    grpc.kind.map(&:name).must_include "User"
+    _(grpc.kind.map(&:name)).must_include "Task"
+    _(grpc.kind.map(&:name)).must_include "User"
   end
 
   it "key returns a Key instance" do
     key = transaction.key "ThisThing", 1234
-    key.must_be_kind_of Google::Cloud::Datastore::Key
-    key.kind.must_equal "ThisThing"
-    key.id.must_equal 1234
-    key.name.must_be :nil?
+    _(key).must_be_kind_of Google::Cloud::Datastore::Key
+    _(key.kind).must_equal "ThisThing"
+    _(key.id).must_equal 1234
+    _(key.name).must_be :nil?
 
     key = transaction.key "ThisThing", "charlie"
-    key.must_be_kind_of Google::Cloud::Datastore::Key
-    key.kind.must_equal "ThisThing"
-    key.id.must_be :nil?
-    key.name.must_equal "charlie"
+    _(key).must_be_kind_of Google::Cloud::Datastore::Key
+    _(key.kind).must_equal "ThisThing"
+    _(key.id).must_be :nil?
+    _(key.name).must_equal "charlie"
   end
 
   it "key sets a parent and grandparent in the constructor" do
     path = [["OtherThing", "root"], ["ThatThing", 6789], ["ThisThing", 1234]]
     key = transaction.key path, project: "custom-ds", namespace: "custom-ns"
-    key.kind.must_equal "ThisThing"
-    key.id.must_equal 1234
-    key.name.must_be :nil?
-    key.path.must_equal [["OtherThing", "root"], ["ThatThing", 6789], ["ThisThing", 1234]]
-    key.project.must_equal "custom-ds"
-    key.namespace.must_equal "custom-ns"
+    _(key.kind).must_equal "ThisThing"
+    _(key.id).must_equal 1234
+    _(key.name).must_be :nil?
+    _(key.path).must_equal [["OtherThing", "root"], ["ThatThing", 6789], ["ThisThing", 1234]]
+    _(key.project).must_equal "custom-ds"
+    _(key.namespace).must_equal "custom-ns"
 
-    key.parent.wont_be :nil?
-    key.parent.kind.must_equal "ThatThing"
-    key.parent.id.must_equal 6789
-    key.parent.name.must_be :nil?
-    key.parent.path.must_equal [["OtherThing", "root"], ["ThatThing", 6789]]
-    key.parent.project.must_equal "custom-ds"
-    key.parent.namespace.must_equal "custom-ns"
+    _(key.parent).wont_be :nil?
+    _(key.parent.kind).must_equal "ThatThing"
+    _(key.parent.id).must_equal 6789
+    _(key.parent.name).must_be :nil?
+    _(key.parent.path).must_equal [["OtherThing", "root"], ["ThatThing", 6789]]
+    _(key.parent.project).must_equal "custom-ds"
+    _(key.parent.namespace).must_equal "custom-ns"
 
-    key.parent.parent.wont_be :nil?
-    key.parent.parent.kind.must_equal "OtherThing"
-    key.parent.parent.id.must_be :nil?
-    key.parent.parent.name.must_equal "root"
-    key.parent.parent.path.must_equal [["OtherThing", "root"]]
-    key.parent.parent.project.must_equal "custom-ds"
-    key.parent.parent.namespace.must_equal "custom-ns"
+    _(key.parent.parent).wont_be :nil?
+    _(key.parent.parent.kind).must_equal "OtherThing"
+    _(key.parent.parent.id).must_be :nil?
+    _(key.parent.parent.name).must_equal "root"
+    _(key.parent.parent.path).must_equal [["OtherThing", "root"]]
+    _(key.parent.parent.project).must_equal "custom-ds"
+    _(key.parent.parent.namespace).must_equal "custom-ns"
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
@@ -66,29 +66,29 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
   end
 
   it "save does not persist entities" do
-    begin_tx_res.wont_equal "poop"
+    _(begin_tx_res).wont_equal "poop"
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
     end
     transaction.save entity
     # Testing implementation like we are writing Java!
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts").must_include entity
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts")).must_include entity
   end
 
   it "save does not persist entities with upsert alias" do
-    begin_tx_res.wont_equal "poop"
+    _(begin_tx_res).wont_equal "poop"
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
     end
     transaction.upsert entity
     # Testing implementation like we are writing Java!
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts").must_include entity
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts")).must_include entity
   end
 
   it "save does not persist multiple entities" do
-    begin_tx_res.wont_equal "poop"
+    _(begin_tx_res).wont_equal "poop"
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
@@ -98,12 +98,12 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
       e["name"] = "thungamajig"
     end
     transaction.save entity1, entity2
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts").must_include entity1
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts").must_include entity2
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts")).must_include entity1
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts")).must_include entity2
   end
 
   it "save does not persist multiple entities in an array" do
-    begin_tx_res.wont_equal "poop"
+    _(begin_tx_res).wont_equal "poop"
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
@@ -113,23 +113,23 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
       e["name"] = "thungamajig"
     end
     transaction.save [entity1, entity2]
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts").must_include entity1
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts").must_include entity2
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts")).must_include entity1
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts")).must_include entity2
   end
 
   it "insert does not persist entities" do
-    begin_tx_res.wont_equal "poop"
+    _(begin_tx_res).wont_equal "poop"
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
     end
     transaction.insert entity
     # Testing implementation like we are writing Java!
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts").must_include entity
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts")).must_include entity
   end
 
   it "insert does not persist multiple entities" do
-    begin_tx_res.wont_equal "poop"
+    _(begin_tx_res).wont_equal "poop"
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
@@ -139,12 +139,12 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
       e["name"] = "thungamajig"
     end
     transaction.insert entity1, entity2
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts").must_include entity1
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts").must_include entity2
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts")).must_include entity1
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts")).must_include entity2
   end
 
   it "insert does not persist multiple entities in an array" do
-    begin_tx_res.wont_equal "poop"
+    _(begin_tx_res).wont_equal "poop"
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
@@ -154,23 +154,23 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
       e["name"] = "thungamajig"
     end
     transaction.insert [entity1, entity2]
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts").must_include entity1
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts").must_include entity2
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts")).must_include entity1
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts")).must_include entity2
   end
 
   it "update does not persist entities" do
-    begin_tx_res.wont_equal "poop"
+    _(begin_tx_res).wont_equal "poop"
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
     end
     transaction.update entity
     # Testing implementation like we are writing Java!
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates").must_include entity
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates")).must_include entity
   end
 
   it "update does not persist multiple entities" do
-    begin_tx_res.wont_equal "poop"
+    _(begin_tx_res).wont_equal "poop"
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
@@ -180,12 +180,12 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
       e["name"] = "thungamajig"
     end
     transaction.update entity1, entity2
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates").must_include entity1
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates").must_include entity2
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates")).must_include entity1
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates")).must_include entity2
   end
 
   it "update does not persist multiple entities in an array" do
-    begin_tx_res.wont_equal "poop"
+    _(begin_tx_res).wont_equal "poop"
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
@@ -195,8 +195,8 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
       e["name"] = "thungamajig"
     end
     transaction.update [entity1, entity2]
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates").must_include entity1
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates").must_include entity2
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates")).must_include entity1
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates")).must_include entity2
   end
 
   it "delete does not persist entities" do
@@ -206,11 +206,11 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
     end
     transaction.delete entity
     # Testing implementation is bad, mkay?
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity.key
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes")).must_include entity.key
   end
 
   it "delete does not persist multiple entities" do
-    begin_tx_res.wont_equal "poop"
+    _(begin_tx_res).wont_equal "poop"
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
@@ -220,12 +220,12 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
       e["name"] = "thungamajig"
     end
     transaction.delete entity1, entity2
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity1.key
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity2.key
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes")).must_include entity1.key
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes")).must_include entity2.key
   end
 
   it "delete does not persist multiple entities in an array" do
-    begin_tx_res.wont_equal "poop"
+    _(begin_tx_res).wont_equal "poop"
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
@@ -235,8 +235,8 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
       e["name"] = "thungamajig"
     end
     transaction.delete [entity1, entity2]
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity1.key
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity2.key
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes")).must_include entity1.key
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes")).must_include entity2.key
   end
 
   it "delete does not persist keys" do
@@ -246,11 +246,11 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
     end
     transaction.delete entity.key
     # Testing implementation like a BOSS!
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity.key
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes")).must_include entity.key
   end
 
   it "delete does not persist multiple keys" do
-    begin_tx_res.wont_equal "poop"
+    _(begin_tx_res).wont_equal "poop"
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
@@ -260,12 +260,12 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
       e["name"] = "thungamajig"
     end
     transaction.delete entity1.key, entity2.key
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity1.key
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity2.key
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes")).must_include entity1.key
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes")).must_include entity2.key
   end
 
   it "delete does not persist multiple keys in an array" do
-    begin_tx_res.wont_equal "poop"
+    _(begin_tx_res).wont_equal "poop"
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
@@ -275,8 +275,8 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
       e["name"] = "thungamajig"
     end
     transaction.delete [entity1.key, entity2.key]
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity1.key
-    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity2.key
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes")).must_include entity1.key
+    _(transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes")).must_include entity2.key
   end
 
   it "commit will save and delete entities" do
@@ -324,14 +324,14 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
       e["name"] = "Gonna be deleted"
     end
 
-    entity_to_be_saved.wont_be :persisted?
+    _(entity_to_be_saved).wont_be :persisted?
     transaction.commit do |c|
       c.save entity_to_be_saved
       c.insert entity_to_be_inserted
       c.update entity_to_be_updated
       c.delete entity_to_be_deleted
     end
-    entity_to_be_saved.must_be :persisted?
+    _(entity_to_be_saved).must_be :persisted?
   end
 
   it "find can take a key" do
@@ -341,7 +341,7 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
 
     key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
     entity = transaction.find key
-    entity.must_be_kind_of Google::Cloud::Datastore::Entity
+    _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
   end
 
   it "find_all takes several keys" do
@@ -353,11 +353,11 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
     key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
     key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
     entities = transaction.find_all key1, key2
-    entities.count.must_equal 2
-    entities.deferred.count.must_equal 0
-    entities.missing.count.must_equal 0
+    _(entities.count).must_equal 2
+    _(entities.deferred.count).must_equal 0
+    _(entities.missing.count).must_equal 0
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
   end
 
@@ -368,13 +368,13 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
 
     query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = transaction.run query
-    entities.count.must_equal 2
+    _(entities.count).must_equal 2
     entities.each do |entity|
-      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+      _(entity).must_be_kind_of Google::Cloud::Datastore::Entity
     end
-    entities.cursor.must_equal query_cursor
-    entities.end_cursor.must_equal query_cursor
-    entities.more_results.must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
+    _(entities.cursor).must_equal query_cursor
+    _(entities.end_cursor).must_equal query_cursor
+    _(entities.more_results).must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
     refute entities.not_finished?
     refute entities.more_after_limit?
     refute entities.more_after_cursor?
@@ -399,12 +399,12 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
     end
-    entity.key.must_be :complete?
+    _(entity.key).must_be :complete?
     transaction.save entity
-    entity.wont_be :persisted?
+    _(entity).wont_be :persisted?
     transaction.commit
-    entity.key.must_be :complete?
-    entity.must_be :persisted?
+    _(entity.key).must_be :complete?
+    _(entity).must_be :persisted?
   end
 
   it "commit persists entities with incomplete keys" do
@@ -428,12 +428,12 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
       e["name"] = "thingamajig"
     end
-    entity.key.must_be :incomplete?
+    _(entity.key).must_be :incomplete?
     transaction.save entity
-    entity.wont_be :persisted?
+    _(entity).wont_be :persisted?
     transaction.commit
-    entity.key.must_be :complete?
-    entity.must_be :persisted?
+    _(entity.key).must_be :complete?
+    _(entity).must_be :persisted?
   end
 
   it "rollback does not persist entities" do
@@ -450,34 +450,34 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
 
   describe "error handling" do
     it "start will raise if transaction is already open" do
-      transaction.id.wont_be :nil?
+      _(transaction.id).wont_be :nil?
       error = assert_raises Google::Cloud::Datastore::TransactionError do
         transaction.start
       end
-      error.wont_be :nil?
-      error.message.must_equal "Transaction already opened."
+      _(error).wont_be :nil?
+      _(error.message).must_equal "Transaction already opened."
     end
 
     it "commit will raise if transaction is not open" do
-      transaction.id.wont_be :nil?
+      _(transaction.id).wont_be :nil?
       transaction.reset!
-      transaction.id.must_be :nil?
+      _(transaction.id).must_be :nil?
       error = assert_raises Google::Cloud::Datastore::TransactionError do
         transaction.commit
       end
-      error.wont_be :nil?
-      error.message.must_equal "Cannot commit when not in a transaction."
+      _(error).wont_be :nil?
+      _(error.message).must_equal "Cannot commit when not in a transaction."
     end
 
     it "transaction will raise if transaction is not open" do
-      transaction.id.wont_be :nil?
+      _(transaction.id).wont_be :nil?
       transaction.reset!
-      transaction.id.must_be :nil?
+      _(transaction.id).must_be :nil?
       error = assert_raises Google::Cloud::Datastore::TransactionError do
         transaction.rollback
       end
-      error.wont_be :nil?
-      error.message.must_equal "Cannot rollback when not in a transaction."
+      _(error).wont_be :nil?
+      _(error.message).must_equal "Cannot rollback when not in a transaction."
     end
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore_test.rb
@@ -20,51 +20,51 @@ describe Google::Cloud do
     it "calls out to Google::Cloud.datastore" do
       gcloud = Google::Cloud.new
       stubbed_datastore = ->(project, keyfile, scope: nil, timeout: nil, host: nil, client_config: nil) {
-        project.must_be :nil?
-        keyfile.must_be :nil?
-        scope.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_be :nil?
+        _(keyfile).must_be :nil?
+        _(scope).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         "datastore-dataset-object-empty"
       }
       Google::Cloud.stub :datastore, stubbed_datastore do
         dataset = gcloud.datastore
-        dataset.must_equal "datastore-dataset-object-empty"
+        _(dataset).must_equal "datastore-dataset-object-empty"
       end
     end
 
     it "passes project and keyfile to Google::Cloud.datastore" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_datastore = ->(project, keyfile, scope: nil, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         "datastore-dataset-object"
       }
       Google::Cloud.stub :datastore, stubbed_datastore do
         dataset = gcloud.datastore
-        dataset.must_equal "datastore-dataset-object"
+        _(dataset).must_equal "datastore-dataset-object"
       end
     end
 
     it "passes project and keyfile and options to Google::Cloud.datastore" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_datastore = ->(project, keyfile, scope: nil, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_equal "http://example.com/scope"
-        timeout.must_equal 60
-        host.must_be :nil?
-        client_config.must_equal({ "gax" => "options" })
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_equal "http://example.com/scope"
+        _(timeout).must_equal 60
+        _(host).must_be :nil?
+        _(client_config).must_equal({ "gax" => "options" })
         "datastore-dataset-object-scoped"
       }
       Google::Cloud.stub :datastore, stubbed_datastore do
         dataset = gcloud.datastore scope: "http://example.com/scope", timeout: 60, client_config: { "gax" => "options" }
-        dataset.must_equal "datastore-dataset-object-scoped"
+        _(dataset).must_equal "datastore-dataset-object-scoped"
       end
     end
   end
@@ -86,9 +86,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Datastore::Credentials.stub :default, default_credentials do
             datastore = Google::Cloud.datastore
-            datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-            datastore.project.must_equal "project-id"
-            datastore.service.credentials.must_equal default_credentials
+            _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+            _(datastore.project).must_equal "project-id"
+            _(datastore.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -96,16 +96,16 @@ describe Google::Cloud do
 
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "datastore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "datastore-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "datastore-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -116,9 +116,9 @@ describe Google::Cloud do
             Google::Cloud::Datastore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Datastore::Service.stub :new, stubbed_service do
                 datastore = Google::Cloud.datastore "project-id", "path/to/keyfile.json"
-                datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-                datastore.project.must_equal "project-id"
-                datastore.service.must_be_kind_of OpenStruct
+                _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+                _(datastore.project).must_equal "project-id"
+                _(datastore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -148,9 +148,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Datastore::Credentials.stub :default, default_credentials do
             datastore = Google::Cloud::Datastore.new
-            datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-            datastore.project.must_equal "project-id"
-            datastore.service.credentials.must_equal default_credentials
+            _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+            _(datastore.project).must_equal "project-id"
+            _(datastore.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -158,16 +158,16 @@ describe Google::Cloud do
 
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "datastore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "datastore-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "datastore-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -178,9 +178,9 @@ describe Google::Cloud do
             Google::Cloud::Datastore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Datastore::Service.stub :new, stubbed_service do
                 datastore = Google::Cloud::Datastore.new project_id: "project-id", credentials: "path/to/keyfile.json"
-                datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-                datastore.project.must_equal "project-id"
-                datastore.service.must_be_kind_of OpenStruct
+                _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+                _(datastore.project).must_equal "project-id"
+                _(datastore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -190,16 +190,16 @@ describe Google::Cloud do
 
     it "uses provided project and keyfile aliases" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "datastore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "datastore-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "datastore-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -210,9 +210,9 @@ describe Google::Cloud do
             Google::Cloud::Datastore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Datastore::Service.stub :new, stubbed_service do
                 datastore = Google::Cloud::Datastore.new project: "project-id", keyfile: "path/to/keyfile.json"
-                datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-                datastore.project.must_equal "project-id"
-                datastore.service.must_be_kind_of OpenStruct
+                _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+                _(datastore.project).must_equal "project-id"
+                _(datastore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -223,11 +223,11 @@ describe Google::Cloud do
     it "uses provided endpoint" do
       endpoint = "datastore-endpoint2.example.com"
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal default_credentials
-        timeout.must_be :nil?
-        host.must_equal endpoint
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(timeout).must_be :nil?
+        _(host).must_equal endpoint
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -235,9 +235,9 @@ describe Google::Cloud do
       ENV.stub :[], nil do
         Google::Cloud::Datastore::Service.stub :new, stubbed_service do
           datastore = Google::Cloud::Datastore.new project: "project-id", credentials: default_credentials, endpoint: endpoint
-          datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-          datastore.project.must_equal "project-id"
-          datastore.service.must_be_kind_of OpenStruct
+          _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+          _(datastore.project).must_equal "project-id"
+          _(datastore.service).must_be_kind_of OpenStruct
         end
       end
     end
@@ -251,10 +251,10 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Datastore::Credentials.stub :default, default_credentials do
             datastore = Google::Cloud::Datastore.new
-            datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-            datastore.project.must_equal "project-id"
-            datastore.service.credentials.must_equal :this_channel_is_insecure
-            datastore.service.host.must_equal emulator_host
+            _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+            _(datastore.project).must_equal "project-id"
+            _(datastore.service.credentials).must_equal :this_channel_is_insecure
+            _(datastore.service.host).must_equal emulator_host
           end
         end
       end
@@ -268,10 +268,10 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           # Google::Cloud::Datastore::Credentials.stub :default, default_credentials do
             datastore = Google::Cloud::Datastore.new emulator_host: emulator_host
-            datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-            datastore.project.must_equal "project-id"
-            datastore.service.credentials.must_equal :this_channel_is_insecure
-            datastore.service.host.must_equal emulator_host
+            _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+            _(datastore.project).must_equal "project-id"
+            _(datastore.service.credentials).must_equal :this_channel_is_insecure
+            _(datastore.service.host).must_equal emulator_host
           # end
         end
       end
@@ -279,17 +279,17 @@ describe Google::Cloud do
 
     it "gets project_id from credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         OpenStruct.new project_id: "project-id"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_be_kind_of OpenStruct
-        credentials.project_id.must_equal "project-id"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_be_kind_of OpenStruct
+        _(credentials.project_id).must_equal "project-id"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
       empty_env = OpenStruct.new
@@ -302,9 +302,9 @@ describe Google::Cloud do
               Google::Cloud::Datastore::Credentials.stub :new, stubbed_credentials do
                 Google::Cloud::Datastore::Service.stub :new, stubbed_service do
                   datastore = Google::Cloud::Datastore.new credentials: "path/to/keyfile.json"
-                  datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-                  datastore.project.must_equal "project-id"
-                  datastore.service.must_be_kind_of OpenStruct
+                  _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+                  _(datastore.project).must_equal "project-id"
+                  _(datastore.service).must_be_kind_of OpenStruct
                 end
               end
             end
@@ -328,16 +328,16 @@ describe Google::Cloud do
 
     it "uses shared config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "datastore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "datastore-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "datastore-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -354,9 +354,9 @@ describe Google::Cloud do
             Google::Cloud::Datastore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Datastore::Service.stub :new, stubbed_service do
                 datastore = Google::Cloud::Datastore.new
-                datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-                datastore.project.must_equal "project-id"
-                datastore.service.must_be_kind_of OpenStruct
+                _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+                _(datastore.project).must_equal "project-id"
+                _(datastore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -366,16 +366,16 @@ describe Google::Cloud do
 
     it "uses shared config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "datastore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "datastore-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "datastore-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -392,9 +392,9 @@ describe Google::Cloud do
             Google::Cloud::Datastore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Datastore::Service.stub :new, stubbed_service do
                 datastore = Google::Cloud::Datastore.new
-                datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-                datastore.project.must_equal "project-id"
-                datastore.service.must_be_kind_of OpenStruct
+                _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+                _(datastore.project).must_equal "project-id"
+                _(datastore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -404,16 +404,16 @@ describe Google::Cloud do
 
     it "uses datastore config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "datastore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "datastore-credentials"
-        timeout.must_equal 42
-        host.must_be :nil?
-        client_config.must_equal datastore_client_config
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "datastore-credentials"
+        _(timeout).must_equal 42
+        _(host).must_be :nil?
+        _(client_config).must_equal datastore_client_config
         OpenStruct.new project: project
       }
 
@@ -432,9 +432,9 @@ describe Google::Cloud do
             Google::Cloud::Datastore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Datastore::Service.stub :new, stubbed_service do
                 datastore = Google::Cloud::Datastore.new
-                datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-                datastore.project.must_equal "project-id"
-                datastore.service.must_be_kind_of OpenStruct
+                _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+                _(datastore.project).must_equal "project-id"
+                _(datastore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -444,16 +444,16 @@ describe Google::Cloud do
 
     it "uses datastore config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "datastore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "datastore-credentials"
-        timeout.must_equal 42
-        host.must_be :nil?
-        client_config.must_equal datastore_client_config
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "datastore-credentials"
+        _(timeout).must_equal 42
+        _(host).must_be :nil?
+        _(client_config).must_equal datastore_client_config
         OpenStruct.new project: project
       }
 
@@ -472,9 +472,9 @@ describe Google::Cloud do
             Google::Cloud::Datastore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Datastore::Service.stub :new, stubbed_service do
                 datastore = Google::Cloud::Datastore.new
-                datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-                datastore.project.must_equal "project-id"
-                datastore.service.must_be_kind_of OpenStruct
+                _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+                _(datastore.project).must_equal "project-id"
+                _(datastore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -484,16 +484,16 @@ describe Google::Cloud do
 
     it "uses datastore config for endpoint" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "datastore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "datastore-credentials"
-        timeout.must_be :nil?
-        host.must_equal "datastore-endpoint2.example.com"
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "datastore-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_equal "datastore-endpoint2.example.com"
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -511,9 +511,9 @@ describe Google::Cloud do
             Google::Cloud::Datastore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Datastore::Service.stub :new, stubbed_service do
                 datastore = Google::Cloud::Datastore.new
-                datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-                datastore.project.must_equal "project-id"
-                datastore.service.must_be_kind_of OpenStruct
+                _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+                _(datastore.project).must_equal "project-id"
+                _(datastore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -531,10 +531,10 @@ describe Google::Cloud do
         end
 
         datastore = Google::Cloud::Datastore.new
-        datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
-        datastore.project.must_equal "project-id"
-        datastore.service.credentials.must_equal :this_channel_is_insecure
-        datastore.service.host.must_equal "localhost:4567"
+        _(datastore).must_be_kind_of Google::Cloud::Datastore::Dataset
+        _(datastore.project).must_equal "project-id"
+        _(datastore.service.credentials).must_equal :this_channel_is_insecure
+        _(datastore.service.host).must_equal "localhost:4567"
       end
     end
   end


### PR DESCRIPTION
Use `rubocop-minitest` gem and `bundle exec rubocop --only Minitest/GlobalExpectations -a` to autocorrect minitest warnings for Ruby 2.7.

refs: #4110
refs: #4116