### PR TITLE
chore(firestore): Update minitest to 5.14

### DIFF
--- a/google-cloud-firestore/.rubocop.yml
+++ b/google-cloud-firestore/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-minitest
+
 inherit_gem:
   google-style: google-style.yml
 
@@ -14,9 +16,7 @@ AllCops:
     - "lib/google/cloud/firestore/admin/v1*.rb"
     - "support/**/*"
     - "Rakefile"
-    - "acceptance/**/*"
     - "conformance/**/*"
-    - "test/**/*"
 
 Documentation:
   Enabled: false

--- a/google-cloud-firestore/.rubocop.yml
+++ b/google-cloud-firestore/.rubocop.yml
@@ -1,5 +1,3 @@
-require: rubocop-minitest
-
 inherit_gem:
   google-style: google-style.yml
 
@@ -16,7 +14,9 @@ AllCops:
     - "lib/google/cloud/firestore/admin/v1*.rb"
     - "support/**/*"
     - "Rakefile"
+    - "acceptance/**/*"
     - "conformance/**/*"
+    - "test/**/*"
 
 Documentation:
   Enabled: false

--- a/google-cloud-firestore/Gemfile
+++ b/google-cloud-firestore/Gemfile
@@ -9,7 +9,3 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "rake"
 
 gem "stackprof" unless Gem.win_platform?
-
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"

--- a/google-cloud-firestore/Gemfile
+++ b/google-cloud-firestore/Gemfile
@@ -9,5 +9,3 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "rake"
 
 gem "stackprof" unless Gem.win_platform?
-
-gem "rubocop-minitest"

--- a/google-cloud-firestore/Gemfile
+++ b/google-cloud-firestore/Gemfile
@@ -9,3 +9,5 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "rake"
 
 gem "stackprof" unless Gem.win_platform?
+
+gem "rubocop-minitest"

--- a/google-cloud-firestore/acceptance/firestore/batch_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/batch_test.rb
@@ -18,15 +18,15 @@ describe "Batch", :firestore_acceptance do
   it "has create method" do
     rand_batch_col = firestore.col "#{root_path}/batch/#{SecureRandom.hex(4)}"
     doc_ref = rand_batch_col.doc
-    doc_ref.get.wont_be :exists?
+    _(doc_ref.get).wont_be :exists?
 
     firestore.batch do |b|
       b.create doc_ref, foo: "bar"
     end
 
     doc_snp = doc_ref.get
-    doc_snp.must_be :exists?
-    doc_snp[:foo].must_equal "bar"
+    _(doc_snp).must_be :exists?
+    _(doc_snp[:foo]).must_equal "bar"
   end
 
   it "has set method" do
@@ -37,7 +37,7 @@ describe "Batch", :firestore_acceptance do
       b.set doc_ref, foo: "baz"
     end
 
-    doc_ref.get[:foo].must_equal "baz"
+    _(doc_ref.get[:foo]).must_equal "baz"
   end
 
   it "has update method" do
@@ -48,13 +48,13 @@ describe "Batch", :firestore_acceptance do
       b.update doc_ref, foo: "baz"
     end
 
-    doc_ref.get[:foo].must_equal "baz"
+    _(doc_ref.get[:foo]).must_equal "baz"
   end
 
   it "enforces that updated document exists" do
     rand_batch_col = firestore.col "#{root_path}/batch/#{SecureRandom.hex(4)}"
     doc_ref = rand_batch_col.doc
-    doc_ref.get.wont_be :exists?
+    _(doc_ref.get).wont_be :exists?
 
     expect do
       firestore.batch do |b|
@@ -72,6 +72,6 @@ describe "Batch", :firestore_acceptance do
       b.delete doc_ref
     end
 
-    doc_ref.get.wont_be :exists?
+    _(doc_ref.get).wont_be :exists?
   end
 end

--- a/google-cloud-firestore/acceptance/firestore/collection_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/collection_test.rb
@@ -16,32 +16,32 @@ require "firestore_helper"
 
 describe "Collection", :firestore_acceptance do
   it "has properties" do
-    root_col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    root_col.collection_id.must_equal root_path
-    root_col.collection_path.must_equal root_path
+    _(root_col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(root_col.collection_id).must_equal root_path
+    _(root_col.collection_path).must_equal root_path
 
-    root_col.parent.must_equal firestore
+    _(root_col.parent).must_equal firestore
   end
 
   it "has doc method" do
     doc_ref = root_col.doc # no id, will create random id instead
 
-    doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    doc_ref.client.must_be_kind_of Google::Cloud::Firestore::Client
-    doc_ref.document_id.length.must_equal 20 # random doc id
+    _(doc_ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_ref.client).must_be_kind_of Google::Cloud::Firestore::Client
+    _(doc_ref.document_id.length).must_equal 20 # random doc id
 
-    doc_ref.parent.collection_path.must_equal root_col.collection_path
+    _(doc_ref.parent.collection_path).must_equal root_col.collection_path
   end
 
   it "has add method" do
     doc_ref = root_col.add({ foo: "hello world" })
-    doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    doc_ref.client.must_be_kind_of Google::Cloud::Firestore::Client
+    _(doc_ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_ref.client).must_be_kind_of Google::Cloud::Firestore::Client
 
     doc_snp = doc_ref.get
-    doc_snp.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(doc_snp).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-    doc_snp[:foo].must_equal "hello world"
+    _(doc_snp[:foo]).must_equal "hello world"
   end
 
   it "lists its documents" do
@@ -50,15 +50,15 @@ describe "Collection", :firestore_acceptance do
     rand_col.add({bar: "foo"})
     docs = rand_col.list_documents
 
-    docs.must_be_kind_of Array
-    docs.size.must_be :>, 1
-    docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    docs.first.client.must_be_kind_of Google::Cloud::Firestore::Client
+    _(docs).must_be_kind_of Array
+    _(docs.size).must_be :>, 1
+    _(docs.first).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(docs.first.client).must_be_kind_of Google::Cloud::Firestore::Client
 
     docs_max_1 = rand_col.list_documents max: 1
-    docs_max_1.size.must_equal 1
+    _(docs_max_1.size).must_equal 1
 
     rand_col.list_documents.map(&:delete)
-    rand_col.list_documents.must_be :empty?
+    _(rand_col.list_documents).must_be :empty?
   end
 end

--- a/google-cloud-firestore/acceptance/firestore/collection_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/collection_test.rb
@@ -50,7 +50,7 @@ describe "Collection", :firestore_acceptance do
     rand_col.add({bar: "foo"})
     docs = rand_col.list_documents
 
-    _(docs).must_be_kind_of Array
+    _(docs).must_be_kind_of Google::Cloud::Firestore::DocumentReference::List
     _(docs.size).must_be :>, 1
     _(docs.first).must_be_kind_of Google::Cloud::Firestore::DocumentReference
     _(docs.first.client).must_be_kind_of Google::Cloud::Firestore::Client

--- a/google-cloud-firestore/acceptance/firestore/document_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/document_test.rb
@@ -18,22 +18,22 @@ describe "Document", :firestore_acceptance do
   it "has properties" do
     doc_ref = firestore.doc "col/doc"
 
-    doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    doc_ref.document_id.must_equal "doc"
-    doc_ref.document_path.must_equal "col/doc"
+    _(doc_ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_ref.document_id).must_equal "doc"
+    _(doc_ref.document_path).must_equal "col/doc"
 
     col_ref = doc_ref.parent
-    col_ref.collection_id.must_equal "col"
-    col_ref.collection_path.must_equal "col"
+    _(col_ref.collection_id).must_equal "col"
+    _(col_ref.collection_path).must_equal "col"
   end
 
   it "has collection method" do
     doc_ref = firestore.doc "col/doc"
 
     sub_col = doc_ref.col "subcol"
-    sub_col.collection_id.must_equal "subcol"
-    sub_col.collection_path.must_equal "col/doc/subcol"
-    sub_col.parent.document_path.must_equal doc_ref.document_path
+    _(sub_col.collection_id).must_equal "subcol"
+    _(sub_col.collection_path).must_equal "col/doc/subcol"
+    _(sub_col.parent.document_path).must_equal doc_ref.document_path
   end
 
   it "has create and get method" do
@@ -41,7 +41,7 @@ describe "Document", :firestore_acceptance do
 
     doc_ref.create foo: :a
     doc_snp = doc_ref.get
-    doc_snp[:foo].must_equal "a"
+    _(doc_snp[:foo]).must_equal "a"
   end
 
   it "has set method" do
@@ -69,26 +69,26 @@ describe "Document", :firestore_acceptance do
     doc_ref.set all_values
     doc_snp = doc_ref.get
 
-    doc_snp[:name].must_equal all_values[:name]
-    doc_snp[:active].must_equal all_values[:active]
-    doc_snp[:score].must_equal all_values[:score]
-    doc_snp[:large_score].must_equal all_values[:large_score]
-    doc_snp[:ratio].must_equal all_values[:ratio]
-    doc_snp[:infinity].must_equal all_values[:infinity]
-    doc_snp[:negative_infinity].must_equal all_values[:negative_infinity]
-    doc_snp[:nan].must_be :nan?
-    doc_snp[:object].must_equal all_values[:object]
-    doc_snp[:date].must_equal all_values[:date]
-    doc_snp[:linked].must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    doc_snp[:linked].document_path.must_equal all_values[:linked].document_path
-    doc_snp[:list].must_equal all_values[:list]
-    doc_snp[:empty_list].must_equal all_values[:empty_list]
-    doc_snp[:null].must_be :nil?
-    doc_snp[:location].must_equal all_values[:location]
-    doc_snp[:binary].must_be_kind_of StringIO
+    _(doc_snp[:name]).must_equal all_values[:name]
+    _(doc_snp[:active]).must_equal all_values[:active]
+    _(doc_snp[:score]).must_equal all_values[:score]
+    _(doc_snp[:large_score]).must_equal all_values[:large_score]
+    _(doc_snp[:ratio]).must_equal all_values[:ratio]
+    _(doc_snp[:infinity]).must_equal all_values[:infinity]
+    _(doc_snp[:negative_infinity]).must_equal all_values[:negative_infinity]
+    _(doc_snp[:nan]).must_be :nan?
+    _(doc_snp[:object]).must_equal all_values[:object]
+    _(doc_snp[:date]).must_equal all_values[:date]
+    _(doc_snp[:linked]).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_snp[:linked].document_path).must_equal all_values[:linked].document_path
+    _(doc_snp[:list]).must_equal all_values[:list]
+    _(doc_snp[:empty_list]).must_equal all_values[:empty_list]
+    _(doc_snp[:null]).must_be :nil?
+    _(doc_snp[:location]).must_equal all_values[:location]
+    _(doc_snp[:binary]).must_be_kind_of StringIO
     doc_snp[:binary].rewind
     all_values[:binary].rewind
-    doc_snp[:binary].read.must_equal all_values[:binary].read
+    _(doc_snp[:binary].read).must_equal all_values[:binary].read
   end
 
   it "supports server timestamps" do
@@ -107,8 +107,8 @@ describe "Document", :firestore_acceptance do
     doc_snp = doc_ref.get
 
     set_timestamp = doc_snp.get "d"
-    set_timestamp.wont_be :nil?
-    doc_snp.data.must_equal({
+    _(set_timestamp).wont_be :nil?
+    _(doc_snp.data).must_equal({
       a: "bar",
       b: { keep: "bar" },
       d: set_timestamp,
@@ -120,7 +120,7 @@ describe "Document", :firestore_acceptance do
     doc_snp = doc_ref.get
 
     update_timestamp = doc_snp[:a]
-    update_timestamp.wont_be :nil?
+    _(update_timestamp).wont_be :nil?
     expected_data = {
       a: update_timestamp,
       b: { c: update_timestamp, keep: "bar" },
@@ -158,8 +158,8 @@ describe "Document", :firestore_acceptance do
 
     doc_snp = doc_ref.get
     timestamp = doc_snp.get :c
-    timestamp.wont_be :nil?
-    doc_snp.data.must_equal({
+    _(timestamp).wont_be :nil?
+    _(doc_snp.data).must_equal({
       a: "b",
       c: timestamp,
     })
@@ -172,7 +172,7 @@ describe "Document", :firestore_acceptance do
     doc_ref.update({ foo: "b" }, update_time: set_result.update_time)
 
     doc_snp = doc_ref.get
-    doc_snp.data.must_equal({
+    _(doc_snp.data).must_equal({
       foo: "b",
     })
   end
@@ -183,21 +183,21 @@ describe "Document", :firestore_acceptance do
     doc_ref.set({ list: [1, 2, 3] })
 
     doc_snp = doc_ref.get
-    doc_snp.data.must_equal({
+    _(doc_snp.data).must_equal({
       list: [1, 2, 3],
     })
 
     doc_ref.update({ list: firestore.field_array_union(42) })
 
     doc_snp = doc_ref.get
-    doc_snp.data.must_equal({
+    _(doc_snp.data).must_equal({
       list: [1, 2, 3, 42],
     })
 
     doc_ref.update({ list: firestore.field_array_delete(42) })
 
     doc_snp = doc_ref.get
-    doc_snp.data.must_equal({
+    _(doc_snp.data).must_equal({
       list: [1, 2, 3],
     })
   end
@@ -216,24 +216,24 @@ describe "Document", :firestore_acceptance do
     doc_ref.set({ foo: "a" })
 
     doc_snp = doc_ref.get
-    doc_snp.must_be :exists?
+    _(doc_snp).must_be :exists?
 
     doc_ref.delete
 
     doc_snp = doc_ref.get
-    doc_snp.wont_be :exists?
+    _(doc_snp).wont_be :exists?
   end
 
   it "can delete a non-existing document" do
     doc_ref = root_col.doc
 
     doc_snp = doc_ref.get
-    doc_snp.wont_be :exists?
+    _(doc_snp).wont_be :exists?
 
     doc_ref.delete
 
     doc_snp = doc_ref.get
-    doc_snp.wont_be :exists?
+    _(doc_snp).wont_be :exists?
   end
 
   it "supports non-alphanumeric field names" do
@@ -256,73 +256,73 @@ describe "Document", :firestore_acceptance do
     end
 
     sub_cols = collections_doc_ref.cols
-    sub_cols.to_a.count.must_equal collections.count
-    sub_cols.map(&:collection_id).sort.must_equal collections.sort
+    _(sub_cols.to_a.count).must_equal collections.count
+    _(sub_cols.map(&:collection_id).sort).must_equal collections.sort
   end
 
   it "can add and delete fields sequentially" do
     doc_ref = root_col.doc
 
     doc_ref.create({})
-    doc_ref.get.data.must_equal({})
+    _(doc_ref.get.data).must_equal({})
 
     doc_ref.delete
-    doc_ref.get.wont_be :exists?
+    _(doc_ref.get).wont_be :exists?
 
     doc_ref.create({ a: { b: "c" } })
-    doc_ref.get.data.must_equal({ a: { b: "c" } })
+    _(doc_ref.get.data).must_equal({ a: { b: "c" } })
 
     doc_ref.set({})
-    doc_ref.get.data.must_equal({})
+    _(doc_ref.get.data).must_equal({})
 
     doc_ref.set({ a: { b: "c" } })
-    doc_ref.get.data.must_equal({ a: { b: "c" } })
+    _(doc_ref.get.data).must_equal({ a: { b: "c" } })
 
     doc_ref.set({ a: { d: "e" } }, merge: true)
-    doc_ref.get.data.must_equal({ a: { b: "c", d: "e" } })
+    _(doc_ref.get.data).must_equal({ a: { b: "c", d: "e" } })
 
     # INFO: the original test used nested deletes, but that is not allowed...
     # doc_ref.update({ a: { d: firestore.field_delete } })
     doc_ref.update({ "a.d" => firestore.field_delete })
-    doc_ref.get.data.must_equal({ a: { b: "c" } })
+    _(doc_ref.get.data).must_equal({ a: { b: "c" } })
 
     # INFO: the original test used nested deletes, but that is not allowed...
     # doc_ref.update({ a: { b: firestore.field_delete } })
     doc_ref.update({ "a.b" => firestore.field_delete })
-    doc_ref.get.data.must_equal({ a: {} })
+    _(doc_ref.get.data).must_equal({ a: {} })
 
     doc_ref.update({ a: { e: "foo" } })
-    doc_ref.get.data.must_equal({ a: { e: "foo" } })
+    _(doc_ref.get.data).must_equal({ a: { e: "foo" } })
 
     doc_ref.update({ f: "foo" })
-    doc_ref.get.data.must_equal({ a: { e: "foo" }, f: "foo" })
+    _(doc_ref.get.data).must_equal({ a: { e: "foo" }, f: "foo" })
 
     doc_ref.update({ f: { g: "foo" } })
-    doc_ref.get.data.must_equal({ a: { e: "foo" }, f: { g: "foo" } })
+    _(doc_ref.get.data).must_equal({ a: { e: "foo" }, f: { g: "foo" } })
 
     doc_ref.update({ "f.h" => "foo" })
-    doc_ref.get.data.must_equal({ a: { e: "foo" }, f: { g: "foo", h: "foo" } })
+    _(doc_ref.get.data).must_equal({ a: { e: "foo" }, f: { g: "foo", h: "foo" } })
 
     doc_ref.update({ "f.g" => firestore.field_delete })
-    doc_ref.get.data.must_equal({ a: { e: "foo" }, f: { h: "foo" } })
+    _(doc_ref.get.data).must_equal({ a: { e: "foo" }, f: { h: "foo" } })
 
     doc_ref.update({ "f.h" => firestore.field_delete })
-    doc_ref.get.data.must_equal({ a: { e: "foo" }, f: {} })
+    _(doc_ref.get.data).must_equal({ a: { e: "foo" }, f: {} })
 
     doc_ref.update({ "f" => firestore.field_delete })
-    doc_ref.get.data.must_equal({ a: { e: "foo" } })
+    _(doc_ref.get.data).must_equal({ a: { e: "foo" } })
 
     doc_ref.update({ "i.j" => { k: "foo" } })
-    doc_ref.get.data.must_equal({ a: { e: "foo" }, i: { j: { k: "foo" } } })
+    _(doc_ref.get.data).must_equal({ a: { e: "foo" }, i: { j: { k: "foo" } } })
 
     doc_ref.update({ "i.j.l" => {} })
-    doc_ref.get.data.must_equal({ a: { e: "foo" }, i: { j: { k: "foo", l: {} } } })
+    _(doc_ref.get.data).must_equal({ a: { e: "foo" }, i: { j: { k: "foo", l: {} } } })
 
     doc_ref.update({ i: firestore.field_delete })
-    doc_ref.get.data.must_equal({ a: { e: "foo" } })
+    _(doc_ref.get.data).must_equal({ a: { e: "foo" } })
 
     doc_ref.update({ a: firestore.field_delete })
-    doc_ref.get.data.must_equal({})
+    _(doc_ref.get.data).must_equal({})
   end
 
   it "can add and delete fields with server timestamps" do
@@ -331,67 +331,67 @@ describe "Document", :firestore_acceptance do
 
     doc_ref.create({ time: firestore.field_server_time, a: { b: firestore.field_server_time } })
     doc_snp = doc_ref.get
-    doc_snp[:time].must_be_kind_of Time
+    _(doc_snp[:time]).must_be_kind_of Time
     times << doc_snp[:time]
-    doc_snp[:a][:b].must_equal times[0]
-    doc_snp.get(:time).must_equal times[0]
-    doc_snp.get("a.b".to_sym).must_equal times[0]
-    doc_snp.get("time").must_equal times[0]
-    doc_snp.get("a.b").must_equal times[0]
+    _(doc_snp[:a][:b]).must_equal times[0]
+    _(doc_snp.get(:time)).must_equal times[0]
+    _(doc_snp.get("a.b".to_sym)).must_equal times[0]
+    _(doc_snp.get("time")).must_equal times[0]
+    _(doc_snp.get("a.b")).must_equal times[0]
 
     doc_ref.set({ time: firestore.field_server_time, a: { c: firestore.field_server_time } })
     doc_snp = doc_ref.get
-    doc_snp[:time].must_be_kind_of Time
+    _(doc_snp[:time]).must_be_kind_of Time
     times << doc_snp[:time]
-    doc_snp[:a][:b].must_be :nil?
-    doc_snp[:a][:c].must_equal times[1]
+    _(doc_snp[:a][:b]).must_be :nil?
+    _(doc_snp[:a][:c]).must_equal times[1]
 
     doc_ref.set({ time: firestore.field_server_time, a: { d: firestore.field_server_time } }, merge: true)
     doc_snp = doc_ref.get
-    doc_snp[:time].must_be_kind_of Time
+    _(doc_snp[:time]).must_be_kind_of Time
     times << doc_snp[:time]
-    doc_snp[:a][:b].must_be :nil?
-    doc_snp[:a][:c].must_equal times[1]
-    doc_snp[:a][:d].must_equal times[2]
+    _(doc_snp[:a][:b]).must_be :nil?
+    _(doc_snp[:a][:c]).must_equal times[1]
+    _(doc_snp[:a][:d]).must_equal times[2]
 
     doc_ref.set({ time: firestore.field_server_time, e: firestore.field_server_time }, merge: true)
     doc_snp = doc_ref.get
-    doc_snp[:time].must_be_kind_of Time
+    _(doc_snp[:time]).must_be_kind_of Time
     times << doc_snp[:time]
-    doc_snp[:a][:b].must_be :nil?
-    doc_snp[:a][:c].must_equal times[1]
-    doc_snp[:a][:d].must_equal times[2]
-    doc_snp[:e].must_equal times[3]
+    _(doc_snp[:a][:b]).must_be :nil?
+    _(doc_snp[:a][:c]).must_equal times[1]
+    _(doc_snp[:a][:d]).must_equal times[2]
+    _(doc_snp[:e]).must_equal times[3]
 
     doc_ref.set({ time: firestore.field_server_time, e: { f: firestore.field_server_time } }, merge: true)
     doc_snp = doc_ref.get
-    doc_snp[:time].must_be_kind_of Time
+    _(doc_snp[:time]).must_be_kind_of Time
     times << doc_snp[:time]
-    doc_snp[:a][:b].must_be :nil?
-    doc_snp[:a][:c].must_equal times[1]
-    doc_snp[:a][:d].must_equal times[2]
-    doc_snp[:e][:f].must_equal times[4]
+    _(doc_snp[:a][:b]).must_be :nil?
+    _(doc_snp[:a][:c]).must_equal times[1]
+    _(doc_snp[:a][:d]).must_equal times[2]
+    _(doc_snp[:e][:f]).must_equal times[4]
 
     doc_ref.update({ time: firestore.field_server_time, "g.h" => firestore.field_server_time })
     doc_snp = doc_ref.get
-    doc_snp[:time].must_be_kind_of Time
+    _(doc_snp[:time]).must_be_kind_of Time
     times << doc_snp[:time]
-    doc_snp[:a][:b].must_be :nil?
-    doc_snp[:a][:c].must_equal times[1]
-    doc_snp[:a][:d].must_equal times[2]
-    doc_snp[:e][:f].must_equal times[4]
-    doc_snp[:g][:h].must_equal times[5]
+    _(doc_snp[:a][:b]).must_be :nil?
+    _(doc_snp[:a][:c]).must_equal times[1]
+    _(doc_snp[:a][:d]).must_equal times[2]
+    _(doc_snp[:e][:f]).must_equal times[4]
+    _(doc_snp[:g][:h]).must_equal times[5]
 
     doc_ref.update({ time: firestore.field_server_time, "g.j.k" => firestore.field_server_time })
     doc_snp = doc_ref.get
-    doc_snp[:time].must_be_kind_of Time
+    _(doc_snp[:time]).must_be_kind_of Time
     times << doc_snp[:time]
-    doc_snp[:a][:b].must_be :nil?
-    doc_snp[:a][:c].must_equal times[1]
-    doc_snp[:a][:d].must_equal times[2]
-    doc_snp[:e][:f].must_equal times[4]
-    doc_snp[:g][:h].must_equal times[5]
-    doc_snp[:g][:j][:k].must_equal times[6]
+    _(doc_snp[:a][:b]).must_be :nil?
+    _(doc_snp[:a][:c]).must_equal times[1]
+    _(doc_snp[:a][:d]).must_equal times[2]
+    _(doc_snp[:e][:f]).must_equal times[4]
+    _(doc_snp[:g][:h]).must_equal times[5]
+    _(doc_snp[:g][:j][:k]).must_equal times[6]
   end
 
   it "can update numeric fields with transforms" do
@@ -399,56 +399,56 @@ describe "Document", :firestore_acceptance do
 
     doc_ref.create({ num: 1, a: { b: 1 } })
     doc_snp = doc_ref.get
-    doc_snp[:a][:b].must_equal 1
-    doc_snp.get(:num).must_equal 1
-    doc_snp.get("a.b".to_sym).must_equal 1
-    doc_snp.get("num").must_equal 1
-    doc_snp.get("a.b").must_equal 1
+    _(doc_snp[:a][:b]).must_equal 1
+    _(doc_snp.get(:num)).must_equal 1
+    _(doc_snp.get("a.b".to_sym)).must_equal 1
+    _(doc_snp.get("num")).must_equal 1
+    _(doc_snp.get("a.b")).must_equal 1
 
     doc_ref.set({ num: firestore.field_increment(50), a: { c: firestore.field_maximum(100) } })
     doc_snp = doc_ref.get
-    doc_snp[:num].must_equal 50
-    doc_snp[:a][:b].must_be :nil?
-    doc_snp[:a][:c].must_equal 100
+    _(doc_snp[:num]).must_equal 50
+    _(doc_snp[:a][:b]).must_be :nil?
+    _(doc_snp[:a][:c]).must_equal 100
 
     doc_ref.set({ num: firestore.field_increment(1), a: { d: firestore.field_minimum(-100) } }, merge: true)
     doc_snp = doc_ref.get
-    doc_snp[:num].must_equal 51
-    doc_snp[:a][:b].must_be :nil?
-    doc_snp[:a][:c].must_equal 100
-    doc_snp[:a][:d].must_equal -100
+    _(doc_snp[:num]).must_equal 51
+    _(doc_snp[:a][:b]).must_be :nil?
+    _(doc_snp[:a][:c]).must_equal 100
+    _(doc_snp[:a][:d]).must_equal -100
 
     doc_ref.set({ num: firestore.field_minimum(100), e: firestore.field_minimum(100) }, merge: true)
     doc_snp = doc_ref.get
-    doc_snp[:num].must_equal 51
-    doc_snp[:a][:b].must_be :nil?
-    doc_snp[:a][:c].must_equal 100
-    doc_snp[:a][:d].must_equal -100
-    doc_snp[:e].must_equal 100
+    _(doc_snp[:num]).must_equal 51
+    _(doc_snp[:a][:b]).must_be :nil?
+    _(doc_snp[:a][:c]).must_equal 100
+    _(doc_snp[:a][:d]).must_equal -100
+    _(doc_snp[:e]).must_equal 100
 
     doc_ref.set({ num: firestore.field_maximum(-100), e: { f: firestore.field_maximum(100) } }, merge: true)
     doc_snp = doc_ref.get
-    doc_snp[:num].must_equal 51
-    doc_snp[:a][:b].must_be :nil?
-    doc_snp[:a][:c].must_equal 100
-    doc_snp[:a][:d].must_equal -100
-    doc_snp[:e][:f].must_equal 100
+    _(doc_snp[:num]).must_equal 51
+    _(doc_snp[:a][:b]).must_be :nil?
+    _(doc_snp[:a][:c]).must_equal 100
+    _(doc_snp[:a][:d]).must_equal -100
+    _(doc_snp[:e][:f]).must_equal 100
 
     doc_ref.update({ num: firestore.field_minimum(-100), e: { f: firestore.field_maximum(1000) } })
     doc_snp = doc_ref.get
-    doc_snp[:num].must_equal -100
-    doc_snp[:a][:b].must_be :nil?
-    doc_snp[:a][:c].must_equal 100
-    doc_snp[:a][:d].must_equal -100
-    doc_snp[:e][:f].must_equal 1000
+    _(doc_snp[:num]).must_equal -100
+    _(doc_snp[:a][:b]).must_be :nil?
+    _(doc_snp[:a][:c]).must_equal 100
+    _(doc_snp[:a][:d]).must_equal -100
+    _(doc_snp[:e][:f]).must_equal 1000
 
     doc_ref.update({ num: firestore.field_maximum(100), e: { f: firestore.field_minimum(10) } })
     doc_snp = doc_ref.get
-    doc_snp[:num].must_equal 100
-    doc_snp[:a][:b].must_be :nil?
-    doc_snp[:a][:c].must_equal 100
-    doc_snp[:a][:d].must_equal -100
-    doc_snp[:e][:f].must_equal 10
+    _(doc_snp[:num]).must_equal 100
+    _(doc_snp[:a][:b]).must_be :nil?
+    _(doc_snp[:a][:c]).must_equal 100
+    _(doc_snp[:a][:d]).must_equal -100
+    _(doc_snp[:e][:f]).must_equal 10
   end
 
   def assert_equal_unordered a, b, msg = nil

--- a/google-cloud-firestore/acceptance/firestore/firestore_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/firestore_test.rb
@@ -19,29 +19,29 @@ describe "Firestore", :firestore_acceptance do
     root_col.add # call to ensure that the collection exists
 
     col_paths = firestore.collections.map do |col|
-      col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
 
       col.collection_path
     end
 
-    col_paths.wont_be :empty?
-    col_paths.must_include root_path
+    _(col_paths).wont_be :empty?
+    _(col_paths).must_include root_path
   end
 
   it "has collection method" do
     col_ref = firestore.col "col"
 
-    col_ref.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    col_ref.collection_id.must_equal "col"
-    col_ref.collection_path.must_equal "col"
+    _(col_ref).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(col_ref.collection_id).must_equal "col"
+    _(col_ref.collection_path).must_equal "col"
   end
 
   it "has doc method" do
     doc_ref = firestore.doc "col/doc"
 
-    doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    doc_ref.document_id.must_equal "doc"
-    doc_ref.document_path.must_equal "col/doc"
+    _(doc_ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_ref.document_id).must_equal "doc"
+    _(doc_ref.document_path).must_equal "col/doc"
   end
 
   it "has get_all method" do
@@ -54,7 +54,7 @@ describe "Firestore", :firestore_acceptance do
     doc2.create foo: :b
 
     docs = firestore.get_all doc1, doc2
-    docs.to_a.count.must_equal 2
+    _(docs.to_a.count).must_equal 2
   end
 
   it "has get_all method with field_mask argument" do
@@ -67,6 +67,6 @@ describe "Firestore", :firestore_acceptance do
     doc2.create foo: :b
 
     docs = firestore.get_all doc1, doc2, field_mask: :foo
-    docs.to_a.count.must_equal 2
+    _(docs.to_a.count).must_equal 2
   end
 end

--- a/google-cloud-firestore/acceptance/firestore/query_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/query_test.rb
@@ -20,7 +20,7 @@ describe "Query", :firestore_acceptance do
     rand_query_col.add({foo: "bar", bar: "foo"})
 
     result_snp = rand_query_col.select("foo").get.first
-    result_snp[:foo].must_equal "bar"
+    _(result_snp[:foo]).must_equal "bar"
   end
 
   it "select() supports empty fields" do
@@ -28,7 +28,7 @@ describe "Query", :firestore_acceptance do
     rand_query_col.add({foo: "bar", bar: "foo"})
 
     result_snp = rand_query_col.select.get.first
-    result_snp.data.must_be :empty?
+    _(result_snp.data).must_be :empty?
   end
 
   it "has where method" do
@@ -36,7 +36,7 @@ describe "Query", :firestore_acceptance do
     rand_query_col.add({foo: "bar", bar: "foo"})
 
     result_snp = rand_query_col.where(:foo, :==, :bar).get.first
-    result_snp[:foo].must_equal "bar"
+    _(result_snp[:foo]).must_equal "bar"
   end
 
   it "has where method with array_contains" do
@@ -44,7 +44,7 @@ describe "Query", :firestore_acceptance do
     rand_query_col.add({foo: ["bar", "baz", "bif"]})
 
     result_snp = rand_query_col.where(:foo, :array_contains, :bif).get.first
-    result_snp[:foo].must_equal ["bar", "baz", "bif"]
+    _(result_snp[:foo]).must_equal ["bar", "baz", "bif"]
   end
 
   it "has where method with in" do
@@ -52,7 +52,7 @@ describe "Query", :firestore_acceptance do
     rand_query_col.add({foo: "bar"})
 
     result_snp = rand_query_col.where(:foo, :in, ["bar", "baz", "bif"]).get.first
-    result_snp[:foo].must_equal "bar"
+    _(result_snp[:foo]).must_equal "bar"
   end
 
   it "has where method with array_contains_any" do
@@ -60,7 +60,7 @@ describe "Query", :firestore_acceptance do
     rand_query_col.add({foo: ["bar", "baz", "bif"]})
 
     result_snp = rand_query_col.where(:foo, :array_contains_any, [:bif, :out]).get.first
-    result_snp[:foo].must_equal ["bar", "baz", "bif"]
+    _(result_snp[:foo]).must_equal ["bar", "baz", "bif"]
   end
 
   it "supports NaN" do
@@ -68,8 +68,8 @@ describe "Query", :firestore_acceptance do
     doc_ref = rand_query_col.add({foo: Float::NAN})
 
     result_snp = rand_query_col.where(:foo, :==, Float::NAN).get.first
-    result_snp.wont_be :nil?
-    result_snp[:foo].must_be :nan?
+    _(result_snp).wont_be :nil?
+    _(result_snp[:foo]).must_be :nan?
   end
 
   it "supports NaN (symbol)" do
@@ -77,8 +77,8 @@ describe "Query", :firestore_acceptance do
     doc_ref = rand_query_col.add({foo: Float::NAN})
 
     result_snp = rand_query_col.where(:foo, :==, :nan).get.first
-    result_snp.wont_be :nil?
-    result_snp[:foo].must_be :nan?
+    _(result_snp).wont_be :nil?
+    _(result_snp[:foo]).must_be :nan?
   end
 
   it "supports NULL" do
@@ -86,8 +86,8 @@ describe "Query", :firestore_acceptance do
     doc_ref = rand_query_col.add({foo: nil})
 
     result_snp = rand_query_col.where(:foo, :==, nil).get.first
-    result_snp.wont_be :nil?
-    result_snp[:foo].must_be :nil?
+    _(result_snp).wont_be :nil?
+    _(result_snp[:foo]).must_be :nil?
   end
 
   it "supports NULL (symbol)" do
@@ -95,8 +95,8 @@ describe "Query", :firestore_acceptance do
     doc_ref = rand_query_col.add({foo: nil})
 
     result_snp = rand_query_col.where(:foo, :==, :null).get.first
-    result_snp.wont_be :nil?
-    result_snp[:foo].must_be :nil?
+    _(result_snp).wont_be :nil?
+    _(result_snp[:foo]).must_be :nil?
   end
 
   it "has order method" do
@@ -105,10 +105,10 @@ describe "Query", :firestore_acceptance do
     rand_query_col.add({foo: "b"})
 
     results = rand_query_col.order(:foo).get.map { |doc| doc[:foo] }
-    results.must_equal ["a", "b"]
+    _(results).must_equal ["a", "b"]
 
     results = rand_query_col.order(:foo, :desc).get.map { |doc| doc[:foo] }
-    results.must_equal ["b", "a"]
+    _(results).must_equal ["b", "a"]
   end
 
   it "can order by document id" do
@@ -117,8 +117,8 @@ describe "Query", :firestore_acceptance do
     rand_query_col.doc("doc2").create({foo: "b"})
 
     results = rand_query_col.order(firestore.document_id).get
-    results.map(&:document_id).must_equal ["doc1", "doc2"]
-    results.map { |doc| doc[:foo] }.must_equal ["a", "b"]
+    _(results.map(&:document_id)).must_equal ["doc1", "doc2"]
+    _(results.map { |doc| doc[:foo] }).must_equal ["a", "b"]
 
     # results = rand_query_col.order(firestore.document_id, :desc).get
     # results.map(&:document_id).must_equal ["doc2", "doc1"]
@@ -131,8 +131,8 @@ describe "Query", :firestore_acceptance do
     rand_query_col.doc("doc2").create({foo: "b"})
 
     results = rand_query_col.order(:foo).limit(1).get
-    results.map(&:document_id).must_equal ["doc1"]
-    results.map { |doc| doc[:foo] }.must_equal ["a"]
+    _(results.map(&:document_id)).must_equal ["doc1"]
+    _(results.map { |doc| doc[:foo] }).must_equal ["a"]
   end
 
   it "has offset method" do
@@ -141,8 +141,8 @@ describe "Query", :firestore_acceptance do
     rand_query_col.doc("doc2").create({foo: "b"})
 
     results = rand_query_col.order(:foo).offset(1).get
-    results.map(&:document_id).must_equal ["doc2"]
-    results.map { |doc| doc[:foo] }.must_equal ["b"]
+    _(results.map(&:document_id)).must_equal ["doc2"]
+    _(results.map { |doc| doc[:foo] }).must_equal ["b"]
   end
 
   it "has start_at method" do
@@ -151,8 +151,8 @@ describe "Query", :firestore_acceptance do
     rand_query_col.doc("doc2").create({foo: "b"})
 
     results = rand_query_col.order(:foo).start_at("a").get
-    results.map(&:document_id).must_equal ["doc1", "doc2"]
-    results.map { |doc| doc[:foo] }.must_equal ["a", "b"]
+    _(results.map(&:document_id)).must_equal ["doc1", "doc2"]
+    _(results.map { |doc| doc[:foo] }).must_equal ["a", "b"]
   end
 
   it "has start_after method" do
@@ -161,8 +161,8 @@ describe "Query", :firestore_acceptance do
     rand_query_col.doc("doc2").create({foo: "b"})
 
     results = rand_query_col.order(:foo).start_after("a").get
-    results.map(&:document_id).must_equal ["doc2"]
-    results.map { |doc| doc[:foo] }.must_equal ["b"]
+    _(results.map(&:document_id)).must_equal ["doc2"]
+    _(results.map { |doc| doc[:foo] }).must_equal ["b"]
   end
 
   it "has end_before method" do
@@ -171,8 +171,8 @@ describe "Query", :firestore_acceptance do
     rand_query_col.doc("doc2").create({foo: "b"})
 
     results = rand_query_col.order(:foo).end_before("b").get
-    results.map(&:document_id).must_equal ["doc1"]
-    results.map { |doc| doc[:foo] }.must_equal ["a"]
+    _(results.map(&:document_id)).must_equal ["doc1"]
+    _(results.map { |doc| doc[:foo] }).must_equal ["a"]
   end
 
   it "has end_at method" do
@@ -181,8 +181,8 @@ describe "Query", :firestore_acceptance do
     rand_query_col.doc("doc2").create({foo: "b"})
 
     results = rand_query_col.order(:foo).end_at("b").get
-    results.map(&:document_id).must_equal ["doc1", "doc2"]
-    results.map { |doc| doc[:foo] }.must_equal ["a", "b"]
+    _(results.map(&:document_id)).must_equal ["doc1", "doc2"]
+    _(results.map { |doc| doc[:foo] }).must_equal ["a", "b"]
   end
 
   it "can call cursor methods with a DocumentSnapshot object" do
@@ -191,20 +191,20 @@ describe "Query", :firestore_acceptance do
     rand_query_col.doc("doc2").create({foo: "b"})
 
     results = rand_query_col.order(:foo).start_at(rand_query_col.doc("doc1").get).get
-    results.map(&:document_id).must_equal ["doc1", "doc2"]
-    results.map { |doc| doc[:foo] }.must_equal ["a", "b"]
+    _(results.map(&:document_id)).must_equal ["doc1", "doc2"]
+    _(results.map { |doc| doc[:foo] }).must_equal ["a", "b"]
 
     results = rand_query_col.order(:foo).start_after(rand_query_col.doc("doc1").get).get
-    results.map(&:document_id).must_equal ["doc2"]
-    results.map { |doc| doc[:foo] }.must_equal ["b"]
+    _(results.map(&:document_id)).must_equal ["doc2"]
+    _(results.map { |doc| doc[:foo] }).must_equal ["b"]
 
     results = rand_query_col.order(:foo).end_before(rand_query_col.doc("doc2").get).get
-    results.map(&:document_id).must_equal ["doc1"]
-    results.map { |doc| doc[:foo] }.must_equal ["a"]
+    _(results.map(&:document_id)).must_equal ["doc1"]
+    _(results.map { |doc| doc[:foo] }).must_equal ["a"]
 
     results = rand_query_col.order(:foo).end_at(rand_query_col.doc("doc2").get).get
-    results.map(&:document_id).must_equal ["doc1", "doc2"]
-    results.map { |doc| doc[:foo] }.must_equal ["a", "b"]
+    _(results.map(&:document_id)).must_equal ["doc1", "doc2"]
+    _(results.map { |doc| doc[:foo] }).must_equal ["a", "b"]
   end
 
   describe "Collection Group" do
@@ -232,7 +232,7 @@ describe "Query", :firestore_acceptance do
 
       query = firestore.collection_group collection_group
       snapshots = query.get
-      snapshots.map(&:document_id).must_equal ["cg-doc1", "cg-doc2", "cg-doc3", "cg-doc4", "cg-doc5"]
+      _(snapshots.map(&:document_id)).must_equal ["cg-doc1", "cg-doc2", "cg-doc3", "cg-doc4", "cg-doc5"]
     end
 
     it "queries a collection group with start_at and end_at" do
@@ -259,14 +259,14 @@ describe "Query", :firestore_acceptance do
         .end_at(firestore.document("a/b0"))
 
       snapshots = query.get
-      snapshots.map(&:document_id).must_equal ["cg-doc2", "cg-doc3", "cg-doc4"]
+      _(snapshots.map(&:document_id)).must_equal ["cg-doc2", "cg-doc3", "cg-doc4"]
 
       query = firestore.collection_group(collection_group)
         .order_by("__name__")
         .start_after(firestore.document("a/b"))
         .end_before(firestore.document("a/b/#{collection_group}/cg-doc3"))
       snapshots = query.get
-      snapshots.map(&:document_id).must_equal ["cg-doc2"]
+      _(snapshots.map(&:document_id)).must_equal ["cg-doc2"]
     end
 
     it "queries a collection group with filters" do
@@ -292,7 +292,7 @@ describe "Query", :firestore_acceptance do
         .where("__name__", "<=", firestore.document("a/b0"))
 
       snapshots = query.get
-      snapshots.map(&:document_id).must_equal ["cg-doc2", "cg-doc3", "cg-doc4"]
+      _(snapshots.map(&:document_id)).must_equal ["cg-doc2", "cg-doc3", "cg-doc4"]
 
       query = firestore.collection_group(collection_group)
         .where("__name__", ">", firestore.document("a/b"))
@@ -300,7 +300,7 @@ describe "Query", :firestore_acceptance do
           "__name__", "<", firestore.document("a/b/#{collection_group}/cg-doc3")
         )
       snapshots = query.get
-      snapshots.map(&:document_id).must_equal ["cg-doc2"]
+      _(snapshots.map(&:document_id)).must_equal ["cg-doc2"]
     end
   end
 end

--- a/google-cloud-firestore/acceptance/firestore/transaction_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/transaction_test.rb
@@ -22,7 +22,7 @@ describe "Transaction", :firestore_acceptance do
     doc_snp = firestore.transaction do |tx|
       tx.get doc_ref
     end
-    doc_snp.wont_be :exists?
+    _(doc_snp).wont_be :exists?
   end
 
   it "returns CommitResponse when commit_response option is true" do
@@ -31,11 +31,11 @@ describe "Transaction", :firestore_acceptance do
 
     resp = firestore.transaction commit_response: true do |tx|
       doc_snp = tx.get doc_ref
-      doc_snp.wont_be :exists?
+      _(doc_snp).wont_be :exists?
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_be_kind_of Time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_be_kind_of Time
   end
 
   it "has get with query" do
@@ -48,8 +48,8 @@ describe "Transaction", :firestore_acceptance do
     results = firestore.transaction do |tx|
       tx.get(query).to_a # all results must be retrieved inside tx
     end
-    results.map(&:document_id).must_equal ["doc1", "doc2"]
-    results.map { |doc| doc[:foo] }.must_equal ["a", "b"]
+    _(results.map(&:document_id)).must_equal ["doc1", "doc2"]
+    _(results.map { |doc| doc[:foo] }).must_equal ["a", "b"]
   end
 
   it "has set method" do
@@ -60,8 +60,8 @@ describe "Transaction", :firestore_acceptance do
       tx.set doc_ref, foo: "bar"
     end
 
-    resp.must_be :nil?
-    doc_ref.get[:foo].must_equal "bar"
+    _(resp).must_be :nil?
+    _(doc_ref.get[:foo]).must_equal "bar"
   end
 
   it "has update method" do
@@ -73,14 +73,14 @@ describe "Transaction", :firestore_acceptance do
       tx.update doc_ref, foo: "baz"
     end
 
-    resp.must_be :nil?
-    doc_ref.get[:foo].must_equal "baz"
+    _(resp).must_be :nil?
+    _(doc_ref.get[:foo]).must_equal "baz"
   end
 
   it "update enforces document exists" do
     rand_tx_col = firestore.col "#{root_path}/tx/#{SecureRandom.hex(4)}"
     doc_ref = rand_tx_col.doc
-    doc_ref.get.wont_be :exists?
+    _(doc_ref.get).wont_be :exists?
 
     expect do
       firestore.transaction do |tx|
@@ -98,7 +98,7 @@ describe "Transaction", :firestore_acceptance do
       tx.delete doc_ref
     end
 
-    resp.must_be :nil?
-    doc_ref.get.wont_be :exists?
+    _(resp).must_be :nil?
+    _(doc_ref.get).wont_be :exists?
   end
 end

--- a/google-cloud-firestore/acceptance/firestore/watch_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/watch_test.rb
@@ -52,32 +52,32 @@ describe "Watch", :firestore_acceptance do
 
     listener.stop
 
-    query_snapshots.count.must_equal 4
-    query_snapshots.each { |qs| qs.must_be_kind_of Google::Cloud::Firestore::QuerySnapshot }
+    _(query_snapshots.count).must_equal 4
+    query_snapshots.each { |qs| _(qs).must_be_kind_of Google::Cloud::Firestore::QuerySnapshot }
 
-    query_snapshots[0].count.must_equal 12
-    query_snapshots[0].changes.count.must_equal 12
-    query_snapshots[0].docs.map(&:document_id).must_equal ["hash", "array", "geo", "ref", "io", "str", "time", "num", "int", "true", "false", "nil"]
-    query_snapshots[0].changes.each { |change| change.must_be :added? }
-    query_snapshots[0].changes.map(&:doc).map(&:document_id).must_equal ["hash", "array", "geo", "ref", "io", "str", "time", "num", "int", "true", "false", "nil"]
+    _(query_snapshots[0].count).must_equal 12
+    _(query_snapshots[0].changes.count).must_equal 12
+    _(query_snapshots[0].docs.map(&:document_id)).must_equal ["hash", "array", "geo", "ref", "io", "str", "time", "num", "int", "true", "false", "nil"]
+    query_snapshots[0].changes.each { |change| _(change).must_be :added? }
+    _(query_snapshots[0].changes.map(&:doc).map(&:document_id)).must_equal ["hash", "array", "geo", "ref", "io", "str", "time", "num", "int", "true", "false", "nil"]
 
-    query_snapshots[1].count.must_equal 13
-    query_snapshots[1].changes.count.must_equal 1
-    query_snapshots[1].docs.map(&:document_id).must_equal ["hash", "array", "geo", "ref", "io", "str", "time", "num", "int", "true", "false", "added", "nil"]
-    query_snapshots[1].changes.each { |change| change.must_be :added? }
-    query_snapshots[1].changes.map(&:doc).map(&:document_id).must_equal ["added"]
+    _(query_snapshots[1].count).must_equal 13
+    _(query_snapshots[1].changes.count).must_equal 1
+    _(query_snapshots[1].docs.map(&:document_id)).must_equal ["hash", "array", "geo", "ref", "io", "str", "time", "num", "int", "true", "false", "added", "nil"]
+    query_snapshots[1].changes.each { |change| _(change).must_be :added? }
+    _(query_snapshots[1].changes.map(&:doc).map(&:document_id)).must_equal ["added"]
 
-    query_snapshots[2].count.must_equal 12
-    query_snapshots[2].changes.count.must_equal 1
-    query_snapshots[2].docs.map(&:document_id).must_equal ["hash", "geo", "ref", "io", "str", "time", "num", "int", "true", "false", "added", "nil"]
-    query_snapshots[2].changes.each { |change| change.must_be :removed? }
-    query_snapshots[2].changes.map(&:doc).map(&:document_id).must_equal ["array"]
+    _(query_snapshots[2].count).must_equal 12
+    _(query_snapshots[2].changes.count).must_equal 1
+    _(query_snapshots[2].docs.map(&:document_id)).must_equal ["hash", "geo", "ref", "io", "str", "time", "num", "int", "true", "false", "added", "nil"]
+    query_snapshots[2].changes.each { |change| _(change).must_be :removed? }
+    _(query_snapshots[2].changes.map(&:doc).map(&:document_id)).must_equal ["array"]
 
-    query_snapshots[3].count.must_equal 12
-    query_snapshots[3].changes.count.must_equal 1
-    query_snapshots[3].docs.map(&:document_id).must_equal ["hash", "geo", "ref", "io", "str", "time", "num", "int", "true", "added", "false", "nil"]
-    query_snapshots[3].changes.each { |change| change.must_be :modified? }
-    query_snapshots[3].changes.map(&:doc).map(&:document_id).must_equal ["added"]
+    _(query_snapshots[3].count).must_equal 12
+    _(query_snapshots[3].changes.count).must_equal 1
+    _(query_snapshots[3].docs.map(&:document_id)).must_equal ["hash", "geo", "ref", "io", "str", "time", "num", "int", "true", "added", "false", "nil"]
+    query_snapshots[3].changes.each { |change| _(change).must_be :modified? }
+    _(query_snapshots[3].changes.map(&:doc).map(&:document_id)).must_equal ["added"]
   end
 
   it "watches a document" do
@@ -106,23 +106,23 @@ describe "Watch", :firestore_acceptance do
 
     listener.stop
 
-    doc_snapshots.count.must_equal 4
-    doc_snapshots.each { |qs| qs.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot }
+    _(doc_snapshots.count).must_equal 4
+    doc_snapshots.each { |qs| _(qs).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot }
 
-    doc_snapshots[0].document_path.must_equal watch_col.doc("watch-doc").document_path
-    doc_snapshots[0].must_be :exists?
-    doc_snapshots[0][:val].must_equal true
+    _(doc_snapshots[0].document_path).must_equal watch_col.doc("watch-doc").document_path
+    _(doc_snapshots[0]).must_be :exists?
+    _(doc_snapshots[0][:val]).must_equal true
 
-    doc_snapshots[1].document_path.must_equal watch_col.doc("watch-doc").document_path
-    doc_snapshots[1].must_be :exists?
-    doc_snapshots[1][:val].must_equal false
+    _(doc_snapshots[1].document_path).must_equal watch_col.doc("watch-doc").document_path
+    _(doc_snapshots[1]).must_be :exists?
+    _(doc_snapshots[1][:val]).must_equal false
 
-    doc_snapshots[2].document_path.must_equal watch_col.doc("watch-doc").document_path
-    doc_snapshots[2].must_be :missing?
+    _(doc_snapshots[2].document_path).must_equal watch_col.doc("watch-doc").document_path
+    _(doc_snapshots[2]).must_be :missing?
 
-    doc_snapshots[3].document_path.must_equal watch_col.doc("watch-doc").document_path
-    doc_snapshots[3].must_be :exists?
-    doc_snapshots[3][:val].must_equal 1
+    _(doc_snapshots[3].document_path).must_equal watch_col.doc("watch-doc").document_path
+    _(doc_snapshots[3]).must_be :exists?
+    _(doc_snapshots[3][:val]).must_equal 1
   end
 
   def wait_until &block

--- a/google-cloud-firestore/google-cloud-firestore.gemspec
+++ b/google-cloud-firestore/google-cloud-firestore.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rbtree", "~> 0.4.2"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
-  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"

--- a/google-cloud-firestore/test/google/cloud/firestore/batch/closed_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/batch/closed_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Firestore::Batch, :closed, :mock_firestore do
       batch.create(document_path, { name: "Mike" })
       batch.commit
     end.must_raise RuntimeError
-    error.message.must_equal "batch is closed"
+    _(error.message).must_equal "batch is closed"
   end
 
   it "set raises when closed" do
@@ -35,7 +35,7 @@ describe Google::Cloud::Firestore::Batch, :closed, :mock_firestore do
       batch.set(document_path, { name: "Mike" })
       batch.commit
     end.must_raise RuntimeError
-    error.message.must_equal "batch is closed"
+    _(error.message).must_equal "batch is closed"
   end
 
   it "update raises when closed" do
@@ -43,7 +43,7 @@ describe Google::Cloud::Firestore::Batch, :closed, :mock_firestore do
       batch.update(document_path, { name: "Mike" })
       batch.commit
     end.must_raise RuntimeError
-    error.message.must_equal "batch is closed"
+    _(error.message).must_equal "batch is closed"
   end
 
   it "delete raises when closed" do
@@ -51,6 +51,6 @@ describe Google::Cloud::Firestore::Batch, :closed, :mock_firestore do
       batch.delete document_path
       batch.commit
     end.must_raise RuntimeError
-    error.message.must_equal "batch is closed"
+    _(error.message).must_equal "batch is closed"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/batch/create_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/batch/create_test.rb
@@ -44,27 +44,27 @@ describe Google::Cloud::Firestore::Batch, :create, :mock_firestore do
     batch.create(document_path, { name: "Mike" })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "creates a new document given a DocumentReference" do
     firestore_mock.expect :commit, commit_resp, [database_path, writes: create_writes, options: default_options]
 
     doc = firestore.doc document_path
-    doc.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     batch.create(doc, { name: "Mike" })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "raises if not given a Hash" do
     error = expect do
       batch.create document_path, "not a hash"
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/batch/delete_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/batch/delete_test.rb
@@ -39,21 +39,21 @@ describe Google::Cloud::Firestore::Batch, :delete, :mock_firestore do
     batch.delete document_path
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "deletes a document given a doc ref" do
     firestore_mock.expect :commit, commit_resp, [database_path, writes: delete_writes, options: default_options]
 
     doc = firestore.doc document_path
-    doc.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     batch.delete doc
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "deletes a document with exists precondition" do
@@ -64,8 +64,8 @@ describe Google::Cloud::Firestore::Batch, :delete, :mock_firestore do
     batch.delete document_path, exists: true
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "deletes a document with update_time precondition" do
@@ -77,14 +77,14 @@ describe Google::Cloud::Firestore::Batch, :delete, :mock_firestore do
     batch.delete document_path, update_time: commit_time
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "can't specify both exists and update_time precondition" do
     error = expect do
       batch.delete document_path, exists: true, update_time: commit_time
     end.must_raise ArgumentError
-    error.message.must_equal "cannot specify both exists and update_time"
+    _(error.message).must_equal "cannot specify both exists and update_time"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/batch/set_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/batch/set_test.rb
@@ -42,27 +42,27 @@ describe Google::Cloud::Firestore::Batch, :set, :mock_firestore do
     batch.set(document_path, { name: "Mike" })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "sets a new document given a DocumentReference" do
     firestore_mock.expect :commit, commit_resp, [database_path, writes: set_writes, options: default_options]
 
     doc = firestore.doc document_path
-    doc.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     batch.set(doc, { name: "Mike" })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "raises if not given a Hash" do
     error = expect do
       batch.set document_path, "not a hash"
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/batch/update_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/batch/update_test.rb
@@ -47,27 +47,27 @@ describe Google::Cloud::Firestore::Batch, :update, :mock_firestore do
     batch.update(document_path, { name: "Mike" })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a new document given a DocumentReference" do
     firestore_mock.expect :commit, commit_resp, [database_path, writes: update_writes, options: default_options]
 
     doc = firestore.doc document_path
-    doc.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     batch.update(doc, { name: "Mike" })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "raises if not given a Hash" do
     error = expect do
       batch.update document_path, "not a hash"
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/batch/values_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/batch/values_test.rb
@@ -53,8 +53,8 @@ describe Google::Cloud::Firestore::Batch, :values, :mock_firestore do
     batch.update(document_path, { val: nil })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a document data with a true" do
@@ -64,8 +64,8 @@ describe Google::Cloud::Firestore::Batch, :values, :mock_firestore do
     batch.update(document_path, { val: true })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a document data with a false" do
@@ -75,8 +75,8 @@ describe Google::Cloud::Firestore::Batch, :values, :mock_firestore do
     batch.update(document_path, { val: false })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a document data with a nan" do
@@ -86,8 +86,8 @@ describe Google::Cloud::Firestore::Batch, :values, :mock_firestore do
     batch.update(document_path, { val: Float::NAN })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a document data with infinity" do
@@ -97,8 +97,8 @@ describe Google::Cloud::Firestore::Batch, :values, :mock_firestore do
     batch.update(document_path, { val: Float::INFINITY })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a document data with an int" do
@@ -108,8 +108,8 @@ describe Google::Cloud::Firestore::Batch, :values, :mock_firestore do
     batch.update(document_path, { val: 42 })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a document data with a float" do
@@ -119,8 +119,8 @@ describe Google::Cloud::Firestore::Batch, :values, :mock_firestore do
     batch.update(document_path, { val: 3.14 })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a document data with a time" do
@@ -130,8 +130,8 @@ describe Google::Cloud::Firestore::Batch, :values, :mock_firestore do
     batch.update(document_path, { val: commit_time })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a document data with a string" do
@@ -141,8 +141,8 @@ describe Google::Cloud::Firestore::Batch, :values, :mock_firestore do
     batch.update(document_path, { val: "hello" })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a document data with a IO" do
@@ -152,8 +152,8 @@ describe Google::Cloud::Firestore::Batch, :values, :mock_firestore do
     batch.update(document_path, { val: StringIO.new("world") })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a document data with a doc ref" do
@@ -163,8 +163,8 @@ describe Google::Cloud::Firestore::Batch, :values, :mock_firestore do
     batch.update(document_path, { val: firestore.doc("C/d") })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a document data with a geo point" do
@@ -174,8 +174,8 @@ describe Google::Cloud::Firestore::Batch, :values, :mock_firestore do
     batch.update(document_path, { val: { longitude: 50.1430847, latitude: -122.947778 } })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a document data with an array" do
@@ -193,8 +193,8 @@ describe Google::Cloud::Firestore::Batch, :values, :mock_firestore do
     batch.update(document_path, { val: [1, 2.0, "3"] })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a document data with a hash" do
@@ -210,7 +210,7 @@ describe Google::Cloud::Firestore::Batch, :values, :mock_firestore do
     batch.update(document_path, { val: { hello: "word" } })
     resp = batch.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/client/batch_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/client/batch_test.rb
@@ -67,8 +67,8 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
       b.create(document_path, { name: "Mike" })
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "creates a new document using doc ref" do
@@ -79,8 +79,8 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
       b.create(doc, { name: "Mike" })
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "raises if create is not given a Hash" do
@@ -89,7 +89,7 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
         b.create document_path, "not a hash"
       end
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 
   it "sets a new document using string path" do
@@ -99,8 +99,8 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
       b.set(document_path, { name: "Mike" })
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "sets a new document using doc ref" do
@@ -111,8 +111,8 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
       b.set(doc, { name: "Mike" })
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "raises if set is not given a Hash" do
@@ -121,7 +121,7 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
         b.set document_path, "not a hash"
       end
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 
   it "updates a new document using string path" do
@@ -131,8 +131,8 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
       b.update(document_path, { name: "Mike" })
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a new document using doc ref" do
@@ -143,8 +143,8 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
       b.update(doc, { name: "Mike" })
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "raises if update is not given a Hash" do
@@ -153,7 +153,7 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
         b.update document_path, "not a hash"
       end
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 
   it "deletes a document using string path" do
@@ -163,8 +163,8 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
       b.delete document_path
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "deletes a document using doc ref" do
@@ -175,8 +175,8 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
       b.delete doc
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "deletes a document with exists precondition" do
@@ -189,8 +189,8 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
       b.delete doc, exists: true
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "deletes a document with update_time precondition" do
@@ -204,8 +204,8 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
       b.delete doc, update_time: commit_time
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "can't specify both exists and update_time precondition" do
@@ -215,15 +215,15 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
         b.delete doc, exists: true, update_time: commit_time
       end
     end.must_raise ArgumentError
-    error.message.must_equal "cannot specify both exists and update_time"
+    _(error.message).must_equal "cannot specify both exists and update_time"
   end
 
   it "returns nil when no work is done in the batch" do
     resp = firestore.batch do |b|
-      b.firestore.must_equal firestore
+      _(b.firestore).must_equal firestore
     end
 
-    resp.must_be :nil?
+    _(resp).must_be :nil?
   end
 
   it "performs multiple writes in the same commit (string)" do
@@ -237,8 +237,8 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
       b.delete document_path
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "performs multiple writes in the same commit (doc ref)" do
@@ -246,7 +246,7 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
     firestore_mock.expect :commit, commit_resp, [database_path, writes: all_writes, options: default_options]
 
     doc_ref = firestore.doc document_path
-    doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     resp = firestore.batch do |b|
       b.create(doc_ref, { name: "Mike" })
@@ -255,32 +255,32 @@ describe Google::Cloud::Firestore::Client, :batch, :mock_firestore do
       b.delete doc_ref
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "closed batches cannot make changes" do
     doc_ref = firestore.doc document_path
-    doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     outside_batch_obj = nil
 
     resp = firestore.batch do |b|
-      b.wont_be :closed?
-      b.firestore.must_equal firestore
+      _(b).wont_be :closed?
+      _(b.firestore).must_equal firestore
 
       outside_batch_obj = b
     end
 
-    resp.must_be :nil?
+    _(resp).must_be :nil?
 
-    outside_batch_obj.must_be :closed?
+    _(outside_batch_obj).must_be :closed?
 
     error = expect do
       firestore.batch do |b|
         outside_batch_obj.create(doc_ref, { name: "Mike" })
       end
     end.must_raise RuntimeError
-    error.message.must_equal "batch is closed"
+    _(error.message).must_equal "batch is closed"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/client/col_group_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/client/col_group_test.rb
@@ -21,31 +21,31 @@ describe Google::Cloud::Firestore::Client, :col_group, :mock_firestore do
   it "creates a collection group query" do
     query = firestore.col_group(collection_id).where "foo", "==", "bar"
 
-    query.must_be_kind_of Google::Cloud::Firestore::Query
+    _(query).must_be_kind_of Google::Cloud::Firestore::Query
     query_gapi = query.query
-    query_gapi.must_be_kind_of Google::Firestore::V1::StructuredQuery
-    query_gapi.from.size.must_equal 1
-    query_gapi.from.first.must_be_kind_of Google::Firestore::V1::StructuredQuery::CollectionSelector
-    query_gapi.from.first.all_descendants.must_equal true
-    query_gapi.from.first.collection_id.must_equal collection_id
+    _(query_gapi).must_be_kind_of Google::Firestore::V1::StructuredQuery
+    _(query_gapi.from.size).must_equal 1
+    _(query_gapi.from.first).must_be_kind_of Google::Firestore::V1::StructuredQuery::CollectionSelector
+    _(query_gapi.from.first.all_descendants).must_equal true
+    _(query_gapi.from.first.collection_id).must_equal collection_id
   end
 
   it "creates a collection group query using collection_group alias" do
     query = firestore.collection_group(collection_id).where "foo", "==", "bar"
 
-    query.must_be_kind_of Google::Cloud::Firestore::Query
+    _(query).must_be_kind_of Google::Cloud::Firestore::Query
     query_gapi = query.query
-    query_gapi.must_be_kind_of Google::Firestore::V1::StructuredQuery
-    query_gapi.from.size.must_equal 1
-    query_gapi.from.first.must_be_kind_of Google::Firestore::V1::StructuredQuery::CollectionSelector
-    query_gapi.from.first.all_descendants.must_equal true
-    query_gapi.from.first.collection_id.must_equal collection_id
+    _(query_gapi).must_be_kind_of Google::Firestore::V1::StructuredQuery
+    _(query_gapi.from.size).must_equal 1
+    _(query_gapi.from.first).must_be_kind_of Google::Firestore::V1::StructuredQuery::CollectionSelector
+    _(query_gapi.from.first.all_descendants).must_equal true
+    _(query_gapi.from.first.collection_id).must_equal collection_id
   end
 
   it "raises when collection_id contains a forward slash" do
     error = expect do
       firestore.col_group collection_id_bad
     end.must_raise ArgumentError
-    error.message.must_equal "Invalid collection_id: 'a/b/my-collection-id', must not contain '/'."
+    _(error.message).must_equal "Invalid collection_id: 'a/b/my-collection-id', must not contain '/'."
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/client/col_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/client/col_test.rb
@@ -18,52 +18,52 @@ describe Google::Cloud::Firestore::Client, :collection, :mock_firestore do
   it "gets a collection by a collection_id" do
     col = firestore.col "users"
 
-    col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    col.collection_id.must_equal "users"
-    col.collection_path.must_equal "users"
-    col.path.must_equal "projects/#{project}/databases/(default)/documents/users"
+    _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(col.collection_id).must_equal "users"
+    _(col.collection_path).must_equal "users"
+    _(col.path).must_equal "projects/#{project}/databases/(default)/documents/users"
   end
 
   it "gets a collection by a nested collection path" do
     col = firestore.col "users/mike/messages"
 
-    col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    col.collection_id.must_equal "messages"
-    col.collection_path.must_equal "users/mike/messages"
-    col.path.must_equal "projects/#{project}/databases/(default)/documents/users/mike/messages"
+    _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(col.collection_id).must_equal "messages"
+    _(col.collection_path).must_equal "users/mike/messages"
+    _(col.path).must_equal "projects/#{project}/databases/(default)/documents/users/mike/messages"
   end
 
   it "does not allow a document path" do
     error = expect do
       firestore.col "users/mike"
     end.must_raise ArgumentError
-    error.message.must_equal "collection_path must refer to a collection."
+    _(error.message).must_equal "collection_path must refer to a collection."
   end
 
   describe "using collection alias" do
     it "gets a collection by a collection_id" do
       col = firestore.collection "users"
 
-      col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      col.collection_id.must_equal "users"
-      col.collection_path.must_equal "users"
-      col.path.must_equal "projects/#{project}/databases/(default)/documents/users"
+      _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(col.collection_id).must_equal "users"
+      _(col.collection_path).must_equal "users"
+      _(col.path).must_equal "projects/#{project}/databases/(default)/documents/users"
     end
 
     it "gets a collection by a nested collection path" do
       col = firestore.collection "users/mike/messages"
 
-      col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      col.collection_id.must_equal "messages"
-      col.collection_path.must_equal "users/mike/messages"
-      col.path.must_equal "projects/#{project}/databases/(default)/documents/users/mike/messages"
+      _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(col.collection_id).must_equal "messages"
+      _(col.collection_path).must_equal "users/mike/messages"
+      _(col.path).must_equal "projects/#{project}/databases/(default)/documents/users/mike/messages"
     end
 
     it "does not allow a document path" do
       error = expect do
         firestore.collection "users/mike"
       end.must_raise ArgumentError
-      error.message.must_equal "collection_path must refer to a collection."
+      _(error.message).must_equal "collection_path must refer to a collection."
     end
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/client/cols_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/client/cols_test.rb
@@ -19,33 +19,33 @@ describe Google::Cloud::Firestore::Client, :cols, :mock_firestore do
     firestore_mock.expect :list_collection_ids, ["users", "lists", "todos"].to_enum, ["projects/#{project}/databases/(default)/documents", options: default_options]
 
     col_enum = firestore.cols
-    col_enum.must_be_kind_of Enumerator
+    _(col_enum).must_be_kind_of Enumerator
 
     col_ids = col_enum.map do |col|
-      col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
 
-      col.parent.must_be_kind_of Google::Cloud::Firestore::Client
+      _(col.parent).must_be_kind_of Google::Cloud::Firestore::Client
 
       col.collection_id
     end
-    col_ids.wont_be :empty?
-    col_ids.must_equal ["users", "lists", "todos"]
+    _(col_ids).wont_be :empty?
+    _(col_ids).must_equal ["users", "lists", "todos"]
   end
 
   it "retrieves collections using collections alias" do
     firestore_mock.expect :list_collection_ids, ["users", "lists", "todos"].to_enum, ["projects/#{project}/databases/(default)/documents", options: default_options]
 
     col_enum = firestore.collections
-    col_enum.must_be_kind_of Enumerator
+    _(col_enum).must_be_kind_of Enumerator
 
     col_ids = col_enum.map do |col|
-      col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
 
-      col.parent.must_be_kind_of Google::Cloud::Firestore::Client
+      _(col.parent).must_be_kind_of Google::Cloud::Firestore::Client
 
       col.collection_id
     end
-    col_ids.wont_be :empty?
-    col_ids.must_equal ["users", "lists", "todos"]
+    _(col_ids).wont_be :empty?
+    _(col_ids).must_equal ["users", "lists", "todos"]
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/client/doc_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/client/doc_test.rb
@@ -20,28 +20,28 @@ describe Google::Cloud::Firestore::Client, :doc, :mock_firestore do
 
     document = firestore.doc document_path
 
-    document.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    document.document_id.must_equal "mike"
-    document.document_path.must_equal document_path
-    document.path.must_equal "projects/projectID/databases/(default)/documents/users/mike"
+    _(document).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(document.document_id).must_equal "mike"
+    _(document.document_path).must_equal document_path
+    _(document.path).must_equal "projects/projectID/databases/(default)/documents/users/mike"
 
-    document.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    document.parent.collection_id.must_equal "users"
-    document.parent.collection_path.must_equal "users"
-    document.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+    _(document.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(document.parent.collection_id).must_equal "users"
+    _(document.parent.collection_path).must_equal "users"
+    _(document.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
   end
 
   it "does not allow a collection_id" do
     error = expect do
       firestore.doc "users"
     end.must_raise ArgumentError
-    error.message.must_equal "document_path must refer to a document."
+    _(error.message).must_equal "document_path must refer to a document."
   end
 
   it "does not allow a collection_path" do
     error = expect do
       firestore.doc "users/mike/messages"
     end.must_raise ArgumentError
-    error.message.must_equal "document_path must refer to a document."
+    _(error.message).must_equal "document_path must refer to a document."
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/client/get_all_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/client/get_all_test.rb
@@ -82,23 +82,23 @@ describe Google::Cloud::Firestore::Client, :get_all, :mock_firestore do
 
     docs_enum = firestore.get_all "users/mike"
 
-    docs_enum.must_be_kind_of Enumerator
+    _(docs_enum).must_be_kind_of Enumerator
 
     docs = docs_enum.to_a
-    docs.count.must_equal 1
+    _(docs.count).must_equal 1
 
-    docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(docs.first).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-    docs.first.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    docs.first.parent.collection_id.must_equal "users"
-    docs.first.parent.collection_path.must_equal "users"
-    docs.first.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+    _(docs.first.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(docs.first.parent.collection_id).must_equal "users"
+    _(docs.first.parent.collection_path).must_equal "users"
+    _(docs.first.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
 
-    docs.first.data.must_be_kind_of Hash
-    docs.first.data.must_equal({ name: "Mike" })
-    docs.first.created_at.must_equal read_time
-    docs.first.updated_at.must_equal read_time
-    docs.first.read_at.must_equal read_time
+    _(docs.first.data).must_be_kind_of Hash
+    _(docs.first.data).must_equal({ name: "Mike" })
+    _(docs.first.created_at).must_equal read_time
+    _(docs.first.updated_at).must_equal read_time
+    _(docs.first.read_at).must_equal read_time
   end
 
   it "gets a single doc (doc ref)" do
@@ -106,23 +106,23 @@ describe Google::Cloud::Firestore::Client, :get_all, :mock_firestore do
 
     docs_enum = firestore.get_all firestore.doc("users/mike")
 
-    docs_enum.must_be_kind_of Enumerator
+    _(docs_enum).must_be_kind_of Enumerator
 
     docs = docs_enum.to_a
-    docs.count.must_equal 1
+    _(docs.count).must_equal 1
 
-    docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(docs.first).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-    docs.first.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    docs.first.parent.collection_id.must_equal "users"
-    docs.first.parent.collection_path.must_equal "users"
-    docs.first.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+    _(docs.first.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(docs.first.parent.collection_id).must_equal "users"
+    _(docs.first.parent.collection_path).must_equal "users"
+    _(docs.first.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
 
-    docs.first.data.must_be_kind_of Hash
-    docs.first.data.must_equal({ name: "Mike" })
-    docs.first.created_at.must_equal read_time
-    docs.first.updated_at.must_equal read_time
-    docs.first.read_at.must_equal read_time
+    _(docs.first.data).must_be_kind_of Hash
+    _(docs.first.data).must_equal({ name: "Mike" })
+    _(docs.first.created_at).must_equal read_time
+    _(docs.first.updated_at).must_equal read_time
+    _(docs.first.read_at).must_equal read_time
   end
 
   describe :field_mask do
@@ -165,23 +165,23 @@ describe Google::Cloud::Firestore::Client, :get_all, :mock_firestore do
 
       docs_enum = firestore.get_all "users/mike", field_mask: firestore.field_path(:name)
 
-      docs_enum.must_be_kind_of Enumerator
+      _(docs_enum).must_be_kind_of Enumerator
 
       docs = docs_enum.to_a
-      docs.count.must_equal 1
+      _(docs.count).must_equal 1
 
-      docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(docs.first).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      docs.first.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      docs.first.parent.collection_id.must_equal "users"
-      docs.first.parent.collection_path.must_equal "users"
-      docs.first.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+      _(docs.first.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(docs.first.parent.collection_id).must_equal "users"
+      _(docs.first.parent.collection_path).must_equal "users"
+      _(docs.first.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
 
-      docs.first.data.must_be_kind_of Hash
-      docs.first.data.must_equal({ name: "Mike" })
-      docs.first.created_at.must_equal read_time
-      docs.first.updated_at.must_equal read_time
-      docs.first.read_at.must_equal read_time
+      _(docs.first.data).must_be_kind_of Hash
+      _(docs.first.data).must_equal({ name: "Mike" })
+      _(docs.first.created_at).must_equal read_time
+      _(docs.first.updated_at).must_equal read_time
+      _(docs.first.read_at).must_equal read_time
     end
 
     it "gets a single doc (doc ref)" do
@@ -189,63 +189,63 @@ describe Google::Cloud::Firestore::Client, :get_all, :mock_firestore do
 
       docs_enum = firestore.get_all firestore.doc("users/mike"), field_mask: [firestore.field_path(:name)]
 
-      docs_enum.must_be_kind_of Enumerator
+      _(docs_enum).must_be_kind_of Enumerator
 
       docs = docs_enum.to_a
-      docs.count.must_equal 1
+      _(docs.count).must_equal 1
 
-      docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(docs.first).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      docs.first.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      docs.first.parent.collection_id.must_equal "users"
-      docs.first.parent.collection_path.must_equal "users"
-      docs.first.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+      _(docs.first.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(docs.first.parent.collection_id).must_equal "users"
+      _(docs.first.parent.collection_path).must_equal "users"
+      _(docs.first.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
 
-      docs.first.data.must_be_kind_of Hash
-      docs.first.data.must_equal({ name: "Mike" })
-      docs.first.created_at.must_equal read_time
-      docs.first.updated_at.must_equal read_time
-      docs.first.read_at.must_equal read_time
+      _(docs.first.data).must_be_kind_of Hash
+      _(docs.first.data).must_equal({ name: "Mike" })
+      _(docs.first.created_at).must_equal read_time
+      _(docs.first.updated_at).must_equal read_time
+      _(docs.first.read_at).must_equal read_time
     end
   end
 
   def assert_docs_enum enum
-    enum.must_be_kind_of Enumerator
+    _(enum).must_be_kind_of Enumerator
 
     docs = enum.to_a
-    docs.count.must_equal 3
+    _(docs.count).must_equal 3
 
     docs.each do |doc|
-      doc.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      doc.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      doc.ref.client.must_equal firestore
+      _(doc.ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(doc.ref.client).must_equal firestore
 
-      doc.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      doc.parent.collection_id.must_equal "users"
-      doc.parent.collection_path.must_equal "users"
-      doc.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
-      doc.parent.client.must_equal firestore
+      _(doc.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(doc.parent.collection_id).must_equal "users"
+      _(doc.parent.collection_path).must_equal "users"
+      _(doc.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
+      _(doc.parent.client).must_equal firestore
     end
 
-    docs[0].must_be :exists?
-    docs[0].data.must_be_kind_of Hash
-    docs[0].data.must_equal({ name: "Mike" })
-    docs[0].created_at.must_equal read_time
-    docs[0].updated_at.must_equal read_time
-    docs[0].read_at.must_equal read_time
+    _(docs[0]).must_be :exists?
+    _(docs[0].data).must_be_kind_of Hash
+    _(docs[0].data).must_equal({ name: "Mike" })
+    _(docs[0].created_at).must_equal read_time
+    _(docs[0].updated_at).must_equal read_time
+    _(docs[0].read_at).must_equal read_time
 
-    docs[1].must_be :missing?
-    docs[1].data.must_be :nil?
-    docs[1].created_at.must_be :nil?
-    docs[1].updated_at.must_be :nil?
-    docs[1].read_at.must_equal read_time
+    _(docs[1]).must_be :missing?
+    _(docs[1].data).must_be :nil?
+    _(docs[1].created_at).must_be :nil?
+    _(docs[1].updated_at).must_be :nil?
+    _(docs[1].read_at).must_equal read_time
 
-    docs[2].must_be :exists?
-    docs[2].data.must_be_kind_of Hash
-    docs[2].data.must_equal({ name: "Chris" })
-    docs[2].created_at.must_equal read_time
-    docs[2].updated_at.must_equal read_time
-    docs[2].read_at.must_equal read_time
+    _(docs[2]).must_be :exists?
+    _(docs[2].data).must_be_kind_of Hash
+    _(docs[2].data).must_equal({ name: "Chris" })
+    _(docs[2].created_at).must_equal read_time
+    _(docs[2].updated_at).must_equal read_time
+    _(docs[2].read_at).must_equal read_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/client/transaction_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/client/transaction_test.rb
@@ -194,8 +194,8 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
       tx.create(document_path, { name: "Mike" })
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "creates a new document using doc ref" do
@@ -207,8 +207,8 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
       tx.create(doc, { name: "Mike" })
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "raises if create is not given a Hash" do
@@ -217,7 +217,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
         tx.create document_path, "not a hash"
       end
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 
   it "sets a new document using string path" do
@@ -228,8 +228,8 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
       tx.set(document_path, { name: "Mike" })
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "sets a new document using doc ref" do
@@ -241,8 +241,8 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
       tx.set(doc, { name: "Mike" })
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "raises if set is not given a Hash" do
@@ -251,7 +251,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
         tx.set document_path, "not a hash"
       end
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 
   it "updates a new document using string path" do
@@ -262,8 +262,8 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
       tx.update(document_path, { name: "Mike" })
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a new document using doc ref" do
@@ -275,8 +275,8 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
       tx.update(doc, { name: "Mike" })
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "raises if update is not given a Hash" do
@@ -285,7 +285,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
         tx.update document_path, "not a hash"
       end
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 
   it "deletes a document using string path" do
@@ -296,8 +296,8 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
       tx.delete document_path
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "deletes a document using doc ref" do
@@ -309,8 +309,8 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
       tx.delete doc
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "returns nil when the transaction is empty and commit_response is false or nil" do
@@ -318,7 +318,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
       # no op
     end
 
-    resp.must_be :nil?
+    _(resp).must_be :nil?
   end
 
   it "returns the user-provided return value from the transaction when commit_response is false or nil" do
@@ -327,7 +327,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
       "my-return-value"
     end
 
-    resp.must_equal "my-return-value"
+    _(resp).must_equal "my-return-value"
   end
 
   it "returns commit_time nil when no work is done in the transaction with commit_response: true" do
@@ -335,8 +335,8 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
       "my-return-value"
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_be :nil?
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_be :nil?
   end
 
   it "performs multiple writes in the same commit (string)" do
@@ -351,8 +351,8 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
       tx.delete document_path
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "performs multiple writes in the same commit (doc ref)" do
@@ -361,7 +361,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
     firestore_mock.expect :commit, write_commit_resp, [database_path, writes: all_writes, transaction: transaction_id, options: default_options]
 
     doc_ref = firestore.doc document_path
-    doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     resp = firestore.transaction commit_response: true do |tx|
       tx.create(doc_ref, { name: "Mike" })
@@ -370,33 +370,33 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
       tx.delete doc_ref
     end
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "closed transactions cannot make changes" do
     doc_ref = firestore.doc document_path
-    doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     outside_transaction_obj = nil
 
     resp = firestore.transaction commit_response: true do |tx|
-      tx.wont_be :closed?
-      tx.firestore.must_equal firestore
+      _(tx).wont_be :closed?
+      _(tx.firestore).must_equal firestore
 
       outside_transaction_obj = tx
     end
 
-    resp.commit_time.must_be :nil?
+    _(resp.commit_time).must_be :nil?
 
-    outside_transaction_obj.must_be :closed?
+    _(outside_transaction_obj).must_be :closed?
 
     error = expect do
       firestore.batch do |b|
         outside_transaction_obj.create(doc_ref, { name: "Mike" })
       end
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 
   describe :retry do
@@ -567,39 +567,39 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
           tx.delete document_path
         end
       end.must_raise RuntimeError
-      error.message.must_equal "unsupported"
+      _(error.message).must_equal "unsupported"
     end
   end
 
   def assert_results_enum enum
-    enum.must_be_kind_of Enumerator
+    _(enum).must_be_kind_of Enumerator
 
     results = enum.to_a
-    results.count.must_equal 2
+    _(results.count).must_equal 2
 
     results.each do |result|
-      result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(result).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      result.ref.client.must_equal firestore
+      _(result.ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(result.ref.client).must_equal firestore
 
-      result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      result.parent.collection_id.must_equal "users"
-      result.parent.collection_path.must_equal "users"
-      result.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
-      result.parent.client.must_equal firestore
+      _(result.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(result.parent.collection_id).must_equal "users"
+      _(result.parent.collection_path).must_equal "users"
+      _(result.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
+      _(result.parent.client).must_equal firestore
     end
 
-    results.first.data.must_be_kind_of Hash
-    results.first.data.must_equal({ name: "Mike" })
-    results.first.created_at.must_equal read_time
-    results.first.updated_at.must_equal read_time
-    results.first.read_at.must_equal read_time
+    _(results.first.data).must_be_kind_of Hash
+    _(results.first.data).must_equal({ name: "Mike" })
+    _(results.first.created_at).must_equal read_time
+    _(results.first.updated_at).must_equal read_time
+    _(results.first.read_at).must_equal read_time
 
-    results.last.data.must_be_kind_of Hash
-    results.last.data.must_equal({ name: "Chris" })
-    results.last.created_at.must_equal read_time
-    results.last.updated_at.must_equal read_time
-    results.last.read_at.must_equal read_time
+    _(results.last.data).must_be_kind_of Hash
+    _(results.last.data).must_equal({ name: "Chris" })
+    _(results.last.created_at).must_equal read_time
+    _(results.last.updated_at).must_equal read_time
+    _(results.last.read_at).must_equal read_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/client/transaction_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/client/transaction_test.rb
@@ -412,7 +412,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
         raise "bad second begin_transaction" unless options_.read_write.retry_transaction == "transaction123"
         Google::Firestore::V1::BeginTransactionResponse.new(transaction: "new_transaction_xyz")
       end
-      def firestore_mock.commit database, writes: writes, transaction: nil, options: nil
+      def firestore_mock.commit database, writes: nil, transaction: nil, options: nil
         if @first_commit.nil?
           @first_commit = true
           raise "bad first commit" unless transaction == "transaction123"
@@ -462,7 +462,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
         raise "bad final begin_transaction" unless options_.read_write.retry_transaction == "transaction_3"
         Google::Firestore::V1::BeginTransactionResponse.new(transaction: "new_transaction_xyz")
       end
-      def firestore_mock.commit database, writes: writes, transaction: nil, options: nil
+      def firestore_mock.commit database, writes: nil, transaction: nil, options: nil
         @commit_retries ||= 0
         @commit_retries += 1
 
@@ -515,7 +515,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
         raise "bad second begin_transaction" unless options_.read_write.retry_transaction == "transaction123"
         Google::Firestore::V1::BeginTransactionResponse.new(transaction: "new_transaction_xyz")
       end
-      def firestore_mock.commit database, writes: writes, transaction: nil, options: nil
+      def firestore_mock.commit database, writes: nil, transaction: nil, options: nil
         if @first_commit.nil?
           @first_commit = true
           raise "bad first commit" unless transaction == "transaction123"
@@ -555,7 +555,7 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
       firestore_mock.expect :rollback, nil, ["projects/#{project}/databases/(default)", transaction_id, options: default_options]
 
       # Unable to use mocks to raise an error, so stub the method instead
-      def firestore_mock.commit database, writes: writes, transaction: nil, options: nil
+      def firestore_mock.commit database, writes: nil, transaction: nil, options: nil
         raise "unsupported"
       end
 

--- a/google-cloud-firestore/test/google/cloud/firestore/client_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/client_test.rb
@@ -16,9 +16,9 @@ require "helper"
 
 describe Google::Cloud::Firestore::Client, :mock_firestore do
   it "knows the project and database identifiers" do
-    firestore.must_be_kind_of Google::Cloud::Firestore::Client
-    firestore.project_id.must_equal project
-    firestore.database_id.must_equal "(default)"
-    firestore.path.must_equal "projects/projectID/databases/(default)"
+    _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+    _(firestore.project_id).must_equal project
+    _(firestore.database_id).must_equal "(default)"
+    _(firestore.path).must_equal "projects/projectID/databases/(default)"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/add_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/add_test.rb
@@ -46,15 +46,15 @@ describe Google::Cloud::Firestore::CollectionReference, :add, :mock_firestore do
     Google::Cloud::Firestore::Generate.stub :unique_id, random_document_id do
       document = collection.add
 
-      document.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      document.document_id.must_equal random_document_id
-      document.document_path.must_equal "#{collection_path}/#{random_document_id}"
-      document.path.must_equal "#{documents_path}/#{collection_path}/#{random_document_id}"
+      _(document).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(document.document_id).must_equal random_document_id
+      _(document.document_path).must_equal "#{collection_path}/#{random_document_id}"
+      _(document.path).must_equal "#{documents_path}/#{collection_path}/#{random_document_id}"
 
-      document.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      document.parent.collection_id.must_equal collection_id
-      document.parent.collection_path.must_equal collection_path
-      document.parent.path.must_equal "#{documents_path}/#{collection_path}"
+      _(document.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(document.parent.collection_id).must_equal collection_id
+      _(document.parent.collection_path).must_equal collection_path
+      _(document.parent.path).must_equal "#{documents_path}/#{collection_path}"
     end
   end
 
@@ -74,15 +74,15 @@ describe Google::Cloud::Firestore::CollectionReference, :add, :mock_firestore do
     Google::Cloud::Firestore::Generate.stub :unique_id, random_document_id do
       document = collection.add hello: :world
 
-      document.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      document.document_id.must_equal random_document_id
-      document.document_path.must_equal "#{collection_path}/#{random_document_id}"
-      document.path.must_equal "#{documents_path}/#{collection_path}/#{random_document_id}"
+      _(document).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(document.document_id).must_equal random_document_id
+      _(document.document_path).must_equal "#{collection_path}/#{random_document_id}"
+      _(document.path).must_equal "#{documents_path}/#{collection_path}/#{random_document_id}"
 
-      document.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      document.parent.collection_id.must_equal collection_id
-      document.parent.collection_path.must_equal collection_path
-      document.parent.path.must_equal "#{documents_path}/#{collection_path}"
+      _(document.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(document.parent.collection_id).must_equal collection_id
+      _(document.parent.collection_path).must_equal collection_path
+      _(document.parent.path).must_equal "#{documents_path}/#{collection_path}"
     end
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/doc_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/doc_test.rb
@@ -24,15 +24,15 @@ describe Google::Cloud::Firestore::CollectionReference, :doc, :mock_firestore do
 
     document = collection.doc document_id
 
-    document.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    document.document_id.must_equal document_id
-    document.document_path.must_equal "#{collection_path}/#{document_id}"
-    document.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/abc123"
+    _(document).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(document.document_id).must_equal document_id
+    _(document.document_path).must_equal "#{collection_path}/#{document_id}"
+    _(document.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/abc123"
 
-    document.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    document.parent.collection_id.must_equal collection_id
-    document.parent.collection_path.must_equal collection_path
-    document.parent.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
+    _(document.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(document.parent.collection_id).must_equal collection_id
+    _(document.parent.collection_path).must_equal collection_path
+    _(document.parent.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
   end
 
   it "produces a Document reference for a document_path" do
@@ -40,15 +40,15 @@ describe Google::Cloud::Firestore::CollectionReference, :doc, :mock_firestore do
 
     document = collection.doc document_path
 
-    document.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    document.document_id.must_equal "xyz789"
-    document.document_path.must_equal "users/mike/messages/abc123/likes/xyz789"
-    document.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/abc123/likes/xyz789"
+    _(document).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(document.document_id).must_equal "xyz789"
+    _(document.document_path).must_equal "users/mike/messages/abc123/likes/xyz789"
+    _(document.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/abc123/likes/xyz789"
 
-    document.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    document.parent.collection_id.must_equal "likes"
-    document.parent.collection_path.must_equal "users/mike/messages/abc123/likes"
-    document.parent.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/abc123/likes"
+    _(document.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(document.parent.collection_id).must_equal "likes"
+    _(document.parent.collection_path).must_equal "users/mike/messages/abc123/likes"
+    _(document.parent.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/abc123/likes"
   end
 
   it "creates a Document reference with a random id" do
@@ -56,15 +56,15 @@ describe Google::Cloud::Firestore::CollectionReference, :doc, :mock_firestore do
     Google::Cloud::Firestore::Generate.stub :unique_id, random_document_id do
       document = collection.doc
 
-      document.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      document.document_id.must_equal random_document_id
-      document.document_path.must_equal "#{collection_path}/#{random_document_id}"
-      document.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/helloiamarandomdocid"
+      _(document).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(document.document_id).must_equal random_document_id
+      _(document.document_path).must_equal "#{collection_path}/#{random_document_id}"
+      _(document.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/helloiamarandomdocid"
 
-      document.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      document.parent.collection_id.must_equal collection_id
-      document.parent.collection_path.must_equal collection_path
-      document.parent.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
+      _(document.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(document.parent.collection_id).must_equal collection_id
+      _(document.parent.collection_path).must_equal collection_path
+      _(document.parent.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
     end
   end
 
@@ -72,7 +72,7 @@ describe Google::Cloud::Firestore::CollectionReference, :doc, :mock_firestore do
     error = expect do
       collection.doc "abc123/likes"
     end.must_raise ArgumentError
-    error.message.must_equal "document_path must refer to a document."
+    _(error.message).must_equal "document_path must refer to a document."
   end
 
   describe "using document alias" do
@@ -81,15 +81,15 @@ describe Google::Cloud::Firestore::CollectionReference, :doc, :mock_firestore do
 
       document = collection.document document_id
 
-      document.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      document.document_id.must_equal document_id
-      document.document_path.must_equal "#{collection_path}/#{document_id}"
-      document.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/abc123"
+      _(document).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(document.document_id).must_equal document_id
+      _(document.document_path).must_equal "#{collection_path}/#{document_id}"
+      _(document.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/abc123"
 
-      document.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      document.parent.collection_id.must_equal collection_id
-      document.parent.collection_path.must_equal collection_path
-      document.parent.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
+      _(document.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(document.parent.collection_id).must_equal collection_id
+      _(document.parent.collection_path).must_equal collection_path
+      _(document.parent.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
     end
 
     it "produces a Document reference for a document_path" do
@@ -97,15 +97,15 @@ describe Google::Cloud::Firestore::CollectionReference, :doc, :mock_firestore do
 
       document = collection.document document_path
 
-      document.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      document.document_id.must_equal "xyz789"
-      document.document_path.must_equal "users/mike/messages/abc123/likes/xyz789"
-      document.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/abc123/likes/xyz789"
+      _(document).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(document.document_id).must_equal "xyz789"
+      _(document.document_path).must_equal "users/mike/messages/abc123/likes/xyz789"
+      _(document.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/abc123/likes/xyz789"
 
-      document.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      document.parent.collection_id.must_equal "likes"
-      document.parent.collection_path.must_equal "users/mike/messages/abc123/likes"
-      document.parent.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/abc123/likes"
+      _(document.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(document.parent.collection_id).must_equal "likes"
+      _(document.parent.collection_path).must_equal "users/mike/messages/abc123/likes"
+      _(document.parent.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/abc123/likes"
     end
 
     it "creates a Document reference with a random id" do
@@ -113,15 +113,15 @@ describe Google::Cloud::Firestore::CollectionReference, :doc, :mock_firestore do
       Google::Cloud::Firestore::Generate.stub :unique_id, random_document_id do
         document = collection.document
 
-        document.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-        document.document_id.must_equal random_document_id
-        document.document_path.must_equal "#{collection_path}/#{random_document_id}"
-        document.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/helloiamarandomdocid"
+        _(document).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+        _(document.document_id).must_equal random_document_id
+        _(document.document_path).must_equal "#{collection_path}/#{random_document_id}"
+        _(document.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages/helloiamarandomdocid"
 
-        document.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-        document.parent.collection_id.must_equal collection_id
-        document.parent.collection_path.must_equal collection_path
-        document.parent.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
+        _(document.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+        _(document.parent.collection_id).must_equal collection_id
+        _(document.parent.collection_path).must_equal collection_path
+        _(document.parent.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
       end
     end
 
@@ -129,7 +129,7 @@ describe Google::Cloud::Firestore::CollectionReference, :doc, :mock_firestore do
       error = expect do
         collection.document "abc123/likes"
       end.must_raise ArgumentError
-      error.message.must_equal "document_path must refer to a document."
+      _(error.message).must_equal "document_path must refer to a document."
     end
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/get_test.rb
@@ -64,34 +64,34 @@ describe Google::Cloud::Firestore::CollectionReference, :get, :mock_firestore do
   end
 
   def assert_docs_enum enum
-    enum.must_be_kind_of Enumerator
+    _(enum).must_be_kind_of Enumerator
 
     docs = enum.to_a
-    docs.count.must_equal 2
+    _(docs.count).must_equal 2
 
     docs.each do |doc|
-      doc.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      doc.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      doc.ref.client.must_equal firestore
+      _(doc.ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(doc.ref.client).must_equal firestore
 
-      doc.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      doc.parent.collection_id.must_equal "messages"
-      doc.parent.collection_path.must_equal "users/mike/messages"
-      doc.parent.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
-      doc.parent.client.must_equal firestore
+      _(doc.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(doc.parent.collection_id).must_equal "messages"
+      _(doc.parent.collection_path).must_equal "users/mike/messages"
+      _(doc.parent.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
+      _(doc.parent.client).must_equal firestore
     end
 
-    docs.first.data.must_be_kind_of Hash
-    docs.first.data.must_equal({ body: "LGTM" })
-    docs.first.created_at.must_equal read_time
-    docs.first.updated_at.must_equal read_time
-    docs.first.read_at.must_equal read_time
+    _(docs.first.data).must_be_kind_of Hash
+    _(docs.first.data).must_equal({ body: "LGTM" })
+    _(docs.first.created_at).must_equal read_time
+    _(docs.first.updated_at).must_equal read_time
+    _(docs.first.read_at).must_equal read_time
 
-    docs.last.data.must_be_kind_of Hash
-    docs.last.data.must_equal({ body: "PTAL" })
-    docs.last.created_at.must_equal read_time
-    docs.last.updated_at.must_equal read_time
-    docs.last.read_at.must_equal read_time
+    _(docs.last.data).must_be_kind_of Hash
+    _(docs.last.data).must_equal({ body: "PTAL" })
+    _(docs.last.created_at).must_equal read_time
+    _(docs.last.updated_at).must_equal read_time
+    _(docs.last.read_at).must_equal read_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/list_documents_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/list_documents_test.rb
@@ -30,8 +30,8 @@ describe Google::Cloud::Firestore::CollectionReference, :list_documents, :mock_f
 
     firestore_mock.verify
 
-    documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
-    documents.size.must_equal num_documents
+    documents.each { |m| _(m).must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    _(documents.size).must_equal num_documents
   end
 
   it "paginates documents" do
@@ -46,14 +46,14 @@ describe Google::Cloud::Firestore::CollectionReference, :list_documents, :mock_f
 
     firestore_mock.verify
 
-    first_documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
-    first_documents.count.must_equal 3
-    first_documents.token.wont_be :nil?
-    first_documents.token.must_equal "next_page_token"
+    first_documents.each { |m| _(m).must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    _(first_documents.count).must_equal 3
+    _(first_documents.token).wont_be :nil?
+    _(first_documents.token).must_equal "next_page_token"
 
-    second_documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
-    second_documents.count.must_equal 2
-    second_documents.token.must_be :nil?
+    second_documents.each { |m| _(m).must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    _(second_documents.count).must_equal 2
+    _(second_documents.token).must_be :nil?
   end
 
   it "paginates documents using next? and next" do
@@ -68,13 +68,13 @@ describe Google::Cloud::Firestore::CollectionReference, :list_documents, :mock_f
 
     firestore_mock.verify
 
-    first_documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
-    first_documents.count.must_equal 3
-    first_documents.next?.must_equal true #must_be :next?
+    first_documents.each { |m| _(m).must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    _(first_documents.count).must_equal 3
+    _(first_documents.next?).must_equal true #must_be :next?
 
-    second_documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
-    second_documents.count.must_equal 2
-    second_documents.next?.must_equal false #wont_be :next?
+    second_documents.each { |m| _(m).must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    _(second_documents.count).must_equal 2
+    _(second_documents.next?).must_equal false #wont_be :next?
   end
 
   it "paginates documents using all" do
@@ -88,8 +88,8 @@ describe Google::Cloud::Firestore::CollectionReference, :list_documents, :mock_f
 
     firestore_mock.verify
 
-    all_documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
-    all_documents.count.must_equal 5
+    all_documents.each { |m| _(m).must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    _(all_documents.count).must_equal 5
   end
 
   it "paginates documents using all using Enumerator" do
@@ -103,8 +103,8 @@ describe Google::Cloud::Firestore::CollectionReference, :list_documents, :mock_f
 
     firestore_mock.verify
 
-    all_documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
-    all_documents.count.must_equal 5
+    all_documents.each { |m| _(m).must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    _(all_documents.count).must_equal 5
   end
 
   it "paginates documents using all with request_limit set" do
@@ -118,8 +118,8 @@ describe Google::Cloud::Firestore::CollectionReference, :list_documents, :mock_f
 
     firestore_mock.verify
 
-    all_documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
-    all_documents.count.must_equal 6
+    all_documents.each { |m| _(m).must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    _(all_documents.count).must_equal 6
   end
 
   it "paginates documents with max set" do
@@ -131,10 +131,10 @@ describe Google::Cloud::Firestore::CollectionReference, :list_documents, :mock_f
 
     firestore_mock.verify
 
-    documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
-    documents.count.must_equal 3
-    documents.token.wont_be :nil?
-    documents.token.must_equal "next_page_token"
+    documents.each { |m| _(m).must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    _(documents.count).must_equal 3
+    _(documents.token).wont_be :nil?
+    _(documents.token).must_equal "next_page_token"
   end
 
   it "paginates documents without max set" do
@@ -146,10 +146,10 @@ describe Google::Cloud::Firestore::CollectionReference, :list_documents, :mock_f
 
     firestore_mock.verify
 
-    documents.each { |m| m.must_be_kind_of Google::Cloud::Firestore::DocumentReference }
-    documents.count.must_equal 3
-    documents.token.wont_be :nil?
-    documents.token.must_equal "next_page_token"
+    documents.each { |m| _(m).must_be_kind_of Google::Cloud::Firestore::DocumentReference }
+    _(documents.count).must_equal 3
+    _(documents.token).wont_be :nil?
+    _(documents.token).must_equal "next_page_token"
   end
 
   def document_gapi

--- a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/listen_restart_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/listen_restart_test.rb
@@ -252,31 +252,31 @@ describe Google::Cloud::Firestore::CollectionReference, :listen, :backoff, :watc
   end
 
   def verify_query_snapshots snapshots
-    snapshots.count.must_equal 4
-    snapshots.each { |qs| qs.must_be_kind_of Google::Cloud::Firestore::QuerySnapshot }
+    _(snapshots.count).must_equal 4
+    snapshots.each { |qs| _(qs).must_be_kind_of Google::Cloud::Firestore::QuerySnapshot }
 
-    snapshots[0].count.must_equal 14
-    snapshots[0].changes.count.must_equal 14
-    snapshots[0].docs.map(&:document_id).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    snapshots[0].changes.each { |change| change.must_be :added? }
-    snapshots[0].changes.map(&:doc).map(&:document_id).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    _(snapshots[0].count).must_equal 14
+    _(snapshots[0].changes.count).must_equal 14
+    _(snapshots[0].docs.map(&:document_id)).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    snapshots[0].changes.each { |change| _(change).must_be :added? }
+    _(snapshots[0].changes.map(&:doc).map(&:document_id)).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
 
-    snapshots[1].count.must_equal 14
-    snapshots[1].changes.count.must_equal 2
-    snapshots[1].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    snapshots[1].changes.each { |change| change.must_be :modified? }
-    snapshots[1].changes.map(&:doc).map(&:document_id).must_equal ["num", "int"]
+    _(snapshots[1].count).must_equal 14
+    _(snapshots[1].changes.count).must_equal 2
+    _(snapshots[1].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    snapshots[1].changes.each { |change| _(change).must_be :modified? }
+    _(snapshots[1].changes.map(&:doc).map(&:document_id)).must_equal ["num", "int"]
 
-    snapshots[2].count.must_equal 14
-    snapshots[2].changes.count.must_equal 1
-    snapshots[2].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    snapshots[2].changes.each { |change| change.must_be :modified? }
-    snapshots[2].changes.map(&:doc).map(&:document_id).must_equal ["array"]
+    _(snapshots[2].count).must_equal 14
+    _(snapshots[2].changes.count).must_equal 1
+    _(snapshots[2].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    snapshots[2].changes.each { |change| _(change).must_be :modified? }
+    _(snapshots[2].changes.map(&:doc).map(&:document_id)).must_equal ["array"]
 
-    snapshots[3].count.must_equal 12
-    snapshots[3].changes.count.must_equal 2
-    snapshots[3].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2"]
-    snapshots[3].changes.each { |change| change.must_be :removed? }
-    snapshots[3].changes.map(&:doc).map(&:document_id).must_equal ["array", "hash"]
+    _(snapshots[3].count).must_equal 12
+    _(snapshots[3].changes.count).must_equal 2
+    _(snapshots[3].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2"]
+    snapshots[3].changes.each { |change| _(change).must_be :removed? }
+    _(snapshots[3].changes.map(&:doc).map(&:document_id)).must_equal ["array", "hash"]
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/listen_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/listen_test.rb
@@ -66,32 +66,32 @@ describe Google::Cloud::Firestore::CollectionReference, :listen, :watch_firestor
     listener.stop
 
     # assert snapshots
-    query_snapshots.count.must_equal 4
-    query_snapshots.each { |qs| qs.must_be_kind_of Google::Cloud::Firestore::QuerySnapshot }
+    _(query_snapshots.count).must_equal 4
+    query_snapshots.each { |qs| _(qs).must_be_kind_of Google::Cloud::Firestore::QuerySnapshot }
 
-    query_snapshots[0].count.must_equal 14
-    query_snapshots[0].changes.count.must_equal 14
-    query_snapshots[0].docs.map(&:document_id).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    query_snapshots[0].changes.each { |change| change.must_be :added? }
-    query_snapshots[0].changes.map(&:doc).map(&:document_id).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    _(query_snapshots[0].count).must_equal 14
+    _(query_snapshots[0].changes.count).must_equal 14
+    _(query_snapshots[0].docs.map(&:document_id)).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    query_snapshots[0].changes.each { |change| _(change).must_be :added? }
+    _(query_snapshots[0].changes.map(&:doc).map(&:document_id)).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
 
-    query_snapshots[1].count.must_equal 14
-    query_snapshots[1].changes.count.must_equal 2
-    query_snapshots[1].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    query_snapshots[1].changes.each { |change| change.must_be :modified? }
-    query_snapshots[1].changes.map(&:doc).map(&:document_id).must_equal ["num", "int"]
+    _(query_snapshots[1].count).must_equal 14
+    _(query_snapshots[1].changes.count).must_equal 2
+    _(query_snapshots[1].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    query_snapshots[1].changes.each { |change| _(change).must_be :modified? }
+    _(query_snapshots[1].changes.map(&:doc).map(&:document_id)).must_equal ["num", "int"]
 
-    query_snapshots[2].count.must_equal 14
-    query_snapshots[2].changes.count.must_equal 1
-    query_snapshots[2].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    query_snapshots[2].changes.each { |change| change.must_be :modified? }
-    query_snapshots[2].changes.map(&:doc).map(&:document_id).must_equal ["array"]
+    _(query_snapshots[2].count).must_equal 14
+    _(query_snapshots[2].changes.count).must_equal 1
+    _(query_snapshots[2].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    query_snapshots[2].changes.each { |change| _(change).must_be :modified? }
+    _(query_snapshots[2].changes.map(&:doc).map(&:document_id)).must_equal ["array"]
 
-    query_snapshots[3].count.must_equal 12
-    query_snapshots[3].changes.count.must_equal 2
-    query_snapshots[3].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2"]
-    query_snapshots[3].changes.each { |change| change.must_be :removed? }
-    query_snapshots[3].changes.map(&:doc).map(&:document_id).must_equal ["array", "hash"]
+    _(query_snapshots[3].count).must_equal 12
+    _(query_snapshots[3].changes.count).must_equal 2
+    _(query_snapshots[3].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2"]
+    query_snapshots[3].changes.each { |change| _(change).must_be :removed? }
+    _(query_snapshots[3].changes.map(&:doc).map(&:document_id)).must_equal ["array", "hash"]
   end
 
   it "resets when RESET is returned" do
@@ -167,32 +167,32 @@ describe Google::Cloud::Firestore::CollectionReference, :listen, :watch_firestor
     listener.stop
 
     # assert snapshots
-    query_snapshots.count.must_equal 4
-    query_snapshots.each { |qs| qs.must_be_kind_of Google::Cloud::Firestore::QuerySnapshot }
+    _(query_snapshots.count).must_equal 4
+    query_snapshots.each { |qs| _(qs).must_be_kind_of Google::Cloud::Firestore::QuerySnapshot }
 
-    query_snapshots[0].count.must_equal 14
-    query_snapshots[0].changes.count.must_equal 14
-    query_snapshots[0].docs.map(&:document_id).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    query_snapshots[0].changes.each { |change| change.must_be :added? }
-    query_snapshots[0].changes.map(&:doc).map(&:document_id).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    _(query_snapshots[0].count).must_equal 14
+    _(query_snapshots[0].changes.count).must_equal 14
+    _(query_snapshots[0].docs.map(&:document_id)).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    query_snapshots[0].changes.each { |change| _(change).must_be :added? }
+    _(query_snapshots[0].changes.map(&:doc).map(&:document_id)).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
 
-    query_snapshots[1].count.must_equal 14
-    query_snapshots[1].changes.count.must_equal 2
-    query_snapshots[1].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    query_snapshots[1].changes.each { |change| change.must_be :modified? }
-    query_snapshots[1].changes.map(&:doc).map(&:document_id).must_equal ["num", "int"]
+    _(query_snapshots[1].count).must_equal 14
+    _(query_snapshots[1].changes.count).must_equal 2
+    _(query_snapshots[1].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    query_snapshots[1].changes.each { |change| _(change).must_be :modified? }
+    _(query_snapshots[1].changes.map(&:doc).map(&:document_id)).must_equal ["num", "int"]
 
-    query_snapshots[2].count.must_equal 14
-    query_snapshots[2].changes.count.must_equal 1
-    query_snapshots[2].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    query_snapshots[2].changes.each { |change| change.must_be :modified? }
-    query_snapshots[2].changes.map(&:doc).map(&:document_id).must_equal ["array"]
+    _(query_snapshots[2].count).must_equal 14
+    _(query_snapshots[2].changes.count).must_equal 1
+    _(query_snapshots[2].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    query_snapshots[2].changes.each { |change| _(change).must_be :modified? }
+    _(query_snapshots[2].changes.map(&:doc).map(&:document_id)).must_equal ["array"]
 
-    query_snapshots[3].count.must_equal 12
-    query_snapshots[3].changes.count.must_equal 2
-    query_snapshots[3].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2"]
-    query_snapshots[3].changes.each { |change| change.must_be :removed? }
-    query_snapshots[3].changes.map(&:doc).map(&:document_id).must_equal ["array", "hash"]
+    _(query_snapshots[3].count).must_equal 12
+    _(query_snapshots[3].changes.count).must_equal 2
+    _(query_snapshots[3].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2"]
+    query_snapshots[3].changes.each { |change| _(change).must_be :removed? }
+    _(query_snapshots[3].changes.map(&:doc).map(&:document_id)).must_equal ["array", "hash"]
   end
 
   it "resets when FILTER count is incorrect" do
@@ -269,31 +269,31 @@ describe Google::Cloud::Firestore::CollectionReference, :listen, :watch_firestor
     listener.stop
 
     # assert snapshots
-    query_snapshots.count.must_equal 4
-    query_snapshots.each { |qs| qs.must_be_kind_of Google::Cloud::Firestore::QuerySnapshot }
+    _(query_snapshots.count).must_equal 4
+    query_snapshots.each { |qs| _(qs).must_be_kind_of Google::Cloud::Firestore::QuerySnapshot }
 
-    query_snapshots[0].count.must_equal 14
-    query_snapshots[0].changes.count.must_equal 14
-    query_snapshots[0].docs.map(&:document_id).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    query_snapshots[0].changes.each { |change| change.must_be :added? }
-    query_snapshots[0].changes.map(&:doc).map(&:document_id).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    _(query_snapshots[0].count).must_equal 14
+    _(query_snapshots[0].changes.count).must_equal 14
+    _(query_snapshots[0].docs.map(&:document_id)).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    query_snapshots[0].changes.each { |change| _(change).must_be :added? }
+    _(query_snapshots[0].changes.map(&:doc).map(&:document_id)).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
 
-    query_snapshots[1].count.must_equal 14
-    query_snapshots[1].changes.count.must_equal 2
-    query_snapshots[1].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    query_snapshots[1].changes.each { |change| change.must_be :modified? }
-    query_snapshots[1].changes.map(&:doc).map(&:document_id).must_equal ["num", "int"]
+    _(query_snapshots[1].count).must_equal 14
+    _(query_snapshots[1].changes.count).must_equal 2
+    _(query_snapshots[1].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    query_snapshots[1].changes.each { |change| _(change).must_be :modified? }
+    _(query_snapshots[1].changes.map(&:doc).map(&:document_id)).must_equal ["num", "int"]
 
-    query_snapshots[2].count.must_equal 14
-    query_snapshots[2].changes.count.must_equal 1
-    query_snapshots[2].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    query_snapshots[2].changes.each { |change| change.must_be :modified? }
-    query_snapshots[2].changes.map(&:doc).map(&:document_id).must_equal ["array"]
+    _(query_snapshots[2].count).must_equal 14
+    _(query_snapshots[2].changes.count).must_equal 1
+    _(query_snapshots[2].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    query_snapshots[2].changes.each { |change| _(change).must_be :modified? }
+    _(query_snapshots[2].changes.map(&:doc).map(&:document_id)).must_equal ["array"]
 
-    query_snapshots[3].count.must_equal 12
-    query_snapshots[3].changes.count.must_equal 2
-    query_snapshots[3].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2"]
-    query_snapshots[3].changes.each { |change| change.must_be :removed? }
-    query_snapshots[3].changes.map(&:doc).map(&:document_id).must_equal ["array", "hash"]
+    _(query_snapshots[3].count).must_equal 12
+    _(query_snapshots[3].changes.count).must_equal 2
+    _(query_snapshots[3].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2"]
+    query_snapshots[3].changes.each { |change| _(change).must_be :removed? }
+    _(query_snapshots[3].changes.map(&:doc).map(&:document_id)).must_equal ["array", "hash"]
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/parent_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/parent_test.rb
@@ -20,26 +20,26 @@ describe Google::Cloud::Firestore::CollectionReference, :parent, :mock_firestore
   let(:collection) { Google::Cloud::Firestore::CollectionReference.from_path "projects/#{project}/databases/(default)/documents/#{collection_path}", firestore }
 
   it "represents a nested collection reference" do
-    collection.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    collection.collection_id.must_equal collection_id
-    collection.collection_path.must_equal collection_path
-    collection.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
+    _(collection).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(collection.collection_id).must_equal collection_id
+    _(collection.collection_path).must_equal collection_path
+    _(collection.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
 
-    collection.parent.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    collection.parent.document_id.must_equal "mike"
-    collection.parent.document_path.must_equal "users/mike"
-    collection.parent.path.must_equal "projects/projectID/databases/(default)/documents/users/mike"
+    _(collection.parent).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(collection.parent.document_id).must_equal "mike"
+    _(collection.parent.document_path).must_equal "users/mike"
+    _(collection.parent.path).must_equal "projects/projectID/databases/(default)/documents/users/mike"
   end
 
   it "represents a top-level collection reference" do
     collection = Google::Cloud::Firestore::CollectionReference.from_path "projects/#{project}/databases/(default)/documents/#{collection_id}", firestore
 
-    collection.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    collection.collection_id.must_equal collection_id
-    collection.collection_path.must_equal collection_id
-    collection.path.must_equal "projects/projectID/databases/(default)/documents/messages"
+    _(collection).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(collection.collection_id).must_equal collection_id
+    _(collection.collection_path).must_equal collection_id
+    _(collection.path).must_equal "projects/projectID/databases/(default)/documents/messages"
 
-    collection.parent.must_be_kind_of Google::Cloud::Firestore::Client
-    collection.parent.path.must_equal "projects/projectID/databases/(default)"
+    _(collection.parent).must_be_kind_of Google::Cloud::Firestore::Client
+    _(collection.parent.path).must_equal "projects/projectID/databases/(default)"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/query_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/query_test.rb
@@ -317,67 +317,67 @@ describe Google::Cloud::Firestore::CollectionReference, :query, :mock_firestore 
     end
 
     def assert_results_enum enum
-      enum.must_be_kind_of Enumerator
+      _(enum).must_be_kind_of Enumerator
 
       results = enum.to_a
-      results.count.must_equal 2
+      _(results.count).must_equal 2
 
       results.each do |result|
-        result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+        _(result).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-        result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-        result.ref.client.must_equal firestore
+        _(result.ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+        _(result.ref.client).must_equal firestore
 
-        result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-        result.parent.collection_id.must_equal "messages"
-        result.parent.collection_path.must_equal "users/mike/messages"
-        result.parent.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
-        result.parent.client.must_equal firestore
+        _(result.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+        _(result.parent.collection_id).must_equal "messages"
+        _(result.parent.collection_path).must_equal "users/mike/messages"
+        _(result.parent.path).must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
+        _(result.parent.client).must_equal firestore
       end
 
-      results.first.data.must_be_kind_of Hash
-      results.first.data.must_equal({ body: "LGTM" })
-      results.first.created_at.must_equal read_time
-      results.first.updated_at.must_equal read_time
-      results.first.read_at.must_equal read_time
+      _(results.first.data).must_be_kind_of Hash
+      _(results.first.data).must_equal({ body: "LGTM" })
+      _(results.first.created_at).must_equal read_time
+      _(results.first.updated_at).must_equal read_time
+      _(results.first.read_at).must_equal read_time
 
-      results.last.data.must_be_kind_of Hash
-      results.last.data.must_equal({ body: "PTAL" })
-      results.last.created_at.must_equal read_time
-      results.last.updated_at.must_equal read_time
-      results.last.read_at.must_equal read_time
+      _(results.last.data).must_be_kind_of Hash
+      _(results.last.data).must_equal({ body: "PTAL" })
+      _(results.last.created_at).must_equal read_time
+      _(results.last.updated_at).must_equal read_time
+      _(results.last.read_at).must_equal read_time
     end
   end
 
   def assert_results_enum enum
-    enum.must_be_kind_of Enumerator
+    _(enum).must_be_kind_of Enumerator
 
     results = enum.to_a
-    results.count.must_equal 2
+    _(results.count).must_equal 2
 
     results.each do |result|
-      result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(result).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      result.ref.client.must_equal firestore
+      _(result.ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(result.ref.client).must_equal firestore
 
-      result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      result.parent.collection_id.must_equal "users"
-      result.parent.collection_path.must_equal "users"
-      result.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
-      result.parent.client.must_equal firestore
+      _(result.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(result.parent.collection_id).must_equal "users"
+      _(result.parent.collection_path).must_equal "users"
+      _(result.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
+      _(result.parent.client).must_equal firestore
     end
 
-    results.first.data.must_be_kind_of Hash
-    results.first.data.must_equal({ name: "Mike" })
-    results.first.created_at.must_equal read_time
-    results.first.updated_at.must_equal read_time
-    results.first.read_at.must_equal read_time
+    _(results.first.data).must_be_kind_of Hash
+    _(results.first.data).must_equal({ name: "Mike" })
+    _(results.first.created_at).must_equal read_time
+    _(results.first.updated_at).must_equal read_time
+    _(results.first.read_at).must_equal read_time
 
-    results.last.data.must_be_kind_of Hash
-    results.last.data.must_equal({ name: "Chris" })
-    results.last.created_at.must_equal read_time
-    results.last.updated_at.must_equal read_time
-    results.last.read_at.must_equal read_time
+    _(results.last.data).must_be_kind_of Hash
+    _(results.last.data).must_equal({ name: "Chris" })
+    _(results.last.created_at).must_equal read_time
+    _(results.last.updated_at).must_equal read_time
+    _(results.last.read_at).must_equal read_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/commit_response_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/commit_response_test.rb
@@ -25,8 +25,8 @@ describe Google::Cloud::Firestore::CommitResponse, :mock_firestore do
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, []
 
-    commit_response.commit_time.must_be :nil?
-    commit_response.write_results.must_be :empty?
+    _(commit_response.commit_time).must_be :nil?
+    _(commit_response.write_results).must_be :empty?
   end
 
   it "can represent an empty result" do
@@ -34,8 +34,8 @@ describe Google::Cloud::Firestore::CommitResponse, :mock_firestore do
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, []
 
-    commit_response.commit_time.must_be :nil?
-    commit_response.write_results.must_be :empty?
+    _(commit_response.commit_time).must_be :nil?
+    _(commit_response.write_results).must_be :empty?
   end
 
   it "can represent results with transforms" do
@@ -55,10 +55,10 @@ describe Google::Cloud::Firestore::CommitResponse, :mock_firestore do
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two]]
 
-    commit_response.commit_time.must_equal update_time
-    commit_response.write_results.size.must_equal 1
+    _(commit_response.commit_time).must_equal update_time
+    _(commit_response.write_results.size).must_equal 1
     commit_response.write_results.first.tap do |write_result|
-      write_result.update_time.must_equal update_time
+      _(write_result.update_time).must_equal update_time
     end
   end
 
@@ -73,9 +73,9 @@ describe Google::Cloud::Firestore::CommitResponse, :mock_firestore do
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two]]
 
-    commit_response.commit_time.must_equal update_time
-    commit_response.write_results.size.must_equal 1
-    commit_response.write_results[0].update_time.must_equal update_time
+    _(commit_response.commit_time).must_equal update_time
+    _(commit_response.write_results.size).must_equal 1
+    _(commit_response.write_results[0].update_time).must_equal update_time
   end
 
   it "can represent results without and with update_time" do
@@ -89,9 +89,9 @@ describe Google::Cloud::Firestore::CommitResponse, :mock_firestore do
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two]]
 
-    commit_response.commit_time.must_equal update_time
-    commit_response.write_results.size.must_equal 1
-    commit_response.write_results[0].update_time.must_equal update_time
+    _(commit_response.commit_time).must_equal update_time
+    _(commit_response.write_results.size).must_equal 1
+    _(commit_response.write_results[0].update_time).must_equal update_time
   end
 
   it "can represent results without update_time" do
@@ -105,9 +105,9 @@ describe Google::Cloud::Firestore::CommitResponse, :mock_firestore do
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two]]
 
-    commit_response.commit_time.must_equal update_time
-    commit_response.write_results.size.must_equal 1
-    commit_response.write_results[0].update_time.must_equal update_time
+    _(commit_response.commit_time).must_equal update_time
+    _(commit_response.write_results.size).must_equal 1
+    _(commit_response.write_results[0].update_time).must_equal update_time
   end
 
   it "can represent results without mismatched writes" do
@@ -121,9 +121,9 @@ describe Google::Cloud::Firestore::CommitResponse, :mock_firestore do
 
     commit_response = Google::Cloud::Firestore::CommitResponse.from_grpc grpc_response, [[:one, :two], :three]
 
-    commit_response.commit_time.must_equal update_time
-    commit_response.write_results.size.must_equal 2
-    commit_response.write_results[0].update_time.must_equal update_time
-    commit_response.write_results[1].update_time.must_equal update_time
+    _(commit_response.commit_time).must_equal update_time
+    _(commit_response.write_results.size).must_equal 2
+    _(commit_response.write_results[0].update_time).must_equal update_time
+    _(commit_response.write_results[1].update_time).must_equal update_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/conformance_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/conformance_test.rb
@@ -311,7 +311,7 @@ class ConformanceListen < ConformanceTest
 
       listener.stop
 
-      query_snapshots.count.must_equal test.snapshots.count
+      _(query_snapshots.count).must_equal test.snapshots.count
       query_snapshots.zip(test.snapshots).each do |ruby_snapshot, proto_snapshot|
         compare_query_snapshot ruby_snapshot, proto_snapshot
       end
@@ -319,16 +319,16 @@ class ConformanceListen < ConformanceTest
   end
 
   def compare_query_snapshot ruby_snapshot, proto_snapshot
-    ruby_snapshot.docs.count.must_equal proto_snapshot.docs.count
-    ruby_snapshot.docs.map(&:path).must_equal proto_snapshot.docs.map(&:name)
+    _(ruby_snapshot.docs.count).must_equal proto_snapshot.docs.count
+    _(ruby_snapshot.docs.map(&:path)).must_equal proto_snapshot.docs.map(&:name)
     ruby_snapshot.docs.zip(proto_snapshot.docs).each do |ruby_doc, proto_doc|
       compare_document_snapshot ruby_doc, proto_doc
     end
-    ruby_snapshot.changes.count.must_equal proto_snapshot.changes.count
+    _(ruby_snapshot.changes.count).must_equal proto_snapshot.changes.count
   end
 
   def compare_document_snapshot ruby_snapshot, proto_snapshot
-    ruby_snapshot.grpc.to_h.must_equal proto_snapshot.to_h
+    _(ruby_snapshot.grpc.to_h).must_equal proto_snapshot.to_h
   end
 end
 

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/build_hash_from_field_paths_and_values_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/build_hash_from_field_paths_and_values_test.rb
@@ -23,20 +23,20 @@ describe Google::Cloud::Firestore::Convert, :build_hash_from_field_paths_and_val
     orig = [[Google::Cloud::Firestore::FieldPath.new("foo", "bar"), "BAZ"]]
 
     hash = Google::Cloud::Firestore::Convert.build_hash_from_field_paths_and_values orig
-    hash.must_equal({ foo: { bar: "BAZ" } })
+    _(hash).must_equal({ foo: { bar: "BAZ" } })
   end
 
   it "extracts only top-level field paths" do
     orig = [[Google::Cloud::Firestore::FieldPath.new("foo", "bar"), { "baz.bif" => 42 }]]
 
     hash = Google::Cloud::Firestore::Convert.build_hash_from_field_paths_and_values orig
-    hash.must_equal({ foo: { bar: { "baz.bif" => 42 } } })
+    _(hash).must_equal({ foo: { bar: { "baz.bif" => 42 } } })
   end
 
   it "handles an empty hash" do
     orig = []
 
     hash = Google::Cloud::Firestore::Convert.build_hash_from_field_paths_and_values orig
-    hash.must_equal({})
+    _(hash).must_equal({})
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/identify_leaf_nodes_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/identify_leaf_nodes_test.rb
@@ -23,20 +23,20 @@ describe Google::Cloud::Firestore::Convert, :identify_leaf_nodes do
     orig = { foo: "FOO", bar: "BAR" }
 
     paths = Google::Cloud::Firestore::Convert.identify_leaf_nodes orig
-    paths.map(&:formatted_string).must_equal ["foo", "bar"]
+    _(paths.map(&:formatted_string)).must_equal ["foo", "bar"]
   end
 
   it "finds paths belonging to a nested hash" do
     orig = { foo: { bar: "BAR", baz: "BAZ" } }
 
     paths = Google::Cloud::Firestore::Convert.identify_leaf_nodes orig
-    paths.map(&:formatted_string).must_equal ["foo.bar", "foo.baz"]
+    _(paths.map(&:formatted_string)).must_equal ["foo.bar", "foo.baz"]
   end
 
   it "finds paths belonging to a deeply nested hash" do
     orig = { foo: { bar: { baz: { bif: "BIF" } } } }
 
     paths = Google::Cloud::Firestore::Convert.identify_leaf_nodes orig
-    paths.map(&:formatted_string).must_equal ["foo.bar.baz.bif"]
+    _(paths.map(&:formatted_string)).must_equal ["foo.bar.baz.bif"]
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/is_field_value_nested_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/is_field_value_nested_test.rb
@@ -25,111 +25,111 @@ describe Google::Cloud::Firestore::Convert, :is_field_value_nested do
     obj = { foo: "FOO", bar: hello_field_value }
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_equal hello_field_value
+    _(resp).must_equal hello_field_value
   end
 
   it "finds values belonging to an array" do
     obj = ["FOO", hello_field_value]
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_equal hello_field_value
+    _(resp).must_equal hello_field_value
   end
 
   it "finds values belonging to a nested hash" do
     obj = { foo: "FOO", bar: { baz: hello_field_value } }
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_equal hello_field_value
+    _(resp).must_equal hello_field_value
   end
 
   it "finds values belonging to a hash nested under an array" do
     obj = [:ZOMG, { foo: "FOO", bar: hello_field_value }]
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_equal hello_field_value
+    _(resp).must_equal hello_field_value
   end
 
   it "finds values belonging to a nested array" do
     obj = ["FOO", ["BAR", hello_field_value]]
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_equal hello_field_value
+    _(resp).must_equal hello_field_value
   end
 
   it "finds values belonging to an array nested under a hash" do
     obj = { foo: ["FOO", hello_field_value] }
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_equal hello_field_value
+    _(resp).must_equal hello_field_value
   end
 
   it "finds value that is the object" do
     obj = hello_field_value
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_equal hello_field_value
+    _(resp).must_equal hello_field_value
   end
 
   it "does not find value on nil" do
     obj = nil
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_be :nil?
+    _(resp).must_be :nil?
   end
 
   it "does not find value on a hash" do
     obj = { foo: "BAR", baz: "BIF" }
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_be :nil?
+    _(resp).must_be :nil?
   end
 
   it "does not find value on an array" do
     obj = ["BAZ", "BIF"]
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_be :nil?
+    _(resp).must_be :nil?
   end
 
   it "does not find value on a nested hash" do
     obj = { foo: { bar: :BAZ } }
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_be :nil?
+    _(resp).must_be :nil?
   end
 
   it "does not find value on a hash nested under an array" do
     obj = ["BAZ", "BIF", { foo: :BAR }]
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_be :nil?
+    _(resp).must_be :nil?
   end
 
   it "does not find value on a nested array" do
     obj = [:foo, :bar, ["BAZ", "BIF"]]
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_be :nil?
+    _(resp).must_be :nil?
   end
 
   it "does not find value on an array nested under a hash" do
     obj = { foo: { bar: ["BAZ", "BIF"] } }
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_be :nil?
+    _(resp).must_be :nil?
   end
 
   it "does not find value on empty hash" do
     obj = {}
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_be :nil?
+    _(resp).must_be :nil?
   end
 
   it "does not find value on empty array" do
     obj = []
 
     resp = Google::Cloud::Firestore::Convert.is_field_value_nested obj, :hello
-    resp.must_be :nil?
+    _(resp).must_be :nil?
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/raw_to_value_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/raw_to_value_test.rb
@@ -23,129 +23,129 @@ describe Google::Cloud::Firestore::Convert, :raw_to_value, :mock_firestore do
     value = Google::Firestore::V1::Value.new null_value: :NULL_VALUE
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value nil
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts a true boolean value" do
     value = Google::Firestore::V1::Value.new boolean_value: true
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value true
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts a false boolean value" do
     value = Google::Firestore::V1::Value.new boolean_value: false
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value false
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts a integer value" do
     value = Google::Firestore::V1::Value.new integer_value: 29
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value 29
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts a double value" do
     value = Google::Firestore::V1::Value.new double_value: 0.9
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value 0.9
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts a nan value" do
     value = Google::Firestore::V1::Value.new double_value: Float::NAN
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value Float::NAN
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts an infinity value" do
     value = Google::Firestore::V1::Value.new double_value: Float::INFINITY
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value Float::INFINITY
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts a timestamp value" do
     value = Google::Firestore::V1::Value.new timestamp_value: Google::Protobuf::Timestamp.new(seconds: 1483326245, nanos: 60000000)
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value Time.parse("2017-01-02 03:04:05.06 UTC")
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts a datetime value" do
     value = Google::Firestore::V1::Value.new timestamp_value: Google::Protobuf::Timestamp.new(seconds: 1483326245, nanos: 60000000)
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value Time.parse("2017-01-02 03:04:05.06 UTC").to_datetime
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts a date value" do
     converted = Google::Cloud::Firestore::Convert.raw_to_value Time.parse("2017-01-02 03:04:05.06 UTC").to_date
-    converted.value_type.must_equal :timestamp_value
+    _(converted.value_type).must_equal :timestamp_value
   end
 
   it "converts a string value" do
     value = Google::Firestore::V1::Value.new string_value: "Mike"
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value "Mike"
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts a bytes value" do
     value = Google::Firestore::V1::Value.new bytes_value: "c\0ntents"
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value StringIO.new("c\0ntents")
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts a reference value" do
     value = Google::Firestore::V1::Value.new reference_value: "projects/#{project}/databases/(default)/documents/users/mike"
     converted = Google::Cloud::Firestore::Convert.raw_to_value firestore.doc("users/mike")
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts a geo_point value" do
     value = Google::Firestore::V1::Value.new geo_point_value: Google::Type::LatLng.new(latitude: 43.878264, longitude: -103.45700740814209)
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value({ "longitude" => -103.45700740814209, "latitude" => 43.878264 })
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts an array of integer values" do
     value = Google::Firestore::V1::Value.new array_value: Google::Firestore::V1::ArrayValue.new(values: [Google::Firestore::V1::Value.new(integer_value: 1), Google::Firestore::V1::Value.new(integer_value: 2), Google::Firestore::V1::Value.new(integer_value: 3)])
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value [1, 2, 3]
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts an array of string values" do
     value = Google::Firestore::V1::Value.new array_value: Google::Firestore::V1::ArrayValue.new(values: [Google::Firestore::V1::Value.new(string_value: "foo"), Google::Firestore::V1::Value.new(string_value: "bar"), Google::Firestore::V1::Value.new(string_value: "baz")])
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value %w(foo bar baz)
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts a simple hash value" do
     value = Google::Firestore::V1::Value.new map_value: Google::Firestore::V1::MapValue.new(fields: {"foo"=>Google::Firestore::V1::Value.new(string_value: "bar")})
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value({ foo: "bar" })
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts a complex hash value" do
     value = Google::Firestore::V1::Value.new map_value: Google::Firestore::V1::MapValue.new(fields: { "score"=>Google::Firestore::V1::Value.new(double_value: 0.9), "env"=>Google::Firestore::V1::Value.new(string_value: "production"), "project_ids"=>Google::Firestore::V1::Value.new(array_value: Google::Firestore::V1::ArrayValue.new(values: [Google::Firestore::V1::Value.new(integer_value: 1), Google::Firestore::V1::Value.new(integer_value: 2), Google::Firestore::V1::Value.new(integer_value: 3)] )) })
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value({ env: "production", score: 0.9, project_ids: [1, 2, 3] })
-    converted.must_equal value
+    _(converted).must_equal value
   end
 
   it "converts an emtpy hash value" do
     value = Google::Firestore::V1::Value.new map_value: Google::Firestore::V1::MapValue.new(fields: {})
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value({})
-    converted.must_equal value
+    _(converted).must_equal value
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/remove_field_value_from_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/remove_field_value_from_test.rb
@@ -25,55 +25,55 @@ describe Google::Cloud::Firestore::Convert, :remove_field_value_from do
     orig = { foo: "FOO", bar: hello_field_value }
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_equal({ "foo" => "FOO" })
-    paths.keys.map(&:formatted_string).must_equal ["bar"]
+    _(hash).must_equal({ "foo" => "FOO" })
+    _(paths.keys.map(&:formatted_string)).must_equal ["bar"]
   end
 
   it "finds dotted paths belonging to the top-level nodes" do
     orig = { "foo.bar" => hello_field_value, baz: { baf: hello_field_value }, hello: :world }
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_equal({ "hello" => :world })
-    paths.keys.map(&:formatted_string).must_equal ["`foo.bar`", "baz.baf"]
+    _(hash).must_equal({ "hello" => :world })
+    _(paths.keys.map(&:formatted_string)).must_equal ["`foo.bar`", "baz.baf"]
   end
   it "does not find paths belonging to an array" do
     orig = ["FOO", hello_field_value]
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_be :nil?
-    paths.must_be :empty?
+    _(hash).must_be :nil?
+    _(paths).must_be :empty?
   end
 
   it "finds paths belonging to a nested hash" do
     orig = { foo: "FOO", bar: { baz: hello_field_value } }
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_equal({ "foo" => "FOO" })
-    paths.keys.map(&:formatted_string).must_equal ["bar.baz"]
+    _(hash).must_equal({ "foo" => "FOO" })
+    _(paths.keys.map(&:formatted_string)).must_equal ["bar.baz"]
   end
 
   it "finds paths belonging to a deeply nested hash" do
     orig = { foo: { bar: { baz: { bif: hello_field_value } } } }
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_equal({ })
-    paths.keys.map(&:formatted_string).must_equal ["foo.bar.baz.bif"]
+    _(hash).must_equal({ })
+    _(paths.keys.map(&:formatted_string)).must_equal ["foo.bar.baz.bif"]
   end
 
   it "does not find paths belonging to a hash nested under an array" do
     orig = [:ZOMG, { "foo" => "FOO", "bar" => hello_field_value }]
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_be :nil?
-    paths.must_be :empty?
+    _(hash).must_be :nil?
+    _(paths).must_be :empty?
   end
 
   it "does not find paths belonging to a nested array" do
     orig = ["FOO", ["BAR", hello_field_value]]
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_be :nil?
-    paths.must_be :empty?
+    _(hash).must_be :nil?
+    _(paths).must_be :empty?
   end
 
   it "raises when finding paths belonging to an array nested under a hash" do
@@ -82,86 +82,86 @@ describe Google::Cloud::Firestore::Convert, :remove_field_value_from do
     error = expect do
       Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
     end.must_raise ArgumentError
-    error.message.must_equal "cannot nest hello under arrays"
+    _(error.message).must_equal "cannot nest hello under arrays"
   end
 
   it "does not find value that is the object" do
     orig = hello_field_value
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_be :nil?
-    paths.must_be :empty?
+    _(hash).must_be :nil?
+    _(paths).must_be :empty?
   end
 
   it "does not find value on nil" do
     orig = nil
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_be :nil?
-    paths.must_be :empty?
+    _(hash).must_be :nil?
+    _(paths).must_be :empty?
   end
 
   it "does not find value on a hash" do
     orig = { foo: "BAR", baz: "BIF" }
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_equal({ "foo" => "BAR", "baz" => "BIF" })
-    paths.must_be :empty?
+    _(hash).must_equal({ "foo" => "BAR", "baz" => "BIF" })
+    _(paths).must_be :empty?
   end
 
   it "does not find value on an array" do
     orig = ["BAZ", "BIF"]
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_be :nil?
-    paths.must_be :empty?
+    _(hash).must_be :nil?
+    _(paths).must_be :empty?
   end
 
   it "does not find value on a nested hash" do
     orig = { foo: { bar: :BAZ } }
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_equal({ "foo" => { "bar" => :BAZ } })
-    paths.must_be :empty?
+    _(hash).must_equal({ "foo" => { "bar" => :BAZ } })
+    _(paths).must_be :empty?
   end
 
   it "does not find value on a hash nested under an array" do
     orig = ["BAZ", "BIF", { foo: :BAR }]
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_be :nil?
-    paths.must_be :empty?
+    _(hash).must_be :nil?
+    _(paths).must_be :empty?
   end
 
   it "does not find value on a nested array" do
     orig = [:foo, :bar, ["BAZ", "BIF"]]
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_be :nil?
-    paths.must_be :empty?
+    _(hash).must_be :nil?
+    _(paths).must_be :empty?
   end
 
   it "does not find value on an array nested under a hash" do
     orig = { foo: { bar: ["BAZ", "BIF"] } }
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_equal({ "foo" => { "bar" => ["BAZ", "BIF"] } })
-    paths.must_be :empty?
+    _(hash).must_equal({ "foo" => { "bar" => ["BAZ", "BIF"] } })
+    _(paths).must_be :empty?
   end
 
   it "does not find value on empty hash" do
     orig = {}
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_equal({ })
-    paths.must_be :empty?
+    _(hash).must_equal({ })
+    _(paths).must_be :empty?
   end
 
   it "does not find value on empty array" do
     orig = []
 
     hash, paths = Google::Cloud::Firestore::Convert.remove_field_value_from orig, :hello
-    hash.must_be :nil?
-    paths.must_be :empty?
+    _(hash).must_be :nil?
+    _(paths).must_be :empty?
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/select_by_field_paths_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/select_by_field_paths_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Firestore::Convert, :select_by_field_paths do
     ]
 
     result = Google::Cloud::Firestore::Convert.select_by_field_paths orig, paths
-    result.must_equal({ "foo" => "FOO", "bar" => "BAR" })
+    _(result).must_equal({ "foo" => "FOO", "bar" => "BAR" })
   end
 
   it "finds all nested selected field paths" do
@@ -38,7 +38,7 @@ describe Google::Cloud::Firestore::Convert, :select_by_field_paths do
     ]
 
     result = Google::Cloud::Firestore::Convert.select_by_field_paths orig, paths
-    result.must_equal({ "foo" => { "bar" => "BAR", "baz" => "BAZ" } })
+    _(result).must_equal({ "foo" => { "bar" => "BAR", "baz" => "BAZ" } })
   end
 
   it "finds deeply nested selected field paths" do
@@ -48,7 +48,7 @@ describe Google::Cloud::Firestore::Convert, :select_by_field_paths do
     ]
 
     result = Google::Cloud::Firestore::Convert.select_by_field_paths orig, paths
-    result.must_equal({ "foo" => { "bar" => { "baz" => { "bif" => "BIF" } } } })
+    _(result).must_equal({ "foo" => { "bar" => { "baz" => { "bif" => "BIF" } } } })
   end
 
   it "finds partial using field paths" do
@@ -58,7 +58,7 @@ describe Google::Cloud::Firestore::Convert, :select_by_field_paths do
     ]
 
     result = Google::Cloud::Firestore::Convert.select_by_field_paths orig, paths
-    result.must_equal({ "foo" => "FOO" })
+    _(result).must_equal({ "foo" => "FOO" })
   end
 
   it "finds partial from nested selected field paths" do
@@ -68,6 +68,6 @@ describe Google::Cloud::Firestore::Convert, :select_by_field_paths do
     ]
 
     result = Google::Cloud::Firestore::Convert.select_by_field_paths orig, paths
-    result.must_equal({ "foo" => { "baz" => "BAZ" } })
+    _(result).must_equal({ "foo" => { "baz" => "BAZ" } })
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
@@ -23,123 +23,123 @@ describe Google::Cloud::Firestore::Convert, :value_to_raw, :mock_firestore do
     value = Google::Firestore::V1::Value.new(null_value: :NULL_VALUE)
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_be :nil?
+    _(raw).must_be :nil?
   end
 
   it "converts a true boolean value" do
     value = Google::Firestore::V1::Value.new(boolean_value: true)
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_equal true
+    _(raw).must_equal true
   end
 
   it "converts a false boolean value" do
     value = Google::Firestore::V1::Value.new(boolean_value: false)
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_equal false
+    _(raw).must_equal false
   end
 
   it "converts a integer value" do
     value = Google::Firestore::V1::Value.new(integer_value: 29)
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_equal 29
+    _(raw).must_equal 29
   end
 
   it "converts a double value" do
     value = Google::Firestore::V1::Value.new(double_value: 0.9)
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_equal 0.9
+    _(raw).must_equal 0.9
   end
 
   it "converts a nan value" do
     value = Google::Firestore::V1::Value.new(double_value: Float::NAN)
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_be :nan?
+    _(raw).must_be :nan?
   end
 
   it "converts an infinity value" do
     value = Google::Firestore::V1::Value.new(double_value: Float::INFINITY)
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_equal Float::INFINITY
+    _(raw).must_equal Float::INFINITY
   end
 
   it "converts a timestamp value" do
     value = Google::Firestore::V1::Value.new(timestamp_value: Google::Protobuf::Timestamp.new(seconds: 1483326245, nanos: 60000000))
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_equal Time.parse("2017-01-02 03:04:05.06 UTC")
+    _(raw).must_equal Time.parse("2017-01-02 03:04:05.06 UTC")
   end
 
   it "converts a string value" do
     value = Google::Firestore::V1::Value.new(string_value: "Mike")
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_equal "Mike"
+    _(raw).must_equal "Mike"
   end
 
   it "converts a bytes value" do
     value = Google::Firestore::V1::Value.new(bytes_value: "c\0ntents")
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_be_kind_of StringIO
-    raw.read.must_equal "c\0ntents"
+    _(raw).must_be_kind_of StringIO
+    _(raw.read).must_equal "c\0ntents"
   end
 
   it "converts a reference value" do
     value = Google::Firestore::V1::Value.new(reference_value: "projects/#{project}/databases/(default)/documents/users/mike" )
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    raw.document_id.must_equal "mike"
-    raw.document_path.must_equal "users/mike"
+    _(raw).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(raw.document_id).must_equal "mike"
+    _(raw.document_path).must_equal "users/mike"
   end
 
   it "converts a geo_point value" do
     value = Google::Firestore::V1::Value.new(geo_point_value: Google::Type::LatLng.new(latitude: 43.878264, longitude: -103.45700740814209))
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_be_kind_of Hash
-    raw[:longitude].must_equal -103.45700740814209
-    raw[:latitude].must_equal 43.878264
+    _(raw).must_be_kind_of Hash
+    _(raw[:longitude]).must_equal -103.45700740814209
+    _(raw[:latitude]).must_equal 43.878264
   end
 
   it "converts an array of integer values" do
     value = Google::Firestore::V1::Value.new(array_value: Google::Firestore::V1::ArrayValue.new(values: [Google::Firestore::V1::Value.new(integer_value: 1), Google::Firestore::V1::Value.new(integer_value: 2), Google::Firestore::V1::Value.new(integer_value: 3)]))
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_equal [1, 2, 3]
+    _(raw).must_equal [1, 2, 3]
   end
 
   it "converts an array of string values" do
     value = Google::Firestore::V1::Value.new(array_value: Google::Firestore::V1::ArrayValue.new(values: [Google::Firestore::V1::Value.new(string_value: "foo"), Google::Firestore::V1::Value.new(string_value: "bar"), Google::Firestore::V1::Value.new(string_value: "baz")]))
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_equal %w(foo bar baz)
+    _(raw).must_equal %w(foo bar baz)
   end
 
   it "converts a simple hash value" do
     value = Google::Firestore::V1::Value.new(map_value: Google::Firestore::V1::MapValue.new(fields: {"foo"=>Google::Firestore::V1::Value.new(string_value: "bar")}))
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_equal({ foo: "bar" })
+    _(raw).must_equal({ foo: "bar" })
   end
 
   it "converts a complex hash value" do
     value = Google::Firestore::V1::Value.new(map_value: Google::Firestore::V1::MapValue.new(fields: { "score"=>Google::Firestore::V1::Value.new(double_value: 0.9), "env"=>Google::Firestore::V1::Value.new(string_value: "production"), "project_ids"=>Google::Firestore::V1::Value.new(array_value: Google::Firestore::V1::ArrayValue.new(values: [Google::Firestore::V1::Value.new(integer_value: 1), Google::Firestore::V1::Value.new(integer_value: 2), Google::Firestore::V1::Value.new(integer_value: 3)] )) }))
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_equal({ env: "production", score: 0.9, project_ids: [1, 2, 3] })
+    _(raw).must_equal({ env: "production", score: 0.9, project_ids: [1, 2, 3] })
   end
 
   it "converts an emtpy hash value" do
     value = Google::Firestore::V1::Value.new(map_value: Google::Firestore::V1::MapValue.new(fields: {}))
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_equal({})
+    _(raw).must_equal({})
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/write_for_delete_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/write_for_delete_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Firestore::Convert, :write_for_delete do
 
     actual_write = Google::Cloud::Firestore::Convert.write_for_delete document_path, exists: true
 
-    actual_write.must_equal expected_write
+    _(actual_write).must_equal expected_write
   end
 
   it "delete without precondition" do
@@ -39,7 +39,7 @@ describe Google::Cloud::Firestore::Convert, :write_for_delete do
 
     actual_write = Google::Cloud::Firestore::Convert.write_for_delete document_path
 
-    actual_write.must_equal expected_write
+    _(actual_write).must_equal expected_write
   end
 
   it "delete with last-update-time precondition" do

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/writes_for_create_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/writes_for_create_test.rb
@@ -40,7 +40,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   it "complex create" do
@@ -71,7 +71,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   it "creating empty data" do
@@ -86,7 +86,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   it "don't split on dots" do
@@ -109,7 +109,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   it "non-alpha characters in map keys" do
@@ -132,7 +132,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   describe :field_delete do
@@ -142,7 +142,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_create document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "DELETE not allowed on create"
+      _(error.message).must_equal "DELETE not allowed on create"
     end
   end
 
@@ -167,7 +167,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "SERVER_TIME with data" do
@@ -199,7 +199,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "multiple SERVER_TIME fields" do
@@ -234,7 +234,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "nested SERVER_TIME field" do
@@ -266,7 +266,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "SERVER_TIME cannot be anywhere inside an array value" do
@@ -275,7 +275,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_create document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest server_time under arrays"
+      _(error.message).must_equal "cannot nest server_time under arrays"
     end
 
     it "SERVER_TIME cannot be in an array value" do
@@ -284,7 +284,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_create document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest server_time under arrays"
+      _(error.message).must_equal "cannot nest server_time under arrays"
     end
   end
 
@@ -317,7 +317,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "ARRAY_UNION with data" do
@@ -355,7 +355,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "multiple ARRAY_UNION fields" do
@@ -402,7 +402,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "nested ARRAY_UNION field" do
@@ -440,7 +440,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "ARRAY_UNION cannot be anywhere inside an array value" do
@@ -449,7 +449,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_create document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest array_union under arrays"
+      _(error.message).must_equal "cannot nest array_union under arrays"
     end
 
     it "ARRAY_UNION cannot be in an array value" do
@@ -458,7 +458,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_create document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest array_union under arrays"
+      _(error.message).must_equal "cannot nest array_union under arrays"
     end
   end
 
@@ -491,7 +491,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "ARRAY_DELETE with data" do
@@ -529,7 +529,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "multiple ARRAY_DELETE fields" do
@@ -576,7 +576,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "nested ARRAY_DELETE field" do
@@ -614,7 +614,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "ARRAY_DELETE cannot be anywhere inside an array value" do
@@ -623,7 +623,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_create document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest array_delete under arrays"
+      _(error.message).must_equal "cannot nest array_delete under arrays"
     end
 
     it "ARRAY_DELETE cannot be in an array value" do
@@ -632,7 +632,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_create document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest array_delete under arrays"
+      _(error.message).must_equal "cannot nest array_delete under arrays"
     end
   end
 
@@ -659,7 +659,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "INCREMENT with data" do
@@ -691,7 +691,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "multiple INCREMENT fields" do
@@ -726,7 +726,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "nested INCREMENT field" do
@@ -758,7 +758,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "INCREMENT cannot be anywhere inside an array value" do
@@ -767,7 +767,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_create document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest increment under arrays"
+      _(error.message).must_equal "cannot nest increment under arrays"
     end
 
     it "INCREMENT cannot be in an array value" do
@@ -776,7 +776,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_create document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest increment under arrays"
+      _(error.message).must_equal "cannot nest increment under arrays"
     end
   end
 
@@ -803,7 +803,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "MAXIMUM with data" do
@@ -835,7 +835,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "multiple MAXIMUM fields" do
@@ -870,7 +870,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "nested MAXIMUM field" do
@@ -902,7 +902,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "MAXIMUM cannot be anywhere inside an array value" do
@@ -911,7 +911,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_create document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest maximum under arrays"
+      _(error.message).must_equal "cannot nest maximum under arrays"
     end
 
     it "MAXIMUM cannot be in an array value" do
@@ -920,7 +920,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_create document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest maximum under arrays"
+      _(error.message).must_equal "cannot nest maximum under arrays"
     end
   end
 
@@ -947,7 +947,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "MINIMUM with data" do
@@ -979,7 +979,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "multiple MINIMUM fields" do
@@ -1014,7 +1014,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "nested MINIMUM field" do
@@ -1046,7 +1046,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_create document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "MINIMUM cannot be anywhere inside an array value" do
@@ -1055,7 +1055,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_create document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest minimum under arrays"
+      _(error.message).must_equal "cannot nest minimum under arrays"
     end
 
     it "MINIMUM cannot be in an array value" do
@@ -1064,7 +1064,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_create do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_create document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest minimum under arrays"
+      _(error.message).must_equal "cannot nest minimum under arrays"
     end
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/writes_for_set_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/writes_for_set_test.rb
@@ -39,7 +39,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_set document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   it "complex set" do
@@ -69,7 +69,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_set document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   it "setting empty data" do
@@ -83,7 +83,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_set document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   it "don't split on dots" do
@@ -105,7 +105,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_set document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   it "DELETE cannot be anywhere inside an array value" do
@@ -114,7 +114,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
     error = expect do
       Google::Cloud::Firestore::Convert.writes_for_set document_path, data
     end.must_raise ArgumentError
-    error.message.must_equal "cannot nest delete under arrays"
+    _(error.message).must_equal "cannot nest delete under arrays"
   end
 
   it "DELETE cannot be in an array value" do
@@ -123,7 +123,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
     error = expect do
       Google::Cloud::Firestore::Convert.writes_for_set document_path, data
     end.must_raise ArgumentError
-    error.message.must_equal "cannot nest delete under arrays"
+    _(error.message).must_equal "cannot nest delete under arrays"
   end
 
   it "DELETE cannot appear in data" do
@@ -132,7 +132,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
     error = expect do
       Google::Cloud::Firestore::Convert.writes_for_set document_path, data
     end.must_raise ArgumentError
-    error.message.must_equal "DELETE not allowed on set"
+    _(error.message).must_equal "DELETE not allowed on set"
   end
 
   describe "merge: []" do
@@ -155,7 +155,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_set document_path, data, merge: "a"
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "merges with FieldPaths (array)" do
@@ -179,7 +179,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_set document_path, data, merge: [["*", "~"]]
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "merges with FieldPaths (FieldPath)" do
@@ -204,7 +204,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
       merge_field_path = Google::Cloud::Firestore::FieldPath.new "*", "~"
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_set document_path, data, merge: merge_field_path
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "merges a nested field (array)" do
@@ -228,7 +228,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_set document_path, data, merge: [["h", "g"]]
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "merges a nested field (string)" do
@@ -252,7 +252,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_set document_path, data, merge: ["h.g"]
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "merges field when not a leaf" do
@@ -277,7 +277,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_set document_path, data, merge: [:h]
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "does not write data when field is not provided" do
@@ -299,7 +299,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_set document_path, data, merge: :b
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "fields must all be present in data" do
@@ -308,7 +308,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_set document_path, data, merge: ["b", "a"]
       end.must_raise ArgumentError
-      error.message.must_equal "all fields must be in data"
+      _(error.message).must_equal "all fields must be in data"
     end
 
     it "DELETE cannot appear in an unmerged field" do
@@ -317,7 +317,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_set document_path, data, merge: [:a]
       end.must_raise ArgumentError
-      error.message.must_equal "deleted field not included in merge"
+      _(error.message).must_equal "deleted field not included in merge"
     end
   end
 
@@ -342,7 +342,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_set document_path, data, merge: true
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "merges with nested fields" do
@@ -367,7 +367,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_set document_path, data, merge: true
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "cannot be specified with empty data" do
@@ -376,7 +376,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_set do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_set document_path, data, merge: []
       end.must_raise ArgumentError
-      error.message.must_equal "data required for set with merge"
+      _(error.message).must_equal "data required for set with merge"
     end
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/writes_for_update_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/writes_for_update_test.rb
@@ -41,7 +41,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   it "nested empty hashes create writes" do
@@ -66,7 +66,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   it "complex update" do
@@ -98,7 +98,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   it "invalid character" do
@@ -107,7 +107,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
     error = expect do
       Google::Cloud::Firestore::Convert.writes_for_update document_path, data
     end.must_raise ArgumentError
-    error.message.must_equal "invalid character, use FieldPath instead"
+    _(error.message).must_equal "invalid character, use FieldPath instead"
   end
 
   it "empty field path component" do
@@ -116,7 +116,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
     error = expect do
       Google::Cloud::Firestore::Convert.writes_for_update document_path, data
     end.must_raise ArgumentError
-    error.message.must_equal "empty paths not allowed"
+    _(error.message).must_equal "empty paths not allowed"
   end
 
   it "no paths" do
@@ -125,7 +125,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
     error = expect do
       Google::Cloud::Firestore::Convert.writes_for_update document_path, data
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 
   it "prefix #1" do
@@ -134,7 +134,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
     error = expect do
       Google::Cloud::Firestore::Convert.writes_for_update document_path, data
     end.must_raise ArgumentError
-    error.message.must_equal "one field cannot be a prefix of another"
+    _(error.message).must_equal "one field cannot be a prefix of another"
   end
 
   it "prefix #2" do
@@ -143,7 +143,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
     error = expect do
       Google::Cloud::Firestore::Convert.writes_for_update document_path, data
     end.must_raise ArgumentError
-    error.message.must_equal "one field cannot be a prefix of another"
+    _(error.message).must_equal "one field cannot be a prefix of another"
   end
 
   it "prefix #3" do
@@ -152,7 +152,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
     error = expect do
       Google::Cloud::Firestore::Convert.writes_for_update document_path, data
     end.must_raise ArgumentError
-    error.message.must_equal "one field cannot be a prefix of another"
+    _(error.message).must_equal "one field cannot be a prefix of another"
   end
 
   it "quotes paths starting with non-letter starting chars, except underscore" do
@@ -177,7 +177,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   it "splits on dots" do
@@ -202,7 +202,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   it "splits on dots for top-level keys only" do
@@ -227,7 +227,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   it "sends update_time as precondition" do
@@ -251,7 +251,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
     actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data, update_time: last_updated_at
 
-    actual_writes.must_equal expected_writes
+    _(actual_writes).must_equal expected_writes
   end
 
   describe "data using field paths" do
@@ -261,7 +261,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "empty paths not allowed"
+      _(error.message).must_equal "empty paths not allowed"
     end
 
     it "prefix #1" do
@@ -270,7 +270,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "one field cannot be a prefix of another"
+      _(error.message).must_equal "one field cannot be a prefix of another"
     end
 
     it "prefix #2" do
@@ -279,7 +279,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "one field cannot be a prefix of another"
+      _(error.message).must_equal "one field cannot be a prefix of another"
     end
 
     it "prefix #3" do
@@ -288,7 +288,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "one field cannot be a prefix of another"
+      _(error.message).must_equal "one field cannot be a prefix of another"
     end
 
     it "quotes paths starting with non-letter starting chars, except underscore" do
@@ -313,7 +313,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "uses field paths" do
@@ -338,7 +338,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "uses field paths for top-level keys only" do
@@ -363,7 +363,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
   end
 
@@ -386,7 +386,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "alone" do
@@ -404,7 +404,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "with a dotted field" do
@@ -428,7 +428,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "DELETE cannot be nested" do
@@ -437,7 +437,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "DELETE cannot be nested"
+      _(error.message).must_equal "DELETE cannot be nested"
     end
 
     it "DELETE cannot be anywhere inside an array value" do
@@ -446,7 +446,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest delete under arrays"
+      _(error.message).must_equal "cannot nest delete under arrays"
     end
 
     it "DELETE cannot be in an array value" do
@@ -455,7 +455,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest delete under arrays"
+      _(error.message).must_equal "cannot nest delete under arrays"
     end
   end
 
@@ -480,7 +480,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "SERVER_TIME with data" do
@@ -512,7 +512,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "SERVER_TIME with dotted field" do
@@ -535,7 +535,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "multiple SERVER_TIME fields" do
@@ -571,7 +571,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "nested SERVER_TIME field" do
@@ -603,7 +603,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "SERVER_TIME cannot be anywhere inside an array value" do
@@ -612,7 +612,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest server_time under arrays"
+      _(error.message).must_equal "cannot nest server_time under arrays"
     end
 
     it "SERVER_TIME cannot be in an array value" do
@@ -621,7 +621,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest server_time under arrays"
+      _(error.message).must_equal "cannot nest server_time under arrays"
     end
   end
 
@@ -654,7 +654,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "ARRAY_UNION with data" do
@@ -692,7 +692,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "ARRAY_UNION with dotted field" do
@@ -721,7 +721,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "multiple ARRAY_UNION fields" do
@@ -769,7 +769,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "nested ARRAY_UNION field" do
@@ -807,7 +807,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "ARRAY_UNION cannot be anywhere inside an array value" do
@@ -816,7 +816,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest array_union under arrays"
+      _(error.message).must_equal "cannot nest array_union under arrays"
     end
 
     it "ARRAY_UNION cannot be in an array value" do
@@ -825,7 +825,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest array_union under arrays"
+      _(error.message).must_equal "cannot nest array_union under arrays"
     end
   end
 
@@ -858,7 +858,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "ARRAY_DELETE with data" do
@@ -896,7 +896,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "ARRAY_DELETE with dotted field" do
@@ -925,7 +925,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "multiple ARRAY_DELETE fields" do
@@ -973,7 +973,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "nested ARRAY_DELETE field" do
@@ -1011,7 +1011,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "ARRAY_DELETE cannot be anywhere inside an array value" do
@@ -1020,7 +1020,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest array_delete under arrays"
+      _(error.message).must_equal "cannot nest array_delete under arrays"
     end
 
     it "ARRAY_DELETE cannot be in an array value" do
@@ -1029,7 +1029,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest array_delete under arrays"
+      _(error.message).must_equal "cannot nest array_delete under arrays"
     end
   end
 
@@ -1056,7 +1056,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "INCREMENT with data" do
@@ -1088,7 +1088,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "INCREMENT with dotted field" do
@@ -1111,7 +1111,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "multiple INCREMENT fields" do
@@ -1147,7 +1147,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "nested INCREMENT field" do
@@ -1179,7 +1179,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "INCREMENT cannot be anywhere inside an array value" do
@@ -1188,7 +1188,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest increment under arrays"
+      _(error.message).must_equal "cannot nest increment under arrays"
     end
 
     it "INCREMENT cannot be in an array value" do
@@ -1197,7 +1197,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest increment under arrays"
+      _(error.message).must_equal "cannot nest increment under arrays"
     end
   end
 
@@ -1224,7 +1224,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "MAXIMUM with data" do
@@ -1256,7 +1256,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "MAXIMUM with dotted field" do
@@ -1279,7 +1279,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "multiple MAXIMUM fields" do
@@ -1315,7 +1315,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "nested MAXIMUM field" do
@@ -1347,7 +1347,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "MAXIMUM cannot be anywhere inside an array value" do
@@ -1356,7 +1356,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest maximum under arrays"
+      _(error.message).must_equal "cannot nest maximum under arrays"
     end
 
     it "MAXIMUM cannot be in an array value" do
@@ -1365,7 +1365,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest maximum under arrays"
+      _(error.message).must_equal "cannot nest maximum under arrays"
     end
   end
 
@@ -1392,7 +1392,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "MINIMUM with data" do
@@ -1424,7 +1424,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "MINIMUM with dotted field" do
@@ -1447,7 +1447,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "multiple MINIMUM fields" do
@@ -1483,7 +1483,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "nested MINIMUM field" do
@@ -1515,7 +1515,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
 
       actual_writes = Google::Cloud::Firestore::Convert.writes_for_update document_path, data
 
-      actual_writes.must_equal expected_writes
+      _(actual_writes).must_equal expected_writes
     end
 
     it "MINIMUM cannot be anywhere inside an array value" do
@@ -1524,7 +1524,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest minimum under arrays"
+      _(error.message).must_equal "cannot nest minimum under arrays"
     end
 
     it "MINIMUM cannot be in an array value" do
@@ -1533,7 +1533,7 @@ describe Google::Cloud::Firestore::Convert, :writes_for_update do
       error = expect do
         Google::Cloud::Firestore::Convert.writes_for_update document_path, data
       end.must_raise ArgumentError
-      error.message.must_equal "cannot nest minimum under arrays"
+      _(error.message).must_equal "cannot nest minimum under arrays"
     end
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/document_reference/attrs_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_reference/attrs_test.rb
@@ -19,14 +19,14 @@ describe Google::Cloud::Firestore::DocumentReference, :attrs, :mock_firestore do
   let(:document) { Google::Cloud::Firestore::DocumentReference.from_path "projects/#{project}/databases/(default)/documents/#{document_path}", firestore }
 
   it "represents a document reference" do
-    document.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    document.document_id.must_equal "mike"
-    document.document_path.must_equal document_path
-    document.path.must_equal "projects/projectID/databases/(default)/documents/users/mike"
+    _(document).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(document.document_id).must_equal "mike"
+    _(document.document_path).must_equal document_path
+    _(document.path).must_equal "projects/projectID/databases/(default)/documents/users/mike"
 
-    document.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    document.parent.collection_id.must_equal "users"
-    document.parent.collection_path.must_equal "users"
-    document.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+    _(document.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(document.parent.collection_id).must_equal "users"
+    _(document.parent.collection_path).must_equal "users"
+    _(document.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/document_reference/col_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_reference/col_test.rb
@@ -21,52 +21,52 @@ describe Google::Cloud::Firestore::DocumentReference, :col, :mock_firestore do
   it "gets a collection by a collection_id" do
     col = document.col "messages"
 
-    col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    col.collection_id.must_equal "messages"
-    col.collection_path.must_equal "users/mike/messages"
-    col.path.must_equal "projects/#{project}/databases/(default)/documents/users/mike/messages"
+    _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(col.collection_id).must_equal "messages"
+    _(col.collection_path).must_equal "users/mike/messages"
+    _(col.path).must_equal "projects/#{project}/databases/(default)/documents/users/mike/messages"
   end
 
   it "gets a collection by a nested collection path" do
     col = document.col "messages/abc123/likes"
 
-    col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    col.collection_id.must_equal "likes"
-    col.collection_path.must_equal "users/mike/messages/abc123/likes"
-    col.path.must_equal "projects/#{project}/databases/(default)/documents/users/mike/messages/abc123/likes"
+    _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(col.collection_id).must_equal "likes"
+    _(col.collection_path).must_equal "users/mike/messages/abc123/likes"
+    _(col.path).must_equal "projects/#{project}/databases/(default)/documents/users/mike/messages/abc123/likes"
   end
 
   it "does not allow a document path" do
     error = expect do
       document.col "messages/abc123"
     end.must_raise ArgumentError
-    error.message.must_equal "collection_path must refer to a collection."
+    _(error.message).must_equal "collection_path must refer to a collection."
   end
 
   describe "using collection alias" do
     it "gets a collection by a collection_id" do
       col = document.collection "messages"
 
-      col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      col.collection_id.must_equal "messages"
-      col.collection_path.must_equal "users/mike/messages"
-      col.path.must_equal "projects/#{project}/databases/(default)/documents/users/mike/messages"
+      _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(col.collection_id).must_equal "messages"
+      _(col.collection_path).must_equal "users/mike/messages"
+      _(col.path).must_equal "projects/#{project}/databases/(default)/documents/users/mike/messages"
     end
 
     it "gets a collection by a nested collection path" do
       col = document.collection "messages/abc123/likes"
 
-      col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      col.collection_id.must_equal "likes"
-      col.collection_path.must_equal "users/mike/messages/abc123/likes"
-      col.path.must_equal "projects/#{project}/databases/(default)/documents/users/mike/messages/abc123/likes"
+      _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(col.collection_id).must_equal "likes"
+      _(col.collection_path).must_equal "users/mike/messages/abc123/likes"
+      _(col.path).must_equal "projects/#{project}/databases/(default)/documents/users/mike/messages/abc123/likes"
     end
 
     it "does not allow a document path" do
       error = expect do
         document.collection "messages/abc123"
       end.must_raise ArgumentError
-      error.message.must_equal "collection_path must refer to a collection."
+      _(error.message).must_equal "collection_path must refer to a collection."
     end
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/document_reference/cols_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_reference/cols_test.rb
@@ -21,19 +21,19 @@ describe Google::Cloud::Firestore::DocumentReference, :col, :mock_firestore do
     firestore_mock.expect :list_collection_ids, ["messages", "follows", "followers"].to_enum, [shallow_doc.path, options: default_options]
 
     col_enum = shallow_doc.cols
-    col_enum.must_be_kind_of Enumerator
+    _(col_enum).must_be_kind_of Enumerator
 
     col_ids = col_enum.map do |col|
-      col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
 
-      col.parent.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      col.parent.document_id.must_equal shallow_doc.document_id
-      col.parent.document_path.must_equal shallow_doc.document_path
+      _(col.parent).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(col.parent.document_id).must_equal shallow_doc.document_id
+      _(col.parent.document_path).must_equal shallow_doc.document_path
 
       col.collection_id
     end
-    col_ids.wont_be :empty?
-    col_ids.must_equal ["messages", "follows", "followers"]
+    _(col_ids).wont_be :empty?
+    _(col_ids).must_equal ["messages", "follows", "followers"]
   end
 
   it "retrieves collections from nested document" do
@@ -42,19 +42,19 @@ describe Google::Cloud::Firestore::DocumentReference, :col, :mock_firestore do
     firestore_mock.expect :list_collection_ids, ["likes", "saves", "hearts"].to_enum, [nested_doc.path, options: default_options]
 
     col_enum = nested_doc.cols
-    col_enum.must_be_kind_of Enumerator
+    _(col_enum).must_be_kind_of Enumerator
 
     col_ids = col_enum.map do |col|
-      col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
 
-      col.parent.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      col.parent.document_id.must_equal nested_doc.document_id
-      col.parent.document_path.must_equal nested_doc.document_path
+      _(col.parent).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(col.parent.document_id).must_equal nested_doc.document_id
+      _(col.parent.document_path).must_equal nested_doc.document_path
 
       col.collection_id
     end
-    col_ids.wont_be :empty?
-    col_ids.must_equal ["likes", "saves", "hearts"]
+    _(col_ids).wont_be :empty?
+    _(col_ids).must_equal ["likes", "saves", "hearts"]
   end
 
   it "retrieves collections from a document that does not exist" do
@@ -63,8 +63,8 @@ describe Google::Cloud::Firestore::DocumentReference, :col, :mock_firestore do
     firestore_mock.expect :list_collection_ids, [].to_enum, [missing_doc.path, options: default_options]
 
     col_enum = missing_doc.cols
-    col_enum.must_be_kind_of Enumerator
-    col_enum.to_a.must_be :empty?
+    _(col_enum).must_be_kind_of Enumerator
+    _(col_enum.to_a).must_be :empty?
   end
 
   describe "using collections alias" do
@@ -74,19 +74,19 @@ describe Google::Cloud::Firestore::DocumentReference, :col, :mock_firestore do
       firestore_mock.expect :list_collection_ids, ["messages", "follows", "followers"].to_enum, [shallow_doc.path, options: default_options]
 
       col_enum = shallow_doc.collections
-      col_enum.must_be_kind_of Enumerator
+      _(col_enum).must_be_kind_of Enumerator
 
       col_ids = col_enum.map do |col|
-        col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
+        _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
 
-        col.parent.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-        col.parent.document_id.must_equal shallow_doc.document_id
-        col.parent.document_path.must_equal shallow_doc.document_path
+        _(col.parent).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+        _(col.parent.document_id).must_equal shallow_doc.document_id
+        _(col.parent.document_path).must_equal shallow_doc.document_path
 
         col.collection_id
       end
-      col_ids.wont_be :empty?
-      col_ids.must_equal ["messages", "follows", "followers"]
+      _(col_ids).wont_be :empty?
+      _(col_ids).must_equal ["messages", "follows", "followers"]
     end
 
     it "retrieves collections from nested document" do
@@ -95,19 +95,19 @@ describe Google::Cloud::Firestore::DocumentReference, :col, :mock_firestore do
       firestore_mock.expect :list_collection_ids, ["likes", "saves", "hearts"].to_enum, [nested_doc.path, options: default_options]
 
       col_enum = nested_doc.collections
-      col_enum.must_be_kind_of Enumerator
+      _(col_enum).must_be_kind_of Enumerator
 
       col_ids = col_enum.map do |col|
-        col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
+        _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
 
-        col.parent.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-        col.parent.document_id.must_equal nested_doc.document_id
-        col.parent.document_path.must_equal nested_doc.document_path
+        _(col.parent).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+        _(col.parent.document_id).must_equal nested_doc.document_id
+        _(col.parent.document_path).must_equal nested_doc.document_path
 
         col.collection_id
       end
-      col_ids.wont_be :empty?
-      col_ids.must_equal ["likes", "saves", "hearts"]
+      _(col_ids).wont_be :empty?
+      _(col_ids).must_equal ["likes", "saves", "hearts"]
     end
 
     it "retrieves collections from a document that does not exist" do
@@ -116,8 +116,8 @@ describe Google::Cloud::Firestore::DocumentReference, :col, :mock_firestore do
       firestore_mock.expect :list_collection_ids, [].to_enum, [missing_doc.path, options: default_options]
 
       col_enum = missing_doc.collections
-      col_enum.must_be_kind_of Enumerator
-      col_enum.to_a.must_be :empty?
+      _(col_enum).must_be_kind_of Enumerator
+      _(col_enum.to_a).must_be :empty?
     end
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/document_reference/create_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_reference/create_test.rb
@@ -41,18 +41,18 @@ describe Google::Cloud::Firestore::DocumentReference, :create, :mock_firestore d
   it "creates a new document" do
     firestore_mock.expect :commit, commit_resp, [database_path, writes: create_writes, options: default_options]
 
-    document.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(document).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     resp = document.create({ name: "Mike" })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "raises if not given a Hash" do
     error = expect do
       document.create "not a hash"
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/document_reference/delete_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_reference/delete_test.rb
@@ -36,11 +36,11 @@ describe Google::Cloud::Firestore::DocumentReference, :delete, :mock_firestore d
   it "deletes a document" do
     firestore_mock.expect :commit, commit_resp, [database_path, writes: delete_writes, options: default_options]
 
-    document.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(document).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     resp = document.delete
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/document_reference/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_reference/get_test.rb
@@ -42,46 +42,46 @@ describe Google::Cloud::Firestore::DocumentReference, :get, :mock_firestore do
     firestore_mock.expect :batch_get_documents, found_doc_enum, [database_path, documents: ["#{documents_path}/users/mike"], mask: nil, options: default_options]
 
     doc_ref = firestore.doc "users/mike"
-    doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     doc = doc_ref.get
 
-    doc.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
-    doc.document_id.must_equal doc_ref.document_id
-    doc.document_path.must_equal doc_ref.document_path
+    _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(doc.document_id).must_equal doc_ref.document_id
+    _(doc.document_path).must_equal doc_ref.document_path
 
-    doc.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    doc.parent.collection_id.must_equal "users"
-    doc.parent.collection_path.must_equal "users"
+    _(doc.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(doc.parent.collection_id).must_equal "users"
+    _(doc.parent.collection_path).must_equal "users"
 
-    doc.must_be :exists?
-    doc.data.must_be_kind_of Hash
-    doc.data.must_equal({ name: "Mike" })
-    doc.created_at.must_equal read_time
-    doc.updated_at.must_equal read_time
-    doc.read_at.must_equal read_time
+    _(doc).must_be :exists?
+    _(doc.data).must_be_kind_of Hash
+    _(doc.data).must_equal({ name: "Mike" })
+    _(doc.created_at).must_equal read_time
+    _(doc.updated_at).must_equal read_time
+    _(doc.read_at).must_equal read_time
   end
 
   it "gets a missing snapshot" do
     firestore_mock.expect :batch_get_documents, missing_doc_enum, [database_path, documents: ["#{documents_path}/users/tad"], mask: nil, options: default_options]
 
     doc_ref = firestore.doc "users/tad"
-    doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     doc = doc_ref.get
 
-    doc.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
-    doc.document_id.must_equal doc_ref.document_id
-    doc.document_path.must_equal doc_ref.document_path
+    _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(doc.document_id).must_equal doc_ref.document_id
+    _(doc.document_path).must_equal doc_ref.document_path
 
-    doc.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    doc.parent.collection_id.must_equal "users"
-    doc.parent.collection_path.must_equal "users"
+    _(doc.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(doc.parent.collection_id).must_equal "users"
+    _(doc.parent.collection_path).must_equal "users"
 
-    doc.must_be :missing?
-    doc.data.must_be :nil?
-    doc.created_at.must_be :nil?
-    doc.updated_at.must_be :nil?
-    doc.read_at.must_equal read_time
+    _(doc).must_be :missing?
+    _(doc.data).must_be :nil?
+    _(doc.created_at).must_be :nil?
+    _(doc.updated_at).must_be :nil?
+    _(doc.read_at).must_equal read_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/document_reference/listen_restart_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_reference/listen_restart_test.rb
@@ -228,29 +228,29 @@ describe Google::Cloud::Firestore::DocumentReference, :listen, :retry, :watch_fi
 
   def verify_doc_snapshots snapshots
     assert snapshots
-    snapshots.count.must_equal 6
-    snapshots.each { |qs| qs.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot }
+    _(snapshots.count).must_equal 6
+    snapshots.each { |qs| _(qs).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot }
 
-    snapshots[0].document_path.must_equal document.document_path
-    snapshots[0].must_be :exists?
-    snapshots[0][:val].must_be :nil?
+    _(snapshots[0].document_path).must_equal document.document_path
+    _(snapshots[0]).must_be :exists?
+    _(snapshots[0][:val]).must_be :nil?
 
-    snapshots[1].document_path.must_equal document.document_path
-    snapshots[1].must_be :exists?
-    snapshots[1][:val].must_equal 42
+    _(snapshots[1].document_path).must_equal document.document_path
+    _(snapshots[1]).must_be :exists?
+    _(snapshots[1][:val]).must_equal 42
 
-    snapshots[2].document_path.must_equal document.document_path
-    snapshots[2].must_be :missing?
+    _(snapshots[2].document_path).must_equal document.document_path
+    _(snapshots[2]).must_be :missing?
 
-    snapshots[3].document_path.must_equal document.document_path
-    snapshots[3].must_be :exists?
-    snapshots[3][:val].must_equal 11.1
+    _(snapshots[3].document_path).must_equal document.document_path
+    _(snapshots[3]).must_be :exists?
+    _(snapshots[3][:val]).must_equal 11.1
 
-    snapshots[4].document_path.must_equal document.document_path
-    snapshots[4].must_be :missing?
+    _(snapshots[4].document_path).must_equal document.document_path
+    _(snapshots[4]).must_be :missing?
 
-    snapshots[5].document_path.must_equal document.document_path
-    snapshots[5].must_be :exists?
-    snapshots[5][:val].must_equal "hi"
+    _(snapshots[5].document_path).must_equal document.document_path
+    _(snapshots[5]).must_be :exists?
+    _(snapshots[5][:val]).must_equal "hi"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/document_reference/listen_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_reference/listen_test.rb
@@ -60,30 +60,30 @@ describe Google::Cloud::Firestore::DocumentReference, :listen, :watch_firestore 
     listener.stop
 
     # assert snapshots
-    doc_snapshots.count.must_equal 6
-    doc_snapshots.each { |qs| qs.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot }
+    _(doc_snapshots.count).must_equal 6
+    doc_snapshots.each { |qs| _(qs).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot }
 
-    doc_snapshots[0].document_path.must_equal document.document_path
-    doc_snapshots[0].must_be :exists?
-    doc_snapshots[0][:val].must_be :nil?
+    _(doc_snapshots[0].document_path).must_equal document.document_path
+    _(doc_snapshots[0]).must_be :exists?
+    _(doc_snapshots[0][:val]).must_be :nil?
 
-    doc_snapshots[1].document_path.must_equal document.document_path
-    doc_snapshots[1].must_be :exists?
-    doc_snapshots[1][:val].must_equal 42
+    _(doc_snapshots[1].document_path).must_equal document.document_path
+    _(doc_snapshots[1]).must_be :exists?
+    _(doc_snapshots[1][:val]).must_equal 42
 
-    doc_snapshots[2].document_path.must_equal document.document_path
-    doc_snapshots[2].must_be :missing?
+    _(doc_snapshots[2].document_path).must_equal document.document_path
+    _(doc_snapshots[2]).must_be :missing?
 
-    doc_snapshots[3].document_path.must_equal document.document_path
-    doc_snapshots[3].must_be :exists?
-    doc_snapshots[3][:val].must_equal 11.1
+    _(doc_snapshots[3].document_path).must_equal document.document_path
+    _(doc_snapshots[3]).must_be :exists?
+    _(doc_snapshots[3][:val]).must_equal 11.1
 
-    doc_snapshots[4].document_path.must_equal document.document_path
-    doc_snapshots[4].must_be :missing?
+    _(doc_snapshots[4].document_path).must_equal document.document_path
+    _(doc_snapshots[4]).must_be :missing?
 
-    doc_snapshots[5].document_path.must_equal document.document_path
-    doc_snapshots[5].must_be :exists?
-    doc_snapshots[5][:val].must_equal "hi"
+    _(doc_snapshots[5].document_path).must_equal document.document_path
+    _(doc_snapshots[5]).must_be :exists?
+    _(doc_snapshots[5][:val]).must_equal "hi"
   end
 
   it "resets when RESET is returned" do
@@ -134,30 +134,30 @@ describe Google::Cloud::Firestore::DocumentReference, :listen, :watch_firestore 
     listener.stop
 
     # assert snapshots
-    doc_snapshots.count.must_equal 6
-    doc_snapshots.each { |qs| qs.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot }
+    _(doc_snapshots.count).must_equal 6
+    doc_snapshots.each { |qs| _(qs).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot }
 
-    doc_snapshots[0].document_path.must_equal document.document_path
-    doc_snapshots[0].must_be :exists?
-    doc_snapshots[0][:val].must_be :nil?
+    _(doc_snapshots[0].document_path).must_equal document.document_path
+    _(doc_snapshots[0]).must_be :exists?
+    _(doc_snapshots[0][:val]).must_be :nil?
 
-    doc_snapshots[1].document_path.must_equal document.document_path
-    doc_snapshots[1].must_be :exists?
-    doc_snapshots[1][:val].must_equal 42
+    _(doc_snapshots[1].document_path).must_equal document.document_path
+    _(doc_snapshots[1]).must_be :exists?
+    _(doc_snapshots[1][:val]).must_equal 42
 
-    doc_snapshots[2].document_path.must_equal document.document_path
-    doc_snapshots[2].must_be :missing?
+    _(doc_snapshots[2].document_path).must_equal document.document_path
+    _(doc_snapshots[2]).must_be :missing?
 
-    doc_snapshots[3].document_path.must_equal document.document_path
-    doc_snapshots[3].must_be :exists?
-    doc_snapshots[3][:val].must_equal 11.1
+    _(doc_snapshots[3].document_path).must_equal document.document_path
+    _(doc_snapshots[3]).must_be :exists?
+    _(doc_snapshots[3][:val]).must_equal 11.1
 
-    doc_snapshots[4].document_path.must_equal document.document_path
-    doc_snapshots[4].must_be :missing?
+    _(doc_snapshots[4].document_path).must_equal document.document_path
+    _(doc_snapshots[4]).must_be :missing?
 
-    doc_snapshots[5].document_path.must_equal document.document_path
-    doc_snapshots[5].must_be :exists?
-    doc_snapshots[5][:val].must_equal "hi"
+    _(doc_snapshots[5].document_path).must_equal document.document_path
+    _(doc_snapshots[5]).must_be :exists?
+    _(doc_snapshots[5][:val]).must_equal "hi"
   end
 
   it "resets when FILTER count is incorrect" do
@@ -209,30 +209,30 @@ describe Google::Cloud::Firestore::DocumentReference, :listen, :watch_firestore 
     listener.stop
 
     # assert snapshots
-    doc_snapshots.count.must_equal 6
-    doc_snapshots.each { |qs| qs.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot }
+    _(doc_snapshots.count).must_equal 6
+    doc_snapshots.each { |qs| _(qs).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot }
 
-    doc_snapshots[0].document_path.must_equal document.document_path
-    doc_snapshots[0].must_be :exists?
-    doc_snapshots[0][:val].must_be :nil?
+    _(doc_snapshots[0].document_path).must_equal document.document_path
+    _(doc_snapshots[0]).must_be :exists?
+    _(doc_snapshots[0][:val]).must_be :nil?
 
-    doc_snapshots[1].document_path.must_equal document.document_path
-    doc_snapshots[1].must_be :exists?
-    doc_snapshots[1][:val].must_equal 42
+    _(doc_snapshots[1].document_path).must_equal document.document_path
+    _(doc_snapshots[1]).must_be :exists?
+    _(doc_snapshots[1][:val]).must_equal 42
 
-    doc_snapshots[2].document_path.must_equal document.document_path
-    doc_snapshots[2].must_be :missing?
+    _(doc_snapshots[2].document_path).must_equal document.document_path
+    _(doc_snapshots[2]).must_be :missing?
 
-    doc_snapshots[3].document_path.must_equal document.document_path
-    doc_snapshots[3].must_be :exists?
-    doc_snapshots[3][:val].must_equal 11.1
+    _(doc_snapshots[3].document_path).must_equal document.document_path
+    _(doc_snapshots[3]).must_be :exists?
+    _(doc_snapshots[3][:val]).must_equal 11.1
 
-    doc_snapshots[4].document_path.must_equal document.document_path
-    doc_snapshots[4].must_be :missing?
+    _(doc_snapshots[4].document_path).must_equal document.document_path
+    _(doc_snapshots[4]).must_be :missing?
 
-    doc_snapshots[5].document_path.must_equal document.document_path
-    doc_snapshots[5].must_be :exists?
-    doc_snapshots[5][:val].must_equal "hi"
+    _(doc_snapshots[5].document_path).must_equal document.document_path
+    _(doc_snapshots[5]).must_be :exists?
+    _(doc_snapshots[5][:val]).must_equal "hi"
   end
 end
 181

--- a/google-cloud-firestore/test/google/cloud/firestore/document_reference/set_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_reference/set_test.rb
@@ -39,18 +39,18 @@ describe Google::Cloud::Firestore::DocumentReference, :set, :mock_firestore do
   it "sets a new document" do
     firestore_mock.expect :commit, commit_resp, [database_path, writes: set_writes, options: default_options]
 
-    document.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(document).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     resp = document.set({ name: "Mike" })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "raises if not given a Hash" do
     error = expect do
       document.set "not a hash"
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/document_reference/update_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_reference/update_test.rb
@@ -44,18 +44,18 @@ describe Google::Cloud::Firestore::DocumentReference, :update, :mock_firestore d
   it "updates a new document" do
     firestore_mock.expect :commit, commit_resp, [database_path, writes: update_writes, options: default_options]
 
-    document.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(document).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     resp = document.update({ name: "Mike" })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "raises if not given a Hash" do
     error = expect do
       document.update "not a hash"
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/document_reference/values_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_reference/values_test.rb
@@ -53,8 +53,8 @@ describe Google::Cloud::Firestore::DocumentReference, :values, :mock_firestore d
 
     resp = document.update({ val: nil })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "updates a document data with a true" do
@@ -63,8 +63,8 @@ describe Google::Cloud::Firestore::DocumentReference, :values, :mock_firestore d
 
     resp = document.update({ val: true })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "updates a document data with a false" do
@@ -73,8 +73,8 @@ describe Google::Cloud::Firestore::DocumentReference, :values, :mock_firestore d
 
     resp = document.update({ val: false })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "updates a document data with a nan" do
@@ -83,8 +83,8 @@ describe Google::Cloud::Firestore::DocumentReference, :values, :mock_firestore d
 
     resp = document.update({ val: Float::NAN })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "updates a document data with infinity" do
@@ -93,8 +93,8 @@ describe Google::Cloud::Firestore::DocumentReference, :values, :mock_firestore d
 
     resp = document.update({ val: Float::INFINITY })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "updates a document data with an int" do
@@ -103,8 +103,8 @@ describe Google::Cloud::Firestore::DocumentReference, :values, :mock_firestore d
 
     resp = document.update({ val: 42 })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "updates a document data with a float" do
@@ -113,8 +113,8 @@ describe Google::Cloud::Firestore::DocumentReference, :values, :mock_firestore d
 
     resp = document.update({ val: 3.14 })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "updates a document data with a time" do
@@ -123,8 +123,8 @@ describe Google::Cloud::Firestore::DocumentReference, :values, :mock_firestore d
 
     resp = document.update({ val: commit_time })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "updates a document data with a string" do
@@ -133,8 +133,8 @@ describe Google::Cloud::Firestore::DocumentReference, :values, :mock_firestore d
 
     resp = document.update({ val: "hello" })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "updates a document data with a IO" do
@@ -143,8 +143,8 @@ describe Google::Cloud::Firestore::DocumentReference, :values, :mock_firestore d
 
     resp = document.update({ val: StringIO.new("world") })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "updates a document data with a doc ref" do
@@ -153,8 +153,8 @@ describe Google::Cloud::Firestore::DocumentReference, :values, :mock_firestore d
 
     resp = document.update({ val: firestore.doc("C/d") })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "updates a document data with a geo point" do
@@ -163,8 +163,8 @@ describe Google::Cloud::Firestore::DocumentReference, :values, :mock_firestore d
 
     resp = document.update({ val: { longitude: 50.1430847, latitude: -122.947778 } })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "updates a document data with an array" do
@@ -181,8 +181,8 @@ describe Google::Cloud::Firestore::DocumentReference, :values, :mock_firestore d
 
     resp = document.update({ val: [1, 2.0, "3"] })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 
   it "updates a document data with a hash" do
@@ -197,7 +197,7 @@ describe Google::Cloud::Firestore::DocumentReference, :values, :mock_firestore d
 
     resp = document.update({ val: { hello: "word" } })
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
-    resp.update_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse::WriteResult
+    _(resp.update_time).must_equal commit_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/document_snapshot/attrs_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_snapshot/attrs_test.rb
@@ -35,68 +35,68 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :attrs, :mock_firestore do
   end
 
   it "represents a document reference" do
-    document.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(document).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
     # document's metadata
-    document.document_id.must_equal "mike"
-    document.document_path.must_equal document_path
+    _(document.document_id).must_equal "mike"
+    _(document.document_path).must_equal document_path
 
-    document.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    document.parent.collection_id.must_equal "users"
-    document.parent.collection_path.must_equal "users"
+    _(document.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(document.parent.collection_id).must_equal "users"
+    _(document.parent.collection_path).must_equal "users"
 
     # a reference document does not have any data
-    document.data.wont_be :nil?
-    document.data.must_be_kind_of Hash
-    document.data.must_equal({ name: "Mike" })
-    document.created_at.wont_be :nil?
-    document.created_at.must_equal document_time
-    document.updated_at.wont_be :nil?
-    document.updated_at.must_equal document_time
-    document.read_at.wont_be :nil?
-    document.read_at.must_equal document_time
-    document.must_be :exists?
-    document.wont_be :missing?
+    _(document.data).wont_be :nil?
+    _(document.data).must_be_kind_of Hash
+    _(document.data).must_equal({ name: "Mike" })
+    _(document.created_at).wont_be :nil?
+    _(document.created_at).must_equal document_time
+    _(document.updated_at).wont_be :nil?
+    _(document.updated_at).must_equal document_time
+    _(document.read_at).wont_be :nil?
+    _(document.read_at).must_equal document_time
+    _(document).must_be :exists?
+    _(document).wont_be :missing?
 
     # aliases for resource methods
-    document.fields.wont_be :nil?
-    document.fields.must_be_kind_of Hash
-    document.fields.must_equal({ name: "Mike" })
-    document.create_time.wont_be :nil?
-    document.create_time.must_equal document_time
-    document.update_time.wont_be :nil?
-    document.update_time.must_equal document_time
-    document.read_time.wont_be :nil?
-    document.read_time.must_equal document_time
+    _(document.fields).wont_be :nil?
+    _(document.fields).must_be_kind_of Hash
+    _(document.fields).must_equal({ name: "Mike" })
+    _(document.create_time).wont_be :nil?
+    _(document.create_time).must_equal document_time
+    _(document.update_time).wont_be :nil?
+    _(document.update_time).must_equal document_time
+    _(document.read_time).wont_be :nil?
+    _(document.read_time).must_equal document_time
   end
 
   it "represents a missing document reference" do
     document.grpc = nil
 
-    document.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(document).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
     # document's metadata
-    document.document_id.must_equal "mike"
-    document.document_path.must_equal document_path
+    _(document.document_id).must_equal "mike"
+    _(document.document_path).must_equal document_path
 
-    document.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    document.parent.collection_id.must_equal "users"
-    document.parent.collection_path.must_equal "users"
+    _(document.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(document.parent.collection_id).must_equal "users"
+    _(document.parent.collection_path).must_equal "users"
 
     # a reference document does not have any data
-    document.data.must_be :nil?
-    document.created_at.must_be :nil?
-    document.updated_at.must_be :nil?
-    document.read_at.wont_be :nil?
-    document.read_at.must_equal document_time
-    document.wont_be :exists?
-    document.must_be :missing?
+    _(document.data).must_be :nil?
+    _(document.created_at).must_be :nil?
+    _(document.updated_at).must_be :nil?
+    _(document.read_at).wont_be :nil?
+    _(document.read_at).must_equal document_time
+    _(document).wont_be :exists?
+    _(document).must_be :missing?
 
     # aliases for resource methods
-    document.fields.must_be :nil?
-    document.create_time.must_be :nil?
-    document.update_time.must_be :nil?
-    document.read_time.wont_be :nil?
-    document.read_time.must_equal document_time
+    _(document.fields).must_be :nil?
+    _(document.create_time).must_be :nil?
+    _(document.update_time).must_be :nil?
+    _(document.read_time).wont_be :nil?
+    _(document.read_time).must_equal document_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/document_snapshot/data_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_snapshot/data_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data.must_equal({ expires_on: nil })
+    _(document.data).must_equal({ expires_on: nil })
   end
 
   it "holds a true value" do
@@ -43,7 +43,7 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data.must_equal({ active: true })
+    _(document.data).must_equal({ active: true })
   end
 
   it "holds a false value" do
@@ -53,7 +53,7 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data.must_equal({ expired: false })
+    _(document.data).must_equal({ expired: false })
   end
 
   it "holds an integer value" do
@@ -63,7 +63,7 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data.must_equal({ score: 29 })
+    _(document.data).must_equal({ score: 29 })
   end
 
   it "holds a nan value" do
@@ -73,7 +73,7 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data[:ratio].must_be :nan?
+    _(document.data[:ratio]).must_be :nan?
   end
 
   it "holds an infinity value" do
@@ -83,7 +83,7 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data.must_equal({ ratio: Float::INFINITY })
+    _(document.data).must_equal({ ratio: Float::INFINITY })
   end
 
   it "holds a float value" do
@@ -93,7 +93,7 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data.must_equal({ ratio: 0.9 })
+    _(document.data).must_equal({ ratio: 0.9 })
   end
 
   it "holds a time value" do
@@ -103,7 +103,7 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data.must_equal({ published_at: Time.parse("2017-01-02 03:04:05.06 UTC") })
+    _(document.data).must_equal({ published_at: Time.parse("2017-01-02 03:04:05.06 UTC") })
   end
 
   it "holds a string value" do
@@ -113,7 +113,7 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data.must_equal({ name: "Mike" })
+    _(document.data).must_equal({ name: "Mike" })
   end
 
   it "holds a bytes value" do
@@ -123,8 +123,8 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data.keys.must_include :avatar
-    document.data[:avatar].read.must_equal "contents"
+    _(document.data.keys).must_include :avatar
+    _(document.data[:avatar].read).must_equal "contents"
   end
 
   it "holds a reference value" do
@@ -134,11 +134,11 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data.keys.must_include :friend
-    document.data[:friend].must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    document.data[:friend].document_id.must_equal "chris"
-    document.data[:friend].document_path.must_equal "users/chris"
-    document.data[:friend].path.must_equal "projects/#{project}/databases/(default)/documents/users/chris"
+    _(document.data.keys).must_include :friend
+    _(document.data[:friend]).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(document.data[:friend].document_id).must_equal "chris"
+    _(document.data[:friend].document_path).must_equal "users/chris"
+    _(document.data[:friend].path).must_equal "projects/#{project}/databases/(default)/documents/users/chris"
   end
 
   it "holds a geo_point value" do
@@ -148,7 +148,7 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data.must_equal({ location: { longitude: -103.45700740814209, latitude: 43.878264 } })
+    _(document.data).must_equal({ location: { longitude: -103.45700740814209, latitude: 43.878264 } })
   end
 
   it "holds an array value" do
@@ -158,7 +158,7 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data.must_equal({ projects: [1, 2, 3] })
+    _(document.data).must_equal({ projects: [1, 2, 3] })
   end
 
   it "holds a hash value" do
@@ -168,7 +168,7 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data.must_equal({ details: { env: "production", score: 0.9, project_ids: [1, 2, 3] } })
+    _(document.data).must_equal({ details: { env: "production", score: 0.9, project_ids: [1, 2, 3] } })
   end
 
   it "holds all the values" do
@@ -188,21 +188,21 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
-    document.data[:expires_on].must_be :nil?
-    document.data[:active].must_equal true
-    document.data[:expired].must_equal false
-    document.data[:score].must_equal 29
-    document.data[:ratio].must_equal 0.9
-    document.data[:published_at].must_equal Time.parse("2017-01-02 03:04:05.06 UTC")
-    document.data[:name].must_equal "Mike"
-    document.data.keys.must_include :avatar
-    document.data[:avatar].read.must_equal "contents"
-    document.data.keys.must_include :friend
-    document.data[:friend].must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    document.data[:friend].document_id.must_equal "chris"
-    document.data[:friend].document_path.must_equal "users/chris"
-    document.data[:friend].path.must_equal "projects/#{project}/databases/(default)/documents/users/chris"
-    document.data[:location].must_equal({ longitude: -103.45700740814209, latitude: 43.878264 })
-    document.data[:details].must_equal({ env: "production", score: 0.9, project_ids: [1, 2, 3] })
+    _(document.data[:expires_on]).must_be :nil?
+    _(document.data[:active]).must_equal true
+    _(document.data[:expired]).must_equal false
+    _(document.data[:score]).must_equal 29
+    _(document.data[:ratio]).must_equal 0.9
+    _(document.data[:published_at]).must_equal Time.parse("2017-01-02 03:04:05.06 UTC")
+    _(document.data[:name]).must_equal "Mike"
+    _(document.data.keys).must_include :avatar
+    _(document.data[:avatar].read).must_equal "contents"
+    _(document.data.keys).must_include :friend
+    _(document.data[:friend]).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(document.data[:friend].document_id).must_equal "chris"
+    _(document.data[:friend].document_path).must_equal "users/chris"
+    _(document.data[:friend].path).must_equal "projects/#{project}/databases/(default)/documents/users/chris"
+    _(document.data[:location]).must_equal({ longitude: -103.45700740814209, latitude: 43.878264 })
+    _(document.data[:details]).must_equal({ env: "production", score: 0.9, project_ids: [1, 2, 3] })
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/document_snapshot/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_snapshot/get_test.rb
@@ -38,85 +38,85 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :get, :mock_firestore do
   end
 
   it "retrieves top-level value from data given a fieldpath (string)" do
-    document.get("name").must_equal "Mike"
+    _(document.get("name")).must_equal "Mike"
   end
 
   it "retrieves top-level value from data given a fieldpath (symbol)" do
-    document.get(:name).must_equal "Mike"
+    _(document.get(:name)).must_equal "Mike"
   end
 
   it "retrieves top-level value from data given a fieldpath (array(string))" do
-    document.get(["name"]).must_equal "Mike"
+    _(document.get(["name"])).must_equal "Mike"
   end
 
   it "retrieves top-level value from data given a fieldpath (array(symbol))" do
-    document.get([:name]).must_equal "Mike"
+    _(document.get([:name])).must_equal "Mike"
   end
 
   it "retrieves nested value from data given a fieldpath (string)" do
-    document.get("foo.bar.baz").must_equal "bif"
+    _(document.get("foo.bar.baz")).must_equal "bif"
   end
 
   it "retrieves nested value from data given a fieldpath (symbol)" do
-    document.get(:"foo.bar.baz").must_equal "bif"
+    _(document.get(:"foo.bar.baz")).must_equal "bif"
   end
 
   it "retrieves nested value from data given a fieldpath (array(string))" do
-    document.get(["foo", "bar", "baz"]).must_equal "bif"
+    _(document.get(["foo", "bar", "baz"])).must_equal "bif"
   end
 
   it "retrieves nested value from data given a fieldpath (array(symbol))" do
-    document.get([:foo, :bar, :baz]).must_equal "bif"
+    _(document.get([:foo, :bar, :baz])).must_equal "bif"
   end
 
   it "retrieves hash structure from data given a top-level node" do
-    document.get(:foo).must_equal({ bar: { baz: "bif" } })
+    _(document.get(:foo)).must_equal({ bar: { baz: "bif" } })
   end
 
   it "returns nil when given a top-level fieldpath (string) that does not exist" do
-    document.get("doesnotexist").must_be :nil?
+    _(document.get("doesnotexist")).must_be :nil?
   end
 
   it "returns nil when given a top-level fieldpath (symbol) that does not exist" do
-    document.get(:doesnotexist).must_be :nil?
+    _(document.get(:doesnotexist)).must_be :nil?
   end
 
   it "raises when given a nested fieldpath (string) that does not exist" do
     error = expect do
       document.get "does.not.exist"
     end.must_raise ArgumentError
-    error.message.must_equal "does.not.exist is not contained in the data"
+    _(error.message).must_equal "does.not.exist is not contained in the data"
   end
 
   it "raises when given a nested fieldpath (symbol) that does not exist" do
     error = expect do
       document.get :"does.not.exist"
     end.must_raise ArgumentError
-    error.message.must_equal "does.not.exist is not contained in the data"
+    _(error.message).must_equal "does.not.exist is not contained in the data"
   end
 
   it "retrieves full data given nil" do
-    document.get(nil).must_equal({ foo: {bar: { baz: "bif" } }, name: "Mike" })
+    _(document.get(nil)).must_equal({ foo: {bar: { baz: "bif" } }, name: "Mike" })
   end
 
   it "retrieves full data given an empty string" do
-    document.get("").must_equal({ foo: {bar: { baz: "bif" } }, name: "Mike" })
+    _(document.get("")).must_equal({ foo: {bar: { baz: "bif" } }, name: "Mike" })
   end
 
   it "retrieves path given __name__" do
-    document.get("__name__").must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    document.get(:__name__).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(document.get("__name__")).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(document.get(:__name__)).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
-    document.get("__name__").path.must_equal document.path
-    document.get(:__name__).path.must_equal document.path
+    _(document.get("__name__").path).must_equal document.path
+    _(document.get(:__name__).path).must_equal document.path
   end
 
   it "retrieves path given document_id" do
-    document.get(firestore.document_id).must_be_kind_of Google::Cloud::Firestore::DocumentReference
-    document.get(Google::Cloud::Firestore::FieldPath.document_id).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(document.get(firestore.document_id)).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(document.get(Google::Cloud::Firestore::FieldPath.document_id)).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
-    document.get(firestore.document_id).path.must_equal document.path
-    document.get(Google::Cloud::Firestore::FieldPath.document_id).path.must_equal document.path
+    _(document.get(firestore.document_id).path).must_equal document.path
+    _(document.get(Google::Cloud::Firestore::FieldPath.document_id).path).must_equal document.path
   end
 
   describe "strange data" do
@@ -133,92 +133,92 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :get, :mock_firestore do
     end
 
     it "can still retrieve data using arrays" do
-      document.get(["foo", "bar.baz", "bif"]).must_equal 42
-      document.get([:foo, "bar.baz".to_sym]).must_equal({ bif: 42 })
+      _(document.get(["foo", "bar.baz", "bif"])).must_equal 42
+      _(document.get([:foo, "bar.baz".to_sym])).must_equal({ bif: 42 })
     end
   end
 
   describe :[] do
     it "retrieves top-level value from data given a fieldpath (string)" do
-      document["name"].must_equal "Mike"
+      _(document["name"]).must_equal "Mike"
     end
 
     it "retrieves top-level value from data given a fieldpath (symbol)" do
-      document[:name].must_equal "Mike"
+      _(document[:name]).must_equal "Mike"
     end
 
     it "retrieves top-level value from data given a fieldpath (array(string))" do
-      document[["name"]].must_equal "Mike"
+      _(document[["name"]]).must_equal "Mike"
     end
 
     it "retrieves top-level value from data given a fieldpath (array(symbol))" do
-      document[[:name]].must_equal "Mike"
+      _(document[[:name]]).must_equal "Mike"
     end
 
     it "retrieves nested value from data given a fieldpath (string)" do
-      document["foo.bar.baz"].must_equal "bif"
+      _(document["foo.bar.baz"]).must_equal "bif"
     end
 
     it "retrieves nested value from data given a fieldpath (symbol)" do
-      document[:"foo.bar.baz"].must_equal "bif"
+      _(document[:"foo.bar.baz"]).must_equal "bif"
     end
 
     it "retrieves nested value from data given a fieldpath (array(string))" do
-      document[["foo", "bar", "baz"]].must_equal "bif"
+      _(document[["foo", "bar", "baz"]]).must_equal "bif"
     end
 
     it "retrieves nested value from data given a fieldpath (array(symbol))" do
-      document[[:foo, :bar, :baz]].must_equal "bif"
+      _(document[[:foo, :bar, :baz]]).must_equal "bif"
     end
 
     it "retrieves hash structure from data given a top-level node" do
-      document[:foo].must_equal({ bar: { baz: "bif" } })
+      _(document[:foo]).must_equal({ bar: { baz: "bif" } })
     end
 
     it "returns nil when given a top-level fieldpath (string) that does not exist" do
-      document["doesnotexist"].must_be :nil?
+      _(document["doesnotexist"]).must_be :nil?
     end
 
     it "returns nil when given a top-level fieldpath (symbol) that does not exist" do
-      document[:doesnotexist].must_be :nil?
+      _(document[:doesnotexist]).must_be :nil?
     end
 
     it "raises when given a nested fieldpath (string) that does not exist" do
       error = expect do
         document["does.not.exist"]
       end.must_raise ArgumentError
-      error.message.must_equal "does.not.exist is not contained in the data"
+      _(error.message).must_equal "does.not.exist is not contained in the data"
     end
 
     it "raises when given a nested fieldpath (symbol) that does not exist" do
       error = expect do
         document[:"does.not.exist"]
       end.must_raise ArgumentError
-      error.message.must_equal "does.not.exist is not contained in the data"
+      _(error.message).must_equal "does.not.exist is not contained in the data"
     end
 
     it "retrieves full data given nil" do
-      document[nil].must_equal({ foo: {bar: { baz: "bif" } }, name: "Mike" })
+      _(document[nil]).must_equal({ foo: {bar: { baz: "bif" } }, name: "Mike" })
     end
 
     it "retrieves full data given an empty string" do
-      document[""].must_equal({ foo: {bar: { baz: "bif" } }, name: "Mike" })
+      _(document[""]).must_equal({ foo: {bar: { baz: "bif" } }, name: "Mike" })
     end
 
     it "retrieves path given __name__" do
-      document["__name__"].must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      document[:__name__].must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(document["__name__"]).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(document[:__name__]).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
-      document["__name__"].path.must_equal document.path
-      document[:__name__].path.must_equal document.path
+      _(document["__name__"].path).must_equal document.path
+      _(document[:__name__].path).must_equal document.path
     end
 
     it "retrieves path given document_id" do
-      document[firestore.document_id].must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      document[Google::Cloud::Firestore::FieldPath.document_id].must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(document[firestore.document_id]).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(document[Google::Cloud::Firestore::FieldPath.document_id]).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
-      document[firestore.document_id].path.must_equal document.path
-      document[Google::Cloud::Firestore::FieldPath.document_id].path.must_equal document.path
+      _(document[firestore.document_id].path).must_equal document.path
+      _(document[Google::Cloud::Firestore::FieldPath.document_id].path).must_equal document.path
     end
 
     describe "strange data" do
@@ -235,8 +235,8 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :get, :mock_firestore do
       end
 
       it "can still retrieve data using arrays" do
-        document[["foo", "bar.baz", "bif"]].must_equal 42
-        document[[:foo, "bar.baz".to_sym]].must_equal({ bif: 42 })
+        _(document[["foo", "bar.baz", "bif"]]).must_equal 42
+        _(document[[:foo, "bar.baz".to_sym]]).must_equal({ bif: 42 })
       end
     end
   end

--- a/google-cloud-firestore/test/google/cloud/firestore/field_value_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/field_value_test.rb
@@ -18,9 +18,9 @@ describe Google::Cloud::Firestore::FieldValue do
   describe :array_union do
     it "represents values to add to an array" do
       field_union = Google::Cloud::Firestore::FieldValue.array_union 1, 2, 3
-      field_union.must_be_kind_of Google::Cloud::Firestore::FieldValue
-      field_union.type.must_equal :array_union
-      field_union.value.must_equal [1, 2, 3]
+      _(field_union).must_be_kind_of Google::Cloud::Firestore::FieldValue
+      _(field_union.type).must_equal :array_union
+      _(field_union.value).must_equal [1, 2, 3]
     end
 
     it "does not allow nested FieldValues" do
@@ -28,16 +28,16 @@ describe Google::Cloud::Firestore::FieldValue do
       err = assert_raises ArgumentError do
         Google::Cloud::Firestore::FieldValue.array_union 1, 2, 3, field_delete
       end
-      err.message.must_equal "A value of type Google::Cloud::Firestore::FieldValue is not supported."
+      _(err.message).must_equal "A value of type Google::Cloud::Firestore::FieldValue is not supported."
     end
   end
 
   describe :array_delete do
     it "represents values to remove from an array" do
       field_delete = Google::Cloud::Firestore::FieldValue.array_delete 7, 8, 9
-      field_delete.must_be_kind_of Google::Cloud::Firestore::FieldValue
-      field_delete.type.must_equal :array_delete
-      field_delete.value.must_equal [7, 8, 9]
+      _(field_delete).must_be_kind_of Google::Cloud::Firestore::FieldValue
+      _(field_delete.type).must_equal :array_delete
+      _(field_delete.value).must_equal [7, 8, 9]
     end
 
     it "does not allow nested FieldValues" do
@@ -45,7 +45,7 @@ describe Google::Cloud::Firestore::FieldValue do
       err = assert_raises ArgumentError do
         Google::Cloud::Firestore::FieldValue.array_delete 7, 8, 9, field_union
       end
-      err.message.must_equal "A value of type Google::Cloud::Firestore::FieldValue is not supported."
+      _(err.message).must_equal "A value of type Google::Cloud::Firestore::FieldValue is not supported."
     end
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/query/cursors_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/cursors_test.rb
@@ -41,7 +41,7 @@ describe Google::Cloud::Firestore::Query, :cursors, :mock_firestore do
     doc_snp = document_snapshot("projects/projectID/databases/(default)/documents/C/D", { a: 7, b: 8 })
 
     generated_query = collection.start_at(doc_snp).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "document snapshot and an equality where clause" do
@@ -75,7 +75,7 @@ describe Google::Cloud::Firestore::Query, :cursors, :mock_firestore do
     doc_snp = document_snapshot("projects/projectID/databases/(default)/documents/C/D", { a: 7, b: 8 })
 
     generated_query = collection.where(:a, "==", 3).end_at(doc_snp).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "document snapshot and an inequality where clause" do
@@ -114,7 +114,7 @@ describe Google::Cloud::Firestore::Query, :cursors, :mock_firestore do
     doc_snp = document_snapshot("projects/projectID/databases/(default)/documents/C/D", { a: 7, b: 8 })
 
     generated_query = collection.where(:a, "<=", 3).end_before(doc_snp).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "doc snapshot, inequality where clause, and existing orderBy clause" do
@@ -153,7 +153,7 @@ describe Google::Cloud::Firestore::Query, :cursors, :mock_firestore do
     doc_snp = document_snapshot("projects/projectID/databases/(default)/documents/C/D", { a: 7, b: 8 })
 
     generated_query = collection.order(:a, :desc).where(:a, "<", 4).start_at(doc_snp).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "existing orderBy" do
@@ -197,7 +197,7 @@ describe Google::Cloud::Firestore::Query, :cursors, :mock_firestore do
     doc_snp = document_snapshot("projects/projectID/databases/(default)/documents/C/D", { a: 7, b: 8 })
 
     generated_query = collection.order(:a).order(:b, :desc).where(:a, "<", 4).start_after(doc_snp).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "existing orderBy __name__" do
@@ -241,7 +241,7 @@ describe Google::Cloud::Firestore::Query, :cursors, :mock_firestore do
     doc_snp = document_snapshot("projects/projectID/databases/(default)/documents/C/D", { a: 7, b: 8 })
 
     generated_query = collection.order(:a, :desc).order(:__name__).start_at(doc_snp).end_at(doc_snp).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "without orderBy" do
@@ -275,7 +275,7 @@ describe Google::Cloud::Firestore::Query, :cursors, :mock_firestore do
     )
 
     generated_query = collection.order(:a).start_at(7).end_before(9).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "StartAfter/EndAt with values" do
@@ -302,7 +302,7 @@ describe Google::Cloud::Firestore::Query, :cursors, :mock_firestore do
     )
 
     generated_query = collection.order(:a).start_after(7).end_at(9).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "Start/End with two values" do
@@ -335,7 +335,7 @@ describe Google::Cloud::Firestore::Query, :cursors, :mock_firestore do
     )
 
     generated_query = collection.order(:a).order(:b, :desc).start_after(7, 8).end_at(9, 10).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "with __name__" do
@@ -373,7 +373,7 @@ describe Google::Cloud::Firestore::Query, :cursors, :mock_firestore do
     )
 
     generated_query = collection.order(:__name__).start_after("D1").end_before("D2").query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "last one wins" do
@@ -390,7 +390,7 @@ describe Google::Cloud::Firestore::Query, :cursors, :mock_firestore do
     )
 
     generated_query = collection.order(:a).start_after(1).start_at(2).end_at(3).end_before(4).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   def document_snapshot path, data

--- a/google-cloud-firestore/test/google/cloud/firestore/query/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/get_test.rb
@@ -254,33 +254,33 @@ describe Google::Cloud::Firestore::Query, :get, :mock_firestore do
   end
 
   def assert_results_enum enum
-    enum.must_be_kind_of Enumerator
+    _(enum).must_be_kind_of Enumerator
 
     results = enum.to_a
-    results.count.must_equal 2
+    _(results.count).must_equal 2
 
     results.each do |result|
-      result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(result).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      result.ref.client.must_equal firestore
+      _(result.ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(result.ref.client).must_equal firestore
 
-      result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      result.parent.collection_id.must_equal "users"
-      result.parent.collection_path.must_equal "users"
-      result.parent.client.must_equal firestore
+      _(result.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(result.parent.collection_id).must_equal "users"
+      _(result.parent.collection_path).must_equal "users"
+      _(result.parent.client).must_equal firestore
     end
 
-    results.first.data.must_be_kind_of Hash
-    results.first.data.must_equal({ name: "Mike" })
-    results.first.created_at.must_equal read_time
-    results.first.updated_at.must_equal read_time
-    results.first.read_at.must_equal read_time
+    _(results.first.data).must_be_kind_of Hash
+    _(results.first.data).must_equal({ name: "Mike" })
+    _(results.first.created_at).must_equal read_time
+    _(results.first.updated_at).must_equal read_time
+    _(results.first.read_at).must_equal read_time
 
-    results.last.data.must_be_kind_of Hash
-    results.last.data.must_equal({ name: "Chris" })
-    results.last.created_at.must_equal read_time
-    results.last.updated_at.must_equal read_time
-    results.last.read_at.must_equal read_time
+    _(results.last.data).must_be_kind_of Hash
+    _(results.last.data).must_equal({ name: "Chris" })
+    _(results.last.created_at).must_equal read_time
+    _(results.last.updated_at).must_equal read_time
+    _(results.last.read_at).must_equal read_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/query/listen_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/listen_test.rb
@@ -67,31 +67,31 @@ describe Google::Cloud::Firestore::Query, :listen, :watch_firestore do
     listener.stop
 
     # assert snapshots
-    query_snapshots.count.must_equal 4
-    query_snapshots.each { |qs| qs.must_be_kind_of Google::Cloud::Firestore::QuerySnapshot }
+    _(query_snapshots.count).must_equal 4
+    query_snapshots.each { |qs| _(qs).must_be_kind_of Google::Cloud::Firestore::QuerySnapshot }
 
-    query_snapshots[0].count.must_equal 14
-    query_snapshots[0].changes.count.must_equal 14
-    query_snapshots[0].docs.map(&:document_id).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    query_snapshots[0].changes.each { |change| change.must_be :added? }
-    query_snapshots[0].changes.map(&:doc).map(&:document_id).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    _(query_snapshots[0].count).must_equal 14
+    _(query_snapshots[0].changes.count).must_equal 14
+    _(query_snapshots[0].docs.map(&:document_id)).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    query_snapshots[0].changes.each { |change| _(change).must_be :added? }
+    _(query_snapshots[0].changes.map(&:doc).map(&:document_id)).must_equal ["nil", "false", "true", "int", "num", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
 
-    query_snapshots[1].count.must_equal 14
-    query_snapshots[1].changes.count.must_equal 2
-    query_snapshots[1].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    query_snapshots[1].changes.each { |change| change.must_be :modified? }
-    query_snapshots[1].changes.map(&:doc).map(&:document_id).must_equal ["num", "int"]
+    _(query_snapshots[1].count).must_equal 14
+    _(query_snapshots[1].changes.count).must_equal 2
+    _(query_snapshots[1].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    query_snapshots[1].changes.each { |change| _(change).must_be :modified? }
+    _(query_snapshots[1].changes.map(&:doc).map(&:document_id)).must_equal ["num", "int"]
 
-    query_snapshots[2].count.must_equal 14
-    query_snapshots[2].changes.count.must_equal 1
-    query_snapshots[2].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
-    query_snapshots[2].changes.each { |change| change.must_be :modified? }
-    query_snapshots[2].changes.map(&:doc).map(&:document_id).must_equal ["array"]
+    _(query_snapshots[2].count).must_equal 14
+    _(query_snapshots[2].changes.count).must_equal 1
+    _(query_snapshots[2].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2", "array", "hash"]
+    query_snapshots[2].changes.each { |change| _(change).must_be :modified? }
+    _(query_snapshots[2].changes.map(&:doc).map(&:document_id)).must_equal ["array"]
 
-    query_snapshots[3].count.must_equal 12
-    query_snapshots[3].changes.count.must_equal 2
-    query_snapshots[3].docs.map(&:document_id).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2"]
-    query_snapshots[3].changes.each { |change| change.must_be :removed? }
-    query_snapshots[3].changes.map(&:doc).map(&:document_id).must_equal ["array", "hash"]
+    _(query_snapshots[3].count).must_equal 12
+    _(query_snapshots[3].changes.count).must_equal 2
+    _(query_snapshots[3].docs.map(&:document_id)).must_equal ["nil", "false", "true", "num", "int", "time", "str", "io", "ref1", "ref2", "geo1", "geo2"]
+    query_snapshots[3].changes.each { |change| _(change).must_be :removed? }
+    _(query_snapshots[3].changes.map(&:doc).map(&:document_id)).must_equal ["array", "hash"]
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/query/where/array_contains_any_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/where/array_contains_any_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Firestore::Query, :where, :array_contains_any, :mock_fir
     )
 
     generated_query = query.where(:foo, "array-contains-any", 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using array_contains_any" do
@@ -44,7 +44,7 @@ describe Google::Cloud::Firestore::Query, :where, :array_contains_any, :mock_fir
     )
 
     generated_query = query.where(:foo, :array_contains_any, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "with multiple values" do
@@ -73,6 +73,6 @@ describe Google::Cloud::Firestore::Query, :where, :array_contains_any, :mock_fir
     )
 
     generated_query = query.where(:foo, :array_contains_any, 42).where(:foo, :array_contains_any, 43).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/query/where/array_contains_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/where/array_contains_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Firestore::Query, :where, :array_contains, :mock_firesto
     )
 
     generated_query = query.where(:foo, "array-contains", 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using array_contains" do
@@ -44,7 +44,7 @@ describe Google::Cloud::Firestore::Query, :where, :array_contains, :mock_firesto
     )
 
     generated_query = query.where(:foo, :array_contains, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using include" do
@@ -59,7 +59,7 @@ describe Google::Cloud::Firestore::Query, :where, :array_contains, :mock_firesto
     )
 
     generated_query = query.where(:foo, :include, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using include?" do
@@ -74,7 +74,7 @@ describe Google::Cloud::Firestore::Query, :where, :array_contains, :mock_firesto
     )
 
     generated_query = query.where(:foo, :include?, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using has" do
@@ -89,7 +89,7 @@ describe Google::Cloud::Firestore::Query, :where, :array_contains, :mock_firesto
     )
 
     generated_query = query.where(:foo, :has, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "with multiple values" do
@@ -118,6 +118,6 @@ describe Google::Cloud::Firestore::Query, :where, :array_contains, :mock_firesto
     )
 
     generated_query = query.where(:foo, :array_contains, 42).where(:foo, :array_contains, 43).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/query/where/equal_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/where/equal_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Firestore::Query, :where, :equal, :mock_firestore do
     )
 
     generated_query = query.where(:foo, "=", 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using ==" do
@@ -44,7 +44,7 @@ describe Google::Cloud::Firestore::Query, :where, :equal, :mock_firestore do
     )
 
     generated_query = query.where(:foo, :==, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using eq" do
@@ -59,7 +59,7 @@ describe Google::Cloud::Firestore::Query, :where, :equal, :mock_firestore do
     )
 
     generated_query = query.where(:foo, :eq, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using eql" do
@@ -74,7 +74,7 @@ describe Google::Cloud::Firestore::Query, :where, :equal, :mock_firestore do
     )
 
     generated_query = query.where(:foo, :eql, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using is" do
@@ -89,7 +89,7 @@ describe Google::Cloud::Firestore::Query, :where, :equal, :mock_firestore do
     )
 
     generated_query = query.where(:foo, :is, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "with multiple values" do
@@ -118,7 +118,7 @@ describe Google::Cloud::Firestore::Query, :where, :equal, :mock_firestore do
     )
 
     generated_query = query.where(:foo, :==, 42).where(:bar, :==, "baz").query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "with nil" do
@@ -132,7 +132,7 @@ describe Google::Cloud::Firestore::Query, :where, :equal, :mock_firestore do
     )
 
     generated_query = query.where(:foo, :==, nil).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "with :nil" do
@@ -146,7 +146,7 @@ describe Google::Cloud::Firestore::Query, :where, :equal, :mock_firestore do
     )
 
     generated_query = query.where(:foo, :==, :nil).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "with :null" do
@@ -160,7 +160,7 @@ describe Google::Cloud::Firestore::Query, :where, :equal, :mock_firestore do
     )
 
     generated_query = query.where(:foo, :==, :null).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "with :nan" do
@@ -174,7 +174,7 @@ describe Google::Cloud::Firestore::Query, :where, :equal, :mock_firestore do
     )
 
     generated_query = query.where(:foo, :==, :nan).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "with Float::NAN" do
@@ -188,6 +188,6 @@ describe Google::Cloud::Firestore::Query, :where, :equal, :mock_firestore do
     )
 
     generated_query = query.where(:foo, :==, Float::NAN).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/query/where/greater_than_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/where/greater_than_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Firestore::Query, :where, :greater_than, :mock_firestore
     )
 
     generated_query = query.where(:foo, :>, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using gt" do
@@ -44,7 +44,7 @@ describe Google::Cloud::Firestore::Query, :where, :greater_than, :mock_firestore
     )
 
     generated_query = query.where(:foo, :gt, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using >=" do
@@ -59,7 +59,7 @@ describe Google::Cloud::Firestore::Query, :where, :greater_than, :mock_firestore
     )
 
     generated_query = query.where(:foo, :>=, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using gte" do
@@ -74,6 +74,6 @@ describe Google::Cloud::Firestore::Query, :where, :greater_than, :mock_firestore
     )
 
     generated_query = query.where(:foo, :gte, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/query/where/in_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/where/in_test.rb
@@ -36,7 +36,7 @@ describe Google::Cloud::Firestore::Query, :where, :array_contains_any, :mock_fir
     )
 
     generated_query = query.where(:foo, :in, [42, 43]).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "with multiple values" do
@@ -79,6 +79,6 @@ describe Google::Cloud::Firestore::Query, :where, :array_contains_any, :mock_fir
     )
 
     generated_query = query.where(:foo, :in, [42, 43]).where(:foo, :in, [43, 44]).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/query/where/less_than_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/where/less_than_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Firestore::Query, :where, :less_than, :mock_firestore do
     )
 
     generated_query = query.where(:foo, :<, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using lt" do
@@ -44,7 +44,7 @@ describe Google::Cloud::Firestore::Query, :where, :less_than, :mock_firestore do
     )
 
     generated_query = query.where(:foo, :lt, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using <=" do
@@ -59,7 +59,7 @@ describe Google::Cloud::Firestore::Query, :where, :less_than, :mock_firestore do
     )
 
     generated_query = query.where(:foo, :<=, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 
   it "using lte" do
@@ -74,6 +74,6 @@ describe Google::Cloud::Firestore::Query, :where, :less_than, :mock_firestore do
     )
 
     generated_query = query.where(:foo, :lte, 42).query
-    generated_query.must_equal expected_query
+    _(generated_query).must_equal expected_query
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/closed/get_all_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/closed/get_all_test.rb
@@ -41,7 +41,7 @@ describe Google::Cloud::Firestore::Transaction, :get_all, :closed, :mock_firesto
     error = expect do
       transaction.get_all "users/mike", "users/tad", "users/chris"
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 
   it "gets a single doc from a doc ref object" do
@@ -50,17 +50,17 @@ describe Google::Cloud::Firestore::Transaction, :get_all, :closed, :mock_firesto
     doc_ref = firestore.doc("users/mike")
     doc_snp = doc_ref.get
 
-    doc_snp.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(doc_snp).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-    doc_snp.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    doc_snp.parent.collection_id.must_equal "users"
-    doc_snp.parent.collection_path.must_equal "users"
-    doc_snp.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+    _(doc_snp.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(doc_snp.parent.collection_id).must_equal "users"
+    _(doc_snp.parent.collection_path).must_equal "users"
+    _(doc_snp.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
 
-    doc_snp.data.must_be_kind_of Hash
-    doc_snp.data.must_equal({ name: "Mike" })
-    doc_snp.created_at.must_equal read_time
-    doc_snp.updated_at.must_equal read_time
-    doc_snp.read_at.must_equal read_time
+    _(doc_snp.data).must_be_kind_of Hash
+    _(doc_snp.data).must_equal({ name: "Mike" })
+    _(doc_snp.created_at).must_equal read_time
+    _(doc_snp.updated_at).must_equal read_time
+    _(doc_snp.read_at).must_equal read_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/closed/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/closed/get_test.rb
@@ -27,14 +27,14 @@ describe Google::Cloud::Firestore::Transaction, :get, :closed, :mock_firestore d
     error = expect do
       transaction.get doc
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 
   it "raises when getting a document (string)" do
     error = expect do
       transaction.get "users/mike"
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 
   it "raises when getting a collection" do
@@ -43,21 +43,21 @@ describe Google::Cloud::Firestore::Transaction, :get, :closed, :mock_firestore d
     error = expect do
       transaction.get col
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 
   it "raises when getting a collection (string)" do
     error = expect do
       transaction.get "users"
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 
   it "raises when getting a collection (symbol)" do
     error = expect do
       transaction.get :users
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 
   it "raises when getting a simple query" do
@@ -66,7 +66,7 @@ describe Google::Cloud::Firestore::Transaction, :get, :closed, :mock_firestore d
     error = expect do
       transaction.get query
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 
   it "raises when getting a complex query" do
@@ -75,6 +75,6 @@ describe Google::Cloud::Firestore::Transaction, :get, :closed, :mock_firestore d
     error = expect do
       transaction.get query
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/closed/query_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/closed/query_test.rb
@@ -26,6 +26,6 @@ describe Google::Cloud::Firestore::Transaction, :query, :closed, :mock_firestore
       query = firestore.col(:users).select(:name)
       transaction.run query
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/closed_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/closed_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Firestore::Transaction, :closed, :mock_firestore do
       transaction.create(document_path, { name: "Mike" })
       transaction.commit
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 
   it "set raises when closed" do
@@ -37,7 +37,7 @@ describe Google::Cloud::Firestore::Transaction, :closed, :mock_firestore do
       transaction.set(document_path, { name: "Mike" })
       transaction.commit
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 
   it "update raises when closed" do
@@ -45,7 +45,7 @@ describe Google::Cloud::Firestore::Transaction, :closed, :mock_firestore do
       transaction.update(document_path, { name: "Mike" })
       transaction.commit
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 
   it "delete raises when closed" do
@@ -53,7 +53,7 @@ describe Google::Cloud::Firestore::Transaction, :closed, :mock_firestore do
       transaction.delete document_path
       transaction.commit
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 
   it "run raises when closed" do
@@ -61,6 +61,6 @@ describe Google::Cloud::Firestore::Transaction, :closed, :mock_firestore do
       transaction.run document_path
       transaction.commit
     end.must_raise RuntimeError
-    error.message.must_equal "transaction is closed"
+    _(error.message).must_equal "transaction is closed"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/create_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/create_test.rb
@@ -49,27 +49,27 @@ describe Google::Cloud::Firestore::Transaction, :create, :mock_firestore do
     transaction.create(document_path, { name: "Mike" })
     resp = transaction.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "creates a new document given a DocumentReference" do
     firestore_mock.expect :commit, commit_resp, [database_path, writes: create_writes, transaction: transaction_id, options: default_options]
 
     doc = firestore.doc document_path
-    doc.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     transaction.create(doc, { name: "Mike" })
     resp = transaction.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "raises if not given a Hash" do
     error = expect do
       transaction.create document_path, "not a hash"
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/delete_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/delete_test.rb
@@ -44,20 +44,20 @@ describe Google::Cloud::Firestore::Transaction, :delete, :mock_firestore do
     transaction.delete document_path
     resp = transaction.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "deletes a document given a doc ref" do
     firestore_mock.expect :commit, commit_resp, [database_path, writes: delete_writes, transaction: transaction_id, options: default_options]
 
     doc = firestore.doc document_path
-    doc.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     transaction.delete doc
     resp = transaction.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/empty/get_all_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/empty/get_all_test.rb
@@ -90,23 +90,23 @@ describe Google::Cloud::Firestore::Transaction, :get_all, :empty, :mock_firestor
 
     docs_enum = transaction.get_all "users/mike"
 
-    docs_enum.must_be_kind_of Enumerator
+    _(docs_enum).must_be_kind_of Enumerator
 
     docs = docs_enum.to_a
-    docs.count.must_equal 1
+    _(docs.count).must_equal 1
 
-    docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(docs.first).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-    docs.first.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    docs.first.parent.collection_id.must_equal "users"
-    docs.first.parent.collection_path.must_equal "users"
-    docs.first.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+    _(docs.first.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(docs.first.parent.collection_id).must_equal "users"
+    _(docs.first.parent.collection_path).must_equal "users"
+    _(docs.first.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
 
-    docs.first.data.must_be_kind_of Hash
-    docs.first.data.must_equal({ name: "Mike" })
-    docs.first.created_at.must_equal read_time
-    docs.first.updated_at.must_equal read_time
-    docs.first.read_at.must_equal read_time
+    _(docs.first.data).must_be_kind_of Hash
+    _(docs.first.data).must_equal({ name: "Mike" })
+    _(docs.first.created_at).must_equal read_time
+    _(docs.first.updated_at).must_equal read_time
+    _(docs.first.read_at).must_equal read_time
   end
 
   it "gets a single doc (doc ref)" do
@@ -114,62 +114,62 @@ describe Google::Cloud::Firestore::Transaction, :get_all, :empty, :mock_firestor
 
     docs_enum = transaction.get_all firestore.doc("users/mike")
 
-    docs_enum.must_be_kind_of Enumerator
+    _(docs_enum).must_be_kind_of Enumerator
 
     docs = docs_enum.to_a
-    docs.count.must_equal 1
+    _(docs.count).must_equal 1
 
-    docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(docs.first).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-    docs.first.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    docs.first.parent.collection_id.must_equal "users"
-    docs.first.parent.collection_path.must_equal "users"
-    docs.first.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+    _(docs.first.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(docs.first.parent.collection_id).must_equal "users"
+    _(docs.first.parent.collection_path).must_equal "users"
+    _(docs.first.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
 
-    docs.first.data.must_be_kind_of Hash
-    docs.first.data.must_equal({ name: "Mike" })
-    docs.first.created_at.must_equal read_time
-    docs.first.updated_at.must_equal read_time
-    docs.first.read_at.must_equal read_time
+    _(docs.first.data).must_be_kind_of Hash
+    _(docs.first.data).must_equal({ name: "Mike" })
+    _(docs.first.created_at).must_equal read_time
+    _(docs.first.updated_at).must_equal read_time
+    _(docs.first.read_at).must_equal read_time
   end
 
   def assert_docs_enum enum
-    enum.must_be_kind_of Enumerator
+    _(enum).must_be_kind_of Enumerator
 
     docs = enum.to_a
-    docs.count.must_equal 3
+    _(docs.count).must_equal 3
 
     docs.each do |doc|
-      doc.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      doc.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      doc.ref.client.must_equal firestore
+      _(doc.ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(doc.ref.client).must_equal firestore
 
-      doc.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      doc.parent.collection_id.must_equal "users"
-      doc.parent.collection_path.must_equal "users"
-      doc.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
-      doc.parent.client.must_equal firestore
+      _(doc.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(doc.parent.collection_id).must_equal "users"
+      _(doc.parent.collection_path).must_equal "users"
+      _(doc.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
+      _(doc.parent.client).must_equal firestore
     end
 
-    docs[0].must_be :exists?
-    docs[0].data.must_be_kind_of Hash
-    docs[0].data.must_equal({ name: "Mike" })
-    docs[0].created_at.must_equal read_time
-    docs[0].updated_at.must_equal read_time
-    docs[0].read_at.must_equal read_time
+    _(docs[0]).must_be :exists?
+    _(docs[0].data).must_be_kind_of Hash
+    _(docs[0].data).must_equal({ name: "Mike" })
+    _(docs[0].created_at).must_equal read_time
+    _(docs[0].updated_at).must_equal read_time
+    _(docs[0].read_at).must_equal read_time
 
-    docs[1].must_be :missing?
-    docs[1].data.must_be :nil?
-    docs[1].created_at.must_be :nil?
-    docs[1].updated_at.must_be :nil?
-    docs[1].read_at.must_equal read_time
+    _(docs[1]).must_be :missing?
+    _(docs[1].data).must_be :nil?
+    _(docs[1].created_at).must_be :nil?
+    _(docs[1].updated_at).must_be :nil?
+    _(docs[1].read_at).must_equal read_time
 
-    docs[2].must_be :exists?
-    docs[2].data.must_be_kind_of Hash
-    docs[2].data.must_equal({ name: "Chris" })
-    docs[2].created_at.must_equal read_time
-    docs[2].updated_at.must_equal read_time
-    docs[2].read_at.must_equal read_time
+    _(docs[2]).must_be :exists?
+    _(docs[2].data).must_be_kind_of Hash
+    _(docs[2].data).must_equal({ name: "Chris" })
+    _(docs[2].created_at).must_equal read_time
+    _(docs[2].updated_at).must_equal read_time
+    _(docs[2].read_at).must_equal read_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/empty/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/empty/get_test.rb
@@ -62,31 +62,31 @@ describe Google::Cloud::Firestore::Transaction, :get, :empty, :mock_firestore do
     firestore_mock.expect :batch_get_documents, batch_get_resp_enum, ["projects/#{project}/databases/(default)", documents: ["projects/#{project}/databases/(default)/documents/users/mike"], mask: nil, new_transaction: transaction_opt, options: default_options]
 
     col = firestore.col :users
-    col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
 
     doc_ref = col.doc :mike
-    doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
-    transaction.transaction_id.must_be :nil?
+    _(transaction.transaction_id).must_be :nil?
 
     doc = transaction.get doc_ref
 
-    transaction.transaction_id.must_equal transaction_id
+    _(transaction.transaction_id).must_equal transaction_id
 
-    doc.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
-    doc.document_id.must_equal doc_ref.document_id
-    doc.document_path.must_equal doc_ref.document_path
+    _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(doc.document_id).must_equal doc_ref.document_id
+    _(doc.document_path).must_equal doc_ref.document_path
 
-    doc.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    doc.parent.collection_id.must_equal col.collection_id
-    doc.parent.collection_path.must_equal col.collection_path
+    _(doc.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(doc.parent.collection_id).must_equal col.collection_id
+    _(doc.parent.collection_path).must_equal col.collection_path
 
-    doc.must_be :exists?
-    doc.data.must_be_kind_of Hash
-    doc.data.must_equal({ name: "Mike" })
-    doc.created_at.must_equal read_time
-    doc.updated_at.must_equal read_time
-    doc.read_at.must_equal read_time
+    _(doc).must_be :exists?
+    _(doc.data).must_be_kind_of Hash
+    _(doc.data).must_equal({ name: "Mike" })
+    _(doc.created_at).must_equal read_time
+    _(doc.updated_at).must_equal read_time
+    _(doc.read_at).must_equal read_time
   end
 
   it "gets a document (string)" do
@@ -106,28 +106,28 @@ describe Google::Cloud::Firestore::Transaction, :get, :empty, :mock_firestore do
     firestore_mock.expect :batch_get_documents, batch_get_resp_enum, ["projects/#{project}/databases/(default)", documents: ["projects/#{project}/databases/(default)/documents/users/mike"], mask: nil, new_transaction: transaction_opt, options: default_options]
 
     doc_ref = firestore.doc "users/mike"
-    doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
-    transaction.transaction_id.must_be :nil?
+    _(transaction.transaction_id).must_be :nil?
 
     doc = transaction.get "users/mike"
 
-    transaction.transaction_id.must_equal transaction_id
+    _(transaction.transaction_id).must_equal transaction_id
 
-    doc.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
-    doc.document_id.must_equal doc_ref.document_id
-    doc.document_path.must_equal doc_ref.document_path
+    _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(doc.document_id).must_equal doc_ref.document_id
+    _(doc.document_path).must_equal doc_ref.document_path
 
-    doc.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    doc.parent.collection_id.must_equal doc_ref.parent.collection_id
-    doc.parent.collection_path.must_equal doc_ref.parent.collection_path
+    _(doc.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(doc.parent.collection_id).must_equal doc_ref.parent.collection_id
+    _(doc.parent.collection_path).must_equal doc_ref.parent.collection_path
 
-    doc.must_be :exists?
-    doc.data.must_be_kind_of Hash
-    doc.data.must_equal({ name: "Mike" })
-    doc.created_at.must_equal read_time
-    doc.updated_at.must_equal read_time
-    doc.read_at.must_equal read_time
+    _(doc).must_be :exists?
+    _(doc.data).must_be_kind_of Hash
+    _(doc.data).must_equal({ name: "Mike" })
+    _(doc.created_at).must_equal read_time
+    _(doc.updated_at).must_equal read_time
+    _(doc.read_at).must_equal read_time
   end
 
   it "gets a collection (ref)" do
@@ -204,34 +204,34 @@ describe Google::Cloud::Firestore::Transaction, :get, :empty, :mock_firestore do
   end
 
   def assert_results_enum enum
-    enum.must_be_kind_of Enumerator
+    _(enum).must_be_kind_of Enumerator
 
     results = enum.to_a
-    results.count.must_equal 2
+    _(results.count).must_equal 2
 
     results.each do |result|
-      result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(result).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      result.ref.client.must_equal firestore
+      _(result.ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(result.ref.client).must_equal firestore
 
-      result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      result.parent.collection_id.must_equal "users"
-      result.parent.collection_path.must_equal "users"
-      result.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
-      result.parent.client.must_equal firestore
+      _(result.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(result.parent.collection_id).must_equal "users"
+      _(result.parent.collection_path).must_equal "users"
+      _(result.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
+      _(result.parent.client).must_equal firestore
     end
 
-    results.first.data.must_be_kind_of Hash
-    results.first.data.must_equal({ name: "Mike" })
-    results.first.created_at.must_equal read_time
-    results.first.updated_at.must_equal read_time
-    results.first.read_at.must_equal read_time
+    _(results.first.data).must_be_kind_of Hash
+    _(results.first.data).must_equal({ name: "Mike" })
+    _(results.first.created_at).must_equal read_time
+    _(results.first.updated_at).must_equal read_time
+    _(results.first.read_at).must_equal read_time
 
-    results.last.data.must_be_kind_of Hash
-    results.last.data.must_equal({ name: "Chris" })
-    results.last.created_at.must_equal read_time
-    results.last.updated_at.must_equal read_time
-    results.last.read_at.must_equal read_time
+    _(results.last.data).must_be_kind_of Hash
+    _(results.last.data).must_equal({ name: "Chris" })
+    _(results.last.created_at).must_equal read_time
+    _(results.last.updated_at).must_equal read_time
+    _(results.last.read_at).must_equal read_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/empty/query_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/empty/query_test.rb
@@ -55,13 +55,13 @@ describe Google::Cloud::Firestore::Transaction, :query, :empty, :mock_firestore 
 
     query = firestore.col(:users).select(:name)
 
-    transaction.transaction_id.must_be :nil?
+    _(transaction.transaction_id).must_be :nil?
 
     results_enum = transaction.run query
 
     assert_results_enum results_enum
 
-    transaction.transaction_id.must_equal transaction_id
+    _(transaction.transaction_id).must_equal transaction_id
   end
 
   it "runs a complex query" do
@@ -85,44 +85,44 @@ describe Google::Cloud::Firestore::Transaction, :query, :empty, :mock_firestore 
 
     query = firestore.col(:users).select(:name).offset(3).limit(42).order(:name).order(firestore.document_id, :desc).start_after(:foo).end_before(:bar)
 
-    transaction.transaction_id.must_be :nil?
+    _(transaction.transaction_id).must_be :nil?
 
     results_enum = transaction.run query
 
     assert_results_enum results_enum
 
-    transaction.transaction_id.must_equal transaction_id
+    _(transaction.transaction_id).must_equal transaction_id
   end
 
   def assert_results_enum enum
-    enum.must_be_kind_of Enumerator
+    _(enum).must_be_kind_of Enumerator
 
     results = enum.to_a
-    results.count.must_equal 2
+    _(results.count).must_equal 2
 
     results.each do |result|
-      result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(result).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      result.ref.client.must_equal firestore
+      _(result.ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(result.ref.client).must_equal firestore
 
-      result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      result.parent.collection_id.must_equal "users"
-      result.parent.collection_path.must_equal "users"
-      result.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
-      result.parent.client.must_equal firestore
+      _(result.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(result.parent.collection_id).must_equal "users"
+      _(result.parent.collection_path).must_equal "users"
+      _(result.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
+      _(result.parent.client).must_equal firestore
     end
 
-    results.first.data.must_be_kind_of Hash
-    results.first.data.must_equal({ name: "Mike" })
-    results.first.created_at.must_equal read_time
-    results.first.updated_at.must_equal read_time
-    results.first.read_at.must_equal read_time
+    _(results.first.data).must_be_kind_of Hash
+    _(results.first.data).must_equal({ name: "Mike" })
+    _(results.first.created_at).must_equal read_time
+    _(results.first.updated_at).must_equal read_time
+    _(results.first.read_at).must_equal read_time
 
-    results.last.data.must_be_kind_of Hash
-    results.last.data.must_equal({ name: "Chris" })
-    results.last.created_at.must_equal read_time
-    results.last.updated_at.must_equal read_time
-    results.last.read_at.must_equal read_time
+    _(results.last.data).must_be_kind_of Hash
+    _(results.last.data).must_equal({ name: "Chris" })
+    _(results.last.created_at).must_equal read_time
+    _(results.last.updated_at).must_equal read_time
+    _(results.last.read_at).must_equal read_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/get_all_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/get_all_test.rb
@@ -88,23 +88,23 @@ describe Google::Cloud::Firestore::Transaction, :get_all, :mock_firestore do
 
     docs_enum = transaction.get_all "users/mike"
 
-    docs_enum.must_be_kind_of Enumerator
+    _(docs_enum).must_be_kind_of Enumerator
 
     docs = docs_enum.to_a
-    docs.count.must_equal 1
+    _(docs.count).must_equal 1
 
-    docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(docs.first).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-    docs.first.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    docs.first.parent.collection_id.must_equal "users"
-    docs.first.parent.collection_path.must_equal "users"
-    docs.first.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+    _(docs.first.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(docs.first.parent.collection_id).must_equal "users"
+    _(docs.first.parent.collection_path).must_equal "users"
+    _(docs.first.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
 
-    docs.first.data.must_be_kind_of Hash
-    docs.first.data.must_equal({ name: "Mike" })
-    docs.first.created_at.must_equal read_time
-    docs.first.updated_at.must_equal read_time
-    docs.first.read_at.must_equal read_time
+    _(docs.first.data).must_be_kind_of Hash
+    _(docs.first.data).must_equal({ name: "Mike" })
+    _(docs.first.created_at).must_equal read_time
+    _(docs.first.updated_at).must_equal read_time
+    _(docs.first.read_at).must_equal read_time
   end
 
   it "gets a single doc (doc ref)" do
@@ -112,23 +112,23 @@ describe Google::Cloud::Firestore::Transaction, :get_all, :mock_firestore do
 
     docs_enum = transaction.get_all firestore.doc("users/mike")
 
-    docs_enum.must_be_kind_of Enumerator
+    _(docs_enum).must_be_kind_of Enumerator
 
     docs = docs_enum.to_a
-    docs.count.must_equal 1
+    _(docs.count).must_equal 1
 
-    docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(docs.first).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-    docs.first.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    docs.first.parent.collection_id.must_equal "users"
-    docs.first.parent.collection_path.must_equal "users"
-    docs.first.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+    _(docs.first.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(docs.first.parent.collection_id).must_equal "users"
+    _(docs.first.parent.collection_path).must_equal "users"
+    _(docs.first.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
 
-    docs.first.data.must_be_kind_of Hash
-    docs.first.data.must_equal({ name: "Mike" })
-    docs.first.created_at.must_equal read_time
-    docs.first.updated_at.must_equal read_time
-    docs.first.read_at.must_equal read_time
+    _(docs.first.data).must_be_kind_of Hash
+    _(docs.first.data).must_equal({ name: "Mike" })
+    _(docs.first.created_at).must_equal read_time
+    _(docs.first.updated_at).must_equal read_time
+    _(docs.first.read_at).must_equal read_time
   end
 
   describe :field_mask do
@@ -171,23 +171,23 @@ describe Google::Cloud::Firestore::Transaction, :get_all, :mock_firestore do
 
       docs_enum = transaction.get_all "users/mike", field_mask: firestore.field_path(:name)
 
-      docs_enum.must_be_kind_of Enumerator
+      _(docs_enum).must_be_kind_of Enumerator
 
       docs = docs_enum.to_a
-      docs.count.must_equal 1
+      _(docs.count).must_equal 1
 
-      docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(docs.first).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      docs.first.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      docs.first.parent.collection_id.must_equal "users"
-      docs.first.parent.collection_path.must_equal "users"
-      docs.first.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+      _(docs.first.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(docs.first.parent.collection_id).must_equal "users"
+      _(docs.first.parent.collection_path).must_equal "users"
+      _(docs.first.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
 
-      docs.first.data.must_be_kind_of Hash
-      docs.first.data.must_equal({ name: "Mike" })
-      docs.first.created_at.must_equal read_time
-      docs.first.updated_at.must_equal read_time
-      docs.first.read_at.must_equal read_time
+      _(docs.first.data).must_be_kind_of Hash
+      _(docs.first.data).must_equal({ name: "Mike" })
+      _(docs.first.created_at).must_equal read_time
+      _(docs.first.updated_at).must_equal read_time
+      _(docs.first.read_at).must_equal read_time
     end
 
     it "gets a single doc (doc ref)" do
@@ -195,63 +195,63 @@ describe Google::Cloud::Firestore::Transaction, :get_all, :mock_firestore do
 
       docs_enum = transaction.get_all firestore.doc("users/mike"), field_mask: [firestore.field_path(:name)]
 
-      docs_enum.must_be_kind_of Enumerator
+      _(docs_enum).must_be_kind_of Enumerator
 
       docs = docs_enum.to_a
-      docs.count.must_equal 1
+      _(docs.count).must_equal 1
 
-      docs.first.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(docs.first).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      docs.first.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      docs.first.parent.collection_id.must_equal "users"
-      docs.first.parent.collection_path.must_equal "users"
-      docs.first.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+      _(docs.first.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(docs.first.parent.collection_id).must_equal "users"
+      _(docs.first.parent.collection_path).must_equal "users"
+      _(docs.first.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
 
-      docs.first.data.must_be_kind_of Hash
-      docs.first.data.must_equal({ name: "Mike" })
-      docs.first.created_at.must_equal read_time
-      docs.first.updated_at.must_equal read_time
-      docs.first.read_at.must_equal read_time
+      _(docs.first.data).must_be_kind_of Hash
+      _(docs.first.data).must_equal({ name: "Mike" })
+      _(docs.first.created_at).must_equal read_time
+      _(docs.first.updated_at).must_equal read_time
+      _(docs.first.read_at).must_equal read_time
     end
   end
 
   def assert_docs_enum enum
-    enum.must_be_kind_of Enumerator
+    _(enum).must_be_kind_of Enumerator
 
     docs = enum.to_a
-    docs.count.must_equal 3
+    _(docs.count).must_equal 3
 
     docs.each do |doc|
-      doc.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      doc.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      doc.ref.client.must_equal firestore
+      _(doc.ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(doc.ref.client).must_equal firestore
 
-      doc.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      doc.parent.collection_id.must_equal "users"
-      doc.parent.collection_path.must_equal "users"
-      doc.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
-      doc.parent.client.must_equal firestore
+      _(doc.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(doc.parent.collection_id).must_equal "users"
+      _(doc.parent.collection_path).must_equal "users"
+      _(doc.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
+      _(doc.parent.client).must_equal firestore
     end
 
-    docs[0].must_be :exists?
-    docs[0].data.must_be_kind_of Hash
-    docs[0].data.must_equal({ name: "Mike" })
-    docs[0].created_at.must_equal read_time
-    docs[0].updated_at.must_equal read_time
-    docs[0].read_at.must_equal read_time
+    _(docs[0]).must_be :exists?
+    _(docs[0].data).must_be_kind_of Hash
+    _(docs[0].data).must_equal({ name: "Mike" })
+    _(docs[0].created_at).must_equal read_time
+    _(docs[0].updated_at).must_equal read_time
+    _(docs[0].read_at).must_equal read_time
 
-    docs[1].must_be :missing?
-    docs[1].data.must_be :nil?
-    docs[1].created_at.must_be :nil?
-    docs[1].updated_at.must_be :nil?
-    docs[1].read_at.must_equal read_time
+    _(docs[1]).must_be :missing?
+    _(docs[1].data).must_be :nil?
+    _(docs[1].created_at).must_be :nil?
+    _(docs[1].updated_at).must_be :nil?
+    _(docs[1].read_at).must_equal read_time
 
-    docs[2].must_be :exists?
-    docs[2].data.must_be_kind_of Hash
-    docs[2].data.must_equal({ name: "Chris" })
-    docs[2].created_at.must_equal read_time
-    docs[2].updated_at.must_equal read_time
-    docs[2].read_at.must_equal read_time
+    _(docs[2]).must_be :exists?
+    _(docs[2].data).must_be_kind_of Hash
+    _(docs[2].data).must_equal({ name: "Chris" })
+    _(docs[2].created_at).must_equal read_time
+    _(docs[2].updated_at).must_equal read_time
+    _(docs[2].read_at).must_equal read_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/get_test.rb
@@ -55,31 +55,31 @@ describe Google::Cloud::Firestore::Transaction, :get, :mock_firestore do
     firestore_mock.expect :batch_get_documents, [get_doc_resp].to_enum, ["projects/#{project}/databases/(default)", documents: ["projects/#{project}/databases/(default)/documents/users/mike"], mask: nil, transaction: transaction_id, options: default_options]
 
     col = firestore.col :users
-    col.must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(col).must_be_kind_of Google::Cloud::Firestore::CollectionReference
 
     doc_ref = col.doc :mike
-    doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
-    transaction.transaction_id.must_equal transaction_id
+    _(transaction.transaction_id).must_equal transaction_id
 
     doc = transaction.get doc_ref
 
-    transaction.transaction_id.must_equal transaction_id
+    _(transaction.transaction_id).must_equal transaction_id
 
-    doc.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
-    doc.document_id.must_equal doc_ref.document_id
-    doc.document_path.must_equal doc_ref.document_path
+    _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(doc.document_id).must_equal doc_ref.document_id
+    _(doc.document_path).must_equal doc_ref.document_path
 
-    doc.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    doc.parent.collection_id.must_equal col.collection_id
-    doc.parent.collection_path.must_equal col.collection_path
+    _(doc.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(doc.parent.collection_id).must_equal col.collection_id
+    _(doc.parent.collection_path).must_equal col.collection_path
 
-    doc.must_be :exists?
-    doc.data.must_be_kind_of Hash
-    doc.data.must_equal({ name: "Mike" })
-    doc.created_at.must_equal read_time
-    doc.updated_at.must_equal read_time
-    doc.read_at.must_equal read_time
+    _(doc).must_be :exists?
+    _(doc.data).must_be_kind_of Hash
+    _(doc.data).must_equal({ name: "Mike" })
+    _(doc.created_at).must_equal read_time
+    _(doc.updated_at).must_equal read_time
+    _(doc.read_at).must_equal read_time
   end
 
   it "gets a document (string)" do
@@ -94,28 +94,28 @@ describe Google::Cloud::Firestore::Transaction, :get, :mock_firestore do
     firestore_mock.expect :batch_get_documents, [get_doc_resp].to_enum, ["projects/#{project}/databases/(default)", documents: ["projects/#{project}/databases/(default)/documents/users/mike"], mask: nil, transaction: transaction_id, options: default_options]
 
     doc_ref = firestore.doc "users/mike"
-    doc_ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc_ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
-    transaction.transaction_id.must_equal transaction_id
+    _(transaction.transaction_id).must_equal transaction_id
 
     doc = transaction.get "users/mike"
 
-    transaction.transaction_id.must_equal transaction_id
+    _(transaction.transaction_id).must_equal transaction_id
 
-    doc.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
-    doc.document_id.must_equal doc_ref.document_id
-    doc.document_path.must_equal doc_ref.document_path
+    _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(doc.document_id).must_equal doc_ref.document_id
+    _(doc.document_path).must_equal doc_ref.document_path
 
-    doc.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-    doc.parent.collection_id.must_equal doc_ref.parent.collection_id
-    doc.parent.collection_path.must_equal doc_ref.parent.collection_path
+    _(doc.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+    _(doc.parent.collection_id).must_equal doc_ref.parent.collection_id
+    _(doc.parent.collection_path).must_equal doc_ref.parent.collection_path
 
-    doc.must_be :exists?
-    doc.data.must_be_kind_of Hash
-    doc.data.must_equal({ name: "Mike" })
-    doc.created_at.must_equal read_time
-    doc.updated_at.must_equal read_time
-    doc.read_at.must_equal read_time
+    _(doc).must_be :exists?
+    _(doc.data).must_be_kind_of Hash
+    _(doc.data).must_equal({ name: "Mike" })
+    _(doc.created_at).must_equal read_time
+    _(doc.updated_at).must_equal read_time
+    _(doc.read_at).must_equal read_time
   end
 
   it "gets a collection (ref)" do
@@ -192,34 +192,34 @@ describe Google::Cloud::Firestore::Transaction, :get, :mock_firestore do
   end
 
   def assert_results_enum enum
-    enum.must_be_kind_of Enumerator
+    _(enum).must_be_kind_of Enumerator
 
     results = enum.to_a
-    results.count.must_equal 2
+    _(results.count).must_equal 2
 
     results.each do |result|
-      result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(result).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      result.ref.client.must_equal firestore
+      _(result.ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(result.ref.client).must_equal firestore
 
-      result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      result.parent.collection_id.must_equal "users"
-      result.parent.collection_path.must_equal "users"
-      result.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
-      result.parent.client.must_equal firestore
+      _(result.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(result.parent.collection_id).must_equal "users"
+      _(result.parent.collection_path).must_equal "users"
+      _(result.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
+      _(result.parent.client).must_equal firestore
     end
 
-    results.first.data.must_be_kind_of Hash
-    results.first.data.must_equal({ name: "Mike" })
-    results.first.created_at.must_equal read_time
-    results.first.updated_at.must_equal read_time
-    results.first.read_at.must_equal read_time
+    _(results.first.data).must_be_kind_of Hash
+    _(results.first.data).must_equal({ name: "Mike" })
+    _(results.first.created_at).must_equal read_time
+    _(results.first.updated_at).must_equal read_time
+    _(results.first.read_at).must_equal read_time
 
-    results.last.data.must_be_kind_of Hash
-    results.last.data.must_equal({ name: "Chris" })
-    results.last.created_at.must_equal read_time
-    results.last.updated_at.must_equal read_time
-    results.last.read_at.must_equal read_time
+    _(results.last.data).must_be_kind_of Hash
+    _(results.last.data).must_equal({ name: "Chris" })
+    _(results.last.created_at).must_equal read_time
+    _(results.last.updated_at).must_equal read_time
+    _(results.last.read_at).must_equal read_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/query_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/query_test.rb
@@ -81,34 +81,34 @@ describe Google::Cloud::Firestore::Transaction, :query, :mock_firestore do
   end
 
   def assert_results_enum enum
-    enum.must_be_kind_of Enumerator
+    _(enum).must_be_kind_of Enumerator
 
     results = enum.to_a
-    results.count.must_equal 2
+    _(results.count).must_equal 2
 
     results.each do |result|
-      result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+      _(result).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
-      result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
-      result.ref.client.must_equal firestore
+      _(result.ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(result.ref.client).must_equal firestore
 
-      result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      result.parent.collection_id.must_equal "users"
-      result.parent.collection_path.must_equal "users"
-      result.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
-      result.parent.client.must_equal firestore
+      _(result.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(result.parent.collection_id).must_equal "users"
+      _(result.parent.collection_path).must_equal "users"
+      _(result.parent.path).must_equal "projects/projectID/databases/(default)/documents/users"
+      _(result.parent.client).must_equal firestore
     end
 
-    results.first.data.must_be_kind_of Hash
-    results.first.data.must_equal({ name: "Mike" })
-    results.first.created_at.must_equal read_time
-    results.first.updated_at.must_equal read_time
-    results.first.read_at.must_equal read_time
+    _(results.first.data).must_be_kind_of Hash
+    _(results.first.data).must_equal({ name: "Mike" })
+    _(results.first.created_at).must_equal read_time
+    _(results.first.updated_at).must_equal read_time
+    _(results.first.read_at).must_equal read_time
 
-    results.last.data.must_be_kind_of Hash
-    results.last.data.must_equal({ name: "Chris" })
-    results.last.created_at.must_equal read_time
-    results.last.updated_at.must_equal read_time
-    results.last.read_at.must_equal read_time
+    _(results.last.data).must_be_kind_of Hash
+    _(results.last.data).must_equal({ name: "Chris" })
+    _(results.last.created_at).must_equal read_time
+    _(results.last.updated_at).must_equal read_time
+    _(results.last.read_at).must_equal read_time
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/set_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/set_test.rb
@@ -47,27 +47,27 @@ describe Google::Cloud::Firestore::Transaction, :set, :mock_firestore do
     transaction.set(document_path, { name: "Mike" })
     resp = transaction.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "sets a new document given a DocumentReference" do
     firestore_mock.expect :commit, commit_resp, [database_path, writes: set_writes, transaction: transaction_id, options: default_options]
 
     doc = firestore.doc document_path
-    doc.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     transaction.set(doc, { name: "Mike" })
     resp = transaction.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "raises if not given a Hash" do
     error = expect do
       transaction.set document_path, "not a hash"
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/update_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/update_test.rb
@@ -52,27 +52,27 @@ describe Google::Cloud::Firestore::Transaction, :update, :mock_firestore do
     transaction.update(document_path, { name: "Mike" })
     resp = transaction.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "updates a new document given a DocumentReference" do
     firestore_mock.expect :commit, commit_resp, [database_path, writes: update_writes, transaction: transaction_id, options: default_options]
 
     doc = firestore.doc document_path
-    doc.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+    _(doc).must_be_kind_of Google::Cloud::Firestore::DocumentReference
 
     transaction.update(doc, { name: "Mike" })
     resp = transaction.commit
 
-    resp.must_be_kind_of Google::Cloud::Firestore::CommitResponse
-    resp.commit_time.must_equal commit_time
+    _(resp).must_be_kind_of Google::Cloud::Firestore::CommitResponse
+    _(resp.commit_time).must_equal commit_time
   end
 
   it "raises if not given a Hash" do
     error = expect do
       transaction.update document_path, "not a hash"
     end.must_raise ArgumentError
-    error.message.must_equal "data is required"
+    _(error.message).must_equal "data is required"
   end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/watch/order_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/watch/order_test.rb
@@ -140,22 +140,22 @@ describe "Watch", :order, :mock_firestore do
 
   it "compares unequal values" do
     comparison_indexes(sorted_values.count).each do |i, j|
-      compare_values(sorted_values[i], sorted_values[j]).must_equal -1
-      compare_values(sorted_values[j], sorted_values[i]).must_equal  1
+      _(compare_values(sorted_values[i], sorted_values[j])).must_equal -1
+      _(compare_values(sorted_values[j], sorted_values[i])).must_equal  1
     end
   end
 
   it "compares self to be equal" do
     sorted_values.each do |value|
-      compare_values(value, value).must_equal 0
+      _(compare_values(value, value)).must_equal 0
     end
   end
 
   it "compares equal values" do
     equality_groups.each do |equality_values|
       comparison_indexes(equality_values.count).each do |i, j|
-        compare_values(equality_values[i], equality_values[j]).must_equal 0
-        compare_values(equality_values[j], equality_values[i]).must_equal 0
+        _(compare_values(equality_values[i], equality_values[j])).must_equal 0
+        _(compare_values(equality_values[j], equality_values[i])).must_equal 0
       end
     end
   end

--- a/google-cloud-firestore/test/google/cloud/firestore_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore_test.rb
@@ -19,51 +19,51 @@ describe Google::Cloud do
     it "calls out to Google::Cloud.firestore" do
       gcloud = Google::Cloud.new
       stubbed_firestore = ->(project, keyfile, scope: nil, timeout: nil, host: nil, client_config: nil) {
-        project.must_be :nil?
-        keyfile.must_be :nil?
-        scope.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_be :nil?
+        _(keyfile).must_be :nil?
+        _(scope).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         "firestore-project-object-empty"
       }
       Google::Cloud.stub :firestore, stubbed_firestore do
         project = gcloud.firestore
-        project.must_equal "firestore-project-object-empty"
+        _(project).must_equal "firestore-project-object-empty"
       end
     end
 
     it "passes project and keyfile to Google::Cloud.firestore" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_firestore = ->(project, keyfile, scope: nil, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         "firestore-project-object"
       }
       Google::Cloud.stub :firestore, stubbed_firestore do
         project = gcloud.firestore
-        project.must_equal "firestore-project-object"
+        _(project).must_equal "firestore-project-object"
       end
     end
 
     it "passes project and keyfile and options to Google::Cloud.firestore" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_firestore = ->(project, keyfile, scope: nil, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_equal "http://example.com/scope"
-        timeout.must_equal 60
-        host.must_be :nil?
-        client_config.must_equal({ "gax" => "options" })
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_equal "http://example.com/scope"
+        _(timeout).must_equal 60
+        _(host).must_be :nil?
+        _(client_config).must_equal({ "gax" => "options" })
         "firestore-project-object-scoped"
       }
       Google::Cloud.stub :firestore, stubbed_firestore do
         project = gcloud.firestore scope: "http://example.com/scope", timeout: 60, client_config: { "gax" => "options" }
-        project.must_equal "firestore-project-object-scoped"
+        _(project).must_equal "firestore-project-object-scoped"
       end
     end
   end
@@ -85,10 +85,10 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Firestore::Credentials.stub :default, default_credentials do
             firestore = Google::Cloud.firestore
-            firestore.must_be_kind_of Google::Cloud::Firestore::Client
-            firestore.project_id.must_equal "project-id"
-            firestore.database_id.must_equal "(default)"
-            firestore.service.credentials.must_equal default_credentials
+            _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+            _(firestore.project_id).must_equal "project-id"
+            _(firestore.database_id).must_equal "(default)"
+            _(firestore.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -96,16 +96,16 @@ describe Google::Cloud do
 
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "firestore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "firestore-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "firestore-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -116,10 +116,10 @@ describe Google::Cloud do
             Google::Cloud::Firestore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Firestore::Service.stub :new, stubbed_service do
                 firestore = Google::Cloud.firestore "project-id", "path/to/keyfile.json"
-                firestore.must_be_kind_of Google::Cloud::Firestore::Client
-                firestore.project_id.must_equal "project-id"
-                firestore.database_id.must_equal "(default)"
-                firestore.service.must_be_kind_of OpenStruct
+                _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+                _(firestore.project_id).must_equal "project-id"
+                _(firestore.database_id).must_equal "(default)"
+                _(firestore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -145,10 +145,10 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Firestore::Credentials.stub :default, default_credentials do
             firestore = Google::Cloud::Firestore.new
-            firestore.must_be_kind_of Google::Cloud::Firestore::Client
-            firestore.project_id.must_equal "project-id"
-            firestore.database_id.must_equal "(default)"
-            firestore.service.credentials.must_equal default_credentials
+            _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+            _(firestore.project_id).must_equal "project-id"
+            _(firestore.database_id).must_equal "(default)"
+            _(firestore.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -156,16 +156,16 @@ describe Google::Cloud do
 
     it "uses provided project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "firestore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "firestore-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "firestore-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -176,10 +176,10 @@ describe Google::Cloud do
             Google::Cloud::Firestore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Firestore::Service.stub :new, stubbed_service do
                 firestore = Google::Cloud::Firestore.new project_id: "project-id", credentials: "path/to/keyfile.json"
-                firestore.must_be_kind_of Google::Cloud::Firestore::Client
-                firestore.project_id.must_equal "project-id"
-                firestore.database_id.must_equal "(default)"
-                firestore.service.must_be_kind_of OpenStruct
+                _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+                _(firestore.project_id).must_equal "project-id"
+                _(firestore.database_id).must_equal "(default)"
+                _(firestore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -189,16 +189,16 @@ describe Google::Cloud do
 
     it "uses provided project and keyfile aliases" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "firestore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "firestore-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "firestore-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -209,10 +209,10 @@ describe Google::Cloud do
             Google::Cloud::Firestore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Firestore::Service.stub :new, stubbed_service do
                 firestore = Google::Cloud::Firestore.new project: "project-id", keyfile: "path/to/keyfile.json"
-                firestore.must_be_kind_of Google::Cloud::Firestore::Client
-                firestore.project_id.must_equal "project-id"
-                firestore.database_id.must_equal "(default)"
-                firestore.service.must_be_kind_of OpenStruct
+                _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+                _(firestore.project_id).must_equal "project-id"
+                _(firestore.database_id).must_equal "(default)"
+                _(firestore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -223,11 +223,11 @@ describe Google::Cloud do
     it "uses provided endpoint" do
       endpoint = "firestore-endpoint2.example.com"
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal default_credentials
-        timeout.must_be :nil?
-        host.must_equal endpoint
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(timeout).must_be :nil?
+        _(host).must_equal endpoint
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -235,10 +235,10 @@ describe Google::Cloud do
       ENV.stub :[], nil do
         Google::Cloud::Firestore::Service.stub :new, stubbed_service do
           firestore = Google::Cloud::Firestore.new project: "project-id", credentials: default_credentials, endpoint: endpoint
-          firestore.must_be_kind_of Google::Cloud::Firestore::Client
-          firestore.project_id.must_equal "project-id"
-          firestore.database_id.must_equal "(default)"
-          firestore.service.must_be_kind_of OpenStruct
+          _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+          _(firestore.project_id).must_equal "project-id"
+          _(firestore.database_id).must_equal "(default)"
+          _(firestore.service).must_be_kind_of OpenStruct
         end
       end
     end
@@ -252,10 +252,10 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Firestore::Credentials.stub :default, default_credentials do
             firestore = Google::Cloud::Firestore.new
-            firestore.must_be_kind_of Google::Cloud::Firestore::Client
-            firestore.project_id.must_equal "project-id"
-            firestore.service.credentials.must_equal :this_channel_is_insecure
-            firestore.service.host.must_equal emulator_host
+            _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+            _(firestore.project_id).must_equal "project-id"
+            _(firestore.service.credentials).must_equal :this_channel_is_insecure
+            _(firestore.service.host).must_equal emulator_host
           end
         end
       end
@@ -269,10 +269,10 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           # Google::Cloud::Firestore::Credentials.stub :default, default_credentials do
             firestore = Google::Cloud::Firestore.new emulator_host: emulator_host
-            firestore.must_be_kind_of Google::Cloud::Firestore::Client
-            firestore.project_id.must_equal "project-id"
-            firestore.service.credentials.must_equal :this_channel_is_insecure
-            firestore.service.host.must_equal emulator_host
+            _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+            _(firestore.project_id).must_equal "project-id"
+            _(firestore.service.credentials).must_equal :this_channel_is_insecure
+            _(firestore.service.host).must_equal emulator_host
           # end
         end
       end
@@ -280,17 +280,17 @@ describe Google::Cloud do
 
     it "gets project_id from credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         OpenStruct.new project_id: "project-id"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_be_kind_of OpenStruct
-        credentials.project_id.must_equal "project-id"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_be_kind_of OpenStruct
+        _(credentials.project_id).must_equal "project-id"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
       empty_env = OpenStruct.new
@@ -303,10 +303,10 @@ describe Google::Cloud do
               Google::Cloud::Firestore::Credentials.stub :new, stubbed_credentials do
                 Google::Cloud::Firestore::Service.stub :new, stubbed_service do
                   firestore = Google::Cloud::Firestore.new credentials: "path/to/keyfile.json"
-                  firestore.must_be_kind_of Google::Cloud::Firestore::Client
-                  firestore.project_id.must_equal "project-id"
-                  firestore.database_id.must_equal "(default)"
-                  firestore.service.must_be_kind_of OpenStruct
+                  _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+                  _(firestore.project_id).must_equal "project-id"
+                  _(firestore.database_id).must_equal "(default)"
+                  _(firestore.service).must_be_kind_of OpenStruct
                 end
               end
             end
@@ -330,16 +330,16 @@ describe Google::Cloud do
 
     it "uses shared config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "firestore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "firestore-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "firestore-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -356,9 +356,9 @@ describe Google::Cloud do
             Google::Cloud::Firestore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Firestore::Service.stub :new, stubbed_service do
                 firestore = Google::Cloud::Firestore.new
-                firestore.must_be_kind_of Google::Cloud::Firestore::Client
-                firestore.project_id.must_equal "project-id"
-                firestore.service.must_be_kind_of OpenStruct
+                _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+                _(firestore.project_id).must_equal "project-id"
+                _(firestore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -368,16 +368,16 @@ describe Google::Cloud do
 
     it "uses shared config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "firestore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "firestore-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "firestore-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -394,9 +394,9 @@ describe Google::Cloud do
             Google::Cloud::Firestore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Firestore::Service.stub :new, stubbed_service do
                 firestore = Google::Cloud::Firestore.new
-                firestore.must_be_kind_of Google::Cloud::Firestore::Client
-                firestore.project_id.must_equal "project-id"
-                firestore.service.must_be_kind_of OpenStruct
+                _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+                _(firestore.project_id).must_equal "project-id"
+                _(firestore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -406,16 +406,16 @@ describe Google::Cloud do
 
     it "uses firestore config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "firestore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "firestore-credentials"
-        timeout.must_equal 42
-        host.must_be :nil?
-        client_config.must_equal firestore_client_config
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "firestore-credentials"
+        _(timeout).must_equal 42
+        _(host).must_be :nil?
+        _(client_config).must_equal firestore_client_config
         OpenStruct.new project: project
       }
 
@@ -434,9 +434,9 @@ describe Google::Cloud do
             Google::Cloud::Firestore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Firestore::Service.stub :new, stubbed_service do
                 firestore = Google::Cloud::Firestore.new
-                firestore.must_be_kind_of Google::Cloud::Firestore::Client
-                firestore.project_id.must_equal "project-id"
-                firestore.service.must_be_kind_of OpenStruct
+                _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+                _(firestore.project_id).must_equal "project-id"
+                _(firestore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -446,16 +446,16 @@ describe Google::Cloud do
 
     it "uses firestore config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "firestore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "firestore-credentials"
-        timeout.must_equal 42
-        host.must_be :nil?
-        client_config.must_equal firestore_client_config
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "firestore-credentials"
+        _(timeout).must_equal 42
+        _(host).must_be :nil?
+        _(client_config).must_equal firestore_client_config
         OpenStruct.new project: project
       }
 
@@ -474,9 +474,9 @@ describe Google::Cloud do
             Google::Cloud::Firestore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Firestore::Service.stub :new, stubbed_service do
                 firestore = Google::Cloud::Firestore.new
-                firestore.must_be_kind_of Google::Cloud::Firestore::Client
-                firestore.project_id.must_equal "project-id"
-                firestore.service.must_be_kind_of OpenStruct
+                _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+                _(firestore.project_id).must_equal "project-id"
+                _(firestore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -486,16 +486,16 @@ describe Google::Cloud do
 
     it "uses firestore config for endpoint" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "firestore-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "firestore-credentials"
-        timeout.must_be :nil?
-        host.must_equal "firestore-endpoint2.example.com"
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "firestore-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_equal "firestore-endpoint2.example.com"
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -513,9 +513,9 @@ describe Google::Cloud do
             Google::Cloud::Firestore::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Firestore::Service.stub :new, stubbed_service do
                 firestore = Google::Cloud::Firestore.new
-                firestore.must_be_kind_of Google::Cloud::Firestore::Client
-                firestore.project_id.must_equal "project-id"
-                firestore.service.must_be_kind_of OpenStruct
+                _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+                _(firestore.project_id).must_equal "project-id"
+                _(firestore.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -533,10 +533,10 @@ describe Google::Cloud do
         end
 
         firestore = Google::Cloud::Firestore.new
-        firestore.must_be_kind_of Google::Cloud::Firestore::Client
-        firestore.project_id.must_equal "project-id"
-        firestore.service.credentials.must_equal :this_channel_is_insecure
-        firestore.service.host.must_equal "localhost:4567"
+        _(firestore).must_be_kind_of Google::Cloud::Firestore::Client
+        _(firestore.project_id).must_equal "project-id"
+        _(firestore.service.credentials).must_equal :this_channel_is_insecure
+        _(firestore.service.host).must_equal "localhost:4567"
       end
     end
   end


### PR DESCRIPTION
Use `rubocop-minitest` gem and `bundle exec rubocop --only Minitest/GlobalExpectations -a` to autocorrect minitest warnings for Ruby 2.7.

refs: #4110
refs: #4116