### PR TITLE
chore(pubsub): Update minitest to 5.14

### DIFF
--- a/google-cloud-pubsub/.rubocop.yml
+++ b/google-cloud-pubsub/.rubocop.yml
@@ -1,15 +1,15 @@
-require: rubocop-minitest
-
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
+    - "acceptance/**/*"
     - "lib/google/pubsub/**/*"
     - "lib/google/cloud/pubsub/v1.rb"
     - "lib/google/cloud/pubsub/v1/**/*"
     - "lib/google/iam/**/*"
     - "support/**/*"
+    - "test/**/*"
 
 Documentation:
   Enabled: false

--- a/google-cloud-pubsub/.rubocop.yml
+++ b/google-cloud-pubsub/.rubocop.yml
@@ -1,15 +1,15 @@
+require: rubocop-minitest
+
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
     - "lib/google/pubsub/**/*"
     - "lib/google/cloud/pubsub/v1.rb"
     - "lib/google/cloud/pubsub/v1/**/*"
     - "lib/google/iam/**/*"
     - "support/**/*"
-    - "test/**/*"
 
 Documentation:
   Enabled: false

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -8,7 +8,3 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
-
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -8,5 +8,3 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
-
-gem "rubocop-minitest"

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -8,3 +8,5 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
+
+gem "rubocop-minitest"

--- a/google-cloud-pubsub/acceptance/pubsub/async_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/async_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::PubSub, :async, :pubsub do
 
   it "publishes and pulls asyncronously" do
     events = sub.pull
-    events.must_be :empty?
+    _(events).must_be :empty?
     # Publish a new message
     publish_result = nil
     topic.publish_async "hello" do |result|
@@ -45,8 +45,8 @@ describe Google::Cloud::PubSub, :async, :pubsub do
       puts "the async publish has not completed yet. sleeping for #{unpublished_retries*unpublished_retries} second(s) and retrying."
       sleep unpublished_retries*unpublished_retries
     end
-    publish_result.wont_be :nil?
-    publish_result.must_be :succeeded?
+    _(publish_result).wont_be :nil?
+    _(publish_result).must_be :succeeded?
 
     received_message = nil
     subscriber = sub.listen do |msg|
@@ -63,8 +63,8 @@ describe Google::Cloud::PubSub, :async, :pubsub do
       puts "received_message has not been received. sleeping for #{subscription_retries} second(s) and retrying."
       sleep subscription_retries
     end
-    received_message.wont_be :nil?
-    received_message.data.must_equal publish_result.data
+    _(received_message).wont_be :nil?
+    _(received_message.data).must_equal publish_result.data
 
     subscriber.stop
     subscriber.wait!
@@ -82,7 +82,7 @@ describe Google::Cloud::PubSub, :async, :pubsub do
     assert sub.message_ordering?
 
     events = sub.pull
-    events.must_be :empty?
+    _(events).must_be :empty?
 
     # Publish a new message
     publish_result = nil
@@ -112,8 +112,8 @@ describe Google::Cloud::PubSub, :async, :pubsub do
       puts "the async publish has not completed yet. sleeping for #{unpublished_retries*unpublished_retries} second(s) and retrying."
       sleep unpublished_retries*unpublished_retries
     end
-    publish_result.wont_be :nil?
-    publish_result.must_be :succeeded?
+    _(publish_result).wont_be :nil?
+    _(publish_result).must_be :succeeded?
 
     received_message_hash = Hash.new { |hash, key| hash[key] = [] }
     subscriber = sub.listen do |msg|
@@ -147,7 +147,7 @@ describe Google::Cloud::PubSub, :async, :pubsub do
         "ordered message 9"
       ]
     }
-    received_message_hash.must_equal expected_message_hash
+    _(received_message_hash).must_equal expected_message_hash
 
     subscriber.stop
     subscriber.wait!

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -54,31 +54,31 @@ describe Google::Cloud::PubSub, :pubsub do
     it "should be listed" do
       topics = pubsub.topics.all
       topics.each do |topic|
-        topic.must_be_kind_of Google::Cloud::PubSub::Topic
+        _(topic).must_be_kind_of Google::Cloud::PubSub::Topic
       end
     end
 
     it "should be created, updated and deleted" do
       topic = pubsub.create_topic new_topic_name, labels: labels
-      topic.must_be_kind_of Google::Cloud::PubSub::Topic
+      _(topic).must_be_kind_of Google::Cloud::PubSub::Topic
       topic = pubsub.topic(topic.name)
-      topic.wont_be :nil?
-      topic.labels.must_equal labels
-      topic.labels.must_be :frozen?
+      _(topic).wont_be :nil?
+      _(topic.labels).must_equal labels
+      _(topic.labels).must_be :frozen?
       topic.labels = {}
-      topic.labels.must_be :empty?
+      _(topic.labels).must_be :empty?
       topic.delete
-      pubsub.topic(topic.name).must_be :nil?
+      _(pubsub.topic(topic.name)).must_be :nil?
     end
 
     it "should publish a message" do
       data = "message from me"
       msg = pubsub.topic(topic_names.first).publish data, foo: :bar
 
-      msg.wont_be :nil?
-      msg.must_be_kind_of Google::Cloud::PubSub::Message
-      msg.data.must_equal data
-      msg.attributes["foo"].must_equal "bar"
+      _(msg).wont_be :nil?
+      _(msg).must_be_kind_of Google::Cloud::PubSub::Message
+      _(msg.data).must_equal data
+      _(msg.attributes["foo"]).must_equal "bar"
     end
 
     it "should publish multiple messages" do
@@ -88,9 +88,9 @@ describe Google::Cloud::PubSub, :pubsub do
         batch.publish "third message", format: :text
       end
 
-      msgs.wont_be :nil?
-      msgs.count.must_equal 3
-      msgs.each { |msg| msg.must_be_kind_of Google::Cloud::PubSub::Message }
+      _(msgs).wont_be :nil?
+      _(msgs.count).must_equal 3
+      msgs.each { |msg| _(msg).must_be_kind_of Google::Cloud::PubSub::Message }
     end
   end
 
@@ -107,7 +107,7 @@ describe Google::Cloud::PubSub, :pubsub do
       subscriptions = pubsub.subscriptions.all
       subscriptions.each do |subscription|
         # subscriptions on project are objects...
-        subscription.must_be_kind_of Google::Cloud::PubSub::Subscription
+        _(subscription).must_be_kind_of Google::Cloud::PubSub::Subscription
       end
     end
   end
@@ -128,172 +128,180 @@ describe Google::Cloud::PubSub, :pubsub do
 
     it "should list all subscriptions registered to the topic" do
       subscriptions = topic.subscriptions.all
-      subscriptions.count.must_be :>=, subs.count
+      _(subscriptions.count).must_be :>=, subs.count
       subscriptions.each do |subscription|
         # subscriptions on topic are strings...
-        subscription.must_be_kind_of Google::Cloud::PubSub::Subscription
+        _(subscription).must_be_kind_of Google::Cloud::PubSub::Subscription
       end
     end
 
     it "should allow create and update of subscription with options" do
-      # create
-      subscription = topic.subscribe "#{$topic_prefix}-sub3", retain_acked: true, retention: 600, labels: labels
-      subscription.wont_be :nil?
-      subscription.must_be_kind_of Google::Cloud::PubSub::Subscription
-      assert subscription.retain_acked
-      subscription.retention.must_equal 600
-      subscription.labels.must_equal labels
-      subscription.labels.must_be :frozen?
+      begin
+        # create
+        subscription = topic.subscribe "#{$topic_prefix}-sub3", retain_acked: true, retention: 600, labels: labels
+        _(subscription).wont_be :nil?
+        _(subscription).must_be_kind_of Google::Cloud::PubSub::Subscription
+        assert subscription.retain_acked
+        _(subscription.retention).must_equal 600
+        _(subscription.labels).must_equal labels
+        _(subscription.labels).must_be :frozen?
 
-      # update
-      subscription.labels = {}
-      subscription.labels.must_be :empty?
-    ensure
-      # delete
-      subscription.delete
+        # update
+        subscription.labels = {}
+        _(subscription.labels).must_be :empty?
+      ensure
+        # delete
+        subscription.delete
+      end
     end
 
     it "should not error when asking for a non-existent subscription" do
       subscription = topic.get_subscription "non-existent-subscription"
-      subscription.must_be :nil?
+      _(subscription).must_be :nil?
     end
 
     it "should be able to pull and ack" do
-      subscription = topic.subscribe "#{$topic_prefix}-sub4"
-      subscription.wont_be :nil?
-      subscription.must_be_kind_of Google::Cloud::PubSub::Subscription
-      # No messages, should be empty
-      received_messages = subscription.pull
-      received_messages.must_be :empty?
-      # Publish a new message
-      msg = topic.publish "hello"
-      msg.wont_be :nil?
-      # Check it received the published message
-      received_messages = pull_with_retry subscription
-      received_messages.wont_be :empty?
-      received_messages.count.must_equal 1
-      received_message = received_messages.first
-      received_message.wont_be :nil?
-      received_message.delivery_attempt.must_be :nil?
-      received_message.msg.data.must_equal msg.data
-      received_message.msg.published_at.wont_be :nil?
-      # Acknowledge the message
-      subscription.ack received_message.ack_id
-    ensure
-      # Remove the subscription
-      subscription.delete
+      begin
+        subscription = topic.subscribe "#{$topic_prefix}-sub4"
+        _(subscription).wont_be :nil?
+        _(subscription).must_be_kind_of Google::Cloud::PubSub::Subscription
+        # No messages, should be empty
+        received_messages = subscription.pull
+        _(received_messages).must_be :empty?
+        # Publish a new message
+        msg = topic.publish "hello"
+        _(msg).wont_be :nil?
+        # Check it received the published message
+        received_messages = pull_with_retry subscription
+        _(received_messages).wont_be :empty?
+        _(received_messages.count).must_equal 1
+        received_message = received_messages.first
+        _(received_message).wont_be :nil?
+        _(received_message.delivery_attempt).must_be :nil?
+        _(received_message.msg.data).must_equal msg.data
+        _(received_message.msg.published_at).wont_be :nil?
+        # Acknowledge the message
+        subscription.ack received_message.ack_id
+      ensure
+        # Remove the subscription
+        subscription.delete
+      end
     end
 
     it "should be able to pull same message again after ack by seeking to snapshot" do
-      subscription = topic.subscribe "#{$topic_prefix}-sub5"
-      subscription.wont_be :nil?
-      subscription.must_be_kind_of Google::Cloud::PubSub::Subscription
+      begin
+        subscription = topic.subscribe "#{$topic_prefix}-sub5"
+        _(subscription).wont_be :nil?
+        _(subscription).must_be_kind_of Google::Cloud::PubSub::Subscription
 
-      # No messages, should be empty
-      received_messages = subscription.pull
-      received_messages.must_be :empty?
-      # Publish a new message
-      msg = topic.publish "hello-#{rand(1000)}"
-      msg.wont_be :nil?
+        # No messages, should be empty
+        received_messages = subscription.pull
+        _(received_messages).must_be :empty?
+        # Publish a new message
+        msg = topic.publish "hello-#{rand(1000)}"
+        _(msg).wont_be :nil?
 
-      snapshot = subscription.create_snapshot labels: labels
+        snapshot = subscription.create_snapshot labels: labels
 
-      # Check it pulls the message
-      received_messages = pull_with_retry subscription
-      received_messages.wont_be :empty?
-      received_messages.count.must_equal 1
-      received_message = received_messages.first
-      received_message.wont_be :nil?
-      received_message.delivery_attempt.must_be :nil?
-      received_message.msg.data.must_equal msg.data
-      received_message.msg.published_at.wont_be :nil?
-      # Acknowledge the message
-      subscription.ack received_message.ack_id
+        # Check it pulls the message
+        received_messages = pull_with_retry subscription
+        _(received_messages).wont_be :empty?
+        _(received_messages.count).must_equal 1
+        received_message = received_messages.first
+        _(received_message).wont_be :nil?
+        _(received_message.delivery_attempt).must_be :nil?
+        _(received_message.msg.data).must_equal msg.data
+        _(received_message.msg.published_at).wont_be :nil?
+        # Acknowledge the message
+        subscription.ack received_message.ack_id
 
-      # No messages, should be empty
-      received_messages = subscription.pull
-      received_messages.must_be :empty?
+        # No messages, should be empty
+        received_messages = subscription.pull
+        _(received_messages).must_be :empty?
 
-      # Reset to the snapshot
-      subscription.seek snapshot
+        # Reset to the snapshot
+        subscription.seek snapshot
 
-      # Check it again pulls the message
-      received_messages = pull_with_retry subscription
-      received_messages.count.must_equal 1
-      received_message = received_messages.first
-      received_message.wont_be :nil?
-      received_message.delivery_attempt.must_be :nil?
-      received_message.msg.data.must_equal msg.data
-      # Acknowledge the message
-      subscription.ack received_message.ack_id
-      # No messages, should be empty
-      received_messages = subscription.pull
-      received_messages.must_be :empty?
+        # Check it again pulls the message
+        received_messages = pull_with_retry subscription
+        _(received_messages.count).must_equal 1
+        received_message = received_messages.first
+        _(received_message).wont_be :nil?
+        _(received_message.delivery_attempt).must_be :nil?
+        _(received_message.msg.data).must_equal msg.data
+        # Acknowledge the message
+        subscription.ack received_message.ack_id
+        # No messages, should be empty
+        received_messages = subscription.pull
+        _(received_messages).must_be :empty?
 
-      # No messages, should be empty
-      received_messages = subscription.pull
-      received_messages.must_be :empty?
+        # No messages, should be empty
+        received_messages = subscription.pull
+        _(received_messages).must_be :empty?
 
-      snapshot.labels.must_equal labels
-      snapshot.labels.must_be :frozen?
-      snapshot.labels = {}
-      snapshot.labels.must_be :empty?
-    ensure
-      # Remove the subscription
-      subscription.delete
+        _(snapshot.labels).must_equal labels
+        _(snapshot.labels).must_be :frozen?
+        snapshot.labels = {}
+        _(snapshot.labels).must_be :empty?
+      ensure
+        # Remove the subscription
+        subscription.delete
+      end
     end
 
     if $project_number
       it "should be able to direct messages to a dead letter topic" do
-        dead_letter_topic = retrieve_topic dead_letter_topic_name
-        dead_letter_subscription = dead_letter_topic.subscribe "#{$topic_prefix}-dead-letter-sub1"
+        begin
+          dead_letter_topic = retrieve_topic dead_letter_topic_name
+          dead_letter_subscription = dead_letter_topic.subscribe "#{$topic_prefix}-dead-letter-sub1"
 
-        # Dead Letter Queue (DLQ) testing requires IAM bindings to the Cloud Pub/Sub service account that is
-        # automatically created and managed by the service team in a private project.
-        service_account_email = "serviceAccount:service-#{$project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+          # Dead Letter Queue (DLQ) testing requires IAM bindings to the Cloud Pub/Sub service account that is
+          # automatically created and managed by the service team in a private project.
+          service_account_email = "serviceAccount:service-#{$project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 
-        dead_letter_topic.policy { |p| p.add "roles/pubsub.publisher", service_account_email }
-        dead_letter_subscription.policy { |p| p.add "roles/pubsub.subscriber", service_account_email }
+          dead_letter_topic.policy { |p| p.add "roles/pubsub.publisher", service_account_email }
+          dead_letter_subscription.policy { |p| p.add "roles/pubsub.subscriber", service_account_email }
 
-        # create
-        subscription = topic.subscribe "#{$topic_prefix}-sub6", dead_letter_topic: dead_letter_topic, dead_letter_max_delivery_attempts: 6
-        subscription.dead_letter_max_delivery_attempts.must_equal 6
-        subscription.dead_letter_topic.reload!.name.must_equal dead_letter_topic.name
+          # create
+          subscription = topic.subscribe "#{$topic_prefix}-sub6", dead_letter_topic: dead_letter_topic, dead_letter_max_delivery_attempts: 6
+          _(subscription.dead_letter_max_delivery_attempts).must_equal 6
+          _(subscription.dead_letter_topic.reload!.name).must_equal dead_letter_topic.name
 
-        # update
-        subscription.dead_letter_max_delivery_attempts = 5
-        subscription.dead_letter_max_delivery_attempts.must_equal 5
-        dead_letter_topic_2 = retrieve_topic dead_letter_topic_name_2
-        dead_letter_subscription_2 = dead_letter_topic_2.subscribe "#{$topic_prefix}-dead-letter-sub2"
-        subscription.dead_letter_topic = dead_letter_topic_2
-        subscription.dead_letter_topic.reload!.name.must_equal dead_letter_topic_2.name
+          # update
+          subscription.dead_letter_max_delivery_attempts = 5
+          _(subscription.dead_letter_max_delivery_attempts).must_equal 5
+          dead_letter_topic_2 = retrieve_topic dead_letter_topic_name_2
+          dead_letter_subscription_2 = dead_letter_topic_2.subscribe "#{$topic_prefix}-dead-letter-sub2"
+          subscription.dead_letter_topic = dead_letter_topic_2
+          _(subscription.dead_letter_topic.reload!.name).must_equal dead_letter_topic_2.name
 
-        # Publish a new message
-        msg = topic.publish "dead-letter-#{rand(1000)}"
-        msg.wont_be :nil?
+          # Publish a new message
+          msg = topic.publish "dead-letter-#{rand(1000)}"
+          _(msg).wont_be :nil?
 
-        # Check it pulls the message
-        (1..7).each do |i|
-          received_messages = pull_with_retry subscription
-          received_messages.count.must_equal 1
+          # Check it pulls the message
+          (1..7).each do |i|
+            received_messages = pull_with_retry subscription
+            _(received_messages.count).must_equal 1
+            received_message = received_messages.first
+            _(received_message.msg.data).must_equal msg.data
+            _(received_message.delivery_attempt).must_be :>, 0
+            received_message.nack!
+          end
+
+          # Check the dead letter subscription pulls the message
+          received_messages = dead_letter_subscription.pull
+          _(received_messages).wont_be :empty?
+          _(received_messages.count).must_equal 1
           received_message = received_messages.first
-          received_message.msg.data.must_equal msg.data
-          received_message.delivery_attempt.must_be :>, 0
-          received_message.nack!
+          _(received_message).wont_be :nil?
+          _(received_message.msg.data).must_equal msg.data
+          _(received_message.delivery_attempt).must_be :nil?
+        ensure
+          # Remove the subscription
+          subscription.delete
+          dead_letter_subscription.delete
         end
-
-        # Check the dead letter subscription pulls the message
-        received_messages = dead_letter_subscription.pull
-        received_messages.wont_be :empty?
-        received_messages.count.must_equal 1
-        received_message = received_messages.first
-        received_message.wont_be :nil?
-        received_message.msg.data.must_equal msg.data
-        received_message.delivery_attempt.must_be :nil?
-      ensure
-        # Remove the subscription
-        subscription.delete
-        dead_letter_subscription.delete
       end
     end
 
@@ -322,10 +330,10 @@ describe Google::Cloud::PubSub, :pubsub do
       permissions = topic.test_permissions roles
       skip "Don't have permissions to get/set topic's policy" unless permissions == roles
 
-      topic.policy.must_be_kind_of Google::Cloud::PubSub::Policy
+      _(topic.policy).must_be_kind_of Google::Cloud::PubSub::Policy
 
       # We need a valid service account in order to update the policy
-      service_account.wont_be :nil?
+      _(service_account).wont_be :nil?
       role = "roles/pubsub.publisher"
       member = "serviceAccount:#{service_account}"
       topic.policy do |p|
@@ -334,7 +342,7 @@ describe Google::Cloud::PubSub, :pubsub do
       end
 
       role_member = topic.policy.role(role).select { |x| x == member }
-      role_member.size.must_equal 1
+      _(role_member.size).must_equal 1
     end
 
     it "allows policy to be updated on a subscription" do
@@ -343,29 +351,29 @@ describe Google::Cloud::PubSub, :pubsub do
       permissions = subscription.test_permissions roles
       skip "Don't have permissions to get/set subscription's policy" unless permissions == roles
 
-      subscription.policy.must_be_kind_of Google::Cloud::PubSub::Policy
+      _(subscription.policy).must_be_kind_of Google::Cloud::PubSub::Policy
 
       # We need a valid service account in order to update the policy
-      service_account.wont_be :nil?
+      _(service_account).wont_be :nil?
       role = "roles/pubsub.subscriber"
       member = "serviceAccount:#{service_account}"
       subscription.policy do |p|
         p.add role, member
       end
 
-      subscription.policy.role(role).must_include member
+      _(subscription.policy.role(role)).must_include member
     end
 
     it "allows permissions to be tested on a topic" do
       roles = ["pubsub.topics.get", "pubsub.topics.publish"]
       permissions = topic.test_permissions roles
-      permissions.must_equal roles
+      _(permissions).must_equal roles
     end
 
     it "allows permissions to be tested on a subscription" do
       roles = ["pubsub.subscriptions.consume", "pubsub.subscriptions.get"]
       permissions = subscription.test_permissions roles
-      permissions.must_equal roles
+      _(permissions).must_equal roles
     end
   end
 
@@ -383,7 +391,7 @@ describe Google::Cloud::PubSub, :pubsub do
       snapshots = pubsub.snapshots.all
       snapshots.each do |snapshot|
         # snapshots on project are objects...
-        snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
+        _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
       end
     end
   end

--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "google-style", "~> 1.24.0"
-  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"

--- a/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher/batch_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher/batch_test.rb
@@ -332,7 +332,7 @@ describe Google::Cloud::PubSub::AsyncPublisher::Batch do
 
     assert batch.canceled?
 
-    canceled_items.count.must_equal 15
+    _(canceled_items.count).must_equal 15
   end
 
   describe :empty? do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher/message_ordering_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher/message_ordering_test.rb
@@ -31,14 +31,14 @@ describe Google::Cloud::PubSub::AsyncPublisher, :message_ordering, :mock_pubsub 
       publisher.publish msg[:message], ordering_key: msg[:key]
     end
 
-    publisher.must_be :started?
-    publisher.wont_be :stopped?
+    _(publisher).must_be :started?
+    _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
     publisher.stop.wait!
 
-    publisher.wont_be :started?
-    publisher.must_be :stopped?
+    _(publisher).wont_be :started?
+    _(publisher).must_be :stopped?
 
     published_messages_hash = pubsub.service.mocked_publisher.message_hash
     assert_equal fixture_expected_hash.keys.sort, published_messages_hash.keys.sort
@@ -61,14 +61,14 @@ describe Google::Cloud::PubSub::AsyncPublisher, :message_ordering, :mock_pubsub 
       end
     end
 
-    publisher.must_be :started?
-    publisher.wont_be :stopped?
+    _(publisher).must_be :started?
+    _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
     publisher.stop.wait!
 
-    publisher.wont_be :started?
-    publisher.must_be :stopped?
+    _(publisher).wont_be :started?
+    _(publisher).must_be :stopped?
 
     published_messages_hash = pubsub.service.mocked_publisher.message_hash
     assert_equal fixture_expected_hash.keys.sort, published_messages_hash.keys.sort
@@ -93,14 +93,14 @@ describe Google::Cloud::PubSub::AsyncPublisher, :message_ordering, :mock_pubsub 
       end
     end
 
-    publisher.must_be :started?
-    publisher.wont_be :stopped?
+    _(publisher).must_be :started?
+    _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
     publisher.stop.wait!
 
-    publisher.wont_be :started?
-    publisher.must_be :stopped?
+    _(publisher).wont_be :started?
+    _(publisher).must_be :stopped?
 
     published_messages_hash = pubsub.service.mocked_publisher.message_hash
     assert_equal fixture_expected_hash.keys.sort, published_messages_hash.keys.sort
@@ -121,14 +121,14 @@ describe Google::Cloud::PubSub::AsyncPublisher, :message_ordering, :mock_pubsub 
       publisher.publish msg[:message], ordering_key: msg[:key]
     end
 
-    publisher.must_be :started?
-    publisher.wont_be :stopped?
+    _(publisher).must_be :started?
+    _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
     publisher.stop.wait!
 
-    publisher.wont_be :started?
-    publisher.must_be :stopped?
+    _(publisher).wont_be :started?
+    _(publisher).must_be :stopped?
 
     published_messages_hash = pubsub.service.mocked_publisher.message_hash
     assert_equal fixture_expected_hash.keys.sort, published_messages_hash.keys.sort
@@ -149,14 +149,14 @@ describe Google::Cloud::PubSub::AsyncPublisher, :message_ordering, :mock_pubsub 
       publisher.publish msg[:message], ordering_key: msg[:key]
     end
 
-    publisher.must_be :started?
-    publisher.wont_be :stopped?
+    _(publisher).must_be :started?
+    _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
     publisher.stop.wait!
 
-    publisher.wont_be :started?
-    publisher.must_be :stopped?
+    _(publisher).wont_be :started?
+    _(publisher).must_be :stopped?
 
     published_messages_hash = pubsub.service.mocked_publisher.message_hash
     assert_equal fixture_expected_hash.keys.sort, published_messages_hash.keys.sort

--- a/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
@@ -36,14 +36,14 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
 
     publisher.publish message1
 
-    publisher.must_be :started?
-    publisher.wont_be :stopped?
+    _(publisher).must_be :started?
+    _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
     publisher.stop.wait!
 
-    publisher.wont_be :started?
-    publisher.must_be :stopped?
+    _(publisher).wont_be :started?
+    _(publisher).must_be :stopped?
 
     published_messages_hash = publisher.service.mocked_publisher.message_hash
     expected_messages_hash = { "" => messages }
@@ -60,14 +60,14 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
 
     publisher.publish message1, format: :text
 
-    publisher.must_be :started?
-    publisher.wont_be :stopped?
+    _(publisher).must_be :started?
+    _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
     publisher.stop.wait!
 
-    publisher.wont_be :started?
-    publisher.must_be :stopped?
+    _(publisher).wont_be :started?
+    _(publisher).must_be :stopped?
 
     published_messages_hash = publisher.service.mocked_publisher.message_hash
     expected_messages_hash = { "" => messages }
@@ -88,19 +88,19 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
       callback_called = true
     end
 
-    publisher.must_be :started?
-    publisher.wont_be :stopped?
+    _(publisher).must_be :started?
+    _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
     publisher.stop.wait!
 
-    publisher.wont_be :started?
-    publisher.must_be :stopped?
+    _(publisher).wont_be :started?
+    _(publisher).must_be :stopped?
 
     published_messages_hash = publisher.service.mocked_publisher.message_hash
     expected_messages_hash = { "" => messages }
     assert_equal expected_messages_hash, published_messages_hash
-    callback_called.must_equal true
+    _(callback_called).must_equal true
   end
 
   it "publishes multiple messages" do
@@ -117,14 +117,14 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     publisher.publish message2
     publisher.publish message3, format: :none
 
-    publisher.must_be :started?
-    publisher.wont_be :stopped?
+    _(publisher).must_be :started?
+    _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
     publisher.stop.wait!
 
-    publisher.wont_be :started?
-    publisher.must_be :stopped?
+    _(publisher).wont_be :started?
+    _(publisher).must_be :stopped?
 
     published_messages_hash = publisher.service.mocked_publisher.message_hash
     expected_messages_hash = { "" => messages }
@@ -155,19 +155,19 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
       callback_count += 1
     end
 
-    publisher.must_be :started?
-    publisher.wont_be :stopped?
+    _(publisher).must_be :started?
+    _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
     publisher.stop.wait!
 
-    publisher.wont_be :started?
-    publisher.must_be :stopped?
+    _(publisher).wont_be :started?
+    _(publisher).must_be :stopped?
 
     published_messages_hash = publisher.service.mocked_publisher.message_hash
     expected_messages_hash = { "" => messages }
     assert_equal expected_messages_hash, published_messages_hash
-    callback_count.must_equal 3
+    _(callback_count).must_equal 3
   end
 
   it "publishes multiple batches when message count limit is reached" do
@@ -186,14 +186,14 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
       end
     end
 
-    publisher.must_be :started?
-    publisher.wont_be :stopped?
+    _(publisher).must_be :started?
+    _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
     publisher.stop.wait!
 
-    publisher.wont_be :started?
-    publisher.must_be :stopped?
+    _(publisher).wont_be :started?
+    _(publisher).must_be :stopped?
 
     expected_messages = Array.new(3) do
       Array.new(10) do |count|
@@ -202,7 +202,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     end
 
     assert_equal expected_messages, publisher.service.mocked_publisher.messages
-    callback_count.must_equal 30
+    _(callback_count).must_equal 30
   end
 
   it "publishes multiple batches when message size limit is reached" do
@@ -221,14 +221,14 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
       end
     end
 
-    publisher.must_be :started?
-    publisher.wont_be :stopped?
+    _(publisher).must_be :started?
+    _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
     publisher.stop.wait!
 
-    publisher.wont_be :started?
-    publisher.must_be :stopped?
+    _(publisher).wont_be :started?
+    _(publisher).must_be :stopped?
 
     expected_messages = Array.new(3) do
       Array.new(10) do |count|
@@ -238,7 +238,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
 
     assert_equal expected_messages.map(&:count), publisher.service.mocked_publisher.messages.map(&:count)
     assert_equal expected_messages, publisher.service.mocked_publisher.messages
-    callback_count.must_equal 30
+    _(callback_count).must_equal 30
   end
 
   it "publishes when message size is greater than the limit" do
@@ -257,21 +257,21 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
       callback_count += 1
     end
 
-    publisher.must_be :started?
-    publisher.wont_be :stopped?
+    _(publisher).must_be :started?
+    _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
     publisher.stop.wait!
 
-    publisher.wont_be :started?
-    publisher.must_be :stopped?
+    _(publisher).wont_be :started?
+    _(publisher).must_be :stopped?
 
     expected_messages = [
       [Google::Cloud::PubSub::V1::PubsubMessage.new(data: msg_encoded1, message_id: "msg0")],
       [Google::Cloud::PubSub::V1::PubsubMessage.new(data: big_msg_data, message_id: "msg1")]
     ]
     assert_equal publisher.service.mocked_publisher.messages, expected_messages
-    callback_count.must_equal 2
+    _(callback_count).must_equal 2
   end
 
   def wait_until delay: 0.01, max: 10, output: nil, msg: "criteria not met", &block

--- a/google-cloud-pubsub/test/google/cloud/pubsub/convert/duration_to_number_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/convert/duration_to_number_test.rb
@@ -23,54 +23,54 @@ describe Google::Cloud::PubSub::Convert, :duration_to_number, :mock_pubsub do
   it "converts an integer" do
     duration = Google::Protobuf::Duration.new seconds: 42, nanos: 0
     number = Google::Cloud::PubSub::Convert.duration_to_number duration
-    number.must_equal 42
+    _(number).must_equal 42
   end
 
   it "converts a negative integer" do
     duration = Google::Protobuf::Duration.new seconds: -42, nanos: 0
     number = Google::Cloud::PubSub::Convert.duration_to_number duration
-    number.must_equal -42
+    _(number).must_equal -42
   end
 
   it "converts a small number" do
     duration = Google::Protobuf::Duration.new seconds: 1, nanos: 500000000
     number = Google::Cloud::PubSub::Convert.duration_to_number duration
-    number.must_equal 1.5
+    _(number).must_equal 1.5
   end
 
   it "converts a negative small number" do
     duration = Google::Protobuf::Duration.new seconds: -1, nanos: -500000000
     number = Google::Cloud::PubSub::Convert.duration_to_number duration
-    number.must_equal -1.5
+    _(number).must_equal -1.5
   end
 
   it "converts a big number" do
     duration = Google::Protobuf::Duration.new seconds: 643383279502884, nanos: 197169399
     number = Google::Cloud::PubSub::Convert.duration_to_number duration
-    number.must_equal 643383279502884.197169399
+    _(number).must_equal 643383279502884.197169399
   end
 
   it "converts a negative big number" do
     duration = Google::Protobuf::Duration.new seconds: -643383279502884, nanos: -197169399
     number = Google::Cloud::PubSub::Convert.duration_to_number duration
-    number.must_equal -643383279502884.197169399
+    _(number).must_equal -643383279502884.197169399
   end
 
   it "converts pi" do
     duration = Google::Protobuf::Duration.new seconds: 3, nanos: 141592654
     number = Google::Cloud::PubSub::Convert.duration_to_number duration
-    number.must_equal 3.141592654
+    _(number).must_equal 3.141592654
   end
 
   it "converts a negative pi" do
     duration = Google::Protobuf::Duration.new seconds: -3, nanos: -141592654
     number = Google::Cloud::PubSub::Convert.duration_to_number duration
-    number.must_equal -3.141592654
+    _(number).must_equal -3.141592654
   end
 
   it "returns nil when given nil" do
     duration = nil
     number = Google::Cloud::PubSub::Convert.duration_to_number duration
-    number.must_be :nil?
+    _(number).must_be :nil?
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/convert/number_to_duration_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/convert/number_to_duration_test.rb
@@ -24,71 +24,71 @@ describe Google::Cloud::PubSub::Convert, :number_to_duration, :mock_pubsub do
   it "converts an Integer" do
     number = 42
     duration = Google::Cloud::PubSub::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
-    duration.seconds.must_equal 42
-    duration.nanos.must_equal 0
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal 42
+    _(duration.nanos).must_equal 0
   end
 
   it "converts a negative Integer" do
     number = -42
     duration = Google::Cloud::PubSub::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
-    duration.seconds.must_equal -42
-    duration.nanos.must_equal 0
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal -42
+    _(duration.nanos).must_equal 0
   end
 
   it "converts a Float" do
     number = 1.5
     duration = Google::Cloud::PubSub::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
-    duration.seconds.must_equal 1
-    duration.nanos.must_equal 500000000
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal 1
+    _(duration.nanos).must_equal 500000000
   end
 
   it "converts a negative Float" do
     number = -1.5
     duration = Google::Cloud::PubSub::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
-    duration.seconds.must_equal -1
-    duration.nanos.must_equal -500000000
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal -1
+    _(duration.nanos).must_equal -500000000
   end
 
   it "converts a BigDecimal" do
     number = BigDecimal "643383279502884.1971693993751058209749445923078164062"
     duration = Google::Cloud::PubSub::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
-    duration.seconds.must_equal 643383279502884
-    duration.nanos.must_equal 197169399
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal 643383279502884
+    _(duration.nanos).must_equal 197169399
   end
 
   it "converts a negative BigDecimal" do
     number = BigDecimal "-643383279502884.1971693993751058209749445923078164062"
     duration = Google::Cloud::PubSub::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
+    _(duration).must_be_kind_of Google::Protobuf::Duration
     # This should really be -643383279502884, but BigDecimal is doing something here...
-    duration.seconds.must_equal -643383279502885
-    duration.nanos.must_equal -197169399
+    _(duration.seconds).must_equal -643383279502885
+    _(duration.nanos).must_equal -197169399
   end
 
   it "converts a Rational" do
     number = Rational "3.14159265358979323846264338327950288419716939937510582097"
     duration = Google::Cloud::PubSub::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
-    duration.seconds.must_equal 3
-    duration.nanos.must_equal 141592654
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal 3
+    _(duration.nanos).must_equal 141592654
   end
 
   it "converts a negative Rational" do
     number = Rational "-3.14159265358979323846264338327950288419716939937510582097"
     duration = Google::Cloud::PubSub::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
-    duration.seconds.must_equal -3
-    duration.nanos.must_equal -141592654
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal -3
+    _(duration.nanos).must_equal -141592654
   end
 
   it "returns nil when given nil" do
     number = nil
     duration = Google::Cloud::PubSub::Convert.number_to_duration number
-    duration.must_be :nil?
+    _(duration).must_be :nil?
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/convert/timestamp_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/convert/timestamp_test.rb
@@ -24,35 +24,35 @@ describe Google::Cloud::PubSub::Convert, :timestamp, :mock_pubsub do
   it "converts a Time to a Timestamp" do
     time = Time.parse "2014-10-02T15:01:23.045123456Z"
     timestamp = Google::Cloud::PubSub::Convert.time_to_timestamp time
-    timestamp.must_be_kind_of Google::Protobuf::Timestamp
-    timestamp.seconds.must_equal 1412262083
-    timestamp.nanos.must_equal 45123456
+    _(timestamp).must_be_kind_of Google::Protobuf::Timestamp
+    _(timestamp.seconds).must_equal 1412262083
+    _(timestamp.nanos).must_equal 45123456
   end
 
   it "converts a DateTime to a Timestamp" do
     datetime = DateTime.parse "2014-10-02T15:01:23.045123456Z"
     timestamp = Google::Cloud::PubSub::Convert.time_to_timestamp datetime
-    timestamp.must_be_kind_of Google::Protobuf::Timestamp
-    timestamp.seconds.must_equal 1412262083
-    timestamp.nanos.must_equal 45123456
+    _(timestamp).must_be_kind_of Google::Protobuf::Timestamp
+    _(timestamp.seconds).must_equal 1412262083
+    _(timestamp.nanos).must_equal 45123456
   end
 
   it "converts an empty Time to an empty Timestamp" do
     time = nil
     timestamp = Google::Cloud::PubSub::Convert.time_to_timestamp time
-    timestamp.must_be :nil?
+    _(timestamp).must_be :nil?
   end
 
   it "converts a Timestamp to a Time" do
     timestamp = Google::Protobuf::Timestamp.new seconds: 1412262083, nanos: 45123456
     time = Google::Cloud::PubSub::Convert.timestamp_to_time timestamp
-    time.must_be_kind_of Time
-    time.must_equal Time.parse("2014-10-02T15:01:23.045123456Z")
+    _(time).must_be_kind_of Time
+    _(time).must_equal Time.parse("2014-10-02T15:01:23.045123456Z")
   end
 
   it "converts an empty Timestamp to an empty Time" do
     timestamp = nil
     time = Google::Cloud::PubSub::Convert.timestamp_to_time timestamp
-    time.must_be :nil?
+    _(time).must_be :nil?
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/message/attributes_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/message/attributes_test.rb
@@ -26,8 +26,8 @@ describe Google::Cloud::PubSub::Message, :attributes do
   let(:message_obj)  { Google::Cloud::PubSub::Message.from_grpc message_grpc }
 
   it "has attributes as a Hash even when being a Google API object" do
-    message_obj.attributes["foo"].must_equal "FOO"
-    message_obj.attributes.keys.must_include "bar"
-    message_obj.attributes.must_be_kind_of Hash
+    _(message_obj.attributes["foo"]).must_equal "FOO"
+    _(message_obj.attributes.keys).must_include "bar"
+    _(message_obj.attributes).must_be_kind_of Hash
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/message_test.rb
@@ -20,12 +20,12 @@ describe Google::Cloud::PubSub::Message, :mock_pubsub do
   let(:msg)    { Google::Cloud::PubSub::Message.new data, attributes }
 
   it "knows its data" do
-    msg.data.must_equal data
+    _(msg.data).must_equal data
   end
 
   it "knows its attributes" do
-    msg.attributes.keys.sort.must_equal   attributes.keys.sort
-    msg.attributes.values.sort.must_equal attributes.values.sort
+    _(msg.attributes.keys.sort).must_equal   attributes.keys.sort
+    _(msg.attributes.values.sort).must_equal attributes.values.sort
   end
 
   describe "from gapi" do
@@ -41,28 +41,28 @@ describe Google::Cloud::PubSub::Message, :mock_pubsub do
     let(:msg)     { Google::Cloud::PubSub::Message.from_grpc rec_message_grpc }
 
     it "knows its data" do
-      msg.data.must_equal rec_message_msg
+      _(msg.data).must_equal rec_message_msg
     end
 
     it "knows its attributes" do
-      msg.attributes.keys.sort.must_equal   rec_message_data[:message][:attributes].keys.sort
-      msg.attributes.values.sort.must_equal rec_message_data[:message][:attributes].values.sort
+      _(msg.attributes.keys.sort).must_equal   rec_message_data[:message][:attributes].keys.sort
+      _(msg.attributes.values.sort).must_equal rec_message_data[:message][:attributes].values.sort
     end
 
     it "knows its message_id" do
-      msg.msg_id.must_equal     rec_message_data[:message][:message_id]
-      msg.message_id.must_equal rec_message_data[:message][:message_id]
+      _(msg.msg_id).must_equal     rec_message_data[:message][:message_id]
+      _(msg.message_id).must_equal rec_message_data[:message][:message_id]
     end
 
     it "knows its published_at" do
-      msg.published_at.must_be :nil?
-      msg.publish_time.must_be :nil?
+      _(msg.published_at).must_be :nil?
+      _(msg.publish_time).must_be :nil?
 
       publish_time = Time.now
       rec_message_grpc.publish_time = Google::Cloud::PubSub::Convert.time_to_timestamp publish_time
 
-      msg.published_at.must_equal publish_time
-      msg.publish_time.must_equal publish_time
+      _(msg.published_at).must_equal publish_time
+      _(msg.publish_time).must_equal publish_time
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/policy_test.rb
@@ -20,18 +20,18 @@ describe Google::Cloud::PubSub::Policy, :mock_pubsub do
   let(:policy)    { Google::Cloud::PubSub::Policy.new etag, roles }
 
   it "knows its etag" do
-    policy.roles.must_equal roles
+    _(policy.roles).must_equal roles
   end
 
   it "knows its roles" do
-    policy.roles.keys.sort.must_equal   roles.keys.sort
-    policy.roles.values.sort.must_equal roles.values.sort
+    _(policy.roles.keys.sort).must_equal   roles.keys.sort
+    _(policy.roles.values.sort).must_equal roles.values.sort
   end
 
   it "returns an empty array for missing role" do
     role = policy.role "roles/does-not-exist"
-    role.must_be_kind_of Array
-    role.must_be :empty?
-    role.frozen?.must_equal false
+    _(role).must_be_kind_of Array
+    _(role).must_be :empty?
+    _(role.frozen?).must_equal false
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
   let(:persistence_regions) { ["us-west1", "us-west2"] }
 
   it "knows the project identifier" do
-    pubsub.project.must_equal project
+    _(pubsub.project).must_equal project
   end
 
   it "creates a topic" do
@@ -71,11 +71,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topic.name.must_equal topic_path(new_topic_name)
-    topic.labels.must_be :empty?
-    topic.labels.must_be :frozen?
-    topic.kms_key.must_be :empty?
-    topic.persistence_regions.must_be :empty?
+    _(topic.name).must_equal topic_path(new_topic_name)
+    _(topic.labels).must_be :empty?
+    _(topic.labels).must_be :frozen?
+    _(topic.kms_key).must_be :empty?
+    _(topic.persistence_regions).must_be :empty?
   end
 
   it "creates a topic with new_topic_alias" do
@@ -90,11 +90,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topic.name.must_equal topic_path(new_topic_name)
-    topic.labels.must_be :empty?
-    topic.labels.must_be :frozen?
-    topic.kms_key.must_be :empty?
-    topic.persistence_regions.must_be :empty?
+    _(topic.name).must_equal topic_path(new_topic_name)
+    _(topic.labels).must_be :empty?
+    _(topic.labels).must_be :frozen?
+    _(topic.kms_key).must_be :empty?
+    _(topic.persistence_regions).must_be :empty?
   end
 
   it "creates a topic with labels" do
@@ -109,11 +109,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topic.name.must_equal topic_path(new_topic_name)
-    topic.labels.must_equal labels
-    topic.labels.must_be :frozen?
-    topic.kms_key.must_be :empty?
-    topic.persistence_regions.must_be :empty?
+    _(topic.name).must_equal topic_path(new_topic_name)
+    _(topic.labels).must_equal labels
+    _(topic.labels).must_be :frozen?
+    _(topic.kms_key).must_be :empty?
+    _(topic.persistence_regions).must_be :empty?
   end
 
   it "creates a topic with kms_key" do
@@ -128,11 +128,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topic.name.must_equal topic_path(new_topic_name)
-    topic.labels.must_be :empty?
-    topic.labels.must_be :frozen?
-    topic.kms_key.must_equal kms_key
-    topic.persistence_regions.must_be :empty?
+    _(topic.name).must_equal topic_path(new_topic_name)
+    _(topic.labels).must_be :empty?
+    _(topic.labels).must_be :frozen?
+    _(topic.kms_key).must_equal kms_key
+    _(topic.persistence_regions).must_be :empty?
   end
 
   it "creates a topic with persistence_regions" do
@@ -147,11 +147,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topic.name.must_equal topic_path(new_topic_name)
-    topic.labels.must_be :empty?
-    topic.labels.must_be :frozen?
-    topic.kms_key.must_be :empty?
-    topic.persistence_regions.must_equal persistence_regions
+    _(topic.name).must_equal topic_path(new_topic_name)
+    _(topic.labels).must_be :empty?
+    _(topic.labels).must_be :frozen?
+    _(topic.kms_key).must_be :empty?
+    _(topic.persistence_regions).must_equal persistence_regions
   end
 
   it "gets a topic" do
@@ -166,9 +166,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topic.name.must_equal topic_path(topic_name)
-    topic.wont_be :reference?
-    topic.must_be :resource?
+    _(topic.name).must_equal topic_path(topic_name)
+    _(topic).wont_be :reference?
+    _(topic).must_be :resource?
   end
 
   it "gets a topic with get_topic alias" do
@@ -183,9 +183,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topic.name.must_equal topic_path(topic_name)
-    topic.wont_be :reference?
-    topic.must_be :resource?
+    _(topic.name).must_equal topic_path(topic_name)
+    _(topic).wont_be :reference?
+    _(topic).must_be :resource?
   end
 
   it "gets a topic with find_topic alias" do
@@ -200,9 +200,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topic.name.must_equal topic_path(topic_name)
-    topic.wont_be :reference?
-    topic.must_be :resource?
+    _(topic.name).must_equal topic_path(topic_name)
+    _(topic).wont_be :reference?
+    _(topic).must_be :resource?
   end
 
   it "returns nil when getting an non-existent topic" do
@@ -217,7 +217,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
     pubsub.service.mocked_publisher = stub
 
     topic = pubsub.find_topic not_found_topic_name
-    topic.must_be :nil?
+    _(topic).must_be :nil?
   end
 
   it "gets a topic with skip_lookup option" do
@@ -225,9 +225,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
     # No HTTP mock needed, since the lookup is not made
 
     topic = pubsub.find_topic topic_name, skip_lookup: true
-    topic.name.must_equal topic_path(topic_name)
-    topic.must_be :reference?
-    topic.wont_be :resource?
+    _(topic.name).must_equal topic_path(topic_name)
+    _(topic).must_be :reference?
+    _(topic).wont_be :resource?
   end
 
   it "gets a topic with skip_lookup and project options" do
@@ -235,9 +235,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
     # No HTTP mock needed, since the lookup is not made
 
     topic = pubsub.find_topic topic_name, skip_lookup: true, project: "custom"
-    topic.name.must_equal "projects/custom/topics/found-topic"
-    topic.must_be :reference?
-    topic.wont_be :resource?
+    _(topic.name).must_equal "projects/custom/topics/found-topic"
+    _(topic).must_be :reference?
+    _(topic).wont_be :resource?
   end
 
   it "lists topics" do
@@ -249,7 +249,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topics.size.must_equal 3
+    _(topics.size).must_equal 3
   end
 
   it "lists topics with find_topics alias" do
@@ -261,7 +261,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topics.size.must_equal 3
+    _(topics.size).must_equal 3
   end
 
   it "lists topics with list_topics alias" do
@@ -273,7 +273,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topics.size.must_equal 3
+    _(topics.size).must_equal 3
   end
 
   it "paginates topics" do
@@ -288,13 +288,13 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    first_topics.size.must_equal 3
+    _(first_topics.size).must_equal 3
     token = first_topics.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
 
-    second_topics.size.must_equal 2
-    second_topics.token.must_be :nil?
+    _(second_topics.size).must_equal 2
+    _(second_topics.token).must_be :nil?
   end
 
   it "paginates topics with max set" do
@@ -306,10 +306,10 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topics.size.must_equal 3
+    _(topics.size).must_equal 3
     token = topics.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
   end
 
   it "paginates topics with next? and next" do
@@ -324,11 +324,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    first_topics.size.must_equal 3
-    first_topics.next?.must_equal true
+    _(first_topics.size).must_equal 3
+    _(first_topics.next?).must_equal true
 
-    second_topics.size.must_equal 2
-    second_topics.next?.must_equal false
+    _(second_topics.size).must_equal 2
+    _(second_topics.next?).must_equal false
   end
 
   it "paginates topics with next? and next and max set" do
@@ -343,11 +343,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    first_topics.size.must_equal 3
-    first_topics.next?.must_equal true
+    _(first_topics.size).must_equal 3
+    _(first_topics.next?).must_equal true
 
-    second_topics.size.must_equal 2
-    second_topics.next?.must_equal false
+    _(second_topics.size).must_equal 2
+    _(second_topics.next?).must_equal false
   end
 
   it "paginates topics with all" do
@@ -361,7 +361,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topics.size.must_equal 5
+    _(topics.size).must_equal 5
   end
 
   it "paginates topics with all and max set" do
@@ -375,7 +375,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topics.size.must_equal 5
+    _(topics.size).must_equal 5
   end
 
   it "iterates topics with all using Enumerator" do
@@ -389,7 +389,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topics.size.must_equal 5
+    _(topics.size).must_equal 5
   end
 
   it "iterates topics with all and request_limit set" do
@@ -403,7 +403,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topics.size.must_equal 6
+    _(topics.size).must_equal 6
   end
 
   it "paginates topics without max set" do
@@ -415,10 +415,10 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    topics.size.must_equal 3
+    _(topics.size).must_equal 3
     token = topics.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
   end
 
   it "gets a subscription" do
@@ -433,11 +433,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.name.must_equal subscription_path(sub_name)
-    sub.wont_be :reference?
-    sub.must_be :resource?
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub.name).must_equal subscription_path(sub_name)
+    _(sub).wont_be :reference?
+    _(sub).must_be :resource?
   end
 
   it "gets a subscription with get_subscription alias" do
@@ -452,11 +452,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.name.must_equal subscription_path(sub_name)
-    sub.wont_be :reference?
-    sub.must_be :resource?
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub.name).must_equal subscription_path(sub_name)
+    _(sub).wont_be :reference?
+    _(sub).must_be :resource?
   end
 
   it "gets a subscription with find_subscription alias" do
@@ -471,11 +471,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.name.must_equal subscription_path(sub_name)
-    sub.wont_be :reference?
-    sub.must_be :resource?
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub.name).must_equal subscription_path(sub_name)
+    _(sub).wont_be :reference?
+    _(sub).must_be :resource?
   end
 
   it "returns nil when getting an non-existent subscription" do
@@ -490,7 +490,7 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
     pubsub.service.mocked_subscriber = stub
 
     sub = pubsub.subscription not_found_sub_name
-    sub.must_be :nil?
+    _(sub).must_be :nil?
   end
 
   it "gets a subscription with skip_lookup option" do
@@ -498,11 +498,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
     # No HTTP mock needed, since the lookup is not made
 
     sub = pubsub.subscription sub_name, skip_lookup: true
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.name.must_equal subscription_path(sub_name)
-    sub.must_be :reference?
-    sub.wont_be :resource?
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub.name).must_equal subscription_path(sub_name)
+    _(sub).must_be :reference?
+    _(sub).wont_be :resource?
   end
 
   it "gets a subscription with skip_lookup and project options" do
@@ -510,11 +510,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
     # No HTTP mock needed, since the lookup is not made
 
     sub = pubsub.subscription sub_name, skip_lookup: true, project: "custom"
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.name.must_equal "projects/custom/subscriptions/#{sub_name}"
-    sub.must_be :reference?
-    sub.wont_be :resource?
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub.name).must_equal "projects/custom/subscriptions/#{sub_name}"
+    _(sub).must_be :reference?
+    _(sub).wont_be :resource?
   end
 
   it "lists subscriptions" do
@@ -526,9 +526,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 3
+    _(subs.count).must_equal 3
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
     end
   end
 
@@ -541,9 +541,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 3
+    _(subs.count).must_equal 3
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
     end
   end
 
@@ -556,9 +556,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 3
+    _(subs.count).must_equal 3
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
     end
   end
 
@@ -574,13 +574,13 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    first_subs.count.must_equal 3
+    _(first_subs.count).must_equal 3
     token = first_subs.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
 
-    second_subs.count.must_equal 2
-    second_subs.token.must_be :nil?
+    _(second_subs.count).must_equal 2
+    _(second_subs.token).must_be :nil?
   end
 
   it "paginates subscriptions with max set" do
@@ -592,10 +592,10 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 3
+    _(subs.count).must_equal 3
     token = subs.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
   end
 
   it "paginates subscriptions with next? and next" do
@@ -610,20 +610,20 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    first_subs.count.must_equal 3
-    first_subs.next?.must_equal true
+    _(first_subs.count).must_equal 3
+    _(first_subs.next?).must_equal true
     first_subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.wont_be :reference?
-      sub.must_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).wont_be :reference?
+      _(sub).must_be :resource?
     end
 
-    second_subs.count.must_equal 2
-    second_subs.next?.must_equal false
+    _(second_subs.count).must_equal 2
+    _(second_subs.next?).must_equal false
     second_subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.wont_be :reference?
-      sub.must_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).wont_be :reference?
+      _(sub).must_be :resource?
     end
   end
 
@@ -639,20 +639,20 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    first_subs.count.must_equal 3
-    first_subs.next?.must_equal true
+    _(first_subs.count).must_equal 3
+    _(first_subs.next?).must_equal true
     first_subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.wont_be :reference?
-      sub.must_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).wont_be :reference?
+      _(sub).must_be :resource?
     end
 
-    second_subs.count.must_equal 2
-    second_subs.next?.must_equal false
+    _(second_subs.count).must_equal 2
+    _(second_subs.next?).must_equal false
     second_subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.wont_be :reference?
-      sub.must_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).wont_be :reference?
+      _(sub).must_be :resource?
     end
   end
 
@@ -667,11 +667,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 5
+    _(subs.count).must_equal 5
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.wont_be :reference?
-      sub.must_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).wont_be :reference?
+      _(sub).must_be :resource?
     end
   end
 
@@ -686,11 +686,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 5
+    _(subs.count).must_equal 5
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.wont_be :reference?
-      sub.must_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).wont_be :reference?
+      _(sub).must_be :resource?
     end
   end
 
@@ -705,11 +705,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 5
+    _(subs.count).must_equal 5
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.wont_be :reference?
-      sub.must_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).wont_be :reference?
+      _(sub).must_be :resource?
     end
   end
 
@@ -724,11 +724,11 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 6
+    _(subs.count).must_equal 6
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.wont_be :reference?
-      sub.must_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).wont_be :reference?
+      _(sub).must_be :resource?
     end
   end
 
@@ -744,9 +744,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    snapshots.count.must_equal 3
+    _(snapshots.count).must_equal 3
     snapshots.each do |snapshot|
-      snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
+      _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
     end
   end
 
@@ -759,9 +759,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    snapshots.count.must_equal 3
+    _(snapshots.count).must_equal 3
     snapshots.each do |snapshot|
-      snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
+      _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
     end
   end
 
@@ -774,9 +774,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    snapshots.count.must_equal 3
+    _(snapshots.count).must_equal 3
     snapshots.each do |snapshot|
-      snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
+      _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
     end
   end
 
@@ -792,13 +792,13 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    first_subs.count.must_equal 3
+    _(first_subs.count).must_equal 3
     token = first_subs.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
 
-    second_subs.count.must_equal 2
-    second_subs.token.must_be :nil?
+    _(second_subs.count).must_equal 2
+    _(second_subs.token).must_be :nil?
   end
 
   it "paginates snapshots with max set" do
@@ -810,10 +810,10 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    snapshots.count.must_equal 3
+    _(snapshots.count).must_equal 3
     token = snapshots.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
   end
 
   it "paginates snapshots with next? and next" do
@@ -828,16 +828,16 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    first_subs.count.must_equal 3
-    first_subs.next?.must_equal true
+    _(first_subs.count).must_equal 3
+    _(first_subs.next?).must_equal true
     first_subs.each do |snapshot|
-      snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
+      _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
     end
 
-    second_subs.count.must_equal 2
-    second_subs.next?.must_equal false
+    _(second_subs.count).must_equal 2
+    _(second_subs.next?).must_equal false
     second_subs.each do |snapshot|
-      snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
+      _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
     end
   end
 
@@ -853,16 +853,16 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    first_subs.count.must_equal 3
-    first_subs.next?.must_equal true
+    _(first_subs.count).must_equal 3
+    _(first_subs.next?).must_equal true
     first_subs.each do |snapshot|
-      snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
+      _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
     end
 
-    second_subs.count.must_equal 2
-    second_subs.next?.must_equal false
+    _(second_subs.count).must_equal 2
+    _(second_subs.next?).must_equal false
     second_subs.each do |snapshot|
-      snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
+      _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
     end
   end
 
@@ -877,9 +877,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    snapshots.count.must_equal 5
+    _(snapshots.count).must_equal 5
     snapshots.each do |snapshot|
-      snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
+      _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
     end
   end
 
@@ -894,9 +894,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    snapshots.count.must_equal 5
+    _(snapshots.count).must_equal 5
     snapshots.each do |snapshot|
-      snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
+      _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
     end
   end
 
@@ -911,9 +911,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    snapshots.count.must_equal 5
+    _(snapshots.count).must_equal 5
     snapshots.each do |snapshot|
-      snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
+      _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
     end
   end
 
@@ -928,9 +928,9 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
 
     mock.verify
 
-    snapshots.count.must_equal 6
+    _(snapshots.count).must_equal 6
     snapshots.each do |snapshot|
-      snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
+      _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/publish_result_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/publish_result_test.rb
@@ -21,36 +21,36 @@ describe Google::Cloud::PubSub::PublishResult, :mock_pubsub do
   let(:result) { Google::Cloud::PubSub::PublishResult.new msg }
 
   it "knows attributes" do
-    result.data.must_equal data
-    result.message.data.must_equal data
-    result.msg.data.must_equal data
+    _(result.data).must_equal data
+    _(result.message.data).must_equal data
+    _(result.msg.data).must_equal data
 
-    result.attributes.keys.sort.must_equal   attributes.keys.sort
-    result.attributes.values.sort.must_equal attributes.values.sort
-    result.message.attributes.keys.sort.must_equal   attributes.keys.sort
-    result.message.attributes.values.sort.must_equal attributes.values.sort
-    result.msg.attributes.keys.sort.must_equal   attributes.keys.sort
-    result.msg.attributes.values.sort.must_equal attributes.values.sort
+    _(result.attributes.keys.sort).must_equal   attributes.keys.sort
+    _(result.attributes.values.sort).must_equal attributes.values.sort
+    _(result.message.attributes.keys.sort).must_equal   attributes.keys.sort
+    _(result.message.attributes.values.sort).must_equal attributes.values.sort
+    _(result.msg.attributes.keys.sort).must_equal   attributes.keys.sort
+    _(result.msg.attributes.values.sort).must_equal attributes.values.sort
 
-    result.message_id.must_be :empty?
-    result.message.message_id.must_be :empty?
-    result.msg.message_id.must_be :empty?
+    _(result.message_id).must_be :empty?
+    _(result.message.message_id).must_be :empty?
+    _(result.msg.message_id).must_be :empty?
 
-    result.published_at.must_be :nil?
-    result.message.published_at.must_be :nil?
-    result.msg.published_at.must_be :nil?
+    _(result.published_at).must_be :nil?
+    _(result.message.published_at).must_be :nil?
+    _(result.msg.published_at).must_be :nil?
 
-    result.publish_time.must_be :nil?
-    result.message.publish_time.must_be :nil?
-    result.msg.publish_time.must_be :nil?
+    _(result.publish_time).must_be :nil?
+    _(result.message.publish_time).must_be :nil?
+    _(result.msg.publish_time).must_be :nil?
 
-    result.message.must_equal msg
-    result.msg.must_equal msg
+    _(result.message).must_equal msg
+    _(result.msg).must_equal msg
 
-    result.error.must_be :nil?
+    _(result.error).must_be :nil?
 
-    result.must_be :succeeded?
-    result.wont_be :failed?
+    _(result).must_be :succeeded?
+    _(result).wont_be :failed?
   end
 
   describe "with error" do
@@ -58,36 +58,36 @@ describe Google::Cloud::PubSub::PublishResult, :mock_pubsub do
     let(:result) { Google::Cloud::PubSub::PublishResult.new msg, error }
 
     it "knows attributes" do
-      result.data.must_equal data
-      result.message.data.must_equal data
-      result.msg.data.must_equal data
+      _(result.data).must_equal data
+      _(result.message.data).must_equal data
+      _(result.msg.data).must_equal data
 
-      result.attributes.keys.sort.must_equal   attributes.keys.sort
-      result.attributes.values.sort.must_equal attributes.values.sort
-      result.message.attributes.keys.sort.must_equal   attributes.keys.sort
-      result.message.attributes.values.sort.must_equal attributes.values.sort
-      result.msg.attributes.keys.sort.must_equal   attributes.keys.sort
-      result.msg.attributes.values.sort.must_equal attributes.values.sort
+      _(result.attributes.keys.sort).must_equal   attributes.keys.sort
+      _(result.attributes.values.sort).must_equal attributes.values.sort
+      _(result.message.attributes.keys.sort).must_equal   attributes.keys.sort
+      _(result.message.attributes.values.sort).must_equal attributes.values.sort
+      _(result.msg.attributes.keys.sort).must_equal   attributes.keys.sort
+      _(result.msg.attributes.values.sort).must_equal attributes.values.sort
 
-      result.message_id.must_be :empty?
-      result.message.message_id.must_be :empty?
-      result.msg.message_id.must_be :empty?
+      _(result.message_id).must_be :empty?
+      _(result.message.message_id).must_be :empty?
+      _(result.msg.message_id).must_be :empty?
 
-      result.published_at.must_be :nil?
-      result.message.published_at.must_be :nil?
-      result.msg.published_at.must_be :nil?
+      _(result.published_at).must_be :nil?
+      _(result.message.published_at).must_be :nil?
+      _(result.msg.published_at).must_be :nil?
 
-      result.publish_time.must_be :nil?
-      result.message.publish_time.must_be :nil?
-      result.msg.publish_time.must_be :nil?
+      _(result.publish_time).must_be :nil?
+      _(result.message.publish_time).must_be :nil?
+      _(result.msg.publish_time).must_be :nil?
 
-      result.message.must_equal msg
-      result.msg.must_equal msg
+      _(result.message).must_equal msg
+      _(result.msg).must_equal msg
 
-      result.error.must_equal error
+      _(result.error).must_equal error
 
-      result.wont_be :succeeded?
-      result.must_be :failed?
+      _(result).wont_be :succeeded?
+      _(result).must_be :failed?
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
@@ -27,56 +27,56 @@ describe Google::Cloud::PubSub::ReceivedMessage, :mock_pubsub do
   let(:rec_message) { Google::Cloud::PubSub::ReceivedMessage.from_grpc rec_message_grpc, subscription }
 
   it "knows its subscription" do
-    rec_message.subscription.wont_be :nil?
-    rec_message.subscription.name.must_equal subscription_path(subscription_name)
+    _(rec_message.subscription).wont_be :nil?
+    _(rec_message.subscription.name).must_equal subscription_path(subscription_name)
   end
 
   it "knows its ack_id" do
-    rec_message.ack_id.must_equal rec_message_data[:ack_id]
+    _(rec_message.ack_id).must_equal rec_message_data[:ack_id]
   end
 
   it "has a message" do
-    rec_message.message.wont_be :nil?
-    rec_message.message.data.must_equal rec_message_msg
-    rec_message.message.attributes.keys.sort.must_equal   rec_message_data[:message][:attributes].keys.sort
-    rec_message.message.attributes.values.sort.must_equal rec_message_data[:message][:attributes].values.sort
-    rec_message.message.msg_id.must_equal rec_message_data[:message][:message_id]
-    rec_message.message.message_id.must_equal rec_message_data[:message][:message_id]
+    _(rec_message.message).wont_be :nil?
+    _(rec_message.message.data).must_equal rec_message_msg
+    _(rec_message.message.attributes.keys.sort).must_equal   rec_message_data[:message][:attributes].keys.sort
+    _(rec_message.message.attributes.values.sort).must_equal rec_message_data[:message][:attributes].values.sort
+    _(rec_message.message.msg_id).must_equal rec_message_data[:message][:message_id]
+    _(rec_message.message.message_id).must_equal rec_message_data[:message][:message_id]
   end
 
   it "knows the message's data" do
-    rec_message.data.must_equal rec_message.message.data
+    _(rec_message.data).must_equal rec_message.message.data
   end
 
   it "knows the message's attributes" do
-    rec_message.attributes.must_equal rec_message.message.attributes
+    _(rec_message.attributes).must_equal rec_message.message.attributes
   end
 
   it "knows the message's message_id" do
-    rec_message.msg_id.must_equal     rec_message.message.msg_id
-    rec_message.message_id.must_equal rec_message.message.message_id
+    _(rec_message.msg_id).must_equal     rec_message.message.msg_id
+    _(rec_message.message_id).must_equal rec_message.message.message_id
   end
 
   it "knows its published_at" do
-    rec_message.published_at.must_be :nil?
-    rec_message.publish_time.must_be :nil?
+    _(rec_message.published_at).must_be :nil?
+    _(rec_message.publish_time).must_be :nil?
 
     publish_time = Time.now
     rec_message_grpc.message.publish_time = Google::Cloud::PubSub::Convert.time_to_timestamp publish_time
 
-    rec_message.published_at.must_equal publish_time
-    rec_message.publish_time.must_equal publish_time
+    _(rec_message.published_at).must_equal publish_time
+    _(rec_message.publish_time).must_equal publish_time
   end
 
   it "knows its delivery_attempt counter" do
-    rec_message.delivery_attempt.must_equal 10
+    _(rec_message.delivery_attempt).must_equal 10
   end
 
   it "returns nil for delivery_attempt when delivery_attempt is 0" do
     rec_message_data_non_dlq = rec_message_hash rec_message_msg, delivery_attempt: 0
     rec_message_grpc_non_dlq = Google::Cloud::PubSub::V1::ReceivedMessage.new rec_message_data_non_dlq
     rec_message_non_dlq = Google::Cloud::PubSub::ReceivedMessage.from_grpc rec_message_grpc_non_dlq, subscription
-    rec_message_non_dlq.delivery_attempt.must_be :nil?
+    _(rec_message_non_dlq.delivery_attempt).must_be :nil?
   end
 
   it "can acknowledge" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/snapshot_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/snapshot_test.rb
@@ -28,27 +28,27 @@ describe Google::Cloud::PubSub::Snapshot, :mock_pubsub do
   end
 
   it "knows its name" do
-    snapshot.name.must_equal snapshot_path(snapshot_name)
+    _(snapshot.name).must_equal snapshot_path(snapshot_name)
   end
 
   it "knows its topic" do
-    snapshot.topic.must_be_kind_of Google::Cloud::PubSub::Topic
-    snapshot.topic.must_be :reference?
-    snapshot.topic.wont_be :resource?
-    snapshot.topic.name.must_equal topic_path(topic_name)
+    _(snapshot.topic).must_be_kind_of Google::Cloud::PubSub::Topic
+    _(snapshot.topic).must_be :reference?
+    _(snapshot.topic).wont_be :resource?
+    _(snapshot.topic.name).must_equal topic_path(topic_name)
   end
 
   it "knows its expiration_time" do
-    snapshot.expiration_time.must_be_kind_of ::Time
+    _(snapshot.expiration_time).must_be_kind_of ::Time
   end
 
   it "knows its labels" do
-    snapshot.labels.must_equal labels
+    _(snapshot.labels).must_equal labels
   end
 
 
   it "updates labels" do
-    snapshot.labels.must_equal labels
+    _(snapshot.labels).must_equal labels
 
     update_sub = snapshot_grpc.dup
     update_sub.labels = new_labels_map
@@ -61,11 +61,11 @@ describe Google::Cloud::PubSub::Snapshot, :mock_pubsub do
 
     mock.verify
 
-    snapshot.labels.must_equal new_labels
+    _(snapshot.labels).must_equal new_labels
   end
 
   it "updates labels to empty hash" do
-    snapshot.labels.must_equal labels
+    _(snapshot.labels).must_equal labels
 
     update_sub = snapshot_grpc.dup
     update_sub.labels = Google::Protobuf::Map.new(:string, :string)
@@ -79,16 +79,16 @@ describe Google::Cloud::PubSub::Snapshot, :mock_pubsub do
 
     mock.verify
 
-    snapshot.labels.wont_be :nil?
-    snapshot.labels.must_be :empty?
+    _(snapshot.labels).wont_be :nil?
+    _(snapshot.labels).must_be :empty?
   end
 
   it "raises when setting labels to nil" do
-    snapshot.labels.must_equal labels
+    _(snapshot.labels).must_equal labels
 
     expect { snapshot.labels = nil }.must_raise ArgumentError
 
-    snapshot.labels.must_equal labels
+    _(snapshot.labels).must_equal labels
   end
 
   it "can delete itself" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
@@ -61,7 +61,7 @@ describe Google::Cloud::PubSub::Subscriber, :acknowledge, :mock_pubsub do
     subscriber.stop
     subscriber.wait!
 
-    stub.requests.map(&:to_a).must_equal [
+    _(stub.requests.map(&:to_a)).must_equal [
       [Google::Cloud::PubSub::V1::StreamingPullRequest.new(
         subscription: sub_path,
         stream_ack_deadline_seconds: 60
@@ -74,7 +74,7 @@ describe Google::Cloud::PubSub::Subscriber, :acknowledge, :mock_pubsub do
       assert_equal ack_sub_path, sub_path
       ack_msg_ids += msg_ids
     end
-    ack_msg_ids.sort.must_equal ["ack-id-123456789"]
+    _(ack_msg_ids.sort).must_equal ["ack-id-123456789"]
 
     # pusher thread pool may deliver out of order, which stinks...
     mod_ack_hash = {}
@@ -86,7 +86,7 @@ describe Google::Cloud::PubSub::Subscriber, :acknowledge, :mock_pubsub do
         mod_ack_hash[deadline] = msg_ids
       end
     end
-    mod_ack_hash[60].sort.must_equal ["ack-id-123456789"]
+    _(mod_ack_hash[60].sort).must_equal ["ack-id-123456789"]
   end
 
   it "can acknowledge multiple messages" do
@@ -117,7 +117,7 @@ describe Google::Cloud::PubSub::Subscriber, :acknowledge, :mock_pubsub do
     subscriber.stop
     subscriber.wait!
 
-    stub.requests.map(&:to_a).must_equal [
+    _(stub.requests.map(&:to_a)).must_equal [
       [Google::Cloud::PubSub::V1::StreamingPullRequest.new(
         subscription: sub_path,
         stream_ack_deadline_seconds: 60
@@ -130,7 +130,7 @@ describe Google::Cloud::PubSub::Subscriber, :acknowledge, :mock_pubsub do
       assert_equal ack_sub_path, sub_path
       ack_msg_ids += msg_ids
     end
-    ack_msg_ids.sort.must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
+    _(ack_msg_ids.sort).must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
 
     # pusher thread pool may deliver out of order, which stinks...
     mod_ack_hash = {}
@@ -142,6 +142,6 @@ describe Google::Cloud::PubSub::Subscriber, :acknowledge, :mock_pubsub do
         mod_ack_hash[deadline] = msg_ids
       end
     end
-    mod_ack_hash[60].sort.must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
+    _(mod_ack_hash[60].sort).must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/error_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/error_test.rb
@@ -50,7 +50,7 @@ describe Google::Cloud::PubSub::Subscriber, :error, :mock_pubsub do
       errors << error
     end
 
-    subscriber.last_error.must_be :nil?
+    _(subscriber.last_error).must_be :nil?
 
     subscriber.start
 
@@ -61,10 +61,10 @@ describe Google::Cloud::PubSub::Subscriber, :error, :mock_pubsub do
       sleep 0.01
     end
 
-    errors.count.must_equal 2
-    errors[0].must_be_kind_of ArgumentError
-    errors[1].must_be_kind_of ZeroDivisionError
-    subscriber.last_error.must_be_kind_of ZeroDivisionError
+    _(errors.count).must_equal 2
+    _(errors[0]).must_be_kind_of ArgumentError
+    _(errors[1]).must_be_kind_of ZeroDivisionError
+    _(subscriber.last_error).must_be_kind_of ZeroDivisionError
 
     subscriber.stop
     subscriber.wait!

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
@@ -66,7 +66,7 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
     subscriber.stop
     subscriber.wait!
 
-    stub.requests.map(&:to_a).must_equal [
+    _(stub.requests.map(&:to_a)).must_equal [
       [Google::Cloud::PubSub::V1::StreamingPullRequest.new(
         subscription: sub_path,
         stream_ack_deadline_seconds: 60
@@ -91,7 +91,7 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
         mod_ack_hash[deadline] = msg_ids
       end
     end
-    mod_ack_hash[60].sort.must_equal ["ack-id-123456789"]
+    _(mod_ack_hash[60].sort).must_equal ["ack-id-123456789"]
   end
 
   it "removes multiple messages from inventory, even when ack or nack are not called" do
@@ -126,7 +126,7 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
     subscriber.stop
     subscriber.wait!
 
-    stub.requests.map(&:to_a).must_equal [
+    _(stub.requests.map(&:to_a)).must_equal [
       [Google::Cloud::PubSub::V1::StreamingPullRequest.new(
         subscription: sub_path,
         stream_ack_deadline_seconds: 60
@@ -151,7 +151,7 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
         mod_ack_hash[deadline] = msg_ids
       end
     end
-    mod_ack_hash[60].sort.must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
+    _(mod_ack_hash[60].sort).must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
   end
 
   it "knows its count limit" do
@@ -159,11 +159,11 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
     inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 2, bytesize: 100_000, extension: 3600, max_duration_per_lease_extension: 0
 
     inventory.add rec_msg1_grpc
-    inventory.wont_be :full?
-    inventory.count.must_equal 1
+    _(inventory).wont_be :full?
+    _(inventory.count).must_equal 1
     inventory.add rec_msg2_grpc, rec_msg3_grpc
-    inventory.count.must_equal 3
-    inventory.must_be :full?
+    _(inventory.count).must_equal 3
+    _(inventory).must_be :full?
   end
 
   it "knows its bytesize limit" do
@@ -171,11 +171,11 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
     inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100, extension: 3600, max_duration_per_lease_extension: 0
 
     inventory.add rec_msg1_grpc
-    inventory.wont_be :full?
-    inventory.total_bytesize.must_equal 58
+    _(inventory).wont_be :full?
+    _(inventory.total_bytesize).must_equal 58
     inventory.add rec_msg2_grpc, rec_msg3_grpc
-    inventory.total_bytesize.must_equal 174
-    inventory.must_be :full?
+    _(inventory.total_bytesize).must_equal 174
+    _(inventory).must_be :full?
   end
 
   it "removes expired items" do
@@ -187,19 +187,19 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
     Time.stub :now, expired_time do
       inventory.add rec_msg1_grpc
     end
-    inventory.ack_ids.must_equal ["ack-id-1111"]
+    _(inventory.ack_ids).must_equal ["ack-id-1111"]
     inventory.add rec_msg2_grpc, rec_msg3_grpc
-    inventory.ack_ids.must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
+    _(inventory.ack_ids).must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
 
     inventory.remove_expired!
 
-    inventory.ack_ids.must_equal ["ack-id-1112", "ack-id-1113"]
+    _(inventory.ack_ids).must_equal ["ack-id-1112", "ack-id-1113"]
   end
 
   it "knows its max_duration_per_lease_extension limit" do
     subscriber_mock = Minitest::Mock.new
     inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100, extension: 3600, max_duration_per_lease_extension: 10
 
-    inventory.max_duration_per_lease_extension.must_equal 10
+    _(inventory.max_duration_per_lease_extension).must_equal 10
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/modify_ack_deadline_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/modify_ack_deadline_test.rb
@@ -61,14 +61,14 @@ describe Google::Cloud::PubSub::Subscriber, :modify_ack_deadline, :mock_pubsub d
     subscriber.stop
     subscriber.wait!
 
-    stub.requests.map(&:to_a).must_equal [
+    _(stub.requests.map(&:to_a)).must_equal [
       [Google::Cloud::PubSub::V1::StreamingPullRequest.new(
         subscription: sub_path,
         stream_ack_deadline_seconds: 60
       )]
     ]
 
-    stub.acknowledge_requests.must_equal []
+    _(stub.acknowledge_requests).must_equal []
 
     # pusher thread pool may deliver out of order, which stinks...
     mod_ack_hash = {}
@@ -80,8 +80,8 @@ describe Google::Cloud::PubSub::Subscriber, :modify_ack_deadline, :mock_pubsub d
         mod_ack_hash[deadline] = msg_ids
       end
     end
-    mod_ack_hash[60].sort.must_equal ["ack-id-123456789"]
-    mod_ack_hash[42].sort.must_equal ["ack-id-123456789"]
+    _(mod_ack_hash[60].sort).must_equal ["ack-id-123456789"]
+    _(mod_ack_hash[42].sort).must_equal ["ack-id-123456789"]
   end
 
   it "can modify_ack_deadline multiple messages" do
@@ -112,14 +112,14 @@ describe Google::Cloud::PubSub::Subscriber, :modify_ack_deadline, :mock_pubsub d
     subscriber.stop
     subscriber.wait!
 
-    stub.requests.map(&:to_a).must_equal [
+    _(stub.requests.map(&:to_a)).must_equal [
       [Google::Cloud::PubSub::V1::StreamingPullRequest.new(
         subscription: sub_path,
         stream_ack_deadline_seconds: 60
       )]
     ]
 
-    stub.acknowledge_requests.must_equal []
+    _(stub.acknowledge_requests).must_equal []
 
     # pusher thread pool may deliver out of order, which stinks...
     mod_ack_hash = {}
@@ -131,7 +131,7 @@ describe Google::Cloud::PubSub::Subscriber, :modify_ack_deadline, :mock_pubsub d
         mod_ack_hash[deadline] = msg_ids
       end
     end
-    mod_ack_hash[60].sort.must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
-    mod_ack_hash[42].sort.must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
+    _(mod_ack_hash[60].sort).must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
+    _(mod_ack_hash[42].sort).must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/nack_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/nack_test.rb
@@ -60,14 +60,14 @@ describe Google::Cloud::PubSub::Subscriber, :nack, :mock_pubsub do
     subscriber.stop
     subscriber.wait!
 
-    stub.requests.map(&:to_a).must_equal [
+    _(stub.requests.map(&:to_a)).must_equal [
       [Google::Cloud::PubSub::V1::StreamingPullRequest.new(
         subscription: sub_path,
         stream_ack_deadline_seconds: 60
       )]
     ]
 
-    stub.acknowledge_requests.must_equal []
+    _(stub.acknowledge_requests).must_equal []
 
     # pusher thread pool may deliver out of order, which stinks...
     mod_ack_hash = {}
@@ -79,8 +79,8 @@ describe Google::Cloud::PubSub::Subscriber, :nack, :mock_pubsub do
         mod_ack_hash[deadline] = msg_ids
       end
     end
-    mod_ack_hash[60].sort.must_equal ["ack-id-123456789"]
-    mod_ack_hash[0].sort.must_equal ["ack-id-123456789"]
+    _(mod_ack_hash[60].sort).must_equal ["ack-id-123456789"]
+    _(mod_ack_hash[0].sort).must_equal ["ack-id-123456789"]
   end
 
   it "can nack multiple messages" do
@@ -111,14 +111,14 @@ describe Google::Cloud::PubSub::Subscriber, :nack, :mock_pubsub do
     subscriber.stop
     subscriber.wait!
 
-    stub.requests.map(&:to_a).must_equal [
+    _(stub.requests.map(&:to_a)).must_equal [
       [Google::Cloud::PubSub::V1::StreamingPullRequest.new(
         subscription: sub_path,
         stream_ack_deadline_seconds: 60
       )]
     ]
 
-    stub.acknowledge_requests.must_equal []
+    _(stub.acknowledge_requests).must_equal []
 
     # pusher thread pool may deliver out of order, which stinks...
     mod_ack_hash = {}
@@ -130,7 +130,7 @@ describe Google::Cloud::PubSub::Subscriber, :nack, :mock_pubsub do
         mod_ack_hash[deadline] = msg_ids
       end
     end
-    mod_ack_hash[60].sort.must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
-    mod_ack_hash[0].sort.must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
+    _(mod_ack_hash[60].sort).must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
+    _(mod_ack_hash[0].sort).must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/restart_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/restart_test.rb
@@ -59,7 +59,7 @@ describe Google::Cloud::PubSub::Subscriber, :error, :mock_pubsub do
       sleep 0.01
     end
 
-    errors.count.must_equal 0
+    _(errors.count).must_equal 0
 
     subscriber.stop
     subscriber.wait!

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -25,24 +25,24 @@ describe Google::Cloud::PubSub::Subscriber, :mock_pubsub do
   let(:subscriber) { Google::Cloud::PubSub::Subscriber.new subscription_name, callback, deadline: deadline, streams: streams, inventory: inventory, threads: { callback: callback_threads, push: push_threads}, service: pubsub.service }
 
   it "knows itself" do
-    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
-    subscriber.callback.must_equal callback
-    subscriber.subscription_name.must_equal subscription_name
-    subscriber.deadline.must_equal deadline
-    subscriber.streams.must_equal streams
-    subscriber.inventory.must_equal inventory
-    subscriber.inventory_limit.must_equal inventory
-    subscriber.max_outstanding_messages.must_equal inventory
-    subscriber.inventory_bytesize.must_equal 100_000_000
-    subscriber.max_outstanding_bytes.must_equal 100_000_000
-    subscriber.inventory_extension.must_equal 3600
-    subscriber.max_total_lease_duration.must_equal 3600
-    subscriber.max_duration_per_lease_extension.must_equal 0
-    subscriber.stream_inventory.must_equal({limit: 250, bytesize: 12500000, max_duration_per_lease_extension: 0, extension: 3600})
-    subscriber.callback_threads.must_equal callback_threads
-    subscriber.push_threads.must_equal push_threads
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.callback).must_equal callback
+    _(subscriber.subscription_name).must_equal subscription_name
+    _(subscriber.deadline).must_equal deadline
+    _(subscriber.streams).must_equal streams
+    _(subscriber.inventory).must_equal inventory
+    _(subscriber.inventory_limit).must_equal inventory
+    _(subscriber.max_outstanding_messages).must_equal inventory
+    _(subscriber.inventory_bytesize).must_equal 100_000_000
+    _(subscriber.max_outstanding_bytes).must_equal 100_000_000
+    _(subscriber.inventory_extension).must_equal 3600
+    _(subscriber.max_total_lease_duration).must_equal 3600
+    _(subscriber.max_duration_per_lease_extension).must_equal 0
+    _(subscriber.stream_inventory).must_equal({limit: 250, bytesize: 12500000, max_duration_per_lease_extension: 0, extension: 3600})
+    _(subscriber.callback_threads).must_equal callback_threads
+    _(subscriber.push_threads).must_equal push_threads
 
-    subscriber.to_s.must_equal "(subscription: subscription-name-goes-here, streams: [(inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started)])"
-    subscriber.stream_pool.first.to_s.must_equal "(inventory: 0, status: running, thread: not started)"
+    _(subscriber.to_s).must_equal "(subscription: subscription-name-goes-here, streams: [(inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started)])"
+    _(subscriber.stream_pool.first.to_s).must_equal "(inventory: 0, status: running, thread: not started)"
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
@@ -27,14 +27,14 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
 
   it "gets topic from the Google API object" do
     # No mocked service means no API calls are happening.
-    subscription.topic.must_be_kind_of Google::Cloud::PubSub::Topic
-    subscription.topic.must_be :reference?
-    subscription.topic.wont_be :resource?
-    subscription.topic.name.must_equal topic_path(topic_name)
+    _(subscription.topic).must_be_kind_of Google::Cloud::PubSub::Topic
+    _(subscription.topic).must_be :reference?
+    _(subscription.topic).wont_be :resource?
+    _(subscription.topic.name).must_equal topic_path(topic_name)
   end
 
   it "gets deadline from the Google API object" do
-    subscription.deadline.must_equal sub_deadline
+    _(subscription.deadline).must_equal sub_deadline
   end
 
   it "gets retain_acked from the Google API object" do
@@ -42,11 +42,11 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
   end
 
   it "gets its retention from the Google API object" do
-    subscription.retention.must_equal 600.9
+    _(subscription.retention).must_equal 600.9
   end
 
   it "gets endpoint from the Google API object" do
-    subscription.endpoint.must_equal sub_endpoint
+    _(subscription.endpoint).must_equal sub_endpoint
   end
 
   it "can update the endpoint" do
@@ -64,28 +64,28 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
 
   it "gets expires_in from the Google API object" do
     two_days_seconds = 60*60*24*2
-    subscription.expires_in.must_equal two_days_seconds
+    _(subscription.expires_in).must_equal two_days_seconds
   end
 
   it "gets push_config from the Google API object" do
-    subscription.push_config.must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig
-    subscription.push_config.endpoint.must_equal sub_endpoint
-    subscription.push_config.authentication.must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig::OidcToken
-    subscription.push_config.authentication.email.must_equal "user@example.com"
-    subscription.push_config.authentication.audience.must_equal "client-12345"
-    subscription.push_config.must_be :oidc_token?
+    _(subscription.push_config).must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig
+    _(subscription.push_config.endpoint).must_equal sub_endpoint
+    _(subscription.push_config.authentication).must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig::OidcToken
+    _(subscription.push_config.authentication.email).must_equal "user@example.com"
+    _(subscription.push_config.authentication.audience).must_equal "client-12345"
+    _(subscription.push_config).must_be :oidc_token?
   end
 
   it "gets labels from the Google API object" do
-    subscription.labels.must_equal labels
+    _(subscription.labels).must_equal labels
   end
 
   it "gets dead_letter_topic from the Google API object" do
-    subscription.dead_letter_topic.name.must_equal dead_letter_topic_path
+    _(subscription.dead_letter_topic.name).must_equal dead_letter_topic_path
   end
 
   it "gets dead_letter_max_delivery_attempts from the Google API object" do
-    subscription.dead_letter_max_delivery_attempts.must_equal 6
+    _(subscription.dead_letter_max_delivery_attempts).must_equal 6
   end
 
   describe "reference subscription object of a subscription that does exist" do
@@ -100,13 +100,13 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      subscription.topic.must_be_kind_of Google::Cloud::PubSub::Topic
+      _(subscription.topic).must_be_kind_of Google::Cloud::PubSub::Topic
 
       mock.verify
 
-      subscription.topic.must_be :reference?
-      subscription.topic.wont_be :resource?
-      subscription.topic.name.must_equal topic_path(topic_name)
+      _(subscription.topic).must_be :reference?
+      _(subscription.topic).wont_be :resource?
+      _(subscription.topic.name).must_equal topic_path(topic_name)
     end
 
     it "makes an HTTP API call to retrieve deadline" do
@@ -115,7 +115,7 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      subscription.deadline.must_equal sub_deadline
+      _(subscription.deadline).must_equal sub_deadline
 
       mock.verify
     end
@@ -137,7 +137,7 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      subscription.endpoint.must_equal sub_endpoint
+      _(subscription.endpoint).must_equal sub_endpoint
 
       mock.verify
     end
@@ -150,7 +150,7 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      subscription.expires_in.must_equal two_days_seconds
+      _(subscription.expires_in).must_equal two_days_seconds
 
       mock.verify
     end
@@ -161,7 +161,7 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      subscription.labels.must_equal labels
+      _(subscription.labels).must_equal labels
 
       mock.verify
     end
@@ -172,8 +172,8 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      subscription.dead_letter_topic.name.must_equal dead_letter_topic_path
-      subscription.dead_letter_max_delivery_attempts.must_equal 7
+      _(subscription.dead_letter_topic.name).must_equal dead_letter_topic_path
+      _(subscription.dead_letter_max_delivery_attempts).must_equal 7
 
       mock.verify
     end
@@ -184,15 +184,15 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      subscription.labels.must_equal labels
+      _(subscription.labels).must_equal labels
 
       mock.verify
     end
 
     it "does not make an HTTP API call to access push_config" do
-      subscription.push_config.must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig
-      subscription.push_config.endpoint.must_be :empty?
-      subscription.push_config.authentication.must_be :nil?
+      _(subscription.push_config).must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig
+      _(subscription.push_config.endpoint).must_be :empty?
+      _(subscription.push_config.authentication).must_be :nil?
     end
   end
 
@@ -273,9 +273,9 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
     end
 
     it "does not raise NotFoundError when accessing push_config" do
-      subscription.push_config.must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig
-      subscription.push_config.endpoint.must_be :empty?
-      subscription.push_config.authentication.must_be :nil?
+      _(subscription.push_config).must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig
+      _(subscription.push_config.endpoint).must_be :empty?
+      _(subscription.push_config.authentication).must_be :nil?
     end
 
     it "raises NotFoundError when retrieving dead_letter_topic" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/exists_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/exists_test.rb
@@ -24,9 +24,9 @@ describe Google::Cloud::PubSub::Subscription, :exists, :mock_pubsub do
   it "knows if it exists when created with an HTTP method" do
     # The absense of a mock means this test will fail
     # if the method exists? makes an HTTP call.
-    subscription.must_be :exists?
+    _(subscription).must_be :exists?
     # Additional exists? calls do not make HTTP calls either
-    subscription.must_be :exists?
+    _(subscription).must_be :exists?
   end
 
   describe "reference subscription object of a subscription that exists" do
@@ -41,12 +41,12 @@ describe Google::Cloud::PubSub::Subscription, :exists, :mock_pubsub do
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      subscription.must_be :exists?
+      _(subscription).must_be :exists?
 
       mock.verify
 
       # Additional exists? calls do not make HTTP calls
-      subscription.must_be :exists?
+      _(subscription).must_be :exists?
     end
   end
 
@@ -65,9 +65,9 @@ describe Google::Cloud::PubSub::Subscription, :exists, :mock_pubsub do
       end
       subscription.service.mocked_subscriber = stub
 
-      subscription.wont_be :exists?
+      _(subscription).wont_be :exists?
       # Additional exists? calls do not make HTTP calls
-      subscription.wont_be :exists?
+      _(subscription).wont_be :exists?
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/lazy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/lazy_test.rb
@@ -23,8 +23,8 @@ describe Google::Cloud::PubSub::Subscription, :name, :mock_pubsub do
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
 
   it "is not reference when created with an HTTP method" do
-    subscription.wont_be :reference?
-    subscription.must_be :resource?
+    _(subscription).wont_be :reference?
+    _(subscription).must_be :resource?
   end
 
   describe "reference subscription" do
@@ -33,8 +33,8 @@ describe Google::Cloud::PubSub::Subscription, :name, :mock_pubsub do
     end
 
     it "is reference" do
-      subscription.must_be :reference?
-      subscription.wont_be :resource?
+      _(subscription).must_be :reference?
+      _(subscription).wont_be :resource?
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
@@ -25,197 +25,197 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     subscriber = subscription.listen do |msg|
       puts msg.msg_id
     end
-    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
-    subscriber.subscription_name.must_equal subscription.name
-    subscriber.deadline.must_equal 60
-    subscriber.streams.must_equal 2
-    subscriber.inventory.must_equal 1000
-    subscriber.inventory_limit.must_equal 1000
-    subscriber.max_outstanding_messages.must_equal 1000
-    subscriber.inventory_bytesize.must_equal 100000000
-    subscriber.max_outstanding_bytes.must_equal 100000000
-    subscriber.inventory_extension.must_equal 3600
-    subscriber.max_total_lease_duration.must_equal 3600
-    subscriber.max_duration_per_lease_extension.must_equal 0
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.subscription_name).must_equal subscription.name
+    _(subscriber.deadline).must_equal 60
+    _(subscriber.streams).must_equal 2
+    _(subscriber.inventory).must_equal 1000
+    _(subscriber.inventory_limit).must_equal 1000
+    _(subscriber.max_outstanding_messages).must_equal 1000
+    _(subscriber.inventory_bytesize).must_equal 100000000
+    _(subscriber.max_outstanding_bytes).must_equal 100000000
+    _(subscriber.inventory_extension).must_equal 3600
+    _(subscriber.max_total_lease_duration).must_equal 3600
+    _(subscriber.max_duration_per_lease_extension).must_equal 0
   end
 
   it "will set deadline while creating a Subscriber" do
     subscriber = subscription.listen deadline: 120 do |msg|
       puts msg.msg_id
     end
-    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
-    subscriber.subscription_name.must_equal subscription.name
-    subscriber.deadline.must_equal 120
-    subscriber.streams.must_equal 2
-    subscriber.inventory.must_equal 1000
-    subscriber.inventory_limit.must_equal 1000
-    subscriber.max_outstanding_messages.must_equal 1000
-    subscriber.inventory_bytesize.must_equal 100000000
-    subscriber.max_outstanding_bytes.must_equal 100000000
-    subscriber.inventory_extension.must_equal 3600
-    subscriber.max_total_lease_duration.must_equal 3600
-    subscriber.max_duration_per_lease_extension.must_equal 0
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.subscription_name).must_equal subscription.name
+    _(subscriber.deadline).must_equal 120
+    _(subscriber.streams).must_equal 2
+    _(subscriber.inventory).must_equal 1000
+    _(subscriber.inventory_limit).must_equal 1000
+    _(subscriber.max_outstanding_messages).must_equal 1000
+    _(subscriber.inventory_bytesize).must_equal 100000000
+    _(subscriber.max_outstanding_bytes).must_equal 100000000
+    _(subscriber.inventory_extension).must_equal 3600
+    _(subscriber.max_total_lease_duration).must_equal 3600
+    _(subscriber.max_duration_per_lease_extension).must_equal 0
   end
 
   it "will set deadline while creating a Subscriber" do
     subscriber = subscription.listen streams: 2 do |msg|
       puts msg.msg_id
     end
-    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
-    subscriber.subscription_name.must_equal subscription.name
-    subscriber.deadline.must_equal 60
-    subscriber.streams.must_equal 2
-    subscriber.inventory.must_equal 1000
-    subscriber.inventory_limit.must_equal 1000
-    subscriber.max_outstanding_messages.must_equal 1000
-    subscriber.inventory_bytesize.must_equal 100000000
-    subscriber.max_outstanding_bytes.must_equal 100000000
-    subscriber.inventory_extension.must_equal 3600
-    subscriber.max_total_lease_duration.must_equal 3600
-    subscriber.max_duration_per_lease_extension.must_equal 0
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.subscription_name).must_equal subscription.name
+    _(subscriber.deadline).must_equal 60
+    _(subscriber.streams).must_equal 2
+    _(subscriber.inventory).must_equal 1000
+    _(subscriber.inventory_limit).must_equal 1000
+    _(subscriber.max_outstanding_messages).must_equal 1000
+    _(subscriber.inventory_bytesize).must_equal 100000000
+    _(subscriber.max_outstanding_bytes).must_equal 100000000
+    _(subscriber.inventory_extension).must_equal 3600
+    _(subscriber.max_total_lease_duration).must_equal 3600
+    _(subscriber.max_duration_per_lease_extension).must_equal 0
   end
 
   it "will set inventory (deprecated) while creating a Subscriber" do
     subscriber = subscription.listen inventory: 500 do |msg|
       puts msg.msg_id
     end
-    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
-    subscriber.subscription_name.must_equal subscription.name
-    subscriber.deadline.must_equal 60
-    subscriber.streams.must_equal 2
-    subscriber.inventory.must_equal 500
-    subscriber.inventory_limit.must_equal 500
-    subscriber.max_outstanding_messages.must_equal 500
-    subscriber.inventory_bytesize.must_equal 100000000
-    subscriber.max_outstanding_bytes.must_equal 100000000
-    subscriber.inventory_extension.must_equal 3600
-    subscriber.max_total_lease_duration.must_equal 3600
-    subscriber.max_duration_per_lease_extension.must_equal 0
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.subscription_name).must_equal subscription.name
+    _(subscriber.deadline).must_equal 60
+    _(subscriber.streams).must_equal 2
+    _(subscriber.inventory).must_equal 500
+    _(subscriber.inventory_limit).must_equal 500
+    _(subscriber.max_outstanding_messages).must_equal 500
+    _(subscriber.inventory_bytesize).must_equal 100000000
+    _(subscriber.max_outstanding_bytes).must_equal 100000000
+    _(subscriber.inventory_extension).must_equal 3600
+    _(subscriber.max_total_lease_duration).must_equal 3600
+    _(subscriber.max_duration_per_lease_extension).must_equal 0
   end
 
   it "will set inventory max_outstanding_messages while creating a Subscriber" do
     subscriber = subscription.listen inventory: { max_outstanding_messages: 500 } do |msg|
       puts msg.msg_id
     end
-    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
-    subscriber.subscription_name.must_equal subscription.name
-    subscriber.deadline.must_equal 60
-    subscriber.streams.must_equal 2
-    subscriber.inventory.must_equal 500
-    subscriber.inventory_limit.must_equal 500
-    subscriber.max_outstanding_messages.must_equal 500
-    subscriber.inventory_bytesize.must_equal 100000000
-    subscriber.max_outstanding_bytes.must_equal 100000000
-    subscriber.inventory_extension.must_equal 3600
-    subscriber.max_total_lease_duration.must_equal 3600
-    subscriber.max_duration_per_lease_extension.must_equal 0
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.subscription_name).must_equal subscription.name
+    _(subscriber.deadline).must_equal 60
+    _(subscriber.streams).must_equal 2
+    _(subscriber.inventory).must_equal 500
+    _(subscriber.inventory_limit).must_equal 500
+    _(subscriber.max_outstanding_messages).must_equal 500
+    _(subscriber.inventory_bytesize).must_equal 100000000
+    _(subscriber.max_outstanding_bytes).must_equal 100000000
+    _(subscriber.inventory_extension).must_equal 3600
+    _(subscriber.max_total_lease_duration).must_equal 3600
+    _(subscriber.max_duration_per_lease_extension).must_equal 0
   end
 
   it "will set inventory limit alias while creating a Subscriber" do
     subscriber = subscription.listen inventory: { limit: 500 } do |msg|
       puts msg.msg_id
     end
-    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
-    subscriber.subscription_name.must_equal subscription.name
-    subscriber.deadline.must_equal 60
-    subscriber.streams.must_equal 2
-    subscriber.inventory.must_equal 500
-    subscriber.inventory_limit.must_equal 500
-    subscriber.max_outstanding_messages.must_equal 500
-    subscriber.inventory_bytesize.must_equal 100000000
-    subscriber.max_outstanding_bytes.must_equal 100000000
-    subscriber.inventory_extension.must_equal 3600
-    subscriber.max_total_lease_duration.must_equal 3600
-    subscriber.max_duration_per_lease_extension.must_equal 0
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.subscription_name).must_equal subscription.name
+    _(subscriber.deadline).must_equal 60
+    _(subscriber.streams).must_equal 2
+    _(subscriber.inventory).must_equal 500
+    _(subscriber.inventory_limit).must_equal 500
+    _(subscriber.max_outstanding_messages).must_equal 500
+    _(subscriber.inventory_bytesize).must_equal 100000000
+    _(subscriber.max_outstanding_bytes).must_equal 100000000
+    _(subscriber.inventory_extension).must_equal 3600
+    _(subscriber.max_total_lease_duration).must_equal 3600
+    _(subscriber.max_duration_per_lease_extension).must_equal 0
   end
 
   it "will set inventory max_outstanding_bytes while creating a Subscriber" do
     subscriber = subscription.listen inventory: { max_outstanding_bytes: 50_000 } do |msg|
       puts msg.msg_id
     end
-    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
-    subscriber.subscription_name.must_equal subscription.name
-    subscriber.deadline.must_equal 60
-    subscriber.streams.must_equal 2
-    subscriber.inventory.must_equal 1000
-    subscriber.inventory_limit.must_equal 1000
-    subscriber.max_outstanding_messages.must_equal 1000
-    subscriber.inventory_bytesize.must_equal 50_000
-    subscriber.max_outstanding_bytes.must_equal 50_000
-    subscriber.inventory_extension.must_equal 3600
-    subscriber.max_total_lease_duration.must_equal 3600
-    subscriber.max_duration_per_lease_extension.must_equal 0
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.subscription_name).must_equal subscription.name
+    _(subscriber.deadline).must_equal 60
+    _(subscriber.streams).must_equal 2
+    _(subscriber.inventory).must_equal 1000
+    _(subscriber.inventory_limit).must_equal 1000
+    _(subscriber.max_outstanding_messages).must_equal 1000
+    _(subscriber.inventory_bytesize).must_equal 50_000
+    _(subscriber.max_outstanding_bytes).must_equal 50_000
+    _(subscriber.inventory_extension).must_equal 3600
+    _(subscriber.max_total_lease_duration).must_equal 3600
+    _(subscriber.max_duration_per_lease_extension).must_equal 0
   end
 
   it "will set inventory bytesize alias while creating a Subscriber" do
     subscriber = subscription.listen inventory: { bytesize: 50_000 } do |msg|
       puts msg.msg_id
     end
-    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
-    subscriber.subscription_name.must_equal subscription.name
-    subscriber.deadline.must_equal 60
-    subscriber.streams.must_equal 2
-    subscriber.inventory.must_equal 1000
-    subscriber.inventory_limit.must_equal 1000
-    subscriber.max_outstanding_messages.must_equal 1000
-    subscriber.inventory_bytesize.must_equal 50_000
-    subscriber.max_outstanding_bytes.must_equal 50_000
-    subscriber.inventory_extension.must_equal 3600
-    subscriber.max_total_lease_duration.must_equal 3600
-    subscriber.max_duration_per_lease_extension.must_equal 0
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.subscription_name).must_equal subscription.name
+    _(subscriber.deadline).must_equal 60
+    _(subscriber.streams).must_equal 2
+    _(subscriber.inventory).must_equal 1000
+    _(subscriber.inventory_limit).must_equal 1000
+    _(subscriber.max_outstanding_messages).must_equal 1000
+    _(subscriber.inventory_bytesize).must_equal 50_000
+    _(subscriber.max_outstanding_bytes).must_equal 50_000
+    _(subscriber.inventory_extension).must_equal 3600
+    _(subscriber.max_total_lease_duration).must_equal 3600
+    _(subscriber.max_duration_per_lease_extension).must_equal 0
   end
 
   it "will set inventory max_total_lease_duration while creating a Subscriber" do
     subscriber = subscription.listen inventory: { max_total_lease_duration: 7_200 } do |msg|
       puts msg.msg_id
     end
-    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
-    subscriber.subscription_name.must_equal subscription.name
-    subscriber.deadline.must_equal 60
-    subscriber.streams.must_equal 2
-    subscriber.inventory.must_equal 1000
-    subscriber.inventory_limit.must_equal 1000
-    subscriber.max_outstanding_messages.must_equal 1000
-    subscriber.inventory_bytesize.must_equal 100000000
-    subscriber.max_outstanding_bytes.must_equal 100000000
-    subscriber.inventory_extension.must_equal 7200
-    subscriber.max_total_lease_duration.must_equal 7200
-    subscriber.max_duration_per_lease_extension.must_equal 0
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.subscription_name).must_equal subscription.name
+    _(subscriber.deadline).must_equal 60
+    _(subscriber.streams).must_equal 2
+    _(subscriber.inventory).must_equal 1000
+    _(subscriber.inventory_limit).must_equal 1000
+    _(subscriber.max_outstanding_messages).must_equal 1000
+    _(subscriber.inventory_bytesize).must_equal 100000000
+    _(subscriber.max_outstanding_bytes).must_equal 100000000
+    _(subscriber.inventory_extension).must_equal 7200
+    _(subscriber.max_total_lease_duration).must_equal 7200
+    _(subscriber.max_duration_per_lease_extension).must_equal 0
   end
 
   it "will set inventory extension alias while creating a Subscriber" do
     subscriber = subscription.listen inventory: { extension: 7_200 } do |msg|
       puts msg.msg_id
     end
-    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
-    subscriber.subscription_name.must_equal subscription.name
-    subscriber.deadline.must_equal 60
-    subscriber.streams.must_equal 2
-    subscriber.inventory.must_equal 1000
-    subscriber.inventory_limit.must_equal 1000
-    subscriber.max_outstanding_messages.must_equal 1000
-    subscriber.inventory_bytesize.must_equal 100000000
-    subscriber.max_outstanding_bytes.must_equal 100000000
-    subscriber.inventory_extension.must_equal 7200
-    subscriber.max_total_lease_duration.must_equal 7200
-    subscriber.max_duration_per_lease_extension.must_equal 0
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.subscription_name).must_equal subscription.name
+    _(subscriber.deadline).must_equal 60
+    _(subscriber.streams).must_equal 2
+    _(subscriber.inventory).must_equal 1000
+    _(subscriber.inventory_limit).must_equal 1000
+    _(subscriber.max_outstanding_messages).must_equal 1000
+    _(subscriber.inventory_bytesize).must_equal 100000000
+    _(subscriber.max_outstanding_bytes).must_equal 100000000
+    _(subscriber.inventory_extension).must_equal 7200
+    _(subscriber.max_total_lease_duration).must_equal 7200
+    _(subscriber.max_duration_per_lease_extension).must_equal 0
   end
 
   it "will set inventory max_duration_per_lease_extension while creating a Subscriber" do
     subscriber = subscription.listen inventory: { max_duration_per_lease_extension: 10 } do |msg|
       puts msg.msg_id
     end
-    subscriber.must_be_kind_of Google::Cloud::PubSub::Subscriber
-    subscriber.subscription_name.must_equal subscription.name
-    subscriber.deadline.must_equal 60
-    subscriber.streams.must_equal 2
-    subscriber.inventory.must_equal 1000
-    subscriber.inventory_limit.must_equal 1000
-    subscriber.max_outstanding_messages.must_equal 1000
-    subscriber.inventory_bytesize.must_equal 100000000
-    subscriber.max_outstanding_bytes.must_equal 100000000
-    subscriber.inventory_extension.must_equal 3600
-    subscriber.max_total_lease_duration.must_equal 3600
-    subscriber.max_duration_per_lease_extension.must_equal 10
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.subscription_name).must_equal subscription.name
+    _(subscriber.deadline).must_equal 60
+    _(subscriber.streams).must_equal 2
+    _(subscriber.inventory).must_equal 1000
+    _(subscriber.inventory_limit).must_equal 1000
+    _(subscriber.max_outstanding_messages).must_equal 1000
+    _(subscriber.inventory_bytesize).must_equal 100000000
+    _(subscriber.max_outstanding_bytes).must_equal 100000000
+    _(subscriber.inventory_extension).must_equal 3600
+    _(subscriber.max_total_lease_duration).must_equal 3600
+    _(subscriber.max_duration_per_lease_extension).must_equal 10
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/name_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/name_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::PubSub::Subscription, :name, :mock_pubsub do
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
 
   it "gives the name returned from the HTTP method" do
-    subscription.name.must_equal sub_path
+    _(subscription.name).must_equal sub_path
   end
 
   describe "reference subscription given the short name" do
@@ -33,7 +33,7 @@ describe Google::Cloud::PubSub::Subscription, :name, :mock_pubsub do
     end
 
     it "matches the name returned from the HTTP method" do
-      subscription.name.must_equal sub_path
+      _(subscription.name).must_equal sub_path
     end
   end
 
@@ -44,7 +44,7 @@ describe Google::Cloud::PubSub::Subscription, :name, :mock_pubsub do
     end
 
     it "matches the name returned from the HTTP method" do
-      subscription.name.must_equal sub_path
+      _(subscription.name).must_equal sub_path
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/policy_test.rb
@@ -41,14 +41,14 @@ describe Google::Cloud::PubSub::Subscription, :policy, :mock_pubsub do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::PubSub::Policy
-    policy.etag.must_equal "\b\x01"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be_kind_of Array
-    policy.roles["roles/viewer"].count.must_equal 2
-    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    _(policy).must_be_kind_of Google::Cloud::PubSub::Policy
+    _(policy.etag).must_equal "\b\x01"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be_kind_of Array
+    _(policy.roles["roles/viewer"].count).must_equal 2
+    _(policy.roles["roles/viewer"].first).must_equal "user:viewer@example.com"
+    _(policy.roles["roles/viewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "sets the IAM Policy" do
@@ -101,15 +101,15 @@ describe Google::Cloud::PubSub::Subscription, :policy, :mock_pubsub do
 
     mock.verify
 
-    policy_2.must_be_kind_of Google::Cloud::PubSub::Policy
-    policy_2.etag.must_equal "\b\x10"
-    policy_2.roles.must_be_kind_of Hash
-    policy_2.roles.size.must_equal 1
-    policy_2.roles["roles/viewer"].must_be :nil?
-    policy_2.roles["roles/owner"].must_be_kind_of Array
-    policy_2.roles["roles/owner"].count.must_equal 2
-    policy_2.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-    policy_2.roles["roles/owner"].last.must_equal "user:newowner@example.com"
+    _(policy_2).must_be_kind_of Google::Cloud::PubSub::Policy
+    _(policy_2.etag).must_equal "\b\x10"
+    _(policy_2.roles).must_be_kind_of Hash
+    _(policy_2.roles.size).must_equal 1
+    _(policy_2.roles["roles/viewer"]).must_be :nil?
+    _(policy_2.roles["roles/owner"]).must_be_kind_of Array
+    _(policy_2.roles["roles/owner"].count).must_equal 2
+    _(policy_2.roles["roles/owner"].first).must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    _(policy_2.roles["roles/owner"].last).must_equal "user:newowner@example.com"
   end
 
   it "sets the IAM Policy in a block" do
@@ -159,15 +159,15 @@ describe Google::Cloud::PubSub::Subscription, :policy, :mock_pubsub do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::PubSub::Policy
-    policy.etag.must_equal "\b\x10"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-    policy.roles["roles/owner"].last.must_equal "user:newowner@example.com"
+    _(policy).must_be_kind_of Google::Cloud::PubSub::Policy
+    _(policy.etag).must_equal "\b\x10"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be :nil?
+    _(policy.roles["roles/owner"]).must_be_kind_of Array
+    _(policy.roles["roles/owner"].count).must_equal 2
+    _(policy.roles["roles/owner"].first).must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    _(policy.roles["roles/owner"].last).must_equal "user:newowner@example.com"
   end
 
   it "tests the available permissions" do
@@ -184,6 +184,6 @@ describe Google::Cloud::PubSub::Subscription, :policy, :mock_pubsub do
 
     mock.verify
 
-    permissions.must_equal ["pubsub.subscriptions.get"]
+    _(permissions).must_equal ["pubsub.subscriptions.get"]
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_test.rb
@@ -32,8 +32,8 @@ describe Google::Cloud::PubSub::Subscription, :pull, :mock_pubsub do
 
     mock.verify
 
-    rec_messages.wont_be :empty?
-    rec_messages.first.message.data.must_equal rec_message_msg
+    _(rec_messages).wont_be :empty?
+    _(rec_messages.first.message.data).must_equal rec_message_msg
   end
 
   describe "reference subscription object of a subscription that does exist" do
@@ -53,8 +53,8 @@ describe Google::Cloud::PubSub::Subscription, :pull, :mock_pubsub do
 
       mock.verify
 
-      rec_messages.wont_be :empty?
-      rec_messages.first.message.data.must_equal rec_message_msg
+      _(rec_messages).wont_be :empty?
+      _(rec_messages.first.message.data).must_equal rec_message_msg
     end
   end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_wait_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_wait_test.rb
@@ -32,8 +32,8 @@ describe Google::Cloud::PubSub::Subscription, :pull, :wait, :mock_pubsub do
 
     mock.verify
 
-    rec_messages.wont_be :empty?
-    rec_messages.first.message.data.must_equal rec_message_msg
+    _(rec_messages).wont_be :empty?
+    _(rec_messages.first.message.data).must_equal rec_message_msg
   end
 
   it "can pull messages by calling wait_for_messages" do
@@ -47,8 +47,8 @@ describe Google::Cloud::PubSub::Subscription, :pull, :wait, :mock_pubsub do
 
     mock.verify
 
-    rec_messages.wont_be :empty?
-    rec_messages.first.message.data.must_equal rec_message_msg
+    _(rec_messages).wont_be :empty?
+    _(rec_messages.first.message.data).must_equal rec_message_msg
   end
 
   it "will not error when a request times out with Google::Cloud::DeadlineExceededError" do
@@ -59,6 +59,6 @@ describe Google::Cloud::PubSub::Subscription, :pull, :wait, :mock_pubsub do
     subscription.service.mocked_subscriber = stub
 
     rec_messages = subscription.pull immediate: false
-    rec_messages.must_be :empty?
+    _(rec_messages).must_be :empty?
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/reload_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/reload_test.rb
@@ -26,21 +26,21 @@ describe Google::Cloud::PubSub::Subscription, :name, :mock_pubsub do
   let(:sub_reference) { Google::Cloud::PubSub::Subscription.from_name sub_name, pubsub.service }
 
   it "it has a reload method and a refresh alias" do
-    sub_resource.must_respond_to :reload!
-    sub_reference.must_respond_to :reload!
+    _(sub_resource).must_respond_to :reload!
+    _(sub_reference).must_respond_to :reload!
 
-    sub_resource.must_respond_to :refresh!
-    sub_reference.must_respond_to :refresh!
+    _(sub_resource).must_respond_to :refresh!
+    _(sub_reference).must_respond_to :refresh!
   end
 
   it "is reloads a resource by calling get_topic API" do
-    sub_resource.name.must_equal sub_path
-    sub_resource.topic.name.must_equal topic_path(topic_name)
-    sub_resource.deadline.must_equal 60
-    sub_resource.endpoint.must_equal "http://example.com/callback"
-    sub_resource.labels.must_be :empty?
-    sub_resource.wont_be :reference?
-    sub_resource.must_be :resource?
+    _(sub_resource.name).must_equal sub_path
+    _(sub_resource.topic.name).must_equal topic_path(topic_name)
+    _(sub_resource.deadline).must_equal 60
+    _(sub_resource.endpoint).must_equal "http://example.com/callback"
+    _(sub_resource.labels).must_be :empty?
+    _(sub_resource).wont_be :reference?
+    _(sub_resource).must_be :resource?
 
     mock = Minitest::Mock.new
     mock.expect :get_subscription, sub_grpc_new, [sub_path, options: default_options]
@@ -50,19 +50,19 @@ describe Google::Cloud::PubSub::Subscription, :name, :mock_pubsub do
 
     mock.verify
 
-    sub_resource.name.must_equal sub_path
-    sub_resource.topic.name.must_equal topic_path(topic_name)
-    sub_resource.deadline.must_equal 30
-    sub_resource.endpoint.must_equal "http://example.net/endpoint"
-    sub_resource.labels.must_equal({ "foo" => "bar" })
-    sub_resource.wont_be :reference?
-    sub_resource.must_be :resource?
+    _(sub_resource.name).must_equal sub_path
+    _(sub_resource.topic.name).must_equal topic_path(topic_name)
+    _(sub_resource.deadline).must_equal 30
+    _(sub_resource.endpoint).must_equal "http://example.net/endpoint"
+    _(sub_resource.labels).must_equal({ "foo" => "bar" })
+    _(sub_resource).wont_be :reference?
+    _(sub_resource).must_be :resource?
   end
 
   it "is reloads a reference by calling get_topic API" do
-    sub_reference.name.must_equal sub_path
-    sub_reference.must_be :reference?
-    sub_reference.wont_be :resource?
+    _(sub_reference.name).must_equal sub_path
+    _(sub_reference).must_be :reference?
+    _(sub_reference).wont_be :resource?
 
     mock = Minitest::Mock.new
     mock.expect :get_subscription, sub_grpc_new, [sub_path, options: default_options]
@@ -72,11 +72,11 @@ describe Google::Cloud::PubSub::Subscription, :name, :mock_pubsub do
 
     mock.verify
 
-    sub_reference.name.must_equal sub_path
-    sub_reference.deadline.must_equal 30
-    sub_reference.endpoint.must_equal "http://example.net/endpoint"
-    sub_reference.labels.must_equal({ "foo" => "bar" })
-    sub_reference.wont_be :reference?
-    sub_reference.must_be :resource?
+    _(sub_reference.name).must_equal sub_path
+    _(sub_reference.deadline).must_equal 30
+    _(sub_reference.endpoint).must_equal "http://example.net/endpoint"
+    _(sub_reference.labels).must_equal({ "foo" => "bar" })
+    _(sub_reference).wont_be :reference?
+    _(sub_reference).must_be :resource?
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -36,7 +36,7 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
   let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
 
   it "updates deadline" do
-    subscription.deadline.must_equal 60
+    _(subscription.deadline).must_equal 60
 
     update_sub = update_sub = Google::Cloud::PubSub::V1::Subscription.new \
       name: sub_path, ack_deadline_seconds: 30
@@ -49,11 +49,11 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
 
     mock.verify
 
-    subscription.deadline.must_equal 30
+    _(subscription.deadline).must_equal 30
   end
 
   it "updates retain_acked" do
-    subscription.retain_acked.must_equal true
+    _(subscription.retain_acked).must_equal true
 
     update_sub = update_sub = Google::Cloud::PubSub::V1::Subscription.new \
       name: sub_path, retain_acked_messages: false
@@ -66,11 +66,11 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
 
     mock.verify
 
-    subscription.retain_acked.must_equal false
+    _(subscription.retain_acked).must_equal false
   end
 
   it "updates retention" do
-    subscription.retention.must_equal 600.9
+    _(subscription.retention).must_equal 600.9
 
     update_sub = Google::Cloud::PubSub::V1::Subscription.new \
       name: sub_path, message_retention_duration: Google::Cloud::PubSub::Convert.number_to_duration(600.2)
@@ -83,11 +83,11 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
 
     mock.verify
 
-    subscription.retention.must_equal 600.2
+    _(subscription.retention).must_equal 600.2
   end
 
   it "updates labels" do
-    subscription.labels.must_equal labels
+    _(subscription.labels).must_equal labels
 
     update_sub = Google::Cloud::PubSub::V1::Subscription.new \
       name: sub_path, labels: new_labels
@@ -100,11 +100,11 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
 
     mock.verify
 
-    subscription.labels.must_equal new_labels
+    _(subscription.labels).must_equal new_labels
   end
 
   it "updates labels to empty hash" do
-    subscription.labels.must_equal labels
+    _(subscription.labels).must_equal labels
 
     update_sub = Google::Cloud::PubSub::V1::Subscription.new \
       name: sub_path, labels: {}
@@ -118,16 +118,16 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
 
     mock.verify
 
-    subscription.labels.wont_be :nil?
-    subscription.labels.must_be :empty?
+    _(subscription.labels).wont_be :nil?
+    _(subscription.labels).must_be :empty?
   end
 
   it "raises when setting labels to nil" do
-    subscription.labels.must_equal labels
+    _(subscription.labels).must_equal labels
 
     expect { subscription.labels = nil }.must_raise ArgumentError
 
-    subscription.labels.must_equal labels
+    _(subscription.labels).must_equal labels
   end
 
   it "can update the endpoint" do
@@ -161,7 +161,7 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
 
     mock.verify
 
-    subscription.expires_in.must_equal week_seconds
+    _(subscription.expires_in).must_equal week_seconds
   end
 
   it "can update the expires_in to nil" do
@@ -177,15 +177,15 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
 
     mock.verify
 
-    subscription.expires_in.must_be :nil?
+    _(subscription.expires_in).must_be :nil?
   end
 
   it "updates push_config" do
-    subscription.push_config.must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig
-    subscription.push_config.endpoint.must_equal "http://example.com/callback"
-    subscription.push_config.authentication.must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig::OidcToken
-    subscription.push_config.authentication.email.must_equal "user@example.com"
-    subscription.push_config.authentication.audience.must_equal "client-12345"
+    _(subscription.push_config).must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig
+    _(subscription.push_config.endpoint).must_equal "http://example.com/callback"
+    _(subscription.push_config.authentication).must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig::OidcToken
+    _(subscription.push_config.authentication.email).must_equal "user@example.com"
+    _(subscription.push_config.authentication.audience).must_equal "client-12345"
 
     update_sub = Google::Cloud::PubSub::V1::Subscription.new(
       name: sub_path, push_config: Google::Cloud::PubSub::V1::PushConfig.new(
@@ -208,11 +208,11 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
 
     mock.verify
 
-    subscription.push_config.must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig
-    subscription.push_config.endpoint.must_equal "http://example.net/endpoint"
-    subscription.push_config.authentication.must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig::OidcToken
-    subscription.push_config.authentication.email.must_equal "admin@example.net"
-    subscription.push_config.authentication.audience.must_equal "some-header-value"
+    _(subscription.push_config).must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig
+    _(subscription.push_config.endpoint).must_equal "http://example.net/endpoint"
+    _(subscription.push_config.authentication).must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig::OidcToken
+    _(subscription.push_config.authentication.email).must_equal "admin@example.net"
+    _(subscription.push_config.authentication.audience).must_equal "some-header-value"
   end
 
   it "updates dead_letter_topic" do
@@ -228,8 +228,8 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
 
     mock.verify
 
-    subscription.dead_letter_topic.name.must_equal new_dead_letter_topic.name
-    subscription.dead_letter_max_delivery_attempts.must_equal 6
+    _(subscription.dead_letter_topic.name).must_equal new_dead_letter_topic.name
+    _(subscription.dead_letter_max_delivery_attempts).must_equal 6
   end
 
   it "updates dead_letter_max_delivery_attempts" do
@@ -245,8 +245,8 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
 
     mock.verify
 
-    subscription.dead_letter_topic.name.must_equal dead_letter_topic_path
-    subscription.dead_letter_max_delivery_attempts.must_equal 7
+    _(subscription.dead_letter_topic.name).must_equal dead_letter_topic_path
+    _(subscription.dead_letter_max_delivery_attempts).must_equal 7
   end
 
   it "raises when updating dead_letter_max_delivery_attempts if dead_letter_topic is not set" do
@@ -261,8 +261,8 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     let(:subscription) { Google::Cloud::PubSub::Subscription.from_name sub_name, pubsub.service }
 
     it "updates deadline" do
-      subscription.must_be :reference?
-      subscription.wont_be :resource?
+      _(subscription).must_be :reference?
+      _(subscription).wont_be :resource?
 
       update_sub = Google::Cloud::PubSub::V1::Subscription.new \
         name: subscription_path(sub_name),
@@ -277,14 +277,14 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
 
       mock.verify
 
-      subscription.wont_be :reference?
-      subscription.must_be :resource?
-      subscription.deadline.must_equal 30
+      _(subscription).wont_be :reference?
+      _(subscription).must_be :resource?
+      _(subscription.deadline).must_equal 30
     end
 
     it "updates retain_acked" do
-      subscription.must_be :reference?
-      subscription.wont_be :resource?
+      _(subscription).must_be :reference?
+      _(subscription).wont_be :resource?
 
       update_sub = Google::Cloud::PubSub::V1::Subscription.new \
         name: subscription_path(sub_name),
@@ -299,14 +299,14 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
 
       mock.verify
 
-      subscription.wont_be :reference?
-      subscription.must_be :resource?
-      subscription.retain_acked.must_equal true
+      _(subscription).wont_be :reference?
+      _(subscription).must_be :resource?
+      _(subscription.retain_acked).must_equal true
     end
 
     it "updates retention" do
-      subscription.must_be :reference?
-      subscription.wont_be :resource?
+      _(subscription).must_be :reference?
+      _(subscription).wont_be :resource?
 
       update_sub = Google::Cloud::PubSub::V1::Subscription.new \
         name: subscription_path(sub_name),
@@ -321,14 +321,14 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
 
       mock.verify
 
-      subscription.wont_be :reference?
-      subscription.must_be :resource?
-      subscription.retention.must_equal 600.2
+      _(subscription).wont_be :reference?
+      _(subscription).must_be :resource?
+      _(subscription.retention).must_equal 600.2
     end
 
     it "updates labels" do
-      subscription.must_be :reference?
-      subscription.wont_be :resource?
+      _(subscription).must_be :reference?
+      _(subscription).wont_be :resource?
 
       update_sub = Google::Cloud::PubSub::V1::Subscription.new \
         name: subscription_path(sub_name),
@@ -343,9 +343,9 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
 
       mock.verify
 
-      subscription.wont_be :reference?
-      subscription.must_be :resource?
-      subscription.labels.must_equal new_labels
+      _(subscription).wont_be :reference?
+      _(subscription).must_be :resource?
+      _(subscription.labels).must_equal new_labels
     end
 
     it "makes an HTTP API call to update endpoint" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription_test.rb
@@ -22,30 +22,30 @@ describe Google::Cloud::PubSub::Subscription, :mock_pubsub do
   let(:labels) { { "foo" => "bar" } }
 
   it "knows its name" do
-    subscription.name.must_equal subscription_path(subscription_name)
+    _(subscription.name).must_equal subscription_path(subscription_name)
   end
 
   it "knows its topic" do
-    subscription.topic.must_be_kind_of Google::Cloud::PubSub::Topic
-    subscription.topic.must_be :reference?
-    subscription.topic.wont_be :resource?
-    subscription.topic.name.must_equal topic_path(topic_name)
+    _(subscription.topic).must_be_kind_of Google::Cloud::PubSub::Topic
+    _(subscription.topic).must_be :reference?
+    _(subscription.topic).wont_be :resource?
+    _(subscription.topic.name).must_equal topic_path(topic_name)
   end
 
   it "has an ack deadline" do
-    subscription.must_respond_to :deadline
+    _(subscription).must_respond_to :deadline
   end
 
   it "knows its retain_acked" do
-    subscription.must_respond_to :retain_acked
+    _(subscription).must_respond_to :retain_acked
   end
 
   it "knows its retention_duration" do
-    subscription.must_respond_to :retention
+    _(subscription).must_respond_to :retention
   end
 
   it "has an endpoint" do
-    subscription.must_respond_to :endpoint
+    _(subscription).must_respond_to :endpoint
   end
 
   it "can update the endpoint" do
@@ -83,8 +83,8 @@ describe Google::Cloud::PubSub::Subscription, :mock_pubsub do
 
     mock.verify
 
-    rec_messages.wont_be :empty?
-    rec_messages.first.message.data.must_equal rec_message_msg
+    _(rec_messages).wont_be :empty?
+    _(rec_messages.first.message.data).must_equal rec_message_msg
   end
 
   it "can acknowledge one message" do
@@ -131,8 +131,8 @@ describe Google::Cloud::PubSub::Subscription, :mock_pubsub do
 
     mock.verify
 
-    snapshot.wont_be :nil?
-    snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
+    _(snapshot).wont_be :nil?
+    _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
   end
 
   it "creates a snapshot with new_snapshot alias" do
@@ -146,8 +146,8 @@ describe Google::Cloud::PubSub::Subscription, :mock_pubsub do
 
     mock.verify
 
-    snapshot.wont_be :nil?
-    snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
+    _(snapshot).wont_be :nil?
+    _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
   end
 
   it "creates a snapshot with labels" do
@@ -161,10 +161,10 @@ describe Google::Cloud::PubSub::Subscription, :mock_pubsub do
 
     mock.verify
 
-    snapshot.wont_be :nil?
-    snapshot.must_be_kind_of Google::Cloud::PubSub::Snapshot
-    snapshot.labels.must_equal labels
-    snapshot.labels.must_be :frozen?
+    _(snapshot).wont_be :nil?
+    _(snapshot).must_be_kind_of Google::Cloud::PubSub::Snapshot
+    _(snapshot.labels).must_equal labels
+    _(snapshot.labels).must_be :frozen?
   end
 
   it "raises when creating a snapshot that already exists" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/attrs_test.rb
@@ -23,24 +23,24 @@ describe Google::Cloud::PubSub::Topic, :attributes, :mock_pubsub do
   let(:topic) { Google::Cloud::PubSub::Topic.from_grpc topic_grpc, pubsub.service }
 
   it "is not reference when created with an HTTP method" do
-    topic.wont_be :reference?
-    topic.must_be :resource?
+    _(topic).wont_be :reference?
+    _(topic).must_be :resource?
   end
 
   it "accesses name without making an API call" do
-    topic.name.must_equal topic_path(topic_name)
+    _(topic.name).must_equal topic_path(topic_name)
   end
 
   it "accesses labels without making an API call" do
-    topic.labels.must_equal labels
+    _(topic.labels).must_equal labels
   end
 
   it "accesses kms_key without making an API call" do
-    topic.kms_key.must_equal kms_key_name
+    _(topic.kms_key).must_equal kms_key_name
   end
 
   it "accesses persistence_regions without making an API call" do
-    topic.persistence_regions.must_equal persistence_regions
+    _(topic.persistence_regions).must_equal persistence_regions
   end
 
   describe "reference topic" do
@@ -49,64 +49,64 @@ describe Google::Cloud::PubSub::Topic, :attributes, :mock_pubsub do
     end
 
     it "is reference" do
-      topic.must_be :reference?
-      topic.wont_be :resource?
+      _(topic).must_be :reference?
+      _(topic).wont_be :resource?
     end
 
     it "accesses name without making an API call" do
-      topic.must_be :reference?
-      topic.wont_be :resource?
+      _(topic).must_be :reference?
+      _(topic).wont_be :resource?
 
-      topic.name.must_equal topic_path(topic_name)
+      _(topic.name).must_equal topic_path(topic_name)
 
-      topic.must_be :reference?
-      topic.wont_be :resource?
+      _(topic).must_be :reference?
+      _(topic).wont_be :resource?
     end
 
     it "accesses labels by making an API call" do
-      topic.must_be :reference?
-      topic.wont_be :resource?
+      _(topic).must_be :reference?
+      _(topic).wont_be :resource?
 
       mock = Minitest::Mock.new
       mock.expect :get_topic, topic_grpc, [topic_path(topic_name), options: default_options]
       topic.service.mocked_publisher = mock
 
-      topic.labels.must_equal labels
+      _(topic.labels).must_equal labels
 
-      topic.wont_be :reference?
-      topic.must_be :resource?
+      _(topic).wont_be :reference?
+      _(topic).must_be :resource?
 
       mock.verify
     end
 
     it "accesses kms_key by making an API call" do
-      topic.must_be :reference?
-      topic.wont_be :resource?
+      _(topic).must_be :reference?
+      _(topic).wont_be :resource?
 
       mock = Minitest::Mock.new
       mock.expect :get_topic, topic_grpc, [topic_path(topic_name), options: default_options]
       topic.service.mocked_publisher = mock
 
-      topic.kms_key.must_equal kms_key_name
+      _(topic.kms_key).must_equal kms_key_name
 
-      topic.wont_be :reference?
-      topic.must_be :resource?
+      _(topic).wont_be :reference?
+      _(topic).must_be :resource?
 
       mock.verify
     end
 
     it "accesses persistence_regions by making an API call" do
-      topic.must_be :reference?
-      topic.wont_be :resource?
+      _(topic).must_be :reference?
+      _(topic).wont_be :resource?
 
       mock = Minitest::Mock.new
       mock.expect :get_topic, topic_grpc, [topic_path(topic_name), options: default_options]
       topic.service.mocked_publisher = mock
 
-      topic.persistence_regions.must_equal persistence_regions
+      _(topic.persistence_regions).must_equal persistence_regions
 
-      topic.wont_be :reference?
-      topic.must_be :resource?
+      _(topic).wont_be :reference?
+      _(topic).must_be :resource?
 
       mock.verify
     end
@@ -115,17 +115,17 @@ describe Google::Cloud::PubSub::Topic, :attributes, :mock_pubsub do
       let(:topic_grpc) { Google::Cloud::PubSub::V1::Topic.new topic_hash(topic_name, labels: labels) }
 
       it "accesses persistence_regions by making an API call" do
-        topic.must_be :reference?
-        topic.wont_be :resource?
+        _(topic).must_be :reference?
+        _(topic).wont_be :resource?
 
         mock = Minitest::Mock.new
         mock.expect :get_topic, topic_grpc, [topic_path(topic_name), options: default_options]
         topic.service.mocked_publisher = mock
 
-        topic.persistence_regions.must_be :empty?
+        _(topic.persistence_regions).must_be :empty?
 
-        topic.wont_be :reference?
-        topic.must_be :resource?
+        _(topic).wont_be :reference?
+        _(topic).must_be :resource?
 
         mock.verify
       end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/autocreate_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/autocreate_test.rb
@@ -19,16 +19,16 @@ describe Google::Cloud::PubSub::Topic, :reference, :mock_pubsub do
   let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
 
   it "will not be reference when created with an HTTP method" do
-    topic.wont_be :reference?
-    topic.must_be :resource?
+    _(topic).wont_be :reference?
+    _(topic).must_be :resource?
   end
 
   describe "reference topic" do
     let(:topic) { Google::Cloud::PubSub::Topic.from_name topic_name, pubsub.service }
 
     it "will be reference when created lazily" do
-      topic.must_be :reference?
-      topic.wont_be :resource?
+      _(topic).must_be :reference?
+      _(topic).wont_be :resource?
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/exists_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/exists_test.rb
@@ -21,9 +21,9 @@ describe Google::Cloud::PubSub::Topic, :exists, :mock_pubsub do
   it "knows if it exists when created with an HTTP method" do
     # The absense of a mock means this test will fail
     # if the method exists? makes an HTTP call.
-    topic.must_be :exists?
+    _(topic).must_be :exists?
     # Additional exists? calls do not make HTTP calls either
-    topic.must_be :exists?
+    _(topic).must_be :exists?
   end
 
   describe "reference topic object of a topic that exists" do
@@ -35,9 +35,9 @@ describe Google::Cloud::PubSub::Topic, :exists, :mock_pubsub do
       mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
       topic.service.mocked_publisher = mock
 
-      topic.must_be :exists?
+      _(topic).must_be :exists?
       # Additional exists? calls do not make HTTP calls
-      topic.must_be :exists?
+      _(topic).must_be :exists?
 
       mock.verify
     end
@@ -55,9 +55,9 @@ describe Google::Cloud::PubSub::Topic, :exists, :mock_pubsub do
       end
       topic.service.mocked_publisher = stub
 
-      topic.wont_be :exists?
+      _(topic).wont_be :exists?
       # Additional exists? calls do not make HTTP calls
-      topic.wont_be :exists?
+      _(topic).wont_be :exists?
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/lazy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/lazy_test.rb
@@ -20,8 +20,8 @@ describe Google::Cloud::PubSub::Topic, :reference, :mock_pubsub do
   let(:topic) { Google::Cloud::PubSub::Topic.from_grpc topic_grpc, pubsub.service }
 
   it "is not reference when created with an HTTP method" do
-    topic.wont_be :reference?
-    topic.must_be :resource?
+    _(topic).wont_be :reference?
+    _(topic).must_be :resource?
   end
 
   describe "reference topic" do
@@ -30,8 +30,8 @@ describe Google::Cloud::PubSub::Topic, :reference, :mock_pubsub do
     end
 
     it "is reference" do
-      topic.must_be :reference?
-      topic.wont_be :resource?
+      _(topic).must_be :reference?
+      _(topic).wont_be :resource?
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/name_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/name_test.rb
@@ -19,6 +19,6 @@ describe Google::Cloud::PubSub::Topic, :name, :mock_pubsub do
   let(:topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)), pubsub.service }
 
   it "gives the name returned from the HTTP method" do
-    topic.name.must_equal "projects/#{project}/topics/#{topic_name}"
+    _(topic.name).must_equal "projects/#{project}/topics/#{topic_name}"
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/ordered_messages_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/ordered_messages_test.rb
@@ -32,14 +32,14 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :ordered_messages, :mock_
       topic.publish_async msg[:message], ordering_key: msg[:key]
     end
 
-    topic.async_publisher.must_be :started?
-    topic.async_publisher.wont_be :stopped?
+    _(topic.async_publisher).must_be :started?
+    _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
     topic.async_publisher.stop.wait!
 
-    topic.async_publisher.wont_be :started?
-    topic.async_publisher.must_be :stopped?
+    _(topic.async_publisher).wont_be :started?
+    _(topic.async_publisher).must_be :stopped?
 
     published_messages_hash = topic.service.mocked_publisher.message_hash
     assert_equal fixture_expected_hash.keys.sort, published_messages_hash.keys.sort
@@ -61,14 +61,14 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :ordered_messages, :mock_
       end
     end
 
-    topic.async_publisher.must_be :started?
-    topic.async_publisher.wont_be :stopped?
+    _(topic.async_publisher).must_be :started?
+    _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
     topic.async_publisher.stop.wait!
 
-    topic.async_publisher.wont_be :started?
-    topic.async_publisher.must_be :stopped?
+    _(topic.async_publisher).wont_be :started?
+    _(topic.async_publisher).must_be :stopped?
 
     published_messages_hash = topic.service.mocked_publisher.message_hash
     assert_equal fixture_expected_hash.keys.sort, published_messages_hash.keys.sort
@@ -92,14 +92,14 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :ordered_messages, :mock_
       end
     end
 
-    topic.async_publisher.must_be :started?
-    topic.async_publisher.wont_be :stopped?
+    _(topic.async_publisher).must_be :started?
+    _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
     topic.async_publisher.stop.wait!
 
-    topic.async_publisher.wont_be :started?
-    topic.async_publisher.must_be :stopped?
+    _(topic.async_publisher).wont_be :started?
+    _(topic.async_publisher).must_be :stopped?
 
     published_messages_hash = topic.service.mocked_publisher.message_hash
     assert_equal fixture_expected_hash.keys.sort, published_messages_hash.keys.sort
@@ -119,14 +119,14 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :ordered_messages, :mock_
       topic.publish_async msg[:message], ordering_key: msg[:key]
     end
 
-    topic.async_publisher.must_be :started?
-    topic.async_publisher.wont_be :stopped?
+    _(topic.async_publisher).must_be :started?
+    _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
     topic.async_publisher.stop.wait!
 
-    topic.async_publisher.wont_be :started?
-    topic.async_publisher.must_be :stopped?
+    _(topic.async_publisher).wont_be :started?
+    _(topic.async_publisher).must_be :stopped?
 
     published_messages_hash = topic.service.mocked_publisher.message_hash
     assert_equal fixture_expected_hash.keys.sort, published_messages_hash.keys.sort
@@ -146,14 +146,14 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :ordered_messages, :mock_
       topic.publish_async msg[:message], ordering_key: msg[:key]
     end
 
-    topic.async_publisher.must_be :started?
-    topic.async_publisher.wont_be :stopped?
+    _(topic.async_publisher).must_be :started?
+    _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
     topic.async_publisher.stop.wait!
 
-    topic.async_publisher.wont_be :started?
-    topic.async_publisher.must_be :stopped?
+    _(topic.async_publisher).wont_be :started?
+    _(topic.async_publisher).must_be :stopped?
 
     published_messages_hash = topic.service.mocked_publisher.message_hash
     assert_equal fixture_expected_hash.keys.sort, published_messages_hash.keys.sort

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
@@ -38,14 +38,14 @@ describe Google::Cloud::PubSub::Topic, :policy, :mock_pubsub do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::PubSub::Policy
-    policy.etag.must_equal "\b\x01"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be_kind_of Array
-    policy.roles["roles/viewer"].count.must_equal 2
-    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    _(policy).must_be_kind_of Google::Cloud::PubSub::Policy
+    _(policy.etag).must_equal "\b\x01"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be_kind_of Array
+    _(policy.roles["roles/viewer"].count).must_equal 2
+    _(policy.roles["roles/viewer"].first).must_equal "user:viewer@example.com"
+    _(policy.roles["roles/viewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "sets the IAM Policy" do
@@ -98,15 +98,15 @@ describe Google::Cloud::PubSub::Topic, :policy, :mock_pubsub do
 
     mock.verify
 
-    policy_2.must_be_kind_of Google::Cloud::PubSub::Policy
-    policy_2.etag.must_equal "\b\x10"
-    policy_2.roles.must_be_kind_of Hash
-    policy_2.roles.size.must_equal 1
-    policy_2.roles["roles/viewer"].must_be :nil?
-    policy_2.roles["roles/owner"].must_be_kind_of Array
-    policy_2.roles["roles/owner"].count.must_equal 2
-    policy_2.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-    policy_2.roles["roles/owner"].last.must_equal "user:newowner@example.com"
+    _(policy_2).must_be_kind_of Google::Cloud::PubSub::Policy
+    _(policy_2.etag).must_equal "\b\x10"
+    _(policy_2.roles).must_be_kind_of Hash
+    _(policy_2.roles.size).must_equal 1
+    _(policy_2.roles["roles/viewer"]).must_be :nil?
+    _(policy_2.roles["roles/owner"]).must_be_kind_of Array
+    _(policy_2.roles["roles/owner"].count).must_equal 2
+    _(policy_2.roles["roles/owner"].first).must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    _(policy_2.roles["roles/owner"].last).must_equal "user:newowner@example.com"
   end
 
   it "sets the IAM Policy in a block" do
@@ -157,15 +157,15 @@ describe Google::Cloud::PubSub::Topic, :policy, :mock_pubsub do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::PubSub::Policy
-    policy.etag.must_equal "\b\x10"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-    policy.roles["roles/owner"].last.must_equal "user:newowner@example.com"
+    _(policy).must_be_kind_of Google::Cloud::PubSub::Policy
+    _(policy.etag).must_equal "\b\x10"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be :nil?
+    _(policy.roles["roles/owner"]).must_be_kind_of Array
+    _(policy.roles["roles/owner"].count).must_equal 2
+    _(policy.roles["roles/owner"].first).must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    _(policy.roles["roles/owner"].last).must_equal "user:newowner@example.com"
   end
 
   it "tests the available permissions" do
@@ -182,6 +182,6 @@ describe Google::Cloud::PubSub::Topic, :policy, :mock_pubsub do
 
     mock.verify
 
-    permissions.must_equal ["pubsub.topics.get"]
+    _(permissions).must_equal ["pubsub.topics.get"]
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
@@ -21,20 +21,20 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
   it "publishes a message" do
     topic.service.mocked_publisher = AsyncPublisherStub.new
 
-    topic.async_publisher.must_be :nil?
+    _(topic.async_publisher).must_be :nil?
 
     topic.publish_async "async-message"
 
-    topic.async_publisher.wont_be :nil?
+    _(topic.async_publisher).wont_be :nil?
 
-    topic.async_publisher.must_be :started?
-    topic.async_publisher.wont_be :stopped?
+    _(topic.async_publisher).must_be :started?
+    _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
     topic.async_publisher.stop.wait!
 
-    topic.async_publisher.wont_be :started?
-    topic.async_publisher.must_be :stopped?
+    _(topic.async_publisher).wont_be :started?
+    _(topic.async_publisher).must_be :stopped?
 
     expected_messages_hash = {
       "" => [
@@ -53,7 +53,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
 
     topic.service.mocked_publisher = AsyncPublisherStub.new
 
-    topic.async_publisher.must_be :nil?
+    _(topic.async_publisher).must_be :nil?
 
     topic.publish_async "async-message" do |result|
       assert_kind_of Google::Cloud::PubSub::PublishResult, result
@@ -62,21 +62,21 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
       callback_called = true
     end
 
-    topic.async_publisher.wont_be :nil?
+    _(topic.async_publisher).wont_be :nil?
 
-    topic.async_publisher.must_be :started?
-    topic.async_publisher.wont_be :stopped?
+    _(topic.async_publisher).must_be :started?
+    _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
     topic.async_publisher.stop.wait!
 
-    topic.async_publisher.wont_be :started?
-    topic.async_publisher.must_be :stopped?
+    _(topic.async_publisher).wont_be :started?
+    _(topic.async_publisher).must_be :stopped?
 
     published_messages_hash = topic.service.mocked_publisher.message_hash
     expected_messages_hash = { "" => messages }
     assert_equal expected_messages_hash, published_messages_hash
-    callback_called.must_equal true
+    _(callback_called).must_equal true
   end
 
   it "publishes a message with multibyte characters" do
@@ -84,7 +84,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
 
     topic.service.mocked_publisher = AsyncPublisherStub.new
 
-    topic.async_publisher.must_be :nil?
+    _(topic.async_publisher).must_be :nil?
 
     topic.publish_async "あ" do |result|
       assert_kind_of Google::Cloud::PubSub::PublishResult, result
@@ -94,16 +94,16 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
       callback_called = true
     end
 
-    topic.async_publisher.wont_be :nil?
+    _(topic.async_publisher).wont_be :nil?
 
-    topic.async_publisher.must_be :started?
-    topic.async_publisher.wont_be :stopped?
+    _(topic.async_publisher).must_be :started?
+    _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
     topic.async_publisher.stop.wait!
 
-    topic.async_publisher.wont_be :started?
-    topic.async_publisher.must_be :stopped?
+    _(topic.async_publisher).wont_be :started?
+    _(topic.async_publisher).must_be :stopped?
 
     expected_messages_hash = {
       "" => [
@@ -112,7 +112,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
     }
     published_messages_hash = topic.service.mocked_publisher.message_hash
     assert_equal expected_messages_hash, published_messages_hash
-    callback_called.must_equal true
+    _(callback_called).must_equal true
   end
 
   it "publishes a message using an IO-ish object" do
@@ -120,7 +120,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
 
     topic.service.mocked_publisher = AsyncPublisherStub.new
 
-    topic.async_publisher.must_be :nil?
+    _(topic.async_publisher).must_be :nil?
 
     Tempfile.open ["message", "txt"] do |tmpfile|
       tmpfile.binmode
@@ -136,16 +136,16 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
       end
     end
 
-    topic.async_publisher.wont_be :nil?
+    _(topic.async_publisher).wont_be :nil?
 
-    topic.async_publisher.must_be :started?
-    topic.async_publisher.wont_be :stopped?
+    _(topic.async_publisher).must_be :started?
+    _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
     topic.async_publisher.stop.wait!
 
-    topic.async_publisher.wont_be :started?
-    topic.async_publisher.must_be :stopped?
+    _(topic.async_publisher).wont_be :started?
+    _(topic.async_publisher).must_be :stopped?
 
     expected_messages_hash = {
       "" => [
@@ -154,7 +154,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
     }
     published_messages_hash = topic.service.mocked_publisher.message_hash
     assert_equal expected_messages_hash, published_messages_hash
-    callback_called.must_equal true
+    _(callback_called).must_equal true
   end
 
   it "publishes a message with attributes" do
@@ -162,7 +162,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
 
     topic.service.mocked_publisher = AsyncPublisherStub.new
 
-    topic.async_publisher.must_be :nil?
+    _(topic.async_publisher).must_be :nil?
 
     topic.publish_async "async-message", format: :text do |result|
       assert_kind_of Google::Cloud::PubSub::PublishResult, result
@@ -173,16 +173,16 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
       callback_called = true
     end
 
-    topic.async_publisher.wont_be :nil?
+    _(topic.async_publisher).wont_be :nil?
 
-    topic.async_publisher.must_be :started?
-    topic.async_publisher.wont_be :stopped?
+    _(topic.async_publisher).must_be :started?
+    _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
     topic.async_publisher.stop.wait!
 
-    topic.async_publisher.wont_be :started?
-    topic.async_publisher.must_be :stopped?
+    _(topic.async_publisher).wont_be :started?
+    _(topic.async_publisher).must_be :stopped?
 
     expected_messages_hash = {
       "" => [
@@ -191,7 +191,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
     }
     published_messages_hash = topic.service.mocked_publisher.message_hash
     assert_equal expected_messages_hash, published_messages_hash
-    callback_called.must_equal true
+    _(callback_called).must_equal true
   end
 
   describe "reference topic that exists" do
@@ -202,20 +202,20 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
     it "publishes a message" do
       topic.service.mocked_publisher = AsyncPublisherStub.new
 
-      topic.async_publisher.must_be :nil?
+      _(topic.async_publisher).must_be :nil?
 
       topic.publish_async "async-message"
 
-      topic.async_publisher.wont_be :nil?
+      _(topic.async_publisher).wont_be :nil?
 
-      topic.async_publisher.must_be :started?
-      topic.async_publisher.wont_be :stopped?
+      _(topic.async_publisher).must_be :started?
+      _(topic.async_publisher).wont_be :stopped?
 
       # force the queued messages to be published
       topic.async_publisher.stop.wait!
 
-      topic.async_publisher.wont_be :started?
-      topic.async_publisher.must_be :stopped?
+      _(topic.async_publisher).wont_be :started?
+      _(topic.async_publisher).must_be :stopped?
 
       expected_messages_hash = {
         "" => [
@@ -231,7 +231,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
 
       topic.service.mocked_publisher = AsyncPublisherStub.new
 
-      topic.async_publisher.must_be :nil?
+      _(topic.async_publisher).must_be :nil?
 
       topic.publish_async "async-message", format: :text do |result|
         assert_kind_of Google::Cloud::PubSub::PublishResult, result
@@ -242,16 +242,16 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
         callback_called = true
       end
 
-      topic.async_publisher.wont_be :nil?
+      _(topic.async_publisher).wont_be :nil?
 
-      topic.async_publisher.must_be :started?
-      topic.async_publisher.wont_be :stopped?
+      _(topic.async_publisher).must_be :started?
+      _(topic.async_publisher).wont_be :stopped?
 
       # force the queued messages to be published
       topic.async_publisher.stop.wait!
 
-      topic.async_publisher.wont_be :started?
-      topic.async_publisher.must_be :stopped?
+      _(topic.async_publisher).wont_be :started?
+      _(topic.async_publisher).must_be :stopped?
 
       expected_messages_hash = {
         "" => [
@@ -260,7 +260,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
       }
       published_messages_hash = topic.service.mocked_publisher.message_hash
       assert_equal expected_messages_hash, published_messages_hash
-      callback_called.must_equal true
+      _(callback_called).must_equal true
     end
   end
 
@@ -288,7 +288,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
       end
       pubsub.service.mocked_publisher = stub
 
-      topic.async_publisher.must_be :nil?
+      _(topic.async_publisher).must_be :nil?
 
       callback_called = false
 
@@ -301,16 +301,16 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
         callback_called = true
       end
 
-      topic.async_publisher.wont_be :nil?
+      _(topic.async_publisher).wont_be :nil?
 
       # force the queued messages to be published
       topic.async_publisher.stop.wait!
 
-      topic.async_publisher.wont_be :started?
-      topic.async_publisher.must_be :stopped?
+      _(topic.async_publisher).wont_be :started?
+      _(topic.async_publisher).must_be :stopped?
 
-      topic.async_publisher.batch.must_be :nil?
-      callback_called.must_equal true
+      _(topic.async_publisher.batch).must_be :nil?
+      _(callback_called).must_equal true
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
@@ -37,8 +37,8 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
 
     mock.verify
 
-    msg.must_be_kind_of Google::Cloud::PubSub::Message
-    msg.message_id.must_equal "msg1"
+    _(msg).must_be_kind_of Google::Cloud::PubSub::Message
+    _(msg.message_id).must_equal "msg1"
   end
 
   it "publishes a message with multibyte characters" do
@@ -54,9 +54,9 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
 
     mock.verify
 
-    msg.must_be_kind_of Google::Cloud::PubSub::Message
-    msg.data.must_equal "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT)
-    msg.message_id.must_equal "msg1"
+    _(msg).must_be_kind_of Google::Cloud::PubSub::Message
+    _(msg.data).must_equal "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT)
+    _(msg.message_id).must_equal "msg1"
   end
 
   it "publishes a message using an IO-ish object" do
@@ -78,9 +78,9 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
     end
     mock.verify
 
-    msg.must_be_kind_of Google::Cloud::PubSub::Message
-    msg.data.must_equal "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT)
-    msg.message_id.must_equal "msg1"
+    _(msg).must_be_kind_of Google::Cloud::PubSub::Message
+    _(msg.data).must_equal "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT)
+    _(msg.message_id).must_equal "msg1"
   end
 
   it "publishes a message with attributes" do
@@ -96,9 +96,9 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
 
     mock.verify
 
-    msg.must_be_kind_of Google::Cloud::PubSub::Message
-    msg.message_id.must_equal "msg1"
-    msg.attributes["format"].must_equal "text"
+    _(msg).must_be_kind_of Google::Cloud::PubSub::Message
+    _(msg.message_id).must_equal "msg1"
+    _(msg.attributes["format"]).must_equal "text"
   end
 
   it "publishes multiple messages with a block" do
@@ -120,11 +120,11 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
 
     mock.verify
 
-    msgs.count.must_equal 3
-    msgs.each { |msg| msg.must_be_kind_of Google::Cloud::PubSub::Message }
-    msgs.first.message_id.must_equal "msg1"
-    msgs.last.message_id.must_equal "msg3"
-    msgs.last.attributes["format"].must_equal "none"
+    _(msgs.count).must_equal 3
+    msgs.each { |msg| _(msg).must_be_kind_of Google::Cloud::PubSub::Message }
+    _(msgs.first.message_id).must_equal "msg1"
+    _(msgs.last.message_id).must_equal "msg3"
+    _(msgs.last.attributes["format"]).must_equal "none"
   end
 
   describe "reference topic that exists" do
@@ -143,8 +143,8 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
 
       mock.verify
 
-      msg.must_be_kind_of Google::Cloud::PubSub::Message
-      msg.message_id.must_equal "msg1"
+      _(msg).must_be_kind_of Google::Cloud::PubSub::Message
+      _(msg.message_id).must_equal "msg1"
     end
 
     it "publishes a message with attributes" do
@@ -160,9 +160,9 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
 
       mock.verify
 
-      msg.must_be_kind_of Google::Cloud::PubSub::Message
-      msg.message_id.must_equal "msg1"
-      msg.attributes["format"].must_equal "text"
+      _(msg).must_be_kind_of Google::Cloud::PubSub::Message
+      _(msg.message_id).must_equal "msg1"
+      _(msg.attributes["format"]).must_equal "text"
     end
 
     it "publishes multiple messages with a block" do
@@ -184,11 +184,11 @@ describe Google::Cloud::PubSub::Topic, :publish, :mock_pubsub do
 
       mock.verify
 
-      msgs.count.must_equal 3
-      msgs.each { |msg| msg.must_be_kind_of Google::Cloud::PubSub::Message }
-      msgs.first.message_id.must_equal "msg1"
-      msgs.last.message_id.must_equal "msg3"
-      msgs.last.attributes["format"].must_equal "none"
+      _(msgs.count).must_equal 3
+      msgs.each { |msg| _(msg).must_be_kind_of Google::Cloud::PubSub::Message }
+      _(msgs.first.message_id).must_equal "msg1"
+      _(msgs.last.message_id).must_equal "msg3"
+      _(msgs.last.attributes["format"]).must_equal "none"
     end
   end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/reload_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/reload_test.rb
@@ -24,18 +24,18 @@ describe Google::Cloud::PubSub::Topic, :reload, :mock_pubsub do
   let(:topic_reference) { Google::Cloud::PubSub::Topic.from_name topic_name, pubsub.service }
 
   it "it has a reload method and a refresh alias" do
-    topic_resource.must_respond_to :reload!
-    topic_reference.must_respond_to :reload!
+    _(topic_resource).must_respond_to :reload!
+    _(topic_reference).must_respond_to :reload!
 
-    topic_resource.must_respond_to :refresh!
-    topic_reference.must_respond_to :refresh!
+    _(topic_resource).must_respond_to :refresh!
+    _(topic_reference).must_respond_to :refresh!
   end
 
   it "is reloads a resource by calling get_topic API" do
-    topic_resource.name.must_equal topic_path(topic_name)
-    topic_resource.labels.must_equal old_labels
-    topic_resource.wont_be :reference?
-    topic_resource.must_be :resource?
+    _(topic_resource.name).must_equal topic_path(topic_name)
+    _(topic_resource.labels).must_equal old_labels
+    _(topic_resource).wont_be :reference?
+    _(topic_resource).must_be :resource?
 
     mock = Minitest::Mock.new
     mock.expect :get_topic, topic_grpc_new, [topic_path(topic_name), options: default_options]
@@ -45,16 +45,16 @@ describe Google::Cloud::PubSub::Topic, :reload, :mock_pubsub do
 
     mock.verify
 
-    topic_resource.name.must_equal topic_path(topic_name)
-    topic_resource.labels.must_equal new_labels
-    topic_resource.wont_be :reference?
-    topic_resource.must_be :resource?
+    _(topic_resource.name).must_equal topic_path(topic_name)
+    _(topic_resource.labels).must_equal new_labels
+    _(topic_resource).wont_be :reference?
+    _(topic_resource).must_be :resource?
   end
 
   it "is reloads a reference by calling get_topic API" do
-    topic_reference.name.must_equal topic_path(topic_name)
-    topic_reference.must_be :reference?
-    topic_reference.wont_be :resource?
+    _(topic_reference.name).must_equal topic_path(topic_name)
+    _(topic_reference).must_be :reference?
+    _(topic_reference).wont_be :resource?
 
     mock = Minitest::Mock.new
     mock.expect :get_topic, topic_grpc_new, [topic_path(topic_name), options: default_options]
@@ -64,9 +64,9 @@ describe Google::Cloud::PubSub::Topic, :reload, :mock_pubsub do
 
     mock.verify
 
-    topic_reference.name.must_equal topic_path(topic_name)
-    topic_reference.labels.must_equal new_labels
-    topic_reference.wont_be :reference?
-    topic_reference.must_be :resource?
+    _(topic_reference.name).must_equal topic_path(topic_name)
+    _(topic_reference.labels).must_equal new_labels
+    _(topic_reference).wont_be :reference?
+    _(topic_reference).must_be :resource?
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
@@ -30,8 +30,8 @@ describe Google::Cloud::PubSub::Topic, :subscribe, :mock_pubsub do
 
     mock.verify
 
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.name.must_equal "projects/#{project}/subscriptions/#{new_sub_name}"
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub.name).must_equal "projects/#{project}/subscriptions/#{new_sub_name}"
   end
 
   it "creates a subscription with labels" do
@@ -44,10 +44,10 @@ describe Google::Cloud::PubSub::Topic, :subscribe, :mock_pubsub do
 
     mock.verify
 
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.name.must_equal "projects/#{project}/subscriptions/#{new_sub_name}"
-    sub.labels.must_equal labels
-    sub.labels.must_be :frozen?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub.name).must_equal "projects/#{project}/subscriptions/#{new_sub_name}"
+    _(sub.labels).must_equal labels
+    _(sub.labels).must_be :frozen?
   end
 
   describe "reference topic that exists" do
@@ -63,8 +63,8 @@ describe Google::Cloud::PubSub::Topic, :subscribe, :mock_pubsub do
 
       mock.verify
 
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.name.must_equal "projects/#{project}/subscriptions/#{new_sub_name}"
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub.name).must_equal "projects/#{project}/subscriptions/#{new_sub_name}"
     end
   end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscription_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscription_test.rb
@@ -30,9 +30,9 @@ describe Google::Cloud::PubSub::Topic, :subscription, :mock_pubsub do
 
     mock.verify
 
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.wont_be :reference?
-    sub.must_be :resource?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub).wont_be :reference?
+    _(sub).must_be :resource?
   end
 
   it "gets an existing subscription with get_subscription alias" do
@@ -45,9 +45,9 @@ describe Google::Cloud::PubSub::Topic, :subscription, :mock_pubsub do
 
     mock.verify
 
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.wont_be :reference?
-    sub.must_be :resource?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub).wont_be :reference?
+    _(sub).must_be :resource?
   end
 
   it "gets an existing subscription with find_subscription alias" do
@@ -60,9 +60,9 @@ describe Google::Cloud::PubSub::Topic, :subscription, :mock_pubsub do
 
     mock.verify
 
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.wont_be :reference?
-    sub.must_be :resource?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub).wont_be :reference?
+    _(sub).must_be :resource?
   end
 
   it "returns nil when getting an non-existant subscription" do
@@ -75,16 +75,16 @@ describe Google::Cloud::PubSub::Topic, :subscription, :mock_pubsub do
     topic.service.mocked_subscriber = stub
 
     sub = topic.subscription found_sub_name
-    sub.must_be :nil?
+    _(sub).must_be :nil?
   end
 
   it "gets a subscription with skip_lookup option" do
     # No HTTP mock needed, since the lookup is not made
 
     sub = topic.find_subscription found_sub_name, skip_lookup: true
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.must_be :reference?
-    sub.wont_be :resource?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub).must_be :reference?
+    _(sub).wont_be :resource?
   end
 
   describe "reference topic that exists" do
@@ -100,9 +100,9 @@ describe Google::Cloud::PubSub::Topic, :subscription, :mock_pubsub do
 
       mock.verify
 
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.wont_be :reference?
-      sub.must_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).wont_be :reference?
+      _(sub).must_be :resource?
     end
 
     it "returns nil when getting an non-existant subscription" do
@@ -115,7 +115,7 @@ describe Google::Cloud::PubSub::Topic, :subscription, :mock_pubsub do
       topic.service.mocked_subscriber = stub
 
       sub = topic.subscription found_sub_name
-      sub.must_be :nil?
+      _(sub).must_be :nil?
     end
   end
 
@@ -132,7 +132,7 @@ describe Google::Cloud::PubSub::Topic, :subscription, :mock_pubsub do
       topic.service.mocked_subscriber = stub
 
       sub = topic.subscription found_sub_name
-      sub.must_be :nil?
+      _(sub).must_be :nil?
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
@@ -31,11 +31,11 @@ describe Google::Cloud::PubSub::Topic, :subscriptions, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 3
+    _(subs.count).must_equal 3
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
   end
 
@@ -51,11 +51,11 @@ describe Google::Cloud::PubSub::Topic, :subscriptions, :mock_pubsub do
 
       mock.verify
 
-      subs.count.must_equal 3
+      _(subs.count).must_equal 3
       subs.each do |sub|
-        sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-        sub.must_be :reference?
-        sub.wont_be :resource?
+        _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+        _(sub).must_be :reference?
+        _(sub).wont_be :resource?
       end
     end
   end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/update_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::PubSub::Topic, :update, :mock_pubsub do
   let(:topic) { Google::Cloud::PubSub::Topic.from_grpc topic_grpc, pubsub.service }
 
   it "updates labels" do
-    topic.labels.must_equal labels
+    _(topic.labels).must_equal labels
 
     update_grpc = topic_grpc.dup
     update_grpc.labels = new_labels_map
@@ -44,11 +44,11 @@ describe Google::Cloud::PubSub::Topic, :update, :mock_pubsub do
 
     mock.verify
 
-    topic.labels.must_equal new_labels
+    _(topic.labels).must_equal new_labels
   end
 
   it "updates labels to empty hash" do
-    topic.labels.must_equal labels
+    _(topic.labels).must_equal labels
 
     update_grpc = topic_grpc.dup
     update_grpc.labels = Google::Protobuf::Map.new(:string, :string)
@@ -62,21 +62,21 @@ describe Google::Cloud::PubSub::Topic, :update, :mock_pubsub do
 
     mock.verify
 
-    topic.labels.wont_be :nil?
-    topic.labels.must_be :empty?
+    _(topic.labels).wont_be :nil?
+    _(topic.labels).must_be :empty?
   end
 
   it "raises when setting labels to nil" do
-    topic.labels.must_equal labels
+    _(topic.labels).must_equal labels
 
     expect { topic.labels = nil }.must_raise ArgumentError
 
-    topic.labels.must_equal labels
+    _(topic.labels).must_equal labels
   end
 
   it "updates kms_key" do
     topic_grpc.kms_key_name = kms_key_name
-    topic.kms_key.must_equal kms_key_name
+    _(topic.kms_key).must_equal kms_key_name
 
     update_grpc = Google::Cloud::PubSub::V1::Topic.new \
       name: topic_path(topic_name),
@@ -90,12 +90,12 @@ describe Google::Cloud::PubSub::Topic, :update, :mock_pubsub do
 
     mock.verify
 
-    topic.kms_key.must_equal new_kms_key_name
+    _(topic.kms_key).must_equal new_kms_key_name
   end
 
   it "updates kms_key to empty string" do
     topic_grpc.kms_key_name = kms_key_name
-    topic.kms_key.must_equal kms_key_name
+    _(topic.kms_key).must_equal kms_key_name
 
     update_grpc = Google::Cloud::PubSub::V1::Topic.new \
       name: topic_path(topic_name),
@@ -109,12 +109,12 @@ describe Google::Cloud::PubSub::Topic, :update, :mock_pubsub do
 
     mock.verify
 
-    topic.kms_key.must_be :empty?
+    _(topic.kms_key).must_be :empty?
   end
 
   it "updates kms_key to nil" do
     topic_grpc.kms_key_name = kms_key_name
-    topic.kms_key.must_equal kms_key_name
+    _(topic.kms_key).must_equal kms_key_name
 
     update_grpc = Google::Cloud::PubSub::V1::Topic.new \
       name: topic_path(topic_name),
@@ -128,14 +128,14 @@ describe Google::Cloud::PubSub::Topic, :update, :mock_pubsub do
 
     mock.verify
 
-    topic.kms_key.must_be :empty?
+    _(topic.kms_key).must_be :empty?
   end
 
   it "updates persistence_regions" do
     topic_grpc.message_storage_policy = Google::Cloud::PubSub::V1::MessageStoragePolicy.new(
       allowed_persistence_regions: persistence_regions
     )
-    topic.persistence_regions.must_equal persistence_regions
+    _(topic.persistence_regions).must_equal persistence_regions
 
     update_grpc = Google::Cloud::PubSub::V1::Topic.new(
       name: topic_path(topic_name),
@@ -150,14 +150,14 @@ describe Google::Cloud::PubSub::Topic, :update, :mock_pubsub do
 
     mock.verify
 
-    topic.persistence_regions.must_equal new_persistence_regions
+    _(topic.persistence_regions).must_equal new_persistence_regions
   end
 
   it "updates persistence_regions to empty array" do
     topic_grpc.message_storage_policy = Google::Cloud::PubSub::V1::MessageStoragePolicy.new(
       allowed_persistence_regions: persistence_regions
     )
-    topic.persistence_regions.must_equal persistence_regions
+    _(topic.persistence_regions).must_equal persistence_regions
 
     update_grpc = Google::Cloud::PubSub::V1::Topic.new(
       name: topic_path(topic_name),
@@ -172,14 +172,14 @@ describe Google::Cloud::PubSub::Topic, :update, :mock_pubsub do
 
     mock.verify
 
-    topic.persistence_regions.must_be :empty?
+    _(topic.persistence_regions).must_be :empty?
   end
 
   it "updates persistence_regions to nil" do
     topic_grpc.message_storage_policy = Google::Cloud::PubSub::V1::MessageStoragePolicy.new(
       allowed_persistence_regions: persistence_regions
     )
-    topic.persistence_regions.must_equal persistence_regions
+    _(topic.persistence_regions).must_equal persistence_regions
 
     update_grpc = Google::Cloud::PubSub::V1::Topic.new(
       name: topic_path(topic_name),
@@ -194,15 +194,15 @@ describe Google::Cloud::PubSub::Topic, :update, :mock_pubsub do
 
     mock.verify
 
-    topic.persistence_regions.must_be :empty?
+    _(topic.persistence_regions).must_be :empty?
   end
 
   describe :reference do
     let(:topic) { Google::Cloud::PubSub::Topic.from_name topic_name, pubsub.service }
 
     it "updates labels" do
-      topic.must_be :reference?
-      topic.wont_be :resource?
+      _(topic).must_be :reference?
+      _(topic).wont_be :resource?
 
       update_grpc = Google::Cloud::PubSub::V1::Topic.new \
         name: topic_path(topic_name),
@@ -217,14 +217,14 @@ describe Google::Cloud::PubSub::Topic, :update, :mock_pubsub do
 
       mock.verify
 
-      topic.wont_be :reference?
-      topic.must_be :resource?
-      topic.labels.must_equal new_labels
+      _(topic).wont_be :reference?
+      _(topic).must_be :resource?
+      _(topic.labels).must_equal new_labels
     end
 
     it "updates kms_key" do
-      topic.must_be :reference?
-      topic.wont_be :resource?
+      _(topic).must_be :reference?
+      _(topic).wont_be :resource?
 
       update_grpc = Google::Cloud::PubSub::V1::Topic.new \
         name: topic_path(topic_name),
@@ -239,9 +239,9 @@ describe Google::Cloud::PubSub::Topic, :update, :mock_pubsub do
 
       mock.verify
 
-      topic.wont_be :reference?
-      topic.must_be :resource?
-      topic.kms_key.must_equal new_kms_key_name
+      _(topic).wont_be :reference?
+      _(topic).must_be :resource?
+      _(topic.kms_key).must_equal new_kms_key_name
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -34,12 +34,12 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
   let(:dead_letter_topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(dead_letter_topic_name)), pubsub.service }
 
   it "knows its name" do
-    topic.name.must_equal topic_path(topic_name)
+    _(topic.name).must_equal topic_path(topic_name)
   end
 
   it "knows its labels" do
-    topic.labels.must_equal labels
-    topic.labels.must_be :frozen?
+    _(topic.labels).must_equal labels
+    _(topic.labels).must_be :frozen?
   end
 
   it "can delete itself" do
@@ -64,8 +64,8 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
   end
 
   it "creates a subscription with create_subscription alias" do
@@ -79,8 +79,8 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
   end
 
   it "creates a subscription with new_subscription alias" do
@@ -94,8 +94,8 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
   end
 
   it "creates a subscription with a deadline" do
@@ -110,8 +110,8 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
   end
 
   it "creates a subscription with retain_acked and retention" do
@@ -127,8 +127,8 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
   end
 
   it "creates a subscription with a push endpoint" do
@@ -144,8 +144,8 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
   end
 
   it "creates a subscription with labels" do
@@ -159,10 +159,10 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.labels.must_equal labels
-    sub.labels.must_be :frozen?
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub.labels).must_equal labels
+    _(sub.labels).must_be :frozen?
   end
 
   it "creates a subscription with dead_letter_topic and dead_letter_max_delivery_attempts" do
@@ -177,10 +177,10 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.dead_letter_topic.name.must_equal topic_path(dead_letter_topic_name)
-    sub.dead_letter_max_delivery_attempts.must_equal 7
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub.dead_letter_topic.name).must_equal topic_path(dead_letter_topic_name)
+    _(sub.dead_letter_max_delivery_attempts).must_equal 7
   end
 
   it "raises when creating a subscription with dead_letter_max_delivery_attempts but no dead_letter_topic" do
@@ -234,10 +234,10 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.wont_be :reference?
-    sub.must_be :resource?
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub).wont_be :reference?
+    _(sub).must_be :resource?
   end
 
   it "gets a subscription with get_subscription alias" do
@@ -252,10 +252,10 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.wont_be :reference?
-    sub.must_be :resource?
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub).wont_be :reference?
+    _(sub).must_be :resource?
   end
 
   it "gets a subscription with find_subscription alias" do
@@ -270,10 +270,10 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    sub.wont_be :nil?
-    sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-    sub.wont_be :reference?
-    sub.must_be :resource?
+    _(sub).wont_be :nil?
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub).wont_be :reference?
+    _(sub).must_be :resource?
   end
 
   it "lists subscriptions" do
@@ -285,11 +285,11 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 3
+    _(subs.count).must_equal 3
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
   end
 
@@ -300,11 +300,11 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     subs = topic.find_subscriptions
 
-    subs.count.must_equal 3
+    _(subs.count).must_equal 3
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
   end
 
@@ -317,11 +317,11 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 3
+    _(subs.count).must_equal 3
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
   end
 
@@ -337,22 +337,22 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    first_subs.count.must_equal 3
+    _(first_subs.count).must_equal 3
     token = first_subs.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
     first_subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
 
-    second_subs.count.must_equal 2
-    second_subs.token.must_be :nil?
+    _(second_subs.count).must_equal 2
+    _(second_subs.token).must_be :nil?
     second_subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
   end
 
@@ -365,14 +365,14 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 3
+    _(subs.count).must_equal 3
     token = subs.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
   end
 
@@ -388,20 +388,20 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    first_subs.count.must_equal 3
-    first_subs.next?.must_equal true
+    _(first_subs.count).must_equal 3
+    _(first_subs.next?).must_equal true
     first_subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
 
-    second_subs.count.must_equal 2
-    second_subs.next?.must_equal false
+    _(second_subs.count).must_equal 2
+    _(second_subs.next?).must_equal false
     second_subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
   end
 
@@ -417,20 +417,20 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    first_subs.count.must_equal 3
-    first_subs.next?.must_equal true
+    _(first_subs.count).must_equal 3
+    _(first_subs.next?).must_equal true
     first_subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
 
-    second_subs.count.must_equal 2
-    second_subs.next?.must_equal false
+    _(second_subs.count).must_equal 2
+    _(second_subs.next?).must_equal false
     second_subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
   end
 
@@ -445,11 +445,11 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 5
+    _(subs.count).must_equal 5
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
   end
 
@@ -464,11 +464,11 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 5
+    _(subs.count).must_equal 5
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
   end
 
@@ -483,11 +483,11 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 5
+    _(subs.count).must_equal 5
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
   end
 
@@ -502,11 +502,11 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    subs.count.must_equal 6
+    _(subs.count).must_equal 6
     subs.each do |sub|
-      sub.must_be_kind_of Google::Cloud::PubSub::Subscription
-      sub.must_be :reference?
-      sub.wont_be :resource?
+      _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+      _(sub).must_be :reference?
+      _(sub).wont_be :resource?
     end
   end
 
@@ -525,8 +525,8 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    msg.must_be_kind_of Google::Cloud::PubSub::Message
-    msg.message_id.must_equal "msg1"
+    _(msg).must_be_kind_of Google::Cloud::PubSub::Message
+    _(msg.message_id).must_equal "msg1"
   end
 
   it "can publish a message with attributes" do
@@ -544,9 +544,9 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    msg.must_be_kind_of Google::Cloud::PubSub::Message
-    msg.message_id.must_equal "msg1"
-    msg.attributes["format"].must_equal "text"
+    _(msg).must_be_kind_of Google::Cloud::PubSub::Message
+    _(msg.message_id).must_equal "msg1"
+    _(msg.attributes["format"]).must_equal "text"
   end
 
   it "can publish multiple messages with a block" do
@@ -570,11 +570,11 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     mock.verify
 
-    msgs.count.must_equal 2
-    msgs.first.must_be_kind_of Google::Cloud::PubSub::Message
-    msgs.first.message_id.must_equal "msg1"
-    msgs.last.must_be_kind_of Google::Cloud::PubSub::Message
-    msgs.last.message_id.must_equal "msg2"
-    msgs.last.attributes["format"].must_equal "none"
+    _(msgs.count).must_equal 2
+    _(msgs.first).must_be_kind_of Google::Cloud::PubSub::Message
+    _(msgs.first.message_id).must_equal "msg1"
+    _(msgs.last).must_be_kind_of Google::Cloud::PubSub::Message
+    _(msgs.last.message_id).must_equal "msg2"
+    _(msgs.last.attributes["format"]).must_equal "none"
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
@@ -20,48 +20,48 @@ describe Google::Cloud do
     it "calls out to Google::Cloud.pubsub" do
       gcloud = Google::Cloud.new
       stubbed_pubsub = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
-        project.must_be :nil?
-        keyfile.must_be :nil?
-        scope.must_be :nil?
-        timeout.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_be :nil?
+        _(keyfile).must_be :nil?
+        _(scope).must_be :nil?
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
         "pubsub-project-object-empty"
       }
       Google::Cloud.stub :pubsub, stubbed_pubsub do
         project = gcloud.pubsub
-        project.must_equal "pubsub-project-object-empty"
+        _(project).must_equal "pubsub-project-object-empty"
       end
     end
 
     it "passes project and keyfile to Google::Cloud.pubsub" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_pubsub = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_be :nil?
-        timeout.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_be :nil?
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
         "pubsub-project-object"
       }
       Google::Cloud.stub :pubsub, stubbed_pubsub do
         project = gcloud.pubsub
-        project.must_equal "pubsub-project-object"
+        _(project).must_equal "pubsub-project-object"
       end
     end
 
     it "passes project and keyfile and options to Google::Cloud.pubsub" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_pubsub = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_equal "http://example.com/scope"
-        timeout.must_equal 60
-        client_config.must_equal 5
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_equal "http://example.com/scope"
+        _(timeout).must_equal 60
+        _(client_config).must_equal 5
         "pubsub-project-object-scoped"
       }
       Google::Cloud.stub :pubsub, stubbed_pubsub do
         project = gcloud.pubsub scope: "http://example.com/scope", timeout: 60, client_config: 5
-        project.must_equal "pubsub-project-object-scoped"
+        _(project).must_equal "pubsub-project-object-scoped"
       end
     end
   end
@@ -83,9 +83,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::PubSub::Credentials.stub :default, default_credentials do
             pubsub = Google::Cloud.pubsub
-            pubsub.must_be_kind_of Google::Cloud::PubSub::Project
-            pubsub.project.must_equal "project-id"
-            pubsub.service.credentials.must_equal default_credentials
+            _(pubsub).must_be_kind_of Google::Cloud::PubSub::Project
+            _(pubsub.project).must_equal "project-id"
+            _(pubsub.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -93,16 +93,16 @@ describe Google::Cloud do
 
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "pubsub-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "pubsub-credentials"
-        client_config.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "pubsub-credentials"
+        _(client_config).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -113,9 +113,9 @@ describe Google::Cloud do
             Google::Cloud::PubSub::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::PubSub::Service.stub :new, stubbed_service do
                 pubsub = Google::Cloud.pubsub "project-id", "path/to/keyfile.json"
-                pubsub.must_be_kind_of Google::Cloud::PubSub::Project
-                pubsub.project.must_equal "project-id"
-                pubsub.service.must_be_kind_of OpenStruct
+                _(pubsub).must_be_kind_of Google::Cloud::PubSub::Project
+                _(pubsub.project).must_equal "project-id"
+                _(pubsub.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -145,9 +145,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::PubSub::Credentials.stub :default, default_credentials do
             pubsub = Google::Cloud::PubSub.new
-            pubsub.must_be_kind_of Google::Cloud::PubSub::Project
-            pubsub.project.must_equal "project-id"
-            pubsub.service.credentials.must_equal default_credentials
+            _(pubsub).must_be_kind_of Google::Cloud::PubSub::Project
+            _(pubsub.project).must_equal "project-id"
+            _(pubsub.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -155,16 +155,16 @@ describe Google::Cloud do
 
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "pubsub-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "pubsub-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "pubsub-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -175,9 +175,9 @@ describe Google::Cloud do
             Google::Cloud::PubSub::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::PubSub::Service.stub :new, stubbed_service do
                 pubsub = Google::Cloud::PubSub.new project_id: "project-id", credentials: "path/to/keyfile.json"
-                pubsub.must_be_kind_of Google::Cloud::PubSub::Project
-                pubsub.project.must_equal "project-id"
-                pubsub.service.must_be_kind_of OpenStruct
+                _(pubsub).must_be_kind_of Google::Cloud::PubSub::Project
+                _(pubsub.project).must_equal "project-id"
+                _(pubsub.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -187,16 +187,16 @@ describe Google::Cloud do
 
     it "uses provided project and keyfile aliases" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "pubsub-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "pubsub-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "pubsub-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -207,9 +207,9 @@ describe Google::Cloud do
             Google::Cloud::PubSub::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::PubSub::Service.stub :new, stubbed_service do
                 pubsub = Google::Cloud::PubSub.new project: "project-id", keyfile: "path/to/keyfile.json"
-                pubsub.must_be_kind_of Google::Cloud::PubSub::Project
-                pubsub.project.must_equal "project-id"
-                pubsub.service.must_be_kind_of OpenStruct
+                _(pubsub).must_be_kind_of Google::Cloud::PubSub::Project
+                _(pubsub.project).must_equal "project-id"
+                _(pubsub.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -226,10 +226,10 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::PubSub::Credentials.stub :default, default_credentials do
             pubsub = Google::Cloud::PubSub.new
-            pubsub.must_be_kind_of Google::Cloud::PubSub::Project
-            pubsub.project.must_equal "project-id"
-            pubsub.service.credentials.must_equal :this_channel_is_insecure
-            pubsub.service.host.must_equal emulator_host
+            _(pubsub).must_be_kind_of Google::Cloud::PubSub::Project
+            _(pubsub.project).must_equal "project-id"
+            _(pubsub.service.credentials).must_equal :this_channel_is_insecure
+            _(pubsub.service.host).must_equal emulator_host
           end
         end
       end
@@ -239,11 +239,11 @@ describe Google::Cloud do
       endpoint = "localhost:4567"
 
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal default_credentials
-        timeout.must_be :nil?
-        host.must_equal endpoint
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(timeout).must_be :nil?
+        _(host).must_equal endpoint
+        _(client_config).must_be :nil?
         OpenStruct.new project: project, credentials: credentials
       }
 
@@ -254,9 +254,9 @@ describe Google::Cloud do
           Google::Cloud::PubSub::Credentials.stub :default, default_credentials do
             Google::Cloud::PubSub::Service.stub :new, stubbed_service do
               pubsub = Google::Cloud::PubSub.new endpoint: endpoint
-              pubsub.must_be_kind_of Google::Cloud::PubSub::Project
-              pubsub.project.must_equal "project-id"
-              pubsub.service.credentials.must_equal default_credentials
+              _(pubsub).must_be_kind_of Google::Cloud::PubSub::Project
+              _(pubsub.project).must_equal "project-id"
+              _(pubsub.service.credentials).must_equal default_credentials
             end
           end
         end
@@ -271,10 +271,10 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::PubSub::Credentials.stub :default, default_credentials do
             pubsub = Google::Cloud::PubSub.new emulator_host: emulator_host
-            pubsub.must_be_kind_of Google::Cloud::PubSub::Project
-            pubsub.project.must_equal "project-id"
-            pubsub.service.credentials.must_equal :this_channel_is_insecure
-            pubsub.service.host.must_equal emulator_host
+            _(pubsub).must_be_kind_of Google::Cloud::PubSub::Project
+            _(pubsub.project).must_equal "project-id"
+            _(pubsub.service.credentials).must_equal :this_channel_is_insecure
+            _(pubsub.service.host).must_equal emulator_host
           end
         end
       end
@@ -282,17 +282,17 @@ describe Google::Cloud do
 
     it "gets project_id from credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         OpenStruct.new project_id: "project-id"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_be_kind_of OpenStruct
-        credentials.project_id.must_equal "project-id"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_be_kind_of OpenStruct
+        _(credentials.project_id).must_equal "project-id"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
       empty_env = OpenStruct.new
@@ -305,9 +305,9 @@ describe Google::Cloud do
               Google::Cloud::PubSub::Credentials.stub :new, stubbed_credentials do
                 Google::Cloud::PubSub::Service.stub :new, stubbed_service do
                   pubsub = Google::Cloud::PubSub.new credentials: "path/to/keyfile.json"
-                  pubsub.must_be_kind_of Google::Cloud::PubSub::Project
-                  pubsub.project.must_equal "project-id"
-                  pubsub.service.must_be_kind_of OpenStruct
+                  _(pubsub).must_be_kind_of Google::Cloud::PubSub::Project
+                  _(pubsub.project).must_equal "project-id"
+                  _(pubsub.service).must_be_kind_of OpenStruct
                 end
               end
             end
@@ -331,16 +331,16 @@ describe Google::Cloud do
 
     it "uses shared config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "pubsub-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "pubsub-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "pubsub-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -357,9 +357,9 @@ describe Google::Cloud do
             Google::Cloud::PubSub::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::PubSub::Service.stub :new, stubbed_service do
                 pubsub = Google::Cloud::PubSub.new
-                pubsub.must_be_kind_of Google::Cloud::PubSub::Project
-                pubsub.project.must_equal "project-id"
-                pubsub.service.must_be_kind_of OpenStruct
+                _(pubsub).must_be_kind_of Google::Cloud::PubSub::Project
+                _(pubsub.project).must_equal "project-id"
+                _(pubsub.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -369,16 +369,16 @@ describe Google::Cloud do
 
     it "uses shared config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "pubsub-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "pubsub-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "pubsub-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -395,9 +395,9 @@ describe Google::Cloud do
             Google::Cloud::PubSub::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::PubSub::Service.stub :new, stubbed_service do
                 pubsub = Google::Cloud::PubSub.new
-                pubsub.must_be_kind_of Google::Cloud::PubSub::Project
-                pubsub.project.must_equal "project-id"
-                pubsub.service.must_be_kind_of OpenStruct
+                _(pubsub).must_be_kind_of Google::Cloud::PubSub::Project
+                _(pubsub.project).must_equal "project-id"
+                _(pubsub.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -407,15 +407,15 @@ describe Google::Cloud do
 
     it "uses pubsub config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "pubsub-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "pubsub-credentials"
-        timeout.must_equal 42
-        client_config.must_equal pubsub_client_config
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "pubsub-credentials"
+        _(timeout).must_equal 42
+        _(client_config).must_equal pubsub_client_config
         OpenStruct.new project: project
       }
 
@@ -434,9 +434,9 @@ describe Google::Cloud do
             Google::Cloud::PubSub::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::PubSub::Service.stub :new, stubbed_service do
                 pubsub = Google::Cloud::PubSub.new
-                pubsub.must_be_kind_of Google::Cloud::PubSub::Project
-                pubsub.project.must_equal "project-id"
-                pubsub.service.must_be_kind_of OpenStruct
+                _(pubsub).must_be_kind_of Google::Cloud::PubSub::Project
+                _(pubsub.project).must_equal "project-id"
+                _(pubsub.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -446,15 +446,15 @@ describe Google::Cloud do
 
     it "uses pubsub config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "pubsub-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "pubsub-credentials"
-        timeout.must_equal 42
-        client_config.must_equal pubsub_client_config
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "pubsub-credentials"
+        _(timeout).must_equal 42
+        _(client_config).must_equal pubsub_client_config
         OpenStruct.new project: project
       }
 
@@ -473,9 +473,9 @@ describe Google::Cloud do
             Google::Cloud::PubSub::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::PubSub::Service.stub :new, stubbed_service do
                 pubsub = Google::Cloud::PubSub.new
-                pubsub.must_be_kind_of Google::Cloud::PubSub::Project
-                pubsub.project.must_equal "project-id"
-                pubsub.service.must_be_kind_of OpenStruct
+                _(pubsub).must_be_kind_of Google::Cloud::PubSub::Project
+                _(pubsub.project).must_equal "project-id"
+                _(pubsub.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -493,10 +493,10 @@ describe Google::Cloud do
         end
 
         pubsub = Google::Cloud::PubSub.new
-        pubsub.must_be_kind_of Google::Cloud::PubSub::Project
-        pubsub.project.must_equal "project-id"
-        pubsub.service.credentials.must_equal :this_channel_is_insecure
-        pubsub.service.host.must_equal "localhost:4567"
+        _(pubsub).must_be_kind_of Google::Cloud::PubSub::Project
+        _(pubsub.project).must_equal "project-id"
+        _(pubsub.service.credentials).must_equal :this_channel_is_insecure
+        _(pubsub.service.host).must_equal "localhost:4567"
       end
     end
   end


### PR DESCRIPTION
Use `rubocop-minitest` gem and `bundle exec rubocop --only Minitest/GlobalExpectations -a` to autocorrect minitest warnings for Ruby 2.7.

refs: #4110
refs: #4116