### PR TITLE
chore(bigquery): Update minitest to 5.14

### DIFF
--- a/google-cloud-bigquery/.rubocop.yml
+++ b/google-cloud-bigquery/.rubocop.yml
@@ -1,12 +1,12 @@
+require: rubocop-minitest
+
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
     - "support/**/*"
     - "benchmark/**/*"
-    - "test/**/*"
 
 Documentation:
   Enabled: false

--- a/google-cloud-bigquery/.rubocop.yml
+++ b/google-cloud-bigquery/.rubocop.yml
@@ -1,12 +1,12 @@
-require: rubocop-minitest
-
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
+    - "acceptance/**/*"
     - "support/**/*"
     - "benchmark/**/*"
+    - "test/**/*"
 
 Documentation:
   Enabled: false

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -9,3 +9,5 @@ gem "google-cloud-storage", path: "../google-cloud-storage"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
+
+gem "rubocop-minitest"

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -9,7 +9,3 @@ gem "google-cloud-storage", path: "../google-cloud-storage"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
-
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -9,5 +9,3 @@ gem "google-cloud-storage", path: "../google-cloud-storage"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
-
-gem "rubocop-minitest"

--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -63,30 +63,30 @@ describe Google::Cloud::Bigquery, :bigquery do
 
   it "should get its project service account email" do
     email = bigquery.service_account_email
-    email.wont_be :nil?
-    email.must_be_kind_of String
+    _(email).wont_be :nil?
+    _(email).must_be_kind_of String
     # https://stackoverflow.com/questions/22993545/ruby-email-validation-with-regex
-    email.must_match /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+    _(email).must_match /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
   end
 
   it "should get a list of datasets" do
     datasets = bigquery.datasets max: 1
     # The code in before ensures we have at least one dataset
-    datasets.count.wont_be :zero?
+    _(datasets.count).wont_be :zero?
     datasets.all(request_limit: 1).each do |ds|
-      ds.must_be_kind_of Google::Cloud::Bigquery::Dataset
-      ds.created_at.must_be_kind_of Time # Loads full representation
+      _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset
+      _(ds.created_at).must_be_kind_of Time # Loads full representation
     end
     more_datasets = datasets.next
-    more_datasets.wont_be :nil?
+    _(more_datasets).wont_be :nil?
   end
 
   it "should get a list of datasets by labels filter" do
     datasets = bigquery.datasets filter: filter
-    datasets.count.must_equal 1
+    _(datasets.count).must_equal 1
     ds = datasets.first
-    ds.must_be_kind_of Google::Cloud::Bigquery::Dataset
-    ds.labels.must_equal labels
+    _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(ds.labels).must_equal labels
   end
 
   it "create a dataset with access rules" do
@@ -96,94 +96,94 @@ describe Google::Cloud::Bigquery, :bigquery do
       end
     end
     fresh = bigquery.dataset dataset_with_access_id
-    fresh.wont_be :nil?
-    fresh.access.wont_be :empty?
-    fresh.access.to_a.must_be_kind_of Array
+    _(fresh).wont_be :nil?
+    _(fresh.access).wont_be :empty?
+    _(fresh.access.to_a).must_be_kind_of Array
     assert fresh.access.writer_special? :all
   end
 
   it "should run a query" do
     rows = bigquery.query publicdata_query
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 100
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 100
   end
 
   it "should run a query without legacy SQL syntax" do
     rows = bigquery.query publicdata_query, legacy_sql: false
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 100
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 100
   end
 
   it "should run a query with standard SQL syntax" do
     rows = bigquery.query publicdata_query, standard_sql: true
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 100
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 100
   end
 
   it "should run a query job with job id" do
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     job = bigquery.query_job publicdata_query, job_id: job_id
-    job.must_be_kind_of Google::Cloud::Bigquery::Job
-    job.job_id.must_equal job_id
-    job.user_email.wont_be_nil
+    _(job).must_be_kind_of Google::Cloud::Bigquery::Job
+    _(job.job_id).must_equal job_id
+    _(job.user_email).wont_be_nil
 
-    job.range_partitioning?.must_equal false
-    job.range_partitioning_field.must_be_nil
-    job.range_partitioning_start.must_be_nil
-    job.range_partitioning_interval.must_be_nil
-    job.range_partitioning_end.must_be_nil
-    job.time_partitioning?.must_equal false
-    job.time_partitioning_type.must_be :nil?
-    job.time_partitioning_field.must_be :nil?
-    job.time_partitioning_expiration.must_be :nil?
-    job.time_partitioning_require_filter?.must_equal false
-    job.clustering?.must_equal false
-    job.clustering_fields.must_be :nil?
+    _(job.range_partitioning?).must_equal false
+    _(job.range_partitioning_field).must_be_nil
+    _(job.range_partitioning_start).must_be_nil
+    _(job.range_partitioning_interval).must_be_nil
+    _(job.range_partitioning_end).must_be_nil
+    _(job.time_partitioning?).must_equal false
+    _(job.time_partitioning_type).must_be :nil?
+    _(job.time_partitioning_field).must_be :nil?
+    _(job.time_partitioning_expiration).must_be :nil?
+    _(job.time_partitioning_require_filter?).must_equal false
+    _(job.clustering?).must_equal false
+    _(job.clustering_fields).must_be :nil?
 
     job.wait_until_done!
     rows = job.data
-    rows.total.must_equal 100
+    _(rows.total).must_equal 100
 
     # @gapi.statistics.query
-    job.bytes_processed.must_equal 0
-    job.query_plan.must_be :nil?
+    _(job.bytes_processed).must_equal 0
+    _(job.query_plan).must_be :nil?
     # Sometimes values are nil in the returned job, so currently comment out unreliable expectations
     # job.statement_type.must_equal "SELECT"
-    job.ddl_operation_performed.must_be :nil?
-    job.ddl_target_table.must_be :nil?
-    job.ddl_target_routine.must_be :nil?
+    _(job.ddl_operation_performed).must_be :nil?
+    _(job.ddl_target_table).must_be :nil?
+    _(job.ddl_target_routine).must_be :nil?
   end
 
   it "should run a query job with dryrun flag" do
     job = bigquery.query_job publicdata_query, dryrun: true
-    job.dryrun?.must_equal true
-    job.dryrun.must_equal true # alias
-    job.dry_run.must_equal true # alias
-    job.dry_run?.must_equal true # alias
+    _(job.dryrun?).must_equal true
+    _(job.dryrun).must_equal true # alias
+    _(job.dry_run).must_equal true # alias
+    _(job.dry_run?).must_equal true # alias
 
     job.wait_until_done!
     data = job.data
-    data.count.must_equal 0
-    data.next?.must_equal false
-    data.total.must_be :nil?
-    data.schema.must_be :nil?
-    data.statement_type.must_equal "SELECT"
+    _(data.count).must_equal 0
+    _(data.next?).must_equal false
+    _(data.total).must_be :nil?
+    _(data.schema).must_be :nil?
+    _(data.statement_type).must_equal "SELECT"
 
     # @gapi.statistics.query
-    job.bytes_processed.must_be :>, 0 # 155625782
-    job.query_plan.must_be :nil?
+    _(job.bytes_processed).must_be :>, 0 # 155625782
+    _(job.query_plan).must_be :nil?
   end
 
   it "should run a query job with job labels" do
     job = bigquery.query_job publicdata_query, labels: labels
-    job.must_be_kind_of Google::Cloud::Bigquery::Job
-    job.labels.must_equal labels
+    _(job).must_be_kind_of Google::Cloud::Bigquery::Job
+    _(job.labels).must_equal labels
   end
 
   it "should run a query job with user defined function resources" do
     job = bigquery.query_job publicdata_query, udfs: udfs
-    job.must_be_kind_of Google::Cloud::Bigquery::Job
-    job.udfs.must_equal udfs
+    _(job).must_be_kind_of Google::Cloud::Bigquery::Job
+    _(job.udfs).must_equal udfs
   end
 
   it "should run a query job with job labels and user defined function resources in a block updater" do
@@ -191,26 +191,26 @@ describe Google::Cloud::Bigquery, :bigquery do
       j.labels = labels
       j.udfs = udfs
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::Job
-    job.labels.must_equal labels
-    job.udfs.must_equal udfs
+    _(job).must_be_kind_of Google::Cloud::Bigquery::Job
+    _(job.labels).must_equal labels
+    _(job.udfs).must_equal udfs
   end
 
   it "should get a list of jobs" do
     jobs = bigquery.jobs.all request_limit: 3
-    jobs.each { |job| job.must_be_kind_of Google::Cloud::Bigquery::Job }
+    jobs.each { |job| _(job).must_be_kind_of Google::Cloud::Bigquery::Job }
   end
 
   it "should get a list of projects" do
     projects = bigquery.projects.all
-    projects.count.must_be :>, 0
+    _(projects.count).must_be :>, 0
     projects.each do |project|
-      project.must_be_kind_of Google::Cloud::Bigquery::Project
-      project.name.must_be_kind_of String
-      project.service.must_be_kind_of Google::Cloud::Bigquery::Service
-      project.service.project.must_be_kind_of String
+      _(project).must_be_kind_of Google::Cloud::Bigquery::Project
+      _(project.name).must_be_kind_of String
+      _(project.service).must_be_kind_of Google::Cloud::Bigquery::Service
+      _(project.service.project).must_be_kind_of String
       project.datasets.each do |ds|
-        ds.must_be_kind_of Google::Cloud::Bigquery::Dataset
+        _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset
       end
     end
   end
@@ -222,11 +222,11 @@ describe Google::Cloud::Bigquery, :bigquery do
       result = bigquery.extract samples_public_table, extract_url do |j|
         j.location = "US"
       end
-      result.must_equal true
+      _(result).must_equal true
 
       extract_file = bucket.file dest_file_name
       downloaded_file = extract_file.download tmp.path
-      downloaded_file.size.must_be :>, 0
+      _(downloaded_file.size).must_be :>, 0
     end
   end
 
@@ -234,6 +234,6 @@ describe Google::Cloud::Bigquery, :bigquery do
     result = bigquery.copy samples_public_table, "#{dataset_id}.shakespeare_copy", create: :needed, write: :empty do |j|
       j.location = "US"
     end
-    result.must_equal true
+    _(result).must_equal true
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_access_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_access_test.rb
@@ -61,8 +61,8 @@ describe Google::Cloud::Bigquery::Dataset, :access, :bigquery do
       acl.add_reader_special :all
     end
     dataset = bigquery.dataset dataset_id
-    dataset.access.wont_be :empty?
-    dataset.access.to_a.must_be_kind_of Array
+    _(dataset.access).wont_be :empty?
+    _(dataset.access.to_a).must_be_kind_of Array
     assert dataset.access.reader_special? :all
 
     dataset.access do |acl|

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_ddl_dml_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_ddl_dml_test.rb
@@ -29,90 +29,90 @@ describe Google::Cloud::Bigquery::Dataset, :ddl_dml, :bigquery do
   it "creates and populates and drops a table with ddl/dml query jobs" do
     create_job = dataset.query_job "CREATE TABLE #{table_id} (x INT64)"
     create_job.wait_until_done!
-    create_job.wont_be :failed?
+    _(create_job).wont_be :failed?
 
-    create_job.statement_type.must_equal "CREATE_TABLE"
-    create_job.ddl_operation_performed.must_equal "CREATE"
+    _(create_job.statement_type).must_equal "CREATE_TABLE"
+    _(create_job.ddl_operation_performed).must_equal "CREATE"
     assert_table_ref create_job.ddl_target_table, table_id
-    create_job.num_dml_affected_rows.must_be :nil?
+    _(create_job.num_dml_affected_rows).must_be :nil?
 
     insert_job = dataset.query_job "INSERT #{table_id} (x) VALUES(101),(102)"
     insert_job.wait_until_done!
-    insert_job.wont_be :failed?
-    insert_job.statement_type.must_equal "INSERT"
-    insert_job.num_dml_affected_rows.must_equal 2
+    _(insert_job).wont_be :failed?
+    _(insert_job.statement_type).must_equal "INSERT"
+    _(insert_job.num_dml_affected_rows).must_equal 2
 
     update_job = dataset.query_job "UPDATE #{table_id} SET x = x + 1 WHERE x IS NOT NULL"
     update_job.wait_until_done!
-    update_job.wont_be :failed?
-    update_job.statement_type.must_equal "UPDATE"
-    update_job.num_dml_affected_rows.must_equal 2
+    _(update_job).wont_be :failed?
+    _(update_job.statement_type).must_equal "UPDATE"
+    _(update_job.num_dml_affected_rows).must_equal 2
 
     delete_job = dataset.query_job "DELETE #{table_id} WHERE x = 103"
     delete_job.wait_until_done!
-    delete_job.wont_be :failed?
-    delete_job.statement_type.must_equal "DELETE"
-    delete_job.num_dml_affected_rows.must_equal 1
+    _(delete_job).wont_be :failed?
+    _(delete_job.statement_type).must_equal "DELETE"
+    _(delete_job.num_dml_affected_rows).must_equal 1
 
     drop_job = dataset.query_job "DROP TABLE #{table_id}"
     drop_job.wait_until_done!
-    drop_job.wont_be :failed?
-    drop_job.statement_type.must_equal "DROP_TABLE"
-    drop_job.ddl_operation_performed.must_equal "DROP"
+    _(drop_job).wont_be :failed?
+    _(drop_job.statement_type).must_equal "DROP_TABLE"
+    _(drop_job.ddl_operation_performed).must_equal "DROP"
     assert_table_ref drop_job.ddl_target_table, table_id, exists: false
-    drop_job.num_dml_affected_rows.must_be :nil?
+    _(drop_job.num_dml_affected_rows).must_be :nil?
   end
 
   it "creates and populates and drops a table with ddl/dml queries" do
     create_data = dataset.query "CREATE TABLE #{table_id_2} (x INT64)"
     assert_table_ref create_data.ddl_target_table, table_id_2
-    create_data.statement_type.must_equal "CREATE_TABLE"
-    create_data.ddl?.must_equal true
-    create_data.dml?.must_equal false
-    create_data.ddl_operation_performed.must_equal "CREATE"
-    create_data.num_dml_affected_rows.must_be :nil?
-    create_data.total.must_be :nil?
-    create_data.next?.must_equal false
-    create_data.next.must_be :nil?
-    create_data.all.must_be_kind_of Enumerator
-    create_data.count.must_equal 0
-    create_data.to_a.must_equal []
+    _(create_data.statement_type).must_equal "CREATE_TABLE"
+    _(create_data.ddl?).must_equal true
+    _(create_data.dml?).must_equal false
+    _(create_data.ddl_operation_performed).must_equal "CREATE"
+    _(create_data.num_dml_affected_rows).must_be :nil?
+    _(create_data.total).must_be :nil?
+    _(create_data.next?).must_equal false
+    _(create_data.next).must_be :nil?
+    _(create_data.all).must_be_kind_of Enumerator
+    _(create_data.count).must_equal 0
+    _(create_data.to_a).must_equal []
 
     insert_data = dataset.query "INSERT #{table_id_2} (x) VALUES(101),(102)"
-    insert_data.ddl_target_table.must_be :nil?
-    insert_data.statement_type.must_equal "INSERT"
-    insert_data.ddl?.must_equal false
-    insert_data.dml?.must_equal true
-    insert_data.ddl_operation_performed.must_be :nil?
-    insert_data.num_dml_affected_rows.must_equal 2
-    insert_data.total.must_be :nil?
-    insert_data.next?.must_equal false
-    insert_data.next.must_be :nil?
-    insert_data.all.must_be_kind_of Enumerator
-    insert_data.count.must_equal 0
-    insert_data.to_a.must_equal []
+    _(insert_data.ddl_target_table).must_be :nil?
+    _(insert_data.statement_type).must_equal "INSERT"
+    _(insert_data.ddl?).must_equal false
+    _(insert_data.dml?).must_equal true
+    _(insert_data.ddl_operation_performed).must_be :nil?
+    _(insert_data.num_dml_affected_rows).must_equal 2
+    _(insert_data.total).must_be :nil?
+    _(insert_data.next?).must_equal false
+    _(insert_data.next).must_be :nil?
+    _(insert_data.all).must_be_kind_of Enumerator
+    _(insert_data.count).must_equal 0
+    _(insert_data.to_a).must_equal []
 
     update_data = dataset.query "UPDATE #{table_id_2} SET x = x + 1 WHERE x IS NOT NULL"
-    update_data.statement_type.must_equal "UPDATE"
-    update_data.num_dml_affected_rows.must_equal 2
+    _(update_data.statement_type).must_equal "UPDATE"
+    _(update_data.num_dml_affected_rows).must_equal 2
 
     delete_data = dataset.query "DELETE #{table_id_2} WHERE x = 103"
-    delete_data.statement_type.must_equal "DELETE"
-    delete_data.num_dml_affected_rows.must_equal 1
+    _(delete_data.statement_type).must_equal "DELETE"
+    _(delete_data.num_dml_affected_rows).must_equal 1
 
     drop_data = dataset.query "DROP TABLE #{table_id_2}"
-    drop_data.statement_type.must_equal "DROP_TABLE"
-    drop_data.ddl_operation_performed.must_equal "DROP"
-    drop_data.num_dml_affected_rows.must_be :nil?
+    _(drop_data.statement_type).must_equal "DROP_TABLE"
+    _(drop_data.ddl_operation_performed).must_equal "DROP"
+    _(drop_data.num_dml_affected_rows).must_be :nil?
     assert_table_ref drop_data.ddl_target_table, table_id_2, exists: false
   end
 
   def assert_table_ref table_ref, table_id, exists: true
-    table_ref.must_be_kind_of Google::Cloud::Bigquery::Table
-    table_ref.project_id.must_equal bigquery.project
-    table_ref.dataset_id.must_equal dataset_id
-    table_ref.table_id.must_equal table_id
-    table_ref.reference?.must_equal true
-    table_ref.exists?.must_equal exists
+    _(table_ref).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table_ref.project_id).must_equal bigquery.project
+    _(table_ref.dataset_id).must_equal dataset_id
+    _(table_ref.table_id).must_equal table_id
+    _(table_ref.reference?).must_equal true
+    _(table_ref.exists?).must_equal exists
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
@@ -83,36 +83,36 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
   end
 
   it "has the attributes of a dataset after reload" do
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
-    dataset.project_id.must_equal bigquery.project
-    dataset.dataset_id.must_equal dataset.dataset_id
-    dataset.etag.must_be_nil
-    dataset.api_url.must_be_nil
-    dataset.created_at.must_be_nil
-    dataset.modified_at.must_be_nil
-    dataset.dataset_ref.must_be_kind_of Hash
-    dataset.dataset_ref[:project_id].must_equal bigquery.project
-    dataset.dataset_ref[:dataset_id].must_equal dataset.dataset_id
+    _(dataset).must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(dataset.project_id).must_equal bigquery.project
+    _(dataset.dataset_id).must_equal dataset.dataset_id
+    _(dataset.etag).must_be_nil
+    _(dataset.api_url).must_be_nil
+    _(dataset.created_at).must_be_nil
+    _(dataset.modified_at).must_be_nil
+    _(dataset.dataset_ref).must_be_kind_of Hash
+    _(dataset.dataset_ref[:project_id]).must_equal bigquery.project
+    _(dataset.dataset_ref[:dataset_id]).must_equal dataset.dataset_id
 
     dataset.reload!
 
-    dataset.project_id.must_equal bigquery.project
-    dataset.dataset_id.must_equal dataset.dataset_id
-    dataset.etag.wont_be_nil
-    dataset.api_url.wont_be_nil
-    dataset.created_at.must_be_kind_of Time
-    dataset.modified_at.must_be_kind_of Time
-    dataset.dataset_ref.must_be_kind_of Hash
-    dataset.dataset_ref[:project_id].must_equal bigquery.project
-    dataset.dataset_ref[:dataset_id].must_equal dataset.dataset_id
+    _(dataset.project_id).must_equal bigquery.project
+    _(dataset.dataset_id).must_equal dataset.dataset_id
+    _(dataset.etag).wont_be_nil
+    _(dataset.api_url).wont_be_nil
+    _(dataset.created_at).must_be_kind_of Time
+    _(dataset.modified_at).must_be_kind_of Time
+    _(dataset.dataset_ref).must_be_kind_of Hash
+    _(dataset.dataset_ref[:project_id]).must_equal bigquery.project
+    _(dataset.dataset_ref[:dataset_id]).must_equal dataset.dataset_id
   end
 
   it "deletes itself and knows it no longer exists" do
-    dataset.exists?.must_equal true
+    _(dataset.exists?).must_equal true
     dataset.tables.all(&:delete)
-    dataset.delete.must_equal true
-    dataset.exists?.must_equal false
-    dataset.exists?(force: true).must_equal false
+    _(dataset.delete).must_equal true
+    _(dataset.exists?).must_equal false
+    _(dataset.exists?(force: true)).must_equal false
   end
 
   it "should set & get metadata" do
@@ -127,13 +127,13 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
     dataset.labels = new_labels
 
     fresh = bigquery.dataset dataset.dataset_id
-    fresh.wont_be_nil
-    fresh.must_be_kind_of Google::Cloud::Bigquery::Dataset
-    fresh.dataset_id.must_equal dataset.dataset_id
-    fresh.name.must_equal new_name
-    fresh.description.must_equal new_desc
-    fresh.default_expiration.must_equal new_default_expiration
-    fresh.labels.must_equal new_labels
+    _(fresh).wont_be_nil
+    _(fresh).must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(fresh.dataset_id).must_equal dataset.dataset_id
+    _(fresh.name).must_equal new_name
+    _(fresh.description).must_equal new_desc
+    _(fresh.default_expiration).must_equal new_default_expiration
+    _(fresh.labels).must_equal new_labels
 
     dataset.default_expiration = nil
   end
@@ -141,19 +141,19 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
   it "should get a list of tables and views" do
     tables = dataset.tables
     # The code in before ensures we have at least one dataset
-    tables.count.must_be :>=, 2
+    _(tables.count).must_be :>=, 2
     tables.each do |t|
-      t.table_id.wont_be_nil
-      t.created_at.must_be_kind_of Time # Loads full representation
+      _(t.table_id).wont_be_nil
+      _(t.created_at).must_be_kind_of Time # Loads full representation
     end
   end
 
   it "should get all tables and views in pages with token" do
     tables = dataset.tables(max: 1).all
-    tables.count.must_be :>=, 2
+    _(tables.count).must_be :>=, 2
     tables.each do |t|
-      t.table_id.wont_be_nil
-      t.created_at.must_be_kind_of Time # Loads full representation
+      _(t.table_id).wont_be_nil
+      _(t.created_at).must_be_kind_of Time # Loads full representation
     end
   end
 
@@ -164,7 +164,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
       schema.string    "name",  description: "name description",  mode: :required
       schema.timestamp "dob",   description: "dob description",   mode: :required
     end
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "imports data from a list of files in your bucket with load_job" do
@@ -176,9 +176,9 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
     # Test both by file object and URL as string
     job = dataset.load_job table_id, [file1, gs_url]
     job.wait_until_done!
-    job.wont_be :failed?
-    job.input_files.must_equal 2
-    job.output_rows.must_equal 6
+    _(job).wont_be :failed?
+    _(job.input_files).must_equal 2
+    _(job.output_rows).must_equal 6
   end
 
   it "imports data from a list of files in your bucket with load" do
@@ -189,7 +189,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
 
     # Test both by file object and URL as string
     result = dataset.load table_id, [file1, gs_url]
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "adds an access entry with specifying user scope" do
@@ -208,21 +208,21 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
 
   it "inserts rows directly and gets its data" do
     insert_response = table.insert rows
-    insert_response.must_be :success?
-    insert_response.insert_count.must_equal 3
-    insert_response.insert_errors.must_be :empty?
-    insert_response.error_rows.must_be :empty?
+    _(insert_response).must_be :success?
+    _(insert_response.insert_count).must_equal 3
+    _(insert_response.insert_errors).must_be :empty?
+    _(insert_response.error_rows).must_be :empty?
 
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     query_job = dataset.query_job query, job_id: job_id
-    query_job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    query_job.job_id.must_equal job_id
+    _(query_job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(query_job.job_id).must_equal job_id
     query_job.wait_until_done!
-    query_job.done?.must_equal true
-    query_job.data.total.wont_be_nil
+    _(query_job.done?).must_equal true
+    _(query_job.data.total).wont_be_nil
 
     data = dataset.query query
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.total.wont_be_nil
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.total).wont_be_nil
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -92,26 +92,26 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
 
   it "has the attributes of a dataset" do
     fresh = bigquery.dataset dataset_id
-    fresh.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(fresh).must_be_kind_of Google::Cloud::Bigquery::Dataset
 
-    fresh.project_id.must_equal bigquery.project
-    fresh.dataset_id.must_equal dataset.dataset_id
-    fresh.etag.wont_be :nil?
-    fresh.api_url.wont_be :nil?
-    fresh.created_at.must_be_kind_of Time
-    fresh.modified_at.must_be_kind_of Time
-    fresh.dataset_ref.must_be_kind_of Hash
-    fresh.dataset_ref[:project_id].must_equal bigquery.project
-    fresh.dataset_ref[:dataset_id].must_equal dataset.dataset_id
+    _(fresh.project_id).must_equal bigquery.project
+    _(fresh.dataset_id).must_equal dataset.dataset_id
+    _(fresh.etag).wont_be :nil?
+    _(fresh.api_url).wont_be :nil?
+    _(fresh.created_at).must_be_kind_of Time
+    _(fresh.modified_at).must_be_kind_of Time
+    _(fresh.dataset_ref).must_be_kind_of Hash
+    _(fresh.dataset_ref[:project_id]).must_equal bigquery.project
+    _(fresh.dataset_ref[:dataset_id]).must_equal dataset.dataset_id
     # fresh.location.must_equal "US"       TODO why nil? Set in dataset
   end
 
   it "deletes itself and knows it no longer exists" do
-    dataset.exists?.must_equal true
+    _(dataset.exists?).must_equal true
     dataset.tables.all(&:delete)
-    dataset.delete.must_equal true
-    dataset.exists?.must_equal false
-    dataset.exists?(force: true).must_equal false
+    _(dataset.delete).must_equal true
+    _(dataset.exists?).must_equal false
+    _(dataset.exists?(force: true)).must_equal false
   end
 
   it "should set & get metadata" do
@@ -126,58 +126,58 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     dataset.labels = new_labels
 
     fresh = bigquery.dataset dataset.dataset_id
-    fresh.wont_be :nil?
-    fresh.must_be_kind_of Google::Cloud::Bigquery::Dataset
-    fresh.dataset_id.must_equal dataset.dataset_id
-    fresh.name.must_equal new_name
-    fresh.description.must_equal new_desc
-    fresh.default_expiration.must_equal new_default_expiration
-    fresh.labels.must_equal new_labels
+    _(fresh).wont_be :nil?
+    _(fresh).must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(fresh.dataset_id).must_equal dataset.dataset_id
+    _(fresh.name).must_equal new_name
+    _(fresh.description).must_equal new_desc
+    _(fresh.default_expiration).must_equal new_default_expiration
+    _(fresh.labels).must_equal new_labels
 
     dataset.default_expiration = nil
   end
 
   it "should fail to set metadata with stale etag" do
     fresh = bigquery.dataset dataset.dataset_id
-    fresh.etag.wont_be :nil?
+    _(fresh.etag).wont_be :nil?
 
     stale = bigquery.dataset dataset_id
-    stale.etag.wont_be :nil?
-    stale.etag.must_equal fresh.etag
+    _(stale.etag).wont_be :nil?
+    _(stale.etag).must_equal fresh.etag
 
     # Modify on the server, which will change the etag
     fresh.description = "Description 1"
-    stale.etag.wont_equal fresh.etag
+    _(stale.etag).wont_equal fresh.etag
     err = expect { stale.description = "Description 2" }.must_raise Google::Cloud::FailedPreconditionError
-    err.message.must_equal "failedPrecondition: Precondition check failed."
+    _(err.message).must_equal "failedPrecondition: Precondition check failed."
   end
 
   it "create dataset returns valid etag equal to get dataset" do
     fresh_dataset_id = "#{prefix}_#{rand 100}_unique"
     fresh = bigquery.create_dataset fresh_dataset_id
-    fresh.etag.wont_be :nil?
+    _(fresh.etag).wont_be :nil?
 
     stale = bigquery.dataset fresh_dataset_id
-    stale.etag.wont_be :nil?
-    stale.etag.must_equal fresh.etag
+    _(stale.etag).wont_be :nil?
+    _(stale.etag).must_equal fresh.etag
   end
 
   it "should get a list of tables and views" do
     tables = dataset.tables
     # The code in before ensures we have at least one dataset
-    tables.count.must_be :>=, 2
+    _(tables.count).must_be :>=, 2
     tables.each do |t|
-      t.table_id.wont_be :nil?
-      t.created_at.must_be_kind_of Time # Loads full representation
+      _(t.table_id).wont_be :nil?
+      _(t.created_at).must_be_kind_of Time # Loads full representation
     end
   end
 
   it "should get all tables and views in pages with token" do
     tables = dataset.tables(max: 1).all
-    tables.count.must_be :>=, 2
+    _(tables.count).must_be :>=, 2
     tables.each do |t|
-      t.table_id.wont_be :nil?
-      t.created_at.must_be_kind_of Time # Loads full representation
+      _(t.table_id).wont_be :nil?
+      _(t.created_at).must_be_kind_of Time # Loads full representation
     end
   end
 
@@ -194,16 +194,16 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
       job.range_partitioning_interval = 10
       job.range_partitioning_end = 100
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job.job_id).must_equal job_id
     job.wait_until_done!
-    job.output_rows.must_equal 3
-    job.schema_update_options.must_equal schema_update_options
-    job.range_partitioning?.must_equal true
-    job.range_partitioning_field.must_equal "id"
-    job.range_partitioning_start.must_equal 0
-    job.range_partitioning_interval.must_equal 10
-    job.range_partitioning_end.must_equal 100
+    _(job.output_rows).must_equal 3
+    _(job.schema_update_options).must_equal schema_update_options
+    _(job.range_partitioning?).must_equal true
+    _(job.range_partitioning_field).must_equal "id"
+    _(job.range_partitioning_start).must_equal 0
+    _(job.range_partitioning_interval).must_equal 10
+    _(job.range_partitioning_end).must_equal 100
   end
 
   it "imports data from a local file and creates a new table with schema and time partitioning in a block with load_job" do
@@ -220,18 +220,18 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
       job.time_partitioning_require_filter = true
       job.clustering_fields = clustering_fields
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job.job_id).must_equal job_id
     job.wait_until_done!
-    job.output_rows.must_equal 3
-    job.schema_update_options.must_equal schema_update_options
-    job.time_partitioning?.must_equal true
-    job.time_partitioning_type.must_equal "DAY"
-    job.time_partitioning_field.must_equal "dob"
-    job.time_partitioning_expiration.must_equal 86_400
-    job.time_partitioning_require_filter?.must_equal true
-    job.clustering?.must_equal true
-    job.clustering_fields.must_equal clustering_fields
+    _(job.output_rows).must_equal 3
+    _(job.schema_update_options).must_equal schema_update_options
+    _(job.time_partitioning?).must_equal true
+    _(job.time_partitioning_type).must_equal "DAY"
+    _(job.time_partitioning_field).must_equal "dob"
+    _(job.time_partitioning_expiration).must_equal 86_400
+    _(job.time_partitioning_require_filter?).must_equal true
+    _(job.clustering?).must_equal true
+    _(job.clustering_fields).must_equal clustering_fields
   end
 
   it "imports data from a local file and creates a new table with schema as an option with load_job" do
@@ -245,13 +245,13 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     job = dataset.load_job "local_file_table_2", local_file, schema: schema
 
     job.wait_until_done!
-    job.output_rows.must_equal 3
+    _(job.output_rows).must_equal 3
   end
 
   it "imports data from a local file and creates a new table without a schema with load_job" do
     job = dataset.load_job table_with_schema.table_id, local_file, create: :never
     job.wait_until_done!
-    job.output_rows.must_equal 3
+    _(job.output_rows).must_equal 3
   end
 
   it "imports data from a list of files in your bucket with load_job" do
@@ -263,9 +263,9 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     # Test both by file object and URL as string
     job = dataset.load_job table_with_schema.table_id, [file1, gs_url]
     job.wait_until_done!
-    job.wont_be :failed?
-    job.input_files.must_equal 2
-    job.output_rows.must_equal 6
+    _(job).wont_be :failed?
+    _(job.input_files).must_equal 2
+    _(job.output_rows).must_equal 6
   end
 
   it "imports data from a local file and creates a new table with specified schema in a block with load" do
@@ -275,7 +275,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
       schema.string    "name",  description: "name description",  mode: :required
       schema.timestamp "dob",   description: "dob description",   mode: :required
     end
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "imports data from a local file and creates a new table with specified schema as an option with load" do
@@ -287,14 +287,14 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     end
 
     result = dataset.load "local_file_table_4", local_file, schema: schema
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "imports data from a local file and creates a new table without a schema with load" do
     result = dataset.load table_with_schema.table_id, local_file do |job|
       job.create = :never
     end
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "imports data from a list of files in your bucket with load" do
@@ -305,14 +305,14 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
 
     # Test both by file object and URL as string
     result = dataset.load table_with_schema.table_id, [file1, gs_url]
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "imports data from GCS Avro file and creates a new table with load" do
     result = dataset.load(
       table_avro_id,
       "gs://#{samples_bucket}/bigquery/us-states/us-states.avro")
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "imports data from GCS Avro file and creates a new table with encryption with load" do
@@ -323,65 +323,65 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
       load.write = :truncate
       load.encryption = encrypt_config
     end
-    result.must_equal true
+    _(result).must_equal true
     table_avro.reload!
-    table_avro.encryption.must_equal encrypt_config
+    _(table_avro.encryption).must_equal encrypt_config
   end
 
   it "imports data from a local ORC file and creates a new table without a schema with load" do
     result = dataset.load table_orc_id, local_orc_file
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "imports data from GCS ORC file and creates a new table with load" do
     result = dataset.load(
         table_orc_id,
         "gs://#{samples_bucket}/bigquery/us-states/us-states.orc")
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "imports data from a local Parquet file and creates a new table without a schema with load" do
     result = dataset.load table_parquet_id, local_parquet_file
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "imports data from GCS Parquet file and creates a new table with load" do
     result = dataset.load(
         table_parquet_id,
         "gs://#{samples_bucket}/bigquery/us-states/us-states.parquet")
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "inserts rows directly and gets its data" do
     insert_response = dataset.insert table_with_schema.table_id, rows
-    insert_response.must_be :success?
-    insert_response.insert_count.must_equal 3
-    insert_response.insert_errors.must_be :empty?
-    insert_response.error_rows.must_be :empty?
+    _(insert_response).must_be :success?
+    _(insert_response.insert_count).must_equal 3
+    _(insert_response.insert_errors).must_be :empty?
+    _(insert_response.error_rows).must_be :empty?
 
     assert_data table_with_schema.data(max: 1)
   end
 
   it "insert skip invalid rows and return insert errors" do
     insert_response = dataset.insert table_with_schema.table_id, invalid_rows, skip_invalid: true
-    insert_response.wont_be :success?
-    insert_response.insert_count.must_equal 2
+    _(insert_response).wont_be :success?
+    _(insert_response.insert_count).must_equal 2
 
-    insert_response.insert_errors.wont_be :empty?
-    insert_response.insert_errors.count.must_equal 1
-    insert_response.insert_errors.first.class.must_equal Google::Cloud::Bigquery::InsertResponse::InsertError
-    insert_response.insert_errors.first.index.must_equal 1
+    _(insert_response.insert_errors).wont_be :empty?
+    _(insert_response.insert_errors.count).must_equal 1
+    _(insert_response.insert_errors.first.class).must_equal Google::Cloud::Bigquery::InsertResponse::InsertError
+    _(insert_response.insert_errors.first.index).must_equal 1
 
     bigquery_row = invalid_rows[insert_response.insert_errors.first.index]
-    insert_response.insert_errors.first.row.must_equal bigquery_row
+    _(insert_response.insert_errors.first.row).must_equal bigquery_row
 
-    insert_response.error_rows.wont_be :empty?
-    insert_response.error_rows.count.must_equal 1
-    insert_response.error_rows.first.must_equal bigquery_row
+    _(insert_response.error_rows).wont_be :empty?
+    _(insert_response.error_rows.count).must_equal 1
+    _(insert_response.error_rows.first).must_equal bigquery_row
 
-    insert_response.insert_error_for(invalid_rows[1]).index.must_equal insert_response.insert_errors.first.index
-    insert_response.errors_for(invalid_rows[1]).wont_be :empty?
-    insert_response.index_for(invalid_rows[1]).must_equal 1
+    _(insert_response.insert_error_for(invalid_rows[1]).index).must_equal insert_response.insert_errors.first.index
+    _(insert_response.errors_for(invalid_rows[1])).wont_be :empty?
+    _(insert_response.index_for(invalid_rows[1])).must_equal 1
   end
 
   it "inserts rows with autocreate option" do
@@ -393,23 +393,23 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
       t.schema.timestamp "dob",   description: "dob description",   mode: :required
     end
 
-    insert_response.must_be :success?
-    insert_response.insert_count.must_equal 3
-    insert_response.insert_errors.must_be :empty?
-    insert_response.error_rows.must_be :empty?
+    _(insert_response).must_be :success?
+    _(insert_response.insert_count).must_equal 3
+    _(insert_response.insert_errors).must_be :empty?
+    _(insert_response.error_rows).must_be :empty?
 
     table = dataset.table table_with_schema_id
-    table.wont_be_nil
+    _(table).wont_be_nil
 
     assert_data table.data(max: 1)
   end
 
   it "inserts rows with insert_ids option" do
     insert_response = dataset.insert table_with_schema.table_id, rows, insert_ids: insert_ids
-    insert_response.must_be :success?
-    insert_response.insert_count.must_equal 3
-    insert_response.insert_errors.must_be :empty?
-    insert_response.error_rows.must_be :empty?
+    _(insert_response).must_be :success?
+    _(insert_response.insert_count).must_equal 3
+    _(insert_response.insert_errors).must_be :empty?
+    _(insert_response.error_rows).must_be :empty?
 
     assert_data table_with_schema.data(max: 1)
   end
@@ -424,13 +424,13 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
       t.schema.timestamp "dob",   description: "dob description",   mode: :required
     end
 
-    insert_response.must_be :success?
-    insert_response.insert_count.must_equal 3
-    insert_response.insert_errors.must_be :empty?
-    insert_response.error_rows.must_be :empty?
+    _(insert_response).must_be :success?
+    _(insert_response.insert_count).must_equal 3
+    _(insert_response.insert_errors).must_be :empty?
+    _(insert_response.error_rows).must_be :empty?
 
     table = dataset.table new_table_id
-    table.wont_be_nil
+    _(table).wont_be_nil
 
     assert_data table.data(max: 1)
   end

--- a/google-cloud-bigquery/acceptance/bigquery/legacy_query_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/legacy_query_test.rb
@@ -19,49 +19,49 @@ describe Google::Cloud::Bigquery, :legacy_query_types, :bigquery do
   it "queries a string value" do
     rows = bigquery.query "SELECT 'hello' AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal "hello"
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal "hello"
   end
 
   it "queries an integer value" do
     rows = bigquery.query "SELECT 999 AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal 999
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal 999
   end
 
   it "queries a float value" do
     rows = bigquery.query "SELECT 12.0 AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal 12.0
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal 12.0
   end
 
   it "queries a numeric value" do
     rows = bigquery.query "SELECT CAST('123456789.123456789' AS NUMERIC) AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal BigDecimal("123456789.123456789")
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
   end
 
   it "queries a boolean value" do
     rows = bigquery.query "SELECT false AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal false
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal false
   end
 
   it "queries a date value" do
     rows = bigquery.query "SELECT CAST(CURRENT_DATE() AS DATE) AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of Date
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of Date
   end
 
   it "queries a datetime value" do
@@ -71,25 +71,25 @@ describe Google::Cloud::Bigquery, :legacy_query_types, :bigquery do
   it "queries a timestamp value" do
     rows = bigquery.query "SELECT CAST(CURRENT_TIMESTAMP() AS TIMESTAMP) AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of ::Time
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of ::Time
   end
 
   it "queries a time value" do
     rows = bigquery.query "SELECT CAST(CURRENT_TIME() AS TIME) AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of Google::Cloud::Bigquery::Time
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of Google::Cloud::Bigquery::Time
   end
 
   it "queries a bytes value" do
     rows = bigquery.query "SELECT CAST('hello' AS BYTES) AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of StringIO
-    rows.first[:value].read.must_equal "hello"
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of StringIO
+    _(rows.first[:value].read).must_equal "hello"
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/location_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/location_test.rb
@@ -52,42 +52,42 @@ describe Google::Cloud::Bigquery, :location, :bigquery do
 
   it "creates a query job with location" do
     insert_response = table.insert rows
-    insert_response.must_be :success?
-    insert_response.insert_count.must_equal 3
-    insert_response.insert_errors.must_be :empty?
-    insert_response.error_rows.must_be :empty?
+    _(insert_response).must_be :success?
+    _(insert_response.insert_count).must_equal 3
+    _(insert_response.insert_errors).must_be :empty?
+    _(insert_response.error_rows).must_be :empty?
 
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     query_job = dataset.query_job query, job_id: job_id
 
-    query_job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    query_job.job_id.must_equal job_id
-    query_job.location.must_equal region
+    _(query_job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(query_job.job_id).must_equal job_id
+    _(query_job.location).must_equal region
     query_job.wait_until_done!
-    query_job.location.must_equal region
-    query_job.wont_be :failed?
+    _(query_job.location).must_equal region
+    _(query_job).wont_be :failed?
     query_job.rerun!
-    query_job.location.must_equal region
+    _(query_job.location).must_equal region
     query_job.wait_until_done!
-    query_job.location.must_equal region
-    query_job.wont_be :failed?
+    _(query_job.location).must_equal region
+    _(query_job).wont_be :failed?
 
-    query_job.data.class.must_equal Google::Cloud::Bigquery::Data
-    query_job.data.total.wont_be :nil?
+    _(query_job.data.class).must_equal Google::Cloud::Bigquery::Data
+    _(query_job.data.total).wont_be :nil?
 
     assert_data table.data(max: 1)
 
     data = dataset.query query
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.total.wont_be(:nil?)
-    data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    data.fields.count.must_equal 4
-    [:id, :breed, :name, :dob].each { |k| data.headers.must_include k }
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.total).wont_be(:nil?)
+    _(data.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(data.fields.count).must_equal 4
+    [:id, :breed, :name, :dob].each { |k| _(data.headers).must_include k }
     data.all.each do |row|
-      row.must_be_kind_of Hash
+      _(row).must_be_kind_of Hash
     end
-    data.next.must_be :nil?
+    _(data.next).must_be :nil?
   end
 
   it "creates a load job with location" do
@@ -98,10 +98,10 @@ describe Google::Cloud::Bigquery, :location, :bigquery do
       # Load the file to a dataset in the region with an load job in the region.
       job = table.load_job load_file
 
-      job.location.must_equal region
+      _(job.location).must_equal region
       job.wait_until_done!
-      job.location.must_equal region
-      job.wont_be :failed?
+      _(job.location).must_equal region
+      _(job).wont_be :failed?
     ensure
       post_bucket = storage.bucket "#{prefix}_load_loc"
       if post_bucket
@@ -118,49 +118,49 @@ describe Google::Cloud::Bigquery, :location, :bigquery do
       j.write = :empty
     end
 
-    copy_job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    copy_job.job_id.must_equal job_id
-    copy_job.location.must_equal region
+    _(copy_job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(copy_job.job_id).must_equal job_id
+    _(copy_job.location).must_equal region
     copy_job.wait_until_done!
 
-    copy_job.wont_be :failed?
-    copy_job.location.must_equal region
-    copy_job.source.table_id.must_equal table.table_id
-    copy_job.destination.table_id.must_equal target_table_2_id
-    copy_job.create_if_needed?.must_equal true
-    copy_job.create_never?.must_equal false
-    copy_job.write_truncate?.must_equal false
-    copy_job.write_append?.must_equal false
-    copy_job.write_empty?.must_equal true
+    _(copy_job).wont_be :failed?
+    _(copy_job.location).must_equal region
+    _(copy_job.source.table_id).must_equal table.table_id
+    _(copy_job.destination.table_id).must_equal target_table_2_id
+    _(copy_job.create_if_needed?).must_equal true
+    _(copy_job.create_never?).must_equal false
+    _(copy_job.write_truncate?).must_equal false
+    _(copy_job.write_append?).must_equal false
+    _(copy_job.write_empty?).must_equal true
   end
 
   it "creates, cancels and gets a job with location" do
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     job = table.load_job local_file, job_id: job_id
 
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    job.location.must_equal region
-    job.wont_be :done?
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job.location).must_equal region
+    _(job).wont_be :done?
 
     # Can cancel the job from the region.
     job.cancel
-    job.location.must_equal region
+    _(job.location).must_equal region
 
     # Cannot get the job without specifying location
     job = bigquery.job job_id
-    job.must_be :nil?
+    _(job).must_be :nil?
 
     # Cannot get the job from the US.
     job = bigquery.job job_id, location: "US"
-    job.must_be :nil?
+    _(job).must_be :nil?
 
     # Can get the job from the region.
     job = bigquery.job job_id, location: region
-    job.wont_be :nil?
+    _(job).wont_be :nil?
     job.wait_until_done!
 
-    job.must_be :done?
-    job.wont_be :failed?
+    _(job).must_be :done?
+    _(job).wont_be :failed?
   end
 
   it "creates an extract job with location" do
@@ -168,27 +168,27 @@ describe Google::Cloud::Bigquery, :location, :bigquery do
       # Make sure there is data to extract...
       load_job = table.load_job local_file
 
-      load_job.location.must_equal region
+      _(load_job.location).must_equal region
       load_job.wait_until_done!
-      load_job.wont_be :failed?
-      load_job.location.must_equal region
+      _(load_job).wont_be :failed?
+      _(load_job.location).must_equal region
 
       Tempfile.open "empty_extract_file.json" do |tmp|
-        tmp.size.must_equal 0
+        _(tmp.size).must_equal 0
         extract_bucket = safe_gcs_execute { storage.create_bucket "#{prefix}_ext_loc", location: region }
         extract_file = extract_bucket.create_file tmp, "kitten-test-data-backup.json"
         job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
 
         extract_job = table.extract_job extract_file, job_id: job_id
 
-        extract_job.job_id.must_equal job_id
+        _(extract_job.job_id).must_equal job_id
         extract_job.wait_until_done!
-        extract_job.wont_be :failed?
-        extract_job.location.must_equal region
+        _(extract_job).wont_be :failed?
+        _(extract_job.location).must_equal region
         # Refresh to get the latest file data
         extract_file = extract_bucket.file "kitten-test-data-backup.json"
         downloaded_file = extract_file.download tmp.path
-        downloaded_file.size.must_be :>, 0
+        _(downloaded_file.size).must_be :>, 0
       end
     ensure
       post_bucket = storage.bucket "#{prefix}_ext_loc"

--- a/google-cloud-bigquery/acceptance/bigquery/model_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/model_test.rb
@@ -43,25 +43,25 @@ describe Google::Cloud::Bigquery, :bigquery do
   it "can create, list, read, update, and delete a model" do
     job = dataset.query_job model_sql
     job.wait_until_done!
-    job.wont_be :failed?
+    _(job).wont_be :failed?
 
     # can find the model in the list of models
-    dataset.models.all.map(&:model_id).must_include model_id
+    _(dataset.models.all.map(&:model_id)).must_include model_id
 
     # can get the model
     model = dataset.model model_id
-    model.must_be_kind_of Google::Cloud::Bigquery::Model
-    model.project_id.must_equal bigquery.project
-    model.dataset_id.must_equal dataset.dataset_id
-    model.model_id.must_equal model_id
+    _(model).must_be_kind_of Google::Cloud::Bigquery::Model
+    _(model.project_id).must_equal bigquery.project
+    _(model.dataset_id).must_equal dataset.dataset_id
+    _(model.model_id).must_equal model_id
 
     new_description = "Model was updated #{Time.now}"
     model.description = new_description
     model.refresh!
-    model.description.must_equal new_description
+    _(model.description).must_equal new_description
 
-    model.delete.must_equal true
+    _(model.delete).must_equal true
 
-    dataset.model(model_id).must_be_nil
+    _(dataset.model(model_id)).must_be_nil
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
@@ -18,322 +18,322 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
   it "queries the data with a string parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: "hello" }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :string?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal "hello"
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :string?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal "hello"
   end
 
   it "queries the data with a nil parameter and string type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :STRING }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :string?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :string?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with an integer parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: 999 }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :integer?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal 999
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :integer?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal 999
   end
 
   it "queries the data with a nil parameter and integer type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :INT64 }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :integer?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :integer?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a float parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: 12.0 }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :float?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal 12.0
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :float?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal 12.0
   end
 
   it "queries the data with a nil parameter and float type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :FLOAT64 }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :float?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :float?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a numeric parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: BigDecimal("123456789.123456789") }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :numeric?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal BigDecimal("123456789.123456789")
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :numeric?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
   end
 
   it "queries the data with a nil parameter and numeric type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :NUMERIC }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :numeric?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :numeric?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a boolean parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: false }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :boolean?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal false
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :boolean?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal false
   end
 
   it "queries the data with a nil parameter and boolean type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :BOOL }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :boolean?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :boolean?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a date parameter" do
     today = Date.today
     rows = bigquery.query "SELECT @value AS value", params: { value: today }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :date?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal Date.today
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :date?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal Date.today
   end
 
   it "queries the data with a nil parameter and boolean type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :DATE }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :date?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :date?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a datetime parameter" do
     now = Time.now.utc.to_datetime
     rows = bigquery.query "SELECT @value AS value", params: { value: now }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :datetime?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of DateTime
-    rows.first[:value].must_be_close_to now
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :datetime?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of DateTime
+    _(rows.first[:value]).must_be_close_to now
     # rows.first[:value].must_equal now.to_s
   end
 
   it "queries the data with a nil parameter and boolean type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :DATETIME }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :datetime?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :datetime?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a timestamp parameter" do
     now = Time.now
     rows = bigquery.query "SELECT @value AS value", params: { value: now }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :timestamp?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of ::Time
-    rows.first[:value].must_be_close_to now
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :timestamp?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of ::Time
+    _(rows.first[:value]).must_be_close_to now
   end
 
   it "queries the data with a nil parameter and boolean type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :TIMESTAMP }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :timestamp?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :timestamp?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a time parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: bigquery.time(12, 30, 0) }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :time?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of Google::Cloud::Bigquery::Time
-    rows.first[:value].value.must_equal "12:30:00"
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :time?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of Google::Cloud::Bigquery::Time
+    _(rows.first[:value].value).must_equal "12:30:00"
   end
 
   it "queries the data with a nil parameter and boolean type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :TIME }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :time?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :time?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a bytes parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: StringIO.new("hello world!") }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :bytes?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of StringIO
-    rows.first[:value].read.must_equal "hello world!"
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :bytes?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of StringIO
+    _(rows.first[:value].read).must_equal "hello world!"
   end
 
   it "queries the data with a nil parameter and boolean type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :BYTES }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :bytes?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :bytes?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with an array of integers parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: [1, 2, 3, 4] }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :integer?
-    rows.fields.first.must_be :repeated?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal [1, 2, 3, 4]
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :integer?
+    _(rows.fields.first).must_be :repeated?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal [1, 2, 3, 4]
   end
 
   it "queries the data with an array of strings parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: ["foo", "bar", "baz"] }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal ["foo", "bar", "baz"]
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal ["foo", "bar", "baz"]
   end
 
   it "queries the data with an empty array of integers and type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: [] }, types: { value: [:INT64] }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :integer?
-    rows.fields.first.must_be :repeated?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal []
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :integer?
+    _(rows.fields.first).must_be :repeated?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal []
   end
 
   it "queries the data with a nil parameter and ARRAY type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: [:INT64] }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :integer?
-    rows.fields.first.must_be :repeated?
-    rows.count.must_equal 1
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :integer?
+    _(rows.fields.first).must_be :repeated?
+    _(rows.count).must_equal 1
     # rows.first[:value].must_be_nil
-    rows.first[:value].must_equal []
+    _(rows.first[:value]).must_equal []
   end
 
   it "queries the data with a struct parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: { message: "hello", repeat: 1 } }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :record?
-    rows.fields.first.fields.count.must_equal 2
-    rows.fields.first.fields.first.name.must_equal "message"
-    rows.fields.first.fields.first.must_be :string?
-    rows.fields.first.fields.last.name.must_equal "repeat"
-    rows.fields.first.fields.last.must_be :integer?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal({ message: "hello", repeat: 1 })
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :record?
+    _(rows.fields.first.fields.count).must_equal 2
+    _(rows.fields.first.fields.first.name).must_equal "message"
+    _(rows.fields.first.fields.first).must_be :string?
+    _(rows.fields.first.fields.last.name).must_equal "repeat"
+    _(rows.fields.first.fields.last).must_be :integer?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal({ message: "hello", repeat: 1 })
   end
 
   it "queries the data with a empty parameter and STRUCT type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: {} }, types: { value: { message: :STRING, repeat: :INT64 } }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :record?
-    rows.fields.first.fields.count.must_equal 2
-    rows.fields.first.fields.first.name.must_equal "message"
-    rows.fields.first.fields.first.must_be :string?
-    rows.fields.first.fields.last.name.must_equal "repeat"
-    rows.fields.first.fields.last.must_be :integer?
-    rows.count.must_equal 1
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :record?
+    _(rows.fields.first.fields.count).must_equal 2
+    _(rows.fields.first.fields.first.name).must_equal "message"
+    _(rows.fields.first.fields.first).must_be :string?
+    _(rows.fields.first.fields.last.name).must_equal "repeat"
+    _(rows.fields.first.fields.last).must_be :integer?
+    _(rows.count).must_equal 1
     # rows.first[:value].must_equal({})
-    rows.first[:value].must_be_nil
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a nil parameter and STRUCT type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: { message: :STRING, repeat: :INT64 } }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :record?
-    rows.fields.first.fields.count.must_equal 2
-    rows.fields.first.fields.first.name.must_equal "message"
-    rows.fields.first.fields.first.must_be :string?
-    rows.fields.first.fields.last.name.must_equal "repeat"
-    rows.fields.first.fields.last.must_be :integer?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :record?
+    _(rows.fields.first.fields.count).must_equal 2
+    _(rows.fields.first.fields.first.name).must_equal "message"
+    _(rows.fields.first.fields.first).must_be :string?
+    _(rows.fields.first.fields.last.name).must_equal "repeat"
+    _(rows.fields.first.fields.last).must_be :integer?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
@@ -18,322 +18,322 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
   it "queries the data with a string parameter" do
     rows = bigquery.query "SELECT ? AS value", params: ["hello"]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :string?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal "hello"
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :string?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal "hello"
   end
 
   it "queries the data with a nil parameter and string type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:STRING]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :string?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :string?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with an integer parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [999]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :integer?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal 999
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :integer?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal 999
   end
 
   it "queries the data with a nil parameter and integer type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:INT64]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :integer?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :integer?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a float parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [12.0]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :float?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal 12.0
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :float?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal 12.0
   end
 
   it "queries the data with a nil parameter and float type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:FLOAT64]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :float?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :float?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a numeric parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [BigDecimal("123456789.123456789")]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :numeric?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal BigDecimal("123456789.123456789")
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :numeric?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
   end
 
   it "queries the data with a nil parameter and numeric type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:NUMERIC]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :numeric?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :numeric?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a boolean parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [false]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :boolean?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal false
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :boolean?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal false
   end
 
   it "queries the data with a nil parameter and boolean type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:BOOL]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :boolean?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :boolean?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a date parameter" do
     today = Date.today
     rows = bigquery.query "SELECT ? AS value", params: [today]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :date?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal Date.today
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :date?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal Date.today
   end
 
   it "queries the data with a nil parameter and boolean type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:DATE]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :date?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :date?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a datetime parameter" do
     now = Time.now.utc.to_datetime
     rows = bigquery.query "SELECT ? AS value", params: [now]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :datetime?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of DateTime
-    rows.first[:value].must_be_close_to now
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :datetime?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of DateTime
+    _(rows.first[:value]).must_be_close_to now
     # rows.first[:value].must_equal now.to_s
   end
 
   it "queries the data with a nil parameter and boolean type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:DATETIME]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :datetime?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :datetime?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a timestamp parameter" do
     now = Time.now
     rows = bigquery.query "SELECT ? AS value", params: [now]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :timestamp?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of ::Time
-    rows.first[:value].must_be_close_to now
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :timestamp?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of ::Time
+    _(rows.first[:value]).must_be_close_to now
   end
 
   it "queries the data with a nil parameter and boolean type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:TIMESTAMP]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :timestamp?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :timestamp?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a time parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [bigquery.time(12, 30, 0)]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :time?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of Google::Cloud::Bigquery::Time
-    rows.first[:value].value.must_equal "12:30:00"
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :time?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of Google::Cloud::Bigquery::Time
+    _(rows.first[:value].value).must_equal "12:30:00"
   end
 
   it "queries the data with a nil parameter and boolean type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:TIME]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :time?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :time?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a bytes parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [StringIO.new("hello world!")]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :bytes?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of StringIO
-    rows.first[:value].read.must_equal "hello world!"
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :bytes?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of StringIO
+    _(rows.first[:value].read).must_equal "hello world!"
   end
 
   it "queries the data with a nil parameter and boolean type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:BYTES]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :bytes?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :bytes?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with an array of integers parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [[1, 2, 3, 4]]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :integer?
-    rows.fields.first.must_be :repeated?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal [1, 2, 3, 4]
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :integer?
+    _(rows.fields.first).must_be :repeated?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal [1, 2, 3, 4]
   end
 
   it "queries the data with an array of strings parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [["foo", "bar", "baz"]]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal ["foo", "bar", "baz"]
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal ["foo", "bar", "baz"]
   end
 
   it "queries the data with an empty array of integers and type" do
     rows = bigquery.query "SELECT ? AS value", params: [[]], types: [[:INT64]]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :integer?
-    rows.fields.first.must_be :repeated?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal []
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :integer?
+    _(rows.fields.first).must_be :repeated?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal []
   end
 
   it "queries the data with a nil parameter and ARRAY type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [[:INT64]]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :integer?
-    rows.fields.first.must_be :repeated?
-    rows.count.must_equal 1
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :integer?
+    _(rows.fields.first).must_be :repeated?
+    _(rows.count).must_equal 1
     # rows.first[:value].must_be_nil
-    rows.first[:value].must_equal []
+    _(rows.first[:value]).must_equal []
   end
 
   it "queries the data with a struct parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [{ message: "hello", repeat: 1 }]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :record?
-    rows.fields.first.fields.count.must_equal 2
-    rows.fields.first.fields.first.name.must_equal "message"
-    rows.fields.first.fields.first.must_be :string?
-    rows.fields.first.fields.last.name.must_equal "repeat"
-    rows.fields.first.fields.last.must_be :integer?
-    rows.count.must_equal 1
-    rows.first[:value].must_equal({ message: "hello", repeat: 1 })
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :record?
+    _(rows.fields.first.fields.count).must_equal 2
+    _(rows.fields.first.fields.first.name).must_equal "message"
+    _(rows.fields.first.fields.first).must_be :string?
+    _(rows.fields.first.fields.last.name).must_equal "repeat"
+    _(rows.fields.first.fields.last).must_be :integer?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal({ message: "hello", repeat: 1 })
   end
 
   it "queries the data with a empty parameter and STRUCT type" do
     rows = bigquery.query "SELECT ? AS value", params: [{}], types: [{ message: :STRING, repeat: :INT64 }]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :record?
-    rows.fields.first.fields.count.must_equal 2
-    rows.fields.first.fields.first.name.must_equal "message"
-    rows.fields.first.fields.first.must_be :string?
-    rows.fields.first.fields.last.name.must_equal "repeat"
-    rows.fields.first.fields.last.must_be :integer?
-    rows.count.must_equal 1
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :record?
+    _(rows.fields.first.fields.count).must_equal 2
+    _(rows.fields.first.fields.first.name).must_equal "message"
+    _(rows.fields.first.fields.first).must_be :string?
+    _(rows.fields.first.fields.last.name).must_equal "repeat"
+    _(rows.fields.first.fields.last).must_be :integer?
+    _(rows.count).must_equal 1
     # rows.first[:value].must_equal({})
-    rows.first[:value].must_be_nil
+    _(rows.first[:value]).must_be_nil
   end
 
   it "queries the data with a nil parameter and STRUCT type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [{ message: :STRING, repeat: :INT64 }]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.fields.count.must_equal 1
-    rows.fields.first.name.must_equal "value"
-    rows.fields.first.must_be :record?
-    rows.fields.first.fields.count.must_equal 2
-    rows.fields.first.fields.first.name.must_equal "message"
-    rows.fields.first.fields.first.must_be :string?
-    rows.fields.first.fields.last.name.must_equal "repeat"
-    rows.fields.first.fields.last.must_be :integer?
-    rows.count.must_equal 1
-    rows.first[:value].must_be_nil
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :record?
+    _(rows.fields.first.fields.count).must_equal 2
+    _(rows.fields.first.fields.first.name).must_equal "message"
+    _(rows.fields.first.fields.first).must_be :string?
+    _(rows.fields.first.fields.last.name).must_equal "repeat"
+    _(rows.fields.first.fields.last).must_be :integer?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/query_destination_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/query_destination_test.rb
@@ -43,9 +43,9 @@ describe Google::Cloud::Bigquery, :bigquery do
 
     dest_table = dataset.table table_id
     rows = dest_table.data
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal 123
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal 123
   end
 
   it "sends query results to destination table with encryption" do
@@ -57,11 +57,11 @@ describe Google::Cloud::Bigquery, :bigquery do
     end
 
     dest_table = dataset.table table_id
-    dest_table.encryption.must_equal encrypt_config
+    _(dest_table.encryption).must_equal encrypt_config
     rows = dest_table.data
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal 456
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal 456
   end
 
   it "sends query results to a range partitioned destination table" do
@@ -74,21 +74,21 @@ describe Google::Cloud::Bigquery, :bigquery do
       job.range_partitioning_end = 100
     end
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
     job.wait_until_done!
-    job.wont_be :failed?
+    _(job).wont_be :failed?
 
-    job.range_partitioning?.must_equal true
-    job.range_partitioning_field.must_equal "num"
-    job.range_partitioning_start.must_equal 0
-    job.range_partitioning_interval.must_equal 10
-    job.range_partitioning_end.must_equal 100
+    _(job.range_partitioning?).must_equal true
+    _(job.range_partitioning_field).must_equal "num"
+    _(job.range_partitioning_start).must_equal 0
+    _(job.range_partitioning_interval).must_equal 10
+    _(job.range_partitioning_end).must_equal 100
 
     dest_table = dataset.table range_table_id
-    dest_table.must_be_kind_of Google::Cloud::Bigquery::Table
+    _(dest_table).must_be_kind_of Google::Cloud::Bigquery::Table
     rows = dest_table.data
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 100
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 100
   end
 
   it "sends query results to a time partitioned destination table" do
@@ -104,20 +104,20 @@ describe Google::Cloud::Bigquery, :bigquery do
       job.time_partitioning_require_filter = true
     end
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
     job.wait_until_done!
-    job.wont_be :failed?
+    _(job).wont_be :failed?
 
-    job.time_partitioning_type.must_equal "DAY"
-    job.time_partitioning_field.must_equal "dob"
-    job.time_partitioning_expiration.must_equal 86_400
-    job.time_partitioning_require_filter?.must_equal true
+    _(job.time_partitioning_type).must_equal "DAY"
+    _(job.time_partitioning_field).must_equal "dob"
+    _(job.time_partitioning_expiration).must_equal 86_400
+    _(job.time_partitioning_require_filter?).must_equal true
 
     dest_table = dataset.table timestamp_table_id
-    dest_table.must_be_kind_of Google::Cloud::Bigquery::Table
+    _(dest_table).must_be_kind_of Google::Cloud::Bigquery::Table
     rows = dest_table.data
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 10
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 10
   end
 
   it "sends query results to a clustered destination table" do
@@ -132,15 +132,15 @@ describe Google::Cloud::Bigquery, :bigquery do
       job.clustering_fields = ["name"]
     end
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
     job.wait_until_done!
-    job.wont_be :failed?
-    job.num_child_jobs.must_equal 0
-    job.parent_job_id.must_be :nil?
+    _(job).wont_be :failed?
+    _(job.num_child_jobs).must_equal 0
+    _(job.parent_job_id).must_be :nil?
 
-    job.time_partitioning_type.must_equal "DAY"
-    job.time_partitioning_field.must_equal "dob"
-    job.clustering?.must_equal true
-    job.clustering_fields.must_equal ["name"]
+    _(job.time_partitioning_type).must_equal "DAY"
+    _(job.time_partitioning_field).must_equal "dob"
+    _(job.clustering?).must_equal true
+    _(job.clustering_fields).must_equal ["name"]
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
@@ -43,8 +43,8 @@ describe Google::Cloud::Bigquery::External, :bigquery do
     ext_table.skip_leading_rows = 1
 
     data = dataset.query "SELECT * FROM pets", external: { pets: ext_table }
-    data.count.must_equal 3
-    data.must_equal [
+    _(data.count).must_equal 3
+    _(data).must_equal [
       { id: 4, name: "silvano", breed: "the cat kind" },
       { id: 5, name: "ryan", breed: "golden retriever?" },
       { id: 6, name: "stephen", breed: "idkanycatbreeds" }
@@ -62,8 +62,8 @@ describe Google::Cloud::Bigquery::External, :bigquery do
     end
 
     data = dataset.query "SELECT id, name, breed FROM pets", external: { pets: ext_table }
-    data.count.must_equal 3
-    data.must_equal [
+    _(data.count).must_equal 3
+    _(data).must_equal [
       { id: 4, name: "silvano", breed: "the cat kind" },
       { id: 5, name: "ryan", breed: "golden retriever?" },
       { id: 6, name: "stephen", breed: "idkanycatbreeds" }

--- a/google-cloud-bigquery/acceptance/bigquery/routine_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/routine_test.rb
@@ -38,81 +38,81 @@ describe Google::Cloud::Bigquery, :bigquery do
     # create from sql
     job = dataset.query_job routine_sql
     job.wait_until_done!
-    job.wont_be :failed?
-    job.ddl_operation_performed.must_equal "CREATE"
+    _(job).wont_be :failed?
+    _(job.ddl_operation_performed).must_equal "CREATE"
     routine = job.ddl_target_routine
-    routine.must_be_kind_of Google::Cloud::Bigquery::Routine
-    routine.reference?.must_equal true
-    routine.project_id.must_equal bigquery.project
-    routine.dataset_id.must_equal dataset.dataset_id
-    routine.routine_id.must_equal routine_id
+    _(routine).must_be_kind_of Google::Cloud::Bigquery::Routine
+    _(routine.reference?).must_equal true
+    _(routine.project_id).must_equal bigquery.project
+    _(routine.dataset_id).must_equal dataset.dataset_id
+    _(routine.routine_id).must_equal routine_id
 
     # list
-    dataset.routines.all.map(&:routine_id).must_include routine_id
+    _(dataset.routines.all.map(&:routine_id)).must_include routine_id
 
     # list with filter
-    dataset.routines(filter: "routineType:SCALAR_FUNCTION").all.map(&:routine_id).must_include routine_id
+    _(dataset.routines(filter: "routineType:SCALAR_FUNCTION").all.map(&:routine_id)).must_include routine_id
 
     # list with filter
-    dataset.routines(filter: "routineType:PROCEDURE").all.map(&:routine_id).wont_include routine_id
+    _(dataset.routines(filter: "routineType:PROCEDURE").all.map(&:routine_id)).wont_include routine_id
 
     # get
     routine = dataset.routine routine_id
-    routine.must_be_kind_of Google::Cloud::Bigquery::Routine
-    routine.project_id.must_equal bigquery.project
-    routine.dataset_id.must_equal dataset.dataset_id
-    routine.routine_id.must_equal routine_id
+    _(routine).must_be_kind_of Google::Cloud::Bigquery::Routine
+    _(routine.project_id).must_equal bigquery.project
+    _(routine.dataset_id).must_equal dataset.dataset_id
+    _(routine.routine_id).must_equal routine_id
 
-    routine.description.must_be :nil?
-    routine.routine_type.must_equal "SCALAR_FUNCTION"
-    routine.language.must_equal "SQL"
-    routine.body.must_equal "(SELECT SUM(IF(elem.name = \"foo\",elem.val,null)) FROM UNNEST(arr) AS elem)"
+    _(routine.description).must_be :nil?
+    _(routine.routine_type).must_equal "SCALAR_FUNCTION"
+    _(routine.language).must_equal "SQL"
+    _(routine.body).must_equal "(SELECT SUM(IF(elem.name = \"foo\",elem.val,null)) FROM UNNEST(arr) AS elem)"
 
     arguments = routine.arguments
-    arguments.must_be_kind_of Array
-    arguments.size.must_equal 1
+    _(arguments).must_be_kind_of Array
+    _(arguments.size).must_equal 1
 
     argument = arguments.first
-    argument.must_be_kind_of Google::Cloud::Bigquery::Argument
-    argument.argument_kind.must_be :nil?
-    argument.fixed_type?.must_equal true
-    argument.any_type?.must_equal false
-    argument.mode.must_be :nil?
-    argument.in?.must_equal false
-    argument.out?.must_equal false
-    argument.inout?.must_equal false
-    argument.name.must_equal "arr"
+    _(argument).must_be_kind_of Google::Cloud::Bigquery::Argument
+    _(argument.argument_kind).must_be :nil?
+    _(argument.fixed_type?).must_equal true
+    _(argument.any_type?).must_equal false
+    _(argument.mode).must_be :nil?
+    _(argument.in?).must_equal false
+    _(argument.out?).must_equal false
+    _(argument.inout?).must_equal false
+    _(argument.name).must_equal "arr"
 
     data_type = argument.data_type
-    data_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    data_type.type_kind.must_equal "ARRAY"
-    data_type.struct_type.must_be :nil?
-    data_type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    data_type.array_element_type.type_kind.must_equal "STRUCT"
-    data_type.array_element_type.struct_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
+    _(data_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(data_type.type_kind).must_equal "ARRAY"
+    _(data_type.struct_type).must_be :nil?
+    _(data_type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(data_type.array_element_type.type_kind).must_equal "STRUCT"
+    _(data_type.array_element_type.struct_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
 
     struct_fields = data_type.array_element_type.struct_type.fields
-    struct_fields.must_be_kind_of Array
-    struct_fields.size.must_equal 2
-    struct_fields[0].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    struct_fields[0].name.must_equal "name"
-    struct_fields[0].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    struct_fields[0].type.type_kind.must_equal "STRING"
-    struct_fields[1].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    struct_fields[1].name.must_equal "val"
-    struct_fields[1].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    struct_fields[1].type.type_kind.must_equal "INT64"
+    _(struct_fields).must_be_kind_of Array
+    _(struct_fields.size).must_equal 2
+    _(struct_fields[0]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(struct_fields[0].name).must_equal "name"
+    _(struct_fields[0].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(struct_fields[0].type.type_kind).must_equal "STRING"
+    _(struct_fields[1]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(struct_fields[1].name).must_equal "val"
+    _(struct_fields[1].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(struct_fields[1].type.type_kind).must_equal "INT64"
 
     # update
     new_description = "Routine was updated #{Time.now}"
     routine.description = new_description
     routine.refresh!
-    routine.description.must_equal new_description
+    _(routine.description).must_equal new_description
 
     # delete
-    routine.delete.must_equal true
+    _(routine.delete).must_equal true
 
-    dataset.routine(routine_id).must_be_nil
+    _(dataset.routine(routine_id)).must_be_nil
   end
 
   it "can create, update and delete a routine" do
@@ -127,31 +127,31 @@ describe Google::Cloud::Bigquery, :bigquery do
       r.description = "my description"
     end
 
-    routine.must_be_kind_of Google::Cloud::Bigquery::Routine
-    routine.project_id.must_equal bigquery.project
-    routine.dataset_id.must_equal dataset.dataset_id
-    routine.routine_id.must_equal routine_id
+    _(routine).must_be_kind_of Google::Cloud::Bigquery::Routine
+    _(routine.project_id).must_equal bigquery.project
+    _(routine.dataset_id).must_equal dataset.dataset_id
+    _(routine.routine_id).must_equal routine_id
 
-    routine.description.must_equal "my description"
-    routine.routine_type.must_equal "SCALAR_FUNCTION"
-    routine.language.must_equal "SQL"
-    routine.body.must_equal "x * 3"
+    _(routine.description).must_equal "my description"
+    _(routine.routine_type).must_equal "SCALAR_FUNCTION"
+    _(routine.language).must_equal "SQL"
+    _(routine.body).must_equal "x * 3"
 
     arguments = routine.arguments
-    arguments.must_be_kind_of Array
-    arguments.size.must_equal 1
+    _(arguments).must_be_kind_of Array
+    _(arguments.size).must_equal 1
 
     argument = arguments.first
-    argument.must_be_kind_of Google::Cloud::Bigquery::Argument
-    argument.argument_kind.must_be :nil?
-    argument.mode.must_be :nil?
-    argument.name.must_equal "x"
+    _(argument).must_be_kind_of Google::Cloud::Bigquery::Argument
+    _(argument.argument_kind).must_be :nil?
+    _(argument.mode).must_be :nil?
+    _(argument.name).must_equal "x"
 
     data_type = argument.data_type
-    data_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    data_type.type_kind.must_equal "INT64"
-    data_type.array_element_type.must_be :nil?
-    data_type.struct_type.must_be :nil?
+    _(data_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(data_type.type_kind).must_equal "INT64"
+    _(data_type.array_element_type).must_be :nil?
+    _(data_type.struct_type).must_be :nil?
  
     # update 
     new_body = "(SELECT SUM(IF(elem.name = \"foo\",elem.val,null)) FROM UNNEST(arr) AS elem)"
@@ -185,46 +185,46 @@ describe Google::Cloud::Bigquery, :bigquery do
       r.arguments = new_arguments
     end
 
-    routine.body.must_equal new_body
+    _(routine.body).must_equal new_body
 
     arguments = routine.arguments
-    arguments.must_be_kind_of Array
-    arguments.size.must_equal 1
+    _(arguments).must_be_kind_of Array
+    _(arguments.size).must_equal 1
 
     argument = arguments.first
-    argument.must_be_kind_of Google::Cloud::Bigquery::Argument
-    argument.argument_kind.must_equal "FIXED_TYPE"
-    argument.mode.must_be :nil?
-    argument.name.must_equal "arr"
+    _(argument).must_be_kind_of Google::Cloud::Bigquery::Argument
+    _(argument.argument_kind).must_equal "FIXED_TYPE"
+    _(argument.mode).must_be :nil?
+    _(argument.name).must_equal "arr"
 
     data_type = argument.data_type
-    data_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    data_type.type_kind.must_equal "ARRAY"
-    data_type.struct_type.must_be :nil?
-    data_type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    data_type.array_element_type.type_kind.must_equal "STRUCT"
-    data_type.array_element_type.struct_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
+    _(data_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(data_type.type_kind).must_equal "ARRAY"
+    _(data_type.struct_type).must_be :nil?
+    _(data_type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(data_type.array_element_type.type_kind).must_equal "STRUCT"
+    _(data_type.array_element_type.struct_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
 
     struct_fields = data_type.array_element_type.struct_type.fields
-    struct_fields.must_be_kind_of Array
-    struct_fields.size.must_equal 2
-    struct_fields[0].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    struct_fields[0].name.must_equal "name"
-    struct_fields[0].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    struct_fields[0].type.type_kind.must_equal "STRING"
-    struct_fields[1].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    struct_fields[1].name.must_equal "val"
-    struct_fields[1].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    struct_fields[1].type.type_kind.must_equal "INT64"
+    _(struct_fields).must_be_kind_of Array
+    _(struct_fields.size).must_equal 2
+    _(struct_fields[0]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(struct_fields[0].name).must_equal "name"
+    _(struct_fields[0].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(struct_fields[0].type.type_kind).must_equal "STRING"
+    _(struct_fields[1]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(struct_fields[1].name).must_equal "val"
+    _(struct_fields[1].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(struct_fields[1].type.type_kind).must_equal "INT64"
 
     # get
     routine.reload!
-    routine.body.must_equal new_body
-    routine.arguments.first.data_type.array_element_type.struct_type.fields.last.type.type_kind.must_equal "INT64"
+    _(routine.body).must_equal new_body
+    _(routine.arguments.first.data_type.array_element_type.struct_type.fields.last.type.type_kind).must_equal "INT64"
 
     # delete
-    routine.delete.must_equal true
+    _(routine.delete).must_equal true
 
-    dataset.routine(routine_id).must_be_nil
+    _(dataset.routine(routine_id)).must_be_nil
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/standard_query_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/standard_query_test.rb
@@ -19,113 +19,113 @@ describe Google::Cloud::Bigquery, :standard_query_types, :bigquery do
   it "queries a string value" do
     rows = bigquery.query "SELECT 'hello' AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal "hello"
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal "hello"
   end
 
   it "queries an integer value" do
     rows = bigquery.query "SELECT 999 AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal 999
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal 999
   end
 
   it "queries a float value" do
     rows = bigquery.query "SELECT 12.0 AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal 12.0
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal 12.0
   end
 
   it "queries a numeric value" do
     rows = bigquery.query "SELECT NUMERIC '123456789.123456789' AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal BigDecimal("123456789.123456789")
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
   end
 
   it "queries a boolean value" do
     rows = bigquery.query "SELECT false AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal false
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal false
   end
 
   it "queries a date value" do
     rows = bigquery.query "SELECT CURRENT_DATE() AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of Date
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of Date
   end
 
   it "queries a datetime value" do
     rows = bigquery.query "SELECT CURRENT_DATETIME() AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of DateTime
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of DateTime
   end
 
   it "queries a timestamp value" do
     rows = bigquery.query "SELECT CURRENT_TIMESTAMP() AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of ::Time
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of ::Time
   end
 
   it "queries a time value" do
     rows = bigquery.query "SELECT CURRENT_TIME() AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of Google::Cloud::Bigquery::Time
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of Google::Cloud::Bigquery::Time
   end
 
   it "queries a bytes value" do
     rows = bigquery.query "SELECT CAST('hello' AS BYTES) AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of StringIO
-    rows.first[:value].read.must_equal "hello"
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_kind_of StringIO
+    _(rows.first[:value].read).must_equal "hello"
   end
 
   it "queries an array of integers value" do
     rows = bigquery.query "SELECT [1, 2, 3, 4] AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal [1, 2, 3, 4]
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal [1, 2, 3, 4]
   end
 
   it "queries an array of strings value" do
     rows = bigquery.query "SELECT ['foo', 'bar', 'baz'] AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal ["foo", "bar", "baz"]
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal ["foo", "bar", "baz"]
   end
 
   it "queries a struct with no names" do
     rows = bigquery.query "SELECT STRUCT(1, 'abc', 3.14) AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal({ _field_1: 1, _field_2: "abc", _field_3: 3.14 })
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal({ _field_1: 1, _field_2: "abc", _field_3: 3.14 })
   end
 
   it "queries a struct with duplicate names" do
     rows = bigquery.query "SELECT STRUCT(1 AS x, 'abc' AS x, 3.14 AS x) AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
-    rows.count.must_equal 1
-    rows.first[:value].must_equal({ x: 1, _field_2: "abc", _field_3: 3.14 })
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal({ x: 1, _field_2: "abc", _field_3: 3.14 })
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/table_external_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_external_test.rb
@@ -48,14 +48,14 @@ describe Google::Cloud::Bigquery::Table, :external, :bigquery do
       tbl.external = csv_table
     end
 
-    table.must_be :external?
-    table.external.wont_be :nil?
-    table.external.must_be :frozen?
-    table.external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    _(table).must_be :external?
+    _(table.external).wont_be :nil?
+    _(table.external).must_be :frozen?
+    _(table.external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
 
     data = dataset.query "SELECT id, name, breed FROM #{table_id} ORDER BY id"
-    data.count.must_equal 3
-    data.must_equal [
+    _(data.count).must_equal 3
+    _(data).must_equal [
       { id: 4, name: "silvano", breed: "the cat kind" },
       { id: 5, name: "ryan", breed: "golden retriever?" },
       { id: 6, name: "stephen", breed: "idkanycatbreeds" }
@@ -77,14 +77,14 @@ describe Google::Cloud::Bigquery::Table, :external, :bigquery do
       tbl.external = csv_table
     end
 
-    table.must_be :external?
-    table.external.wont_be :nil?
-    table.external.must_be :frozen?
-    table.external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    _(table).must_be :external?
+    _(table.external).wont_be :nil?
+    _(table.external).must_be :frozen?
+    _(table.external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
 
     data = dataset.query "SELECT id, name, breed FROM #{table_id} ORDER BY id"
-    data.count.must_equal 3
-    data.must_equal [
+    _(data.count).must_equal 3
+    _(data).must_equal [
       { id: 4, name: "silvano", breed: "the cat kind" },
       { id: 5, name: "ryan", breed: "golden retriever?" },
       { id: 6, name: "stephen", breed: "idkanycatbreeds" }

--- a/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
@@ -54,50 +54,50 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
   let(:labels) { { "foo" => "bar" } }
 
   it "has the attributes of a table" do
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
 
-    table.table_id.must_equal table_id
-    table.dataset_id.must_equal dataset_id
-    table.project_id.must_equal bigquery.project
+    _(table.table_id).must_equal table_id
+    _(table.dataset_id).must_equal dataset_id
+    _(table.project_id).must_equal bigquery.project
 
-    table.time_partitioning?.must_be_nil
-    table.time_partitioning_type.must_be_nil
-    table.time_partitioning_field.must_be_nil
-    table.time_partitioning_expiration.must_be_nil
-    table.range_partitioning?.must_be_nil
-    table.range_partitioning_field.must_be_nil
-    table.range_partitioning_start.must_be_nil
-    table.range_partitioning_interval.must_be_nil
-    table.range_partitioning_end.must_be_nil
-    table.id.must_be_nil
-    table.name.must_be_nil
-    table.etag.must_be_nil
-    table.api_url.must_be_nil
-    table.description.must_be_nil
-    table.bytes_count.must_be_nil
-    table.rows_count.must_be_nil
-    table.created_at.must_be_nil
-    table.expires_at.must_be_nil
-    table.modified_at.must_be_nil
-    table.table?.must_be_nil
-    table.view?.must_be_nil
-    table.external?.must_be_nil
-    table.location.must_be_nil
-    table.labels.must_be_nil
-    table.schema.must_be_nil
-    table.fields.must_be_nil
-    table.headers.must_be_nil
-    table.external.must_be_nil
-    table.buffer_bytes.must_be_nil
-    table.buffer_rows.must_be_nil
-    table.buffer_oldest_at.must_be_nil
+    _(table.time_partitioning?).must_be_nil
+    _(table.time_partitioning_type).must_be_nil
+    _(table.time_partitioning_field).must_be_nil
+    _(table.time_partitioning_expiration).must_be_nil
+    _(table.range_partitioning?).must_be_nil
+    _(table.range_partitioning_field).must_be_nil
+    _(table.range_partitioning_start).must_be_nil
+    _(table.range_partitioning_interval).must_be_nil
+    _(table.range_partitioning_end).must_be_nil
+    _(table.id).must_be_nil
+    _(table.name).must_be_nil
+    _(table.etag).must_be_nil
+    _(table.api_url).must_be_nil
+    _(table.description).must_be_nil
+    _(table.bytes_count).must_be_nil
+    _(table.rows_count).must_be_nil
+    _(table.created_at).must_be_nil
+    _(table.expires_at).must_be_nil
+    _(table.modified_at).must_be_nil
+    _(table.table?).must_be_nil
+    _(table.view?).must_be_nil
+    _(table.external?).must_be_nil
+    _(table.location).must_be_nil
+    _(table.labels).must_be_nil
+    _(table.schema).must_be_nil
+    _(table.fields).must_be_nil
+    _(table.headers).must_be_nil
+    _(table.external).must_be_nil
+    _(table.buffer_bytes).must_be_nil
+    _(table.buffer_rows).must_be_nil
+    _(table.buffer_oldest_at).must_be_nil
   end
 
   it "deletes itself and knows it no longer exists" do
-    table.exists?.must_equal true
-    table.delete.must_equal true
-    table.exists?.must_equal false
-    table.exists?(force: true).must_equal false
+    _(table.exists?).must_equal true
+    _(table.delete).must_equal true
+    _(table.exists?).must_equal false
+    _(table.exists?(force: true)).must_equal false
   end
 
   it "gets and sets metadata" do
@@ -110,10 +110,10 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
     table.labels = new_labels
 
     table.reload!
-    table.table_id.must_equal table_id
-    table.name.must_equal new_name
-    table.description.must_equal new_desc
-    table.labels.must_equal new_labels
+    _(table.table_id).must_equal table_id
+    _(table.name).must_equal new_name
+    _(table.description).must_equal new_desc
+    _(table.labels).must_equal new_labels
   end
 
   it "gets and sets time partitioning" do
@@ -129,10 +129,10 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
     partitioned_table.time_partitioning_expiration = 1
 
     partitioned_table.reload!
-    partitioned_table.table_id.must_equal partitioned_table_id
-    partitioned_table.time_partitioning_type.must_equal "DAY"
-    partitioned_table.time_partitioning_field.must_be_nil
-    partitioned_table.time_partitioning_expiration.must_equal 1
+    _(partitioned_table.table_id).must_equal partitioned_table_id
+    _(partitioned_table.time_partitioning_type).must_equal "DAY"
+    _(partitioned_table.time_partitioning_field).must_be_nil
+    _(partitioned_table.time_partitioning_expiration).must_equal 1
   end
 
   it "gets and sets time partitioning by field" do
@@ -152,10 +152,10 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
     partitioned_table.time_partitioning_expiration = 1
 
     partitioned_table.reload!
-    partitioned_table.table_id.must_equal partitioned_field_table_id
-    partitioned_table.time_partitioning_type.must_equal "DAY"
-    partitioned_table.time_partitioning_field.must_equal "dob"
-    partitioned_table.time_partitioning_expiration.must_equal 1
+    _(partitioned_table.table_id).must_equal partitioned_field_table_id
+    _(partitioned_table.time_partitioning_type).must_equal "DAY"
+    _(partitioned_table.time_partitioning_field).must_equal "dob"
+    _(partitioned_table.time_partitioning_expiration).must_equal 1
   end
 
   it "updates its schema" do
@@ -165,14 +165,14 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
       t.schema do |s|
         s.boolean "available", description: "available description", mode: :nullable
       end
-      t.headers.must_equal [:available]
+      _(t.headers).must_equal [:available]
       t.schema replace: true do |s|
         s.boolean "available", description: "available description", mode: :nullable
         s.record "countries_lived", description: "countries_lived description", mode: :repeated do |nested|
           nested.float "rating", description: "An value from 1 to 10", mode: :nullable
         end
       end
-      t.headers.must_equal [:available, :countries_lived]
+      _(t.headers).must_equal [:available, :countries_lived]
     ensure
       t2 = dataset.table "table_schema_test"
       t2.delete if t2
@@ -181,18 +181,18 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
 
   it "inserts rows directly and gets its data" do
     insert_response = table.insert rows
-    insert_response.must_be :success?
-    insert_response.insert_count.must_equal 3
-    insert_response.insert_errors.must_be :empty?
-    insert_response.error_rows.must_be :empty?
+    _(insert_response).must_be :success?
+    _(insert_response.insert_count).must_equal 3
+    _(insert_response.insert_errors).must_be :empty?
+    _(insert_response.error_rows).must_be :empty?
 
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     query_job = dataset.query_job query, job_id: job_id
-    query_job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    query_job.job_id.must_equal job_id
+    _(query_job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(query_job.job_id).must_equal job_id
     query_job.wait_until_done!
-    query_job.done?.must_equal true
-    query_job.data.total.wont_be_nil
+    _(query_job.done?).must_equal true
+    _(query_job.data.total).wont_be_nil
 
     assert_data table.data(max: 1)
   end
@@ -208,19 +208,19 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
     inserter.flush
     inserter.stop.wait!
 
-    insert_result.must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
-    insert_result.must_be :success?
-    insert_result.insert_count.must_equal 3
-    insert_result.insert_errors.must_be :empty?
-    insert_result.error_rows.must_be :empty?
+    _(insert_result).must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
+    _(insert_result).must_be :success?
+    _(insert_result.insert_count).must_equal 3
+    _(insert_result.insert_errors).must_be :empty?
+    _(insert_result.error_rows).must_be :empty?
 
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     query_job = dataset.query_job query, job_id: job_id
-    query_job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    query_job.job_id.must_equal job_id
+    _(query_job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(query_job.job_id).must_equal job_id
     query_job.wait_until_done!
-    query_job.done?.must_equal true
-    query_job.data.total.wont_be :nil?
+    _(query_job.done?).must_equal true
+    _(query_job.data.total).wont_be :nil?
 
     assert_data table.data(max: 1)
   end
@@ -228,13 +228,13 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
   it "imports data from a local file with load_job" do
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     job = table.load_job local_file, job_id: job_id, labels: labels
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    job.job_id.must_equal job_id
-    job.labels.must_equal labels
-    job.wont_be :autodetect?
-    job.null_marker.must_equal ""
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job.job_id).must_equal job_id
+    _(job.labels).must_equal labels
+    _(job).wont_be :autodetect?
+    _(job.null_marker).must_equal ""
     job.wait_until_done!
-    job.output_rows.must_equal 3
+    _(job.output_rows).must_equal 3
   end
 
   it "imports data from a file in your bucket with load_job" do
@@ -242,7 +242,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
 
     job = table.load_job file
     job.wait_until_done!
-    job.wont_be :failed?
+    _(job).wont_be :failed?
   end
 
   it "imports data from a list of files in your bucket with load_job" do
@@ -254,21 +254,21 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
     # Test both by file object and URL as string
     job = table.load_job [file1, gs_url]
     job.wait_until_done!
-    job.wont_be :failed?
-    job.input_files.must_equal 2
-    job.output_rows.must_equal 6
+    _(job).wont_be :failed?
+    _(job.input_files).must_equal 2
+    _(job.output_rows).must_equal 6
   end
 
   it "imports data from a local file with load" do
     result = table.load local_file
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "imports data from a file in your bucket with load" do
     file = bucket.create_file local_file, random_file_destination_name
 
     result = table.load file
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "imports data from a list of files in your bucket with load" do
@@ -279,31 +279,31 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
 
     # Test both by file object and URL as string
     result = table.load [file1, gs_url]
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "copies itself to another table with copy_job" do
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     copy_job = table.copy_job target_table_id, create: :needed, write: :empty, job_id: job_id, labels: labels
 
-    copy_job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    copy_job.job_id.must_equal job_id
-    copy_job.labels.must_equal labels
+    _(copy_job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(copy_job.job_id).must_equal job_id
+    _(copy_job.labels).must_equal labels
     copy_job.wait_until_done!
 
-    copy_job.wont_be :failed?
-    copy_job.source.table_id.must_equal table.table_id
-    copy_job.destination.table_id.must_equal target_table_id
-    copy_job.create_if_needed?.must_equal true
-    copy_job.create_never?.must_equal false
-    copy_job.write_truncate?.must_equal false
-    copy_job.write_append?.must_equal false
-    copy_job.write_empty?.must_equal true
+    _(copy_job).wont_be :failed?
+    _(copy_job.source.table_id).must_equal table.table_id
+    _(copy_job.destination.table_id).must_equal target_table_id
+    _(copy_job.create_if_needed?).must_equal true
+    _(copy_job.create_never?).must_equal false
+    _(copy_job.write_truncate?).must_equal false
+    _(copy_job.write_append?).must_equal false
+    _(copy_job.write_empty?).must_equal true
   end
 
   it "copies itself to another table with copy" do
     result = table.copy target_table_2_id, create: :needed, write: :empty
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "extracts data to a file in your bucket with extract_job" do
@@ -311,37 +311,37 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
     load_job = table.load_job local_file
     load_job.wait_until_done!
     Tempfile.open "empty_extract_file.json" do |tmp|
-      tmp.size.must_equal 0
+      _(tmp.size).must_equal 0
       dest_file_name = random_file_destination_name
       extract_file = bucket.create_file tmp, dest_file_name
       job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
 
       extract_job = table.extract_job extract_file, job_id: job_id
-      extract_job.job_id.must_equal job_id
+      _(extract_job.job_id).must_equal job_id
       extract_job.wait_until_done!
-      extract_job.wont_be :failed?
+      _(extract_job).wont_be :failed?
       # Refresh to get the latest file data
       extract_file = bucket.file dest_file_name
       downloaded_file = extract_file.download tmp.path
-      downloaded_file.size.must_be :>, 0
+      _(downloaded_file.size).must_be :>, 0
     end
   end
 
   it "extracts data to a file in your bucket with extract" do
     # Make sure there is data to extract...
     result = table.load local_file
-    result.must_equal true
+    _(result).must_equal true
     Tempfile.open "empty_extract_file.json" do |tmp|
-      tmp.size.must_equal 0
+      _(tmp.size).must_equal 0
       dest_file_name = random_file_destination_name
       extract_file = bucket.create_file tmp, dest_file_name
 
       result = table.extract extract_file
-      result.must_equal true
+      _(result).must_equal true
       # Refresh to get the latest file data
       extract_file = bucket.file dest_file_name
       downloaded_file = extract_file.download tmp.path
-      downloaded_file.size.must_be :>, 0
+      _(downloaded_file.size).must_be :>, 0
     end
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -100,46 +100,46 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
 
   it "has the attributes of a table" do
     fresh = dataset.table table.table_id
-    fresh.must_be_kind_of Google::Cloud::Bigquery::Table
+    _(fresh).must_be_kind_of Google::Cloud::Bigquery::Table
 
-    fresh.project_id.must_equal bigquery.project
-    fresh.id.must_equal "#{bigquery.project}:#{dataset.dataset_id}.#{table.table_id}"
-    fresh.query_id.must_equal "`#{bigquery.project}.#{dataset.dataset_id}.#{table.table_id}`"
-    fresh.etag.wont_be :nil?
-    fresh.api_url.wont_be :nil?
-    fresh.bytes_count.wont_be :nil?
-    fresh.rows_count.wont_be :nil?
-    fresh.created_at.must_be_kind_of Time
-    fresh.expires_at.must_be :nil?
-    fresh.modified_at.must_be_kind_of Time
-    fresh.table?.must_equal true
-    fresh.view?.must_equal false
-    fresh.time_partitioning?.must_equal false
-    fresh.time_partitioning_type.must_be_nil
-    fresh.time_partitioning_field.must_be_nil
-    fresh.time_partitioning_expiration.must_be_nil
-    fresh.range_partitioning?.must_equal false
-    fresh.range_partitioning_field.must_be_nil
-    fresh.range_partitioning_start.must_be_nil
-    fresh.range_partitioning_interval.must_be_nil
-    fresh.range_partitioning_end.must_be_nil
+    _(fresh.project_id).must_equal bigquery.project
+    _(fresh.id).must_equal "#{bigquery.project}:#{dataset.dataset_id}.#{table.table_id}"
+    _(fresh.query_id).must_equal "`#{bigquery.project}.#{dataset.dataset_id}.#{table.table_id}`"
+    _(fresh.etag).wont_be :nil?
+    _(fresh.api_url).wont_be :nil?
+    _(fresh.bytes_count).wont_be :nil?
+    _(fresh.rows_count).wont_be :nil?
+    _(fresh.created_at).must_be_kind_of Time
+    _(fresh.expires_at).must_be :nil?
+    _(fresh.modified_at).must_be_kind_of Time
+    _(fresh.table?).must_equal true
+    _(fresh.view?).must_equal false
+    _(fresh.time_partitioning?).must_equal false
+    _(fresh.time_partitioning_type).must_be_nil
+    _(fresh.time_partitioning_field).must_be_nil
+    _(fresh.time_partitioning_expiration).must_be_nil
+    _(fresh.range_partitioning?).must_equal false
+    _(fresh.range_partitioning_field).must_be_nil
+    _(fresh.range_partitioning_start).must_be_nil
+    _(fresh.range_partitioning_interval).must_be_nil
+    _(fresh.range_partitioning_end).must_be_nil
     #fresh.location.must_equal "US"       TODO why nil? Set in dataset
 
     # streaming buffer is transient, it seems it may or may not be present?
-    fresh.buffer_bytes.must_be_kind_of Integer if fresh.buffer_bytes
-    fresh.buffer_rows.must_be_kind_of Integer if fresh.buffer_rows
-    fresh.buffer_oldest_at.must_be_kind_of Time if fresh.buffer_oldest_at
+    _(fresh.buffer_bytes).must_be_kind_of Integer if fresh.buffer_bytes
+    _(fresh.buffer_rows).must_be_kind_of Integer if fresh.buffer_rows
+    _(fresh.buffer_oldest_at).must_be_kind_of Time if fresh.buffer_oldest_at
 
-    fresh.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    fresh.schema.wont_be :empty?
-    [:id, :breed, :name, :dob].each { |k| fresh.headers.must_include k }
+    _(fresh.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(fresh.schema).wont_be :empty?
+    [:id, :breed, :name, :dob].each { |k| _(fresh.headers).must_include k }
 
     fields = fresh.schema.fields
     fields.each do |f|
-      f.name.wont_be :nil?
-      f.type.wont_be :nil?
-      f.description.wont_be :nil?
-      f.mode.wont_be :nil?
+      _(f.name).wont_be :nil?
+      _(f.type).wont_be :nil?
+      _(f.description).wont_be :nil?
+      _(f.mode).wont_be :nil?
       f.name = f.name
       f.type = f.type
       f.description = f.description
@@ -148,10 +148,10 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
   end
 
   it "deletes itself and knows it no longer exists" do
-    table.exists?.must_equal true
-    table.delete.must_equal true
-    table.exists?.must_equal false
-    table.exists?(force: true).must_equal false
+    _(table.exists?).must_equal true
+    _(table.delete).must_equal true
+    _(table.exists?).must_equal false
+    _(table.exists?(force: true)).must_equal false
   end
 
   it "gets and sets metadata" do
@@ -164,25 +164,25 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     table.labels = new_labels
 
     table.reload!
-    table.table_id.must_equal table_id
-    table.name.must_equal new_name
-    table.description.must_equal new_desc
-    table.labels.must_equal new_labels
+    _(table.table_id).must_equal table_id
+    _(table.name).must_equal new_name
+    _(table.description).must_equal new_desc
+    _(table.labels).must_equal new_labels
   end
 
   it "should fail to set metadata with stale etag" do
     fresh = dataset.table table.table_id
-    fresh.etag.wont_be :nil?
+    _(fresh.etag).wont_be :nil?
 
     stale = dataset.table table_id
-    stale.etag.wont_be :nil?
-    stale.etag.must_equal fresh.etag
+    _(stale.etag).wont_be :nil?
+    _(stale.etag).must_equal fresh.etag
 
     # Modify on the server, which will change the etag
     fresh.description = "Description 1"
-    stale.etag.wont_equal fresh.etag
+    _(stale.etag).wont_equal fresh.etag
     err = expect { stale.description = "Description 2" }.must_raise Google::Cloud::FailedPreconditionError
-    err.message.must_equal "failedPrecondition: Precondition check failed."
+    _(err.message).must_equal "failedPrecondition: Precondition check failed."
   end
 
   it "create table returns valid etag equal to get table" do
@@ -193,11 +193,11 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
       schema.string    "name",  description: "name description",  mode: :required
       schema.timestamp "dob",   description: "dob description",   mode: :required
     end
-    fresh.etag.wont_be :nil?
+    _(fresh.etag).wont_be :nil?
 
     stale = dataset.table fresh_table_id
-    stale.etag.wont_be :nil?
-    stale.etag.must_equal fresh.etag
+    _(stale.etag).wont_be :nil?
+    _(stale.etag).must_equal fresh.etag
   end
 
   it "create table with cmek sets encryption" do
@@ -208,14 +208,14 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
       end
 
       cmek_table.reload!
-      cmek_table.table_id.must_equal "cmek_kittens"
-      cmek_table.encryption.must_equal encrypt_config
+      _(cmek_table.table_id).must_equal "cmek_kittens"
+      _(cmek_table.encryption).must_equal encrypt_config
 
       new_encrypt_config = bigquery.encryption(kms_key: kms_key_2)
       cmek_table.encryption = new_encrypt_config
 
       cmek_table.reload!
-      cmek_table.encryption.must_equal new_encrypt_config
+      _(cmek_table.encryption).must_equal new_encrypt_config
 
     ensure
       t2 = dataset.table "cmek_kittens"
@@ -229,26 +229,26 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
         t.schema.load File.open("acceptance/data/schema.json")
       end
 
-      table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-      table.schema.wont_be :empty?
+      _(table.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+      _(table.schema).wont_be :empty?
       %i[id breed name dob features].each do |k|
-        table.headers.must_include k
+        _(table.headers).must_include k
       end
 
       fields = table.schema.fields
       fields.each do |f|
-        f.name.wont_be :nil?
-        f.type.wont_be :nil?
-        f.description.wont_be :nil?
-        f.mode.wont_be :nil?
+        _(f.name).wont_be :nil?
+        _(f.type).wont_be :nil?
+        _(f.description).wont_be :nil?
+        _(f.mode).wont_be :nil?
 
         next unless f.name == "features"
-        f.fields.wont_be :empty?
+        _(f.fields).wont_be :empty?
         f.fields.each do |c|
-          c.name.wont_be :nil?
-          c.type.wont_be :nil?
-          c.description.wont_be :nil?
-          c.mode.wont_be :nil?
+          _(c.name).wont_be :nil?
+          _(c.type).wont_be :nil?
+          _(c.description).wont_be :nil?
+          _(c.mode).wont_be :nil?
         end
       end
     ensure
@@ -264,26 +264,26 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
         t.schema.load json
       end
 
-      table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-      table.schema.wont_be :empty?
+      _(table.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+      _(table.schema).wont_be :empty?
       %i[id breed name dob features].each do |k|
-        table.headers.must_include k
+        _(table.headers).must_include k
       end
 
       fields = table.schema.fields
       fields.each do |f|
-        f.name.wont_be :nil?
-        f.type.wont_be :nil?
-        f.description.wont_be :nil?
-        f.mode.wont_be :nil?
+        _(f.name).wont_be :nil?
+        _(f.type).wont_be :nil?
+        _(f.description).wont_be :nil?
+        _(f.mode).wont_be :nil?
 
         next unless f.name == "features"
-        f.fields.wont_be :empty?
+        _(f.fields).wont_be :empty?
         f.fields.each do |c|
-          c.name.wont_be :nil?
-          c.type.wont_be :nil?
-          c.description.wont_be :nil?
-          c.mode.wont_be :nil?
+          _(c.name).wont_be :nil?
+          _(c.type).wont_be :nil?
+          _(c.description).wont_be :nil?
+          _(c.mode).wont_be :nil?
         end
       end
     ensure
@@ -299,26 +299,26 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
         t.schema.load json
       end
 
-      table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-      table.schema.wont_be :empty?
+      _(table.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+      _(table.schema).wont_be :empty?
       %i[id breed name dob features].each do |k|
-        table.headers.must_include k
+        _(table.headers).must_include k
       end
 
       fields = table.schema.fields
       fields.each do |f|
-        f.name.wont_be :nil?
-        f.type.wont_be :nil?
-        f.description.wont_be :nil?
-        f.mode.wont_be :nil?
+        _(f.name).wont_be :nil?
+        _(f.type).wont_be :nil?
+        _(f.description).wont_be :nil?
+        _(f.mode).wont_be :nil?
 
         next unless f.name == "features"
-        f.fields.wont_be :empty?
+        _(f.fields).wont_be :empty?
         f.fields.each do |c|
-          c.name.wont_be :nil?
-          c.type.wont_be :nil?
-          c.description.wont_be :nil?
-          c.mode.wont_be :nil?
+          _(c.name).wont_be :nil?
+          _(c.type).wont_be :nil?
+          _(c.description).wont_be :nil?
+          _(c.mode).wont_be :nil?
         end
       end
     ensure
@@ -334,13 +334,13 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
       file.close
 
       json = JSON.parse(File.read(file.path))
-      json.length.must_equal 4
+      _(json.length).must_equal 4
 
       json.each do |f|
-        f["name"].wont_be :nil?
-        f["type"].wont_be :nil?
-        f["description"].wont_be :nil?
-        f["mode"].wont_be :nil?
+        _(f["name"]).wont_be :nil?
+        _(f["type"]).wont_be :nil?
+        _(f["description"]).wont_be :nil?
+        _(f["mode"]).wont_be :nil?
       end
     ensure
       if file
@@ -357,13 +357,13 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
       table.schema.dump file.path
 
       json = JSON.parse(File.read(file.path))
-      json.length.must_equal 4
+      _(json.length).must_equal 4
 
       json.each do |f|
-        f["name"].wont_be :nil?
-        f["type"].wont_be :nil?
-        f["description"].wont_be :nil?
-        f["mode"].wont_be :nil?
+        _(f["name"]).wont_be :nil?
+        _(f["type"]).wont_be :nil?
+        _(f["description"]).wont_be :nil?
+        _(f["mode"]).wont_be :nil?
       end
     ensure
       if file
@@ -389,10 +389,10 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     partitioned_table.time_partitioning_expiration = 1
 
     partitioned_table.reload!
-    partitioned_table.table_id.must_equal "kittens_field_reference"
-    partitioned_table.time_partitioning_type.must_equal "DAY"
-    partitioned_table.time_partitioning_field.must_equal "dob"
-    partitioned_table.time_partitioning_expiration.must_equal 1
+    _(partitioned_table.table_id).must_equal "kittens_field_reference"
+    _(partitioned_table.time_partitioning_type).must_equal "DAY"
+    _(partitioned_table.time_partitioning_field).must_equal "dob"
+    _(partitioned_table.time_partitioning_expiration).must_equal 1
   end
 
   it "updates its schema" do
@@ -401,14 +401,14 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
       t.schema do |s|
         s.boolean "available", description: "available description", mode: :nullable
       end
-      t.headers.must_equal [:available]
+      _(t.headers).must_equal [:available]
       t.schema replace: true do |s|
         s.boolean "available", description: "available description", mode: :nullable
         s.record "countries_lived", description: "countries_lived description", mode: :repeated do |nested|
           nested.float "rating", description: "An value from 1 to 10", mode: :nullable
         end
       end
-      t.headers.must_equal [:available, :countries_lived]
+      _(t.headers).must_equal [:available, :countries_lived]
     ensure
       t2 = dataset.table "table_schema_test"
       t2.delete if t2
@@ -426,14 +426,14 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
           s2.string "feature", description: "feature description", mode: :required
         end
       end
-      t.headers.must_equal %i[id breed name features]
+      _(t.headers).must_equal %i[id breed name features]
 
       t.schema do |s|
         s.load File.open("acceptance/data/schema.json")
       end
 
-      t.schema.wont_be :empty?
-      t.headers.must_equal %i[id breed name features dob]
+      _(t.schema).wont_be :empty?
+      _(t.headers).must_equal %i[id breed name features dob]
     ensure
       t2 = dataset.table "table_schema_test"
       t2.delete if t2
@@ -469,13 +469,13 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
       end
 
       data = t.data
-      data.count.must_equal 1
-      data.first[:id].must_equal 1
-      data.first[:breed].must_equal "thecatkind"
-      data.first[:name].must_equal "mike"
-      data.first[:dob].must_be_nil
-      data.first[:features].count.must_equal 1
-      data.first[:features].first[:feature].must_equal "Long Hair"
+      _(data.count).must_equal 1
+      _(data.first[:id]).must_equal 1
+      _(data.first[:breed]).must_equal "thecatkind"
+      _(data.first[:name]).must_equal "mike"
+      _(data.first[:dob]).must_be_nil
+      _(data.first[:features].count).must_equal 1
+      _(data.first[:features].first[:feature]).must_equal "Long Hair"
     ensure
       t2 = dataset.table "table_schema_test"
       t2.delete if t2
@@ -484,131 +484,131 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
 
   it "allows tables to be created with time_partitioning and clustering" do
     table = time_partitioned_table
-    table.time_partitioning?.must_equal true
-    table.time_partitioning_type.must_equal "DAY"
-    table.time_partitioning_field.must_equal "dob"
-    table.time_partitioning_expiration.must_equal seven_days
-    table.clustering_fields.must_equal clustering_fields
+    _(table.time_partitioning?).must_equal true
+    _(table.time_partitioning_type).must_equal "DAY"
+    _(table.time_partitioning_field).must_equal "dob"
+    _(table.time_partitioning_expiration).must_equal seven_days
+    _(table.clustering_fields).must_equal clustering_fields
   end
 
   it "allows tables to be created with range_partitioning" do
     table = range_partitioned_table
-    table.range_partitioning?.must_equal true
-    table.range_partitioning_field.must_equal "my_table_id"
-    table.range_partitioning_start.must_equal 0
-    table.range_partitioning_interval.must_equal 10
-    table.range_partitioning_end.must_equal 100
+    _(table.range_partitioning?).must_equal true
+    _(table.range_partitioning_field).must_equal "my_table_id"
+    _(table.range_partitioning_start).must_equal 0
+    _(table.range_partitioning_interval).must_equal 10
+    _(table.range_partitioning_end).must_equal 100
   end
 
   it "inserts rows directly and gets its data" do
     # data = table.data
     insert_response = table.insert rows
-    insert_response.must_be :success?
-    insert_response.insert_count.must_equal 3
-    insert_response.insert_errors.must_be :empty?
-    insert_response.error_rows.must_be :empty?
+    _(insert_response).must_be :success?
+    _(insert_response.insert_count).must_equal 3
+    _(insert_response.insert_errors).must_be :empty?
+    _(insert_response.error_rows).must_be :empty?
 
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     query_job = dataset.query_job query, job_id: job_id
-    query_job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    query_job.job_id.must_equal job_id
+    _(query_job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(query_job.job_id).must_equal job_id
     query_job.wait_until_done!
 
     # Job methods
-    query_job.done?.must_equal true
-    query_job.running?.must_equal false
-    query_job.pending?.must_equal false
-    query_job.created_at.must_be_kind_of Time
-    query_job.started_at.must_be_kind_of Time
-    query_job.ended_at.must_be_kind_of Time
-    query_job.configuration.wont_be :nil?
-    query_job.statistics.wont_be :nil?
-    query_job.status.wont_be :nil?
-    query_job.errors.must_be :empty?
+    _(query_job.done?).must_equal true
+    _(query_job.running?).must_equal false
+    _(query_job.pending?).must_equal false
+    _(query_job.created_at).must_be_kind_of Time
+    _(query_job.started_at).must_be_kind_of Time
+    _(query_job.ended_at).must_be_kind_of Time
+    _(query_job.configuration).wont_be :nil?
+    _(query_job.statistics).wont_be :nil?
+    _(query_job.status).wont_be :nil?
+    _(query_job.errors).must_be :empty?
     query_job.rerun!
     query_job.wait_until_done!
 
-    query_job.batch?.must_equal false
-    query_job.interactive?.must_equal true
-    query_job.large_results?.must_equal false
-    query_job.cache?.must_equal true
-    query_job.flatten?.must_equal true
-    query_job.bytes_processed.wont_be :nil?
-    query_job.destination.wont_be :nil?
-    query_job.data.class.must_equal Google::Cloud::Bigquery::Data
-    query_job.data.total.wont_be :nil?
+    _(query_job.batch?).must_equal false
+    _(query_job.interactive?).must_equal true
+    _(query_job.large_results?).must_equal false
+    _(query_job.cache?).must_equal true
+    _(query_job.flatten?).must_equal true
+    _(query_job.bytes_processed).wont_be :nil?
+    _(query_job.destination).wont_be :nil?
+    _(query_job.data.class).must_equal Google::Cloud::Bigquery::Data
+    _(query_job.data.total).wont_be :nil?
 
     # Query Job - Statistics Query Plan
-    query_job.query_plan.wont_be_nil
-    query_job.query_plan.must_be_kind_of Array
-    query_job.query_plan.wont_be :empty?
+    _(query_job.query_plan).wont_be_nil
+    _(query_job.query_plan).must_be_kind_of Array
+    _(query_job.query_plan).wont_be :empty?
     stage = query_job.query_plan.first
-    stage.must_be_kind_of Google::Cloud::Bigquery::QueryJob::Stage
-    stage.compute_ratio_avg.must_be_kind_of Numeric
-    stage.compute_ratio_max.must_be_kind_of Numeric
-    stage.id.must_be_kind_of Integer
-    stage.name.must_be_kind_of String
-    stage.read_ratio_avg.must_be_kind_of Numeric
-    stage.read_ratio_max.must_be_kind_of Numeric
-    stage.records_read.must_be_kind_of Integer
-    stage.records_written.must_be_kind_of Integer
-    stage.status.must_be_kind_of String
-    stage.wait_ratio_avg.must_be_kind_of Numeric
-    stage.wait_ratio_max.must_be_kind_of Numeric
-    stage.write_ratio_avg.must_be_kind_of Numeric
-    stage.write_ratio_max.must_be_kind_of Numeric
-    stage.steps.wont_be_nil
-    stage.steps.must_be_kind_of Array
-    stage.steps.wont_be :empty?
+    _(stage).must_be_kind_of Google::Cloud::Bigquery::QueryJob::Stage
+    _(stage.compute_ratio_avg).must_be_kind_of Numeric
+    _(stage.compute_ratio_max).must_be_kind_of Numeric
+    _(stage.id).must_be_kind_of Integer
+    _(stage.name).must_be_kind_of String
+    _(stage.read_ratio_avg).must_be_kind_of Numeric
+    _(stage.read_ratio_max).must_be_kind_of Numeric
+    _(stage.records_read).must_be_kind_of Integer
+    _(stage.records_written).must_be_kind_of Integer
+    _(stage.status).must_be_kind_of String
+    _(stage.wait_ratio_avg).must_be_kind_of Numeric
+    _(stage.wait_ratio_max).must_be_kind_of Numeric
+    _(stage.write_ratio_avg).must_be_kind_of Numeric
+    _(stage.write_ratio_max).must_be_kind_of Numeric
+    _(stage.steps).wont_be_nil
+    _(stage.steps).must_be_kind_of Array
+    _(stage.steps).wont_be :empty?
     step = stage.steps.first
-    step.must_be_kind_of Google::Cloud::Bigquery::QueryJob::Step
-    step.kind.must_be_kind_of String
-    step.substeps.wont_be_nil
-    step.substeps.must_be_kind_of Array
-    step.substeps.wont_be :empty?
+    _(step).must_be_kind_of Google::Cloud::Bigquery::QueryJob::Step
+    _(step.kind).must_be_kind_of String
+    _(step.substeps).wont_be_nil
+    _(step.substeps).must_be_kind_of Array
+    _(step.substeps).wont_be :empty?
 
     assert_data table.data(max: 1)
 
     data = dataset.query query
     assert_data data
-    data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    data.fields.count.must_equal 4
-    [:id, :breed, :name, :dob].each { |k| data.headers.must_include k }
+    _(data.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(data.fields.count).must_equal 4
+    [:id, :breed, :name, :dob].each { |k| _(data.headers).must_include k }
     data.all.each do |row|
-      row.must_be_kind_of Hash
+      _(row).must_be_kind_of Hash
     end
-    data.next.must_be :nil?
+    _(data.next).must_be :nil?
   end
 
   it "insert skip invalid rows and return insert errors" do
     # data = table.data
     insert_response = table.insert invalid_rows, skip_invalid: true
-    insert_response.wont_be :success?
-    insert_response.insert_count.must_equal 2
+    _(insert_response).wont_be :success?
+    _(insert_response.insert_count).must_equal 2
 
-    insert_response.insert_errors.wont_be :empty?
-    insert_response.insert_errors.count.must_equal 1
-    insert_response.insert_errors.first.class.must_equal Google::Cloud::Bigquery::InsertResponse::InsertError
-    insert_response.insert_errors.first.index.must_equal 1
+    _(insert_response.insert_errors).wont_be :empty?
+    _(insert_response.insert_errors.count).must_equal 1
+    _(insert_response.insert_errors.first.class).must_equal Google::Cloud::Bigquery::InsertResponse::InsertError
+    _(insert_response.insert_errors.first.index).must_equal 1
 
     bigquery_row = invalid_rows[insert_response.insert_errors.first.index]
-    insert_response.insert_errors.first.row.must_equal bigquery_row
+    _(insert_response.insert_errors.first.row).must_equal bigquery_row
 
-    insert_response.error_rows.wont_be :empty?
-    insert_response.error_rows.count.must_equal 1
-    insert_response.error_rows.first.must_equal bigquery_row
+    _(insert_response.error_rows).wont_be :empty?
+    _(insert_response.error_rows.count).must_equal 1
+    _(insert_response.error_rows.first).must_equal bigquery_row
 
-    insert_response.insert_error_for(invalid_rows[1]).index.must_equal insert_response.insert_errors.first.index
-    insert_response.errors_for(invalid_rows[1]).wont_be :empty?
-    insert_response.index_for(invalid_rows[1]).must_equal 1
+    _(insert_response.insert_error_for(invalid_rows[1]).index).must_equal insert_response.insert_errors.first.index
+    _(insert_response.errors_for(invalid_rows[1])).wont_be :empty?
+    _(insert_response.index_for(invalid_rows[1])).must_equal 1
   end
 
   it "inserts rows with insert_ids option" do
     insert_response = table.insert rows, insert_ids: insert_ids
-    insert_response.must_be :success?
-    insert_response.insert_count.must_equal 3
-    insert_response.insert_errors.must_be :empty?
-    insert_response.error_rows.must_be :empty?
+    _(insert_response).must_be :success?
+    _(insert_response.insert_count).must_equal 3
+    _(insert_response.insert_errors).must_be :empty?
+    _(insert_response.error_rows).must_be :empty?
 
     assert_data table.data(max: 1)
   end
@@ -625,82 +625,82 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     inserter.flush
     inserter.stop.wait!
 
-    insert_result.must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
-    insert_result.must_be :success?
-    insert_result.insert_count.must_equal 3
-    insert_result.insert_errors.must_be :empty?
-    insert_result.error_rows.must_be :empty?
+    _(insert_result).must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
+    _(insert_result).must_be :success?
+    _(insert_result.insert_count).must_equal 3
+    _(insert_result.insert_errors).must_be :empty?
+    _(insert_result.error_rows).must_be :empty?
 
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     query_job = dataset.query_job query, job_id: job_id
-    query_job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    query_job.job_id.must_equal job_id
+    _(query_job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(query_job.job_id).must_equal job_id
     query_job.wait_until_done!
 
     # Job methods
-    query_job.done?.must_equal true
-    query_job.running?.must_equal false
-    query_job.pending?.must_equal false
-    query_job.created_at.must_be_kind_of Time
-    query_job.started_at.must_be_kind_of Time
-    query_job.ended_at.must_be_kind_of Time
-    query_job.configuration.wont_be :nil?
-    query_job.statistics.wont_be :nil?
-    query_job.status.wont_be :nil?
-    query_job.errors.must_be :empty?
+    _(query_job.done?).must_equal true
+    _(query_job.running?).must_equal false
+    _(query_job.pending?).must_equal false
+    _(query_job.created_at).must_be_kind_of Time
+    _(query_job.started_at).must_be_kind_of Time
+    _(query_job.ended_at).must_be_kind_of Time
+    _(query_job.configuration).wont_be :nil?
+    _(query_job.statistics).wont_be :nil?
+    _(query_job.status).wont_be :nil?
+    _(query_job.errors).must_be :empty?
     query_job.rerun!
     query_job.wait_until_done!
 
-    query_job.batch?.must_equal false
-    query_job.interactive?.must_equal true
-    query_job.large_results?.must_equal false
-    query_job.cache?.must_equal true
-    query_job.flatten?.must_equal true
-    query_job.bytes_processed.wont_be :nil?
-    query_job.destination.wont_be :nil?
-    query_job.data.class.must_equal Google::Cloud::Bigquery::Data
-    query_job.data.total.wont_be :nil?
+    _(query_job.batch?).must_equal false
+    _(query_job.interactive?).must_equal true
+    _(query_job.large_results?).must_equal false
+    _(query_job.cache?).must_equal true
+    _(query_job.flatten?).must_equal true
+    _(query_job.bytes_processed).wont_be :nil?
+    _(query_job.destination).wont_be :nil?
+    _(query_job.data.class).must_equal Google::Cloud::Bigquery::Data
+    _(query_job.data.total).wont_be :nil?
 
     # Query Job - Statistics Query Plan
-    query_job.query_plan.wont_be_nil
-    query_job.query_plan.must_be_kind_of Array
-    query_job.query_plan.wont_be :empty?
+    _(query_job.query_plan).wont_be_nil
+    _(query_job.query_plan).must_be_kind_of Array
+    _(query_job.query_plan).wont_be :empty?
     stage = query_job.query_plan.first
-    stage.must_be_kind_of Google::Cloud::Bigquery::QueryJob::Stage
-    stage.compute_ratio_avg.must_be_kind_of Numeric
-    stage.compute_ratio_max.must_be_kind_of Numeric
-    stage.id.must_be_kind_of Integer
-    stage.name.must_be_kind_of String
-    stage.read_ratio_avg.must_be_kind_of Numeric
-    stage.read_ratio_max.must_be_kind_of Numeric
-    stage.records_read.must_be_kind_of Integer
-    stage.records_written.must_be_kind_of Integer
-    stage.status.must_be_kind_of String
-    stage.wait_ratio_avg.must_be_kind_of Numeric
-    stage.wait_ratio_max.must_be_kind_of Numeric
-    stage.write_ratio_avg.must_be_kind_of Numeric
-    stage.write_ratio_max.must_be_kind_of Numeric
-    stage.steps.wont_be_nil
-    stage.steps.must_be_kind_of Array
-    stage.steps.wont_be :empty?
+    _(stage).must_be_kind_of Google::Cloud::Bigquery::QueryJob::Stage
+    _(stage.compute_ratio_avg).must_be_kind_of Numeric
+    _(stage.compute_ratio_max).must_be_kind_of Numeric
+    _(stage.id).must_be_kind_of Integer
+    _(stage.name).must_be_kind_of String
+    _(stage.read_ratio_avg).must_be_kind_of Numeric
+    _(stage.read_ratio_max).must_be_kind_of Numeric
+    _(stage.records_read).must_be_kind_of Integer
+    _(stage.records_written).must_be_kind_of Integer
+    _(stage.status).must_be_kind_of String
+    _(stage.wait_ratio_avg).must_be_kind_of Numeric
+    _(stage.wait_ratio_max).must_be_kind_of Numeric
+    _(stage.write_ratio_avg).must_be_kind_of Numeric
+    _(stage.write_ratio_max).must_be_kind_of Numeric
+    _(stage.steps).wont_be_nil
+    _(stage.steps).must_be_kind_of Array
+    _(stage.steps).wont_be :empty?
     step = stage.steps.first
-    step.must_be_kind_of Google::Cloud::Bigquery::QueryJob::Step
-    step.kind.must_be_kind_of String
-    step.substeps.wont_be_nil
-    step.substeps.must_be_kind_of Array
-    step.substeps.wont_be :empty?
+    _(step).must_be_kind_of Google::Cloud::Bigquery::QueryJob::Step
+    _(step.kind).must_be_kind_of String
+    _(step.substeps).wont_be_nil
+    _(step.substeps).must_be_kind_of Array
+    _(step.substeps).wont_be :empty?
 
     assert_data table.data(max: 1)
 
     data = dataset.query query
     assert_data data
-    data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    data.fields.count.must_equal 4
-    [:id, :breed, :name, :dob].each { |k| data.headers.must_include k }
+    _(data.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(data.fields.count).must_equal 4
+    [:id, :breed, :name, :dob].each { |k| _(data.headers).must_include k }
     data.all.each do |row|
-      row.must_be_kind_of Hash
+      _(row).must_be_kind_of Hash
     end
-    data.next.must_be :nil?
+    _(data.next).must_be :nil?
   end
 
   it "inserts rows asynchronously with insert_ids option" do
@@ -714,11 +714,11 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     inserter.flush
     inserter.stop.wait!
 
-    insert_result.must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
-    insert_result.must_be :success?
-    insert_result.insert_count.must_equal 3
-    insert_result.insert_errors.must_be :empty?
-    insert_result.error_rows.must_be :empty?
+    _(insert_result).must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
+    _(insert_result).must_be :success?
+    _(insert_result.insert_count).must_equal 3
+    _(insert_result.insert_errors).must_be :empty?
+    _(insert_result.error_rows).must_be :empty?
 
     assert_data table.data(max: 1)
   end
@@ -728,13 +728,13 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     job = table.load_job local_file, job_id: job_id do |j|
       j.labels = labels
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    job.job_id.must_equal job_id
-    job.labels.must_equal labels
-    job.wont_be :autodetect?
-    job.null_marker.must_equal ""
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job.job_id).must_equal job_id
+    _(job.labels).must_equal labels
+    _(job).wont_be :autodetect?
+    _(job.null_marker).must_equal ""
     job.wait_until_done!
-    job.output_rows.must_equal 3
+    _(job.output_rows).must_equal 3
   end
 
   it "imports data from a file in your bucket with load_job" do
@@ -742,7 +742,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
 
     job = table.load_job file
     job.wait_until_done!
-    job.wont_be :failed?
+    _(job).wont_be :failed?
   end
 
   it "imports data from a list of files in your bucket with load_job" do
@@ -754,21 +754,21 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     # Test both by file object and URL as string
     job = table.load_job [file1, gs_url]
     job.wait_until_done!
-    job.wont_be :failed?
-    job.input_files.must_equal 2
-    job.output_rows.must_equal 6
+    _(job).wont_be :failed?
+    _(job.input_files).must_equal 2
+    _(job.output_rows).must_equal 6
   end
 
   it "imports data from a local file with load" do
     result = table.load local_file
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "imports data from a file in your bucket with load" do
     file = bucket.create_file local_file, random_file_destination_name
 
     result = table.load file
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "imports data from a list of files in your bucket with load" do
@@ -779,26 +779,26 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
 
     # Test both by file object and URL as string
     result = table.load [file1, gs_url]
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "copies itself to another table with copy_job" do
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     copy_job = table.copy_job target_table_id, create: :needed, write: :empty, job_id: job_id, labels: labels
 
-    copy_job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    copy_job.job_id.must_equal job_id
-    copy_job.labels.must_equal labels
+    _(copy_job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(copy_job.job_id).must_equal job_id
+    _(copy_job.labels).must_equal labels
     copy_job.wait_until_done!
 
-    copy_job.wont_be :failed?
-    copy_job.source.table_id.must_equal table.table_id
-    copy_job.destination.table_id.must_equal target_table_id
-    copy_job.create_if_needed?.must_equal true
-    copy_job.create_never?.must_equal false
-    copy_job.write_truncate?.must_equal false
-    copy_job.write_append?.must_equal false
-    copy_job.write_empty?.must_equal true
+    _(copy_job).wont_be :failed?
+    _(copy_job.source.table_id).must_equal table.table_id
+    _(copy_job.destination.table_id).must_equal target_table_id
+    _(copy_job.create_if_needed?).must_equal true
+    _(copy_job.create_never?).must_equal false
+    _(copy_job.write_truncate?).must_equal false
+    _(copy_job.write_append?).must_equal false
+    _(copy_job.write_empty?).must_equal true
   end
 
   it "copies itself to another table with copy_job block updater" do
@@ -809,24 +809,24 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
       j.labels = labels
     end
 
-    copy_job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    copy_job.job_id.must_equal job_id
-    copy_job.labels.must_equal labels
+    _(copy_job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(copy_job.job_id).must_equal job_id
+    _(copy_job.labels).must_equal labels
     copy_job.wait_until_done!
 
-    copy_job.wont_be :failed?
-    copy_job.source.table_id.must_equal table.table_id
-    copy_job.destination.table_id.must_equal target_table_2_id
-    copy_job.create_if_needed?.must_equal true
-    copy_job.create_never?.must_equal false
-    copy_job.write_truncate?.must_equal false
-    copy_job.write_append?.must_equal false
-    copy_job.write_empty?.must_equal true
+    _(copy_job).wont_be :failed?
+    _(copy_job.source.table_id).must_equal table.table_id
+    _(copy_job.destination.table_id).must_equal target_table_2_id
+    _(copy_job.create_if_needed?).must_equal true
+    _(copy_job.create_never?).must_equal false
+    _(copy_job.write_truncate?).must_equal false
+    _(copy_job.write_append?).must_equal false
+    _(copy_job.write_empty?).must_equal true
   end
 
   it "copies itself to another table with copy" do
     result = table.copy target_table_3_id, create: :needed, write: :empty
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "copies itself to another table with copy with encryption" do
@@ -835,67 +835,67 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
                                            write: :truncate do |copy|
       copy.encryption = encrypt_config
     end
-    result.must_equal true
+    _(result).must_equal true
 
     cmek_table = dataset.table target_table_4_id
-    cmek_table.encryption.must_equal encrypt_config
+    _(cmek_table.encryption).must_equal encrypt_config
   end
 
   it "creates and cancels jobs" do
     load_job = table.load_job local_file
 
-    load_job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    load_job.wont_be :done?
+    _(load_job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(load_job).wont_be :done?
 
     load_job.cancel
     load_job.wait_until_done!
 
-    load_job.must_be :done?
+    _(load_job).must_be :done?
 
-    load_job.wont_be :failed?
+    _(load_job).wont_be :failed?
   end
 
   it "extracts data to a url in your bucket with extract_job" do
     # Make sure there is data to extract...
     load_job = table.load_job local_file
 
-    load_job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(load_job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
     load_job.wait_until_done!
 
-    load_job.wont_be :failed?
-    load_job.destination.table_id.must_equal table.table_id
-    load_job.delimiter.must_equal ","
-    load_job.skip_leading_rows.must_equal 0
-    load_job.utf8?.must_equal true
-    load_job.iso8859_1?.must_equal false
-    load_job.quote.must_equal "\""
-    load_job.max_bad_records.must_equal 0
-    load_job.quoted_newlines?.must_equal false
-    load_job.json?.must_equal true
-    load_job.csv?.must_equal false
-    load_job.backup?.must_equal false
-    load_job.allow_jagged_rows?.must_equal false
-    load_job.ignore_unknown_values?.must_equal false
-    load_job.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    load_job.schema.wont_be :empty?
-    load_job.schema_update_options.must_be_kind_of Array
-    load_job.schema_update_options.must_be :empty?
-    load_job.range_partitioning?.must_equal false
-    load_job.range_partitioning_field.must_be_nil
-    load_job.range_partitioning_start.must_be_nil
-    load_job.range_partitioning_interval.must_be_nil
-    load_job.range_partitioning_end.must_be_nil
-    load_job.time_partitioning?.must_equal false
-    load_job.time_partitioning_type.must_be :nil?
-    load_job.time_partitioning_field.must_be :nil?
-    load_job.time_partitioning_expiration.must_be :nil?
-    load_job.time_partitioning_require_filter?.must_equal false
-    load_job.clustering?.must_equal false
-    load_job.clustering_fields.must_be :nil?
-    load_job.input_files.must_equal 1
-    load_job.input_file_bytes.must_be :>, 0
-    load_job.output_rows.must_be :>, 0
-    load_job.output_bytes.must_be :>, 0
+    _(load_job).wont_be :failed?
+    _(load_job.destination.table_id).must_equal table.table_id
+    _(load_job.delimiter).must_equal ","
+    _(load_job.skip_leading_rows).must_equal 0
+    _(load_job.utf8?).must_equal true
+    _(load_job.iso8859_1?).must_equal false
+    _(load_job.quote).must_equal "\""
+    _(load_job.max_bad_records).must_equal 0
+    _(load_job.quoted_newlines?).must_equal false
+    _(load_job.json?).must_equal true
+    _(load_job.csv?).must_equal false
+    _(load_job.backup?).must_equal false
+    _(load_job.allow_jagged_rows?).must_equal false
+    _(load_job.ignore_unknown_values?).must_equal false
+    _(load_job.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(load_job.schema).wont_be :empty?
+    _(load_job.schema_update_options).must_be_kind_of Array
+    _(load_job.schema_update_options).must_be :empty?
+    _(load_job.range_partitioning?).must_equal false
+    _(load_job.range_partitioning_field).must_be_nil
+    _(load_job.range_partitioning_start).must_be_nil
+    _(load_job.range_partitioning_interval).must_be_nil
+    _(load_job.range_partitioning_end).must_be_nil
+    _(load_job.time_partitioning?).must_equal false
+    _(load_job.time_partitioning_type).must_be :nil?
+    _(load_job.time_partitioning_field).must_be :nil?
+    _(load_job.time_partitioning_expiration).must_be :nil?
+    _(load_job.time_partitioning_require_filter?).must_equal false
+    _(load_job.clustering?).must_equal false
+    _(load_job.clustering_fields).must_be :nil?
+    _(load_job.input_files).must_equal 1
+    _(load_job.input_file_bytes).must_be :>, 0
+    _(load_job.output_rows).must_be :>, 0
+    _(load_job.output_bytes).must_be :>, 0
 
     Tempfile.open "empty_extract_file.json" do |tmp|
       dest_file_name = random_file_destination_name
@@ -904,23 +904,23 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
         j.labels = labels
       end
 
-      extract_job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-      extract_job.labels.must_equal labels
+      _(extract_job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+      _(extract_job.labels).must_equal labels
       extract_job.wait_until_done!
 
-      extract_job.wont_be :failed?
-      extract_job.source.table_id.must_equal table.table_id
-      extract_job.compression?.must_equal false
-      extract_job.json?.must_equal true
-      extract_job.csv?.must_equal false
-      extract_job.delimiter.must_equal ","
-      extract_job.print_header?.must_equal true
-      extract_job.destinations_file_counts.wont_be :empty?
-      extract_job.destinations_counts.wont_be :empty?
+      _(extract_job).wont_be :failed?
+      _(extract_job.source.table_id).must_equal table.table_id
+      _(extract_job.compression?).must_equal false
+      _(extract_job.json?).must_equal true
+      _(extract_job.csv?).must_equal false
+      _(extract_job.delimiter).must_equal ","
+      _(extract_job.print_header?).must_equal true
+      _(extract_job.destinations_file_counts).wont_be :empty?
+      _(extract_job.destinations_counts).wont_be :empty?
 
       extract_file = bucket.file dest_file_name
       downloaded_file = extract_file.download tmp.path
-      downloaded_file.size.must_be :>, 0
+      _(downloaded_file.size).must_be :>, 0
     end
   end
 
@@ -929,54 +929,54 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     load_job = table.load_job local_file
     load_job.wait_until_done!
     Tempfile.open "empty_extract_file.json" do |tmp|
-      tmp.size.must_equal 0
+      _(tmp.size).must_equal 0
       dest_file_name = random_file_destination_name
       extract_file = bucket.create_file tmp, dest_file_name
       job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
 
       extract_job = table.extract_job extract_file, job_id: job_id
-      extract_job.job_id.must_equal job_id
+      _(extract_job.job_id).must_equal job_id
       extract_job.wait_until_done!
-      extract_job.wont_be :failed?
+      _(extract_job).wont_be :failed?
       # Refresh to get the latest file data
       extract_file = bucket.file dest_file_name
       downloaded_file = extract_file.download tmp.path
-      downloaded_file.size.must_be :>, 0
+      _(downloaded_file.size).must_be :>, 0
     end
   end
 
   it "extracts data to a url in your bucket with extract" do
     # Make sure there is data to extract...
     result = table.load local_file
-    result.must_equal true
+    _(result).must_equal true
 
     Tempfile.open "empty_extract_file.json" do |tmp|
       dest_file_name = random_file_destination_name
       extract_url = "gs://#{bucket.name}/#{dest_file_name}"
       result = table.extract extract_url
-      result.must_equal true
+      _(result).must_equal true
 
       extract_file = bucket.file dest_file_name
       downloaded_file = extract_file.download tmp.path
-      downloaded_file.size.must_be :>, 0
+      _(downloaded_file.size).must_be :>, 0
     end
   end
 
   it "extracts data to a file in your bucket with extract" do
     # Make sure there is data to extract...
     result = table.load local_file
-    result.must_equal true
+    _(result).must_equal true
     Tempfile.open "empty_extract_file.json" do |tmp|
-      tmp.size.must_equal 0
+      _(tmp.size).must_equal 0
       dest_file_name = random_file_destination_name
       extract_file = bucket.create_file tmp, dest_file_name
 
       result = table.extract extract_file
-      result.must_equal true
+      _(result).must_equal true
       # Refresh to get the latest file data
       extract_file = bucket.file dest_file_name
       downloaded_file = extract_file.download tmp.path
-      downloaded_file.size.must_be :>, 0
+      _(downloaded_file.size).must_be :>, 0
     end
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/view_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/view_test.rb
@@ -36,22 +36,22 @@ describe Google::Cloud::Bigquery::Table, :view, :bigquery do
 
   it "has the attributes of a view" do
     fresh = dataset.table view.table_id
-    fresh.must_be_kind_of  Google::Cloud::Bigquery::Table
+    _(fresh).must_be_kind_of  Google::Cloud::Bigquery::Table
 
-    fresh.project_id.must_equal bigquery.project
-    fresh.id.must_equal "#{bigquery.project}:#{dataset.dataset_id}.#{view.table_id}"
-    fresh.query_id.must_equal "`#{bigquery.project}.#{dataset.dataset_id}.#{view.table_id}`"
-    fresh.etag.wont_be :nil?
-    fresh.api_url.wont_be :nil?
-    fresh.query_id.must_equal view.query_id
-    fresh.created_at.must_be_kind_of Time
-    fresh.expires_at.must_be :nil?
-    fresh.modified_at.must_be_kind_of Time
-    fresh.table?.must_equal false
-    fresh.view?.must_equal true
+    _(fresh.project_id).must_equal bigquery.project
+    _(fresh.id).must_equal "#{bigquery.project}:#{dataset.dataset_id}.#{view.table_id}"
+    _(fresh.query_id).must_equal "`#{bigquery.project}.#{dataset.dataset_id}.#{view.table_id}`"
+    _(fresh.etag).wont_be :nil?
+    _(fresh.api_url).wont_be :nil?
+    _(fresh.query_id).must_equal view.query_id
+    _(fresh.created_at).must_be_kind_of Time
+    _(fresh.expires_at).must_be :nil?
+    _(fresh.modified_at).must_be_kind_of Time
+    _(fresh.table?).must_equal false
+    _(fresh.view?).must_equal true
     #fresh.location.must_equal "US"       TODO why nil? Set in dataset
-    fresh.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    fresh.headers.must_equal [:url]
+    _(fresh.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(fresh.headers).must_equal [:url]
   end
 
   it "gets and sets attributes" do
@@ -63,24 +63,24 @@ describe Google::Cloud::Bigquery::Table, :view, :bigquery do
     view.query = publicdata_query_2
 
     view.reload!
-    view.table_id.must_equal view_id
-    view.name.must_equal new_name
-    view.description.must_equal new_desc
-    view.query.must_equal publicdata_query_2
+    _(view.table_id).must_equal view_id
+    _(view.name).must_equal new_name
+    _(view.description).must_equal new_desc
+    _(view.query).must_equal publicdata_query_2
   end
 
   it "should fail to set metadata with stale etag" do
     fresh = dataset.table view.table_id
-    fresh.etag.wont_be :nil?
+    _(fresh.etag).wont_be :nil?
 
     stale = dataset.table view_id
-    stale.etag.wont_be :nil?
-    stale.etag.must_equal fresh.etag
+    _(stale.etag).wont_be :nil?
+    _(stale.etag).must_equal fresh.etag
 
     # Modify on the server, which will change the etag
     fresh.description = "Description 1"
-    stale.etag.wont_equal fresh.etag
+    _(stale.etag).wont_equal fresh.etag
     err = expect { stale.description = "Description 2" }.must_raise Google::Cloud::FailedPreconditionError
-    err.message.must_equal "failedPrecondition: Precondition check failed."
+    _(err.message).must_equal "failedPrecondition: Precondition check failed."
   end
 end

--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "google-style", "~> 1.24.0"
-  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
@@ -28,8 +28,8 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
 
     mock.verify
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
-    dataset.dataset_id.must_equal dataset_id
+    _(dataset).must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(dataset.dataset_id).must_equal dataset_id
   end
 
   it "handles a single 404 error (retriable) and retries with backoff" do
@@ -66,8 +66,8 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
     Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
       dataset = bigquery.dataset dataset_id
 
-      dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
-      dataset.dataset_id.must_equal dataset_id
+      _(dataset).must_be_kind_of Google::Cloud::Bigquery::Dataset
+      _(dataset.dataset_id).must_equal dataset_id
     end
 
     mock.verify
@@ -107,8 +107,8 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
     Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
       dataset = bigquery.dataset dataset_id
 
-      dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
-      dataset.dataset_id.must_equal dataset_id
+      _(dataset).must_be_kind_of Google::Cloud::Bigquery::Dataset
+      _(dataset.dataset_id).must_equal dataset_id
     end
 
     mock.verify
@@ -132,8 +132,8 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
         bigquery.dataset dataset_id
       end
 
-      err.message.must_equal "notfound"
-      err.cause.body.must_equal "{\"error\":{\"errors\":[{\"reason\":\"backendError\"},{\"reason\":\"other\"}]}}"
+      _(err.message).must_equal "notfound"
+      _(err.cause.body).must_equal "{\"error\":{\"errors\":[{\"reason\":\"backendError\"},{\"reason\":\"other\"}]}}"
     end
 
     mock.verify
@@ -175,8 +175,8 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
     Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
       dataset = bigquery.dataset dataset_id
 
-      dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
-      dataset.dataset_id.must_equal dataset_id
+      _(dataset).must_be_kind_of Google::Cloud::Bigquery::Dataset
+      _(dataset.dataset_id).must_equal dataset_id
     end
 
     mock.verify
@@ -210,8 +210,8 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
         bigquery.dataset dataset_id
       end
 
-      err.message.must_equal "invalid"
-      err.cause.body.must_be :nil?
+      _(err.message).must_equal "invalid"
+      _(err.cause.body).must_be :nil?
     end
 
     mock.verify
@@ -240,8 +240,8 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
         bigquery.dataset dataset_id
       end
 
-      err.message.must_equal "invalid"
-      err.cause.body.must_equal "{\"error\":{\"errors\":[{\"reason\":\"backendError\"}]}}"
+      _(err.message).must_equal "invalid"
+      _(err.cause.body).must_equal "{\"error\":{\"errors\":[{\"reason\":\"backendError\"}]}}"
     end
 
     mock.verify
@@ -258,7 +258,7 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
       bigquery.dataset dataset_id
     end
 
-    err.message.must_equal "invalid"
+    _(err.message).must_equal "invalid"
   end
 
   it "does not handle a single 404 error with reason (non-retriable)" do
@@ -273,7 +273,7 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
       bigquery.dataset dataset_id
     end
 
-    err.message.must_equal "invalid"
+    _(err.message).must_equal "invalid"
   end
 
   it "re-raises non-retriable errors" do
@@ -290,7 +290,7 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
       bigquery.dataset dataset_id
     end
 
-    err.message.must_equal "nope"
+    _(err.message).must_equal "nope"
   end
 
   def find_dataset_gapi id

--- a/google-cloud-bigquery/test/google/cloud/bigquery/convert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/convert_test.rb
@@ -20,25 +20,25 @@ describe Google::Cloud::Bigquery::Convert do
 
   describe :millis_to_time do
     it "converts nil to nil with no error" do
-      Google::Cloud::Bigquery::Convert.millis_to_time(nil).must_be :nil?
+      _(Google::Cloud::Bigquery::Convert.millis_to_time(nil)).must_be :nil?
     end
 
     it "converts time in millis to a Time object with same value in seconds" do
       converted_time = Google::Cloud::Bigquery::Convert.millis_to_time time_millis
-      converted_time.must_be_kind_of ::Time
-      converted_time.must_equal time_object
+      _(converted_time).must_be_kind_of ::Time
+      _(converted_time).must_equal time_object
     end
   end
 
   describe :time_to_millis do
     it "converts nil to nil with no error" do
-      Google::Cloud::Bigquery::Convert.time_to_millis(nil).must_be :nil?
+      _(Google::Cloud::Bigquery::Convert.time_to_millis(nil)).must_be :nil?
     end
 
     it "converts time in millis to a Time object with same value in seconds" do
       converted_millis = Google::Cloud::Bigquery::Convert.time_to_millis time_object
-      converted_millis.must_be_kind_of ::Integer
-      converted_millis.must_equal time_millis
+      _(converted_millis).must_be_kind_of ::Integer
+      _(converted_millis).must_equal time_millis
     end
   end
 
@@ -47,20 +47,20 @@ describe Google::Cloud::Bigquery::Convert do
       float_type = Google::Apis::BigqueryV2::TableFieldSchema.new(type: "FLOAT")
 
       f = Google::Cloud::Bigquery::Convert.format_value({ v: "3.333" }, float_type)
-      f.must_be_kind_of ::Float
-      f.must_equal 3.333
+      _(f).must_be_kind_of ::Float
+      _(f).must_equal 3.333
 
       f = Google::Cloud::Bigquery::Convert.format_value({ v: "Infinity" }, float_type)
-      f.must_be_kind_of ::Float
-      f.must_equal Float::INFINITY
+      _(f).must_be_kind_of ::Float
+      _(f).must_equal Float::INFINITY
 
       f = Google::Cloud::Bigquery::Convert.format_value({ v: "-Infinity" }, float_type)
-      f.must_be_kind_of ::Float
-      f.must_equal -Float::INFINITY
+      _(f).must_be_kind_of ::Float
+      _(f).must_equal -Float::INFINITY
 
       f = Google::Cloud::Bigquery::Convert.format_value({ v: "NaN" }, float_type)
-      f.must_be_kind_of ::Float
-      f.must_be :nan?
+      _(f).must_be_kind_of ::Float
+      _(f).must_be :nan?
     end
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/copy_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/copy_job_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Bigquery::CopyJob, :mock_bigquery do
   let(:job_id) { job.job_id }
 
   it "knows it is copy job" do
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "knows its copy tables" do
@@ -32,34 +32,34 @@ describe Google::Cloud::Bigquery::CopyJob, :mock_bigquery do
     mock.expect :get_table, source_table_gapi, ["source_project_id", "source_dataset_id", "source_table_id"]
 
     source = job.source
-    source.must_be_kind_of Google::Cloud::Bigquery::Table
-    source.project_id.must_equal "source_project_id"
-    source.dataset_id.must_equal "source_dataset_id"
-    source.table_id.must_equal   "source_table_id"
+    _(source).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(source.project_id).must_equal "source_project_id"
+    _(source.dataset_id).must_equal "source_dataset_id"
+    _(source.table_id).must_equal   "source_table_id"
 
     mock.expect :get_table, destination_table_gapi, ["target_project_id", "target_dataset_id", "target_table_id"]
     destination = job.destination
-    destination.must_be_kind_of Google::Cloud::Bigquery::Table
-    destination.project_id.must_equal "target_project_id"
-    destination.dataset_id.must_equal "target_dataset_id"
-    destination.table_id.must_equal   "target_table_id"
+    _(destination).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(destination.project_id).must_equal "target_project_id"
+    _(destination.dataset_id).must_equal "target_dataset_id"
+    _(destination.table_id).must_equal   "target_table_id"
 
     mock.verify
   end
 
   it "knows its create/write disposition flags" do
-    job.must_be :create_if_needed?
-    job.wont_be :create_never?
-    job.wont_be :write_truncate?
-    job.wont_be :write_append?
-    job.must_be :write_empty?
+    _(job).must_be :create_if_needed?
+    _(job).wont_be :create_never?
+    _(job).wont_be :write_truncate?
+    _(job).wont_be :write_append?
+    _(job).must_be :write_empty?
   end
 
   it "knows its copy config" do
-    job.config.must_be_kind_of Hash
-    job.config["copy"]["sourceTable"]["projectId"].must_equal "source_project_id"
-    job.config["copy"]["destinationTable"]["tableId"].must_equal "target_table_id"
-    job.config["copy"]["createDisposition"].must_equal "CREATE_IF_NEEDED"
+    _(job.config).must_be_kind_of Hash
+    _(job.config["copy"]["sourceTable"]["projectId"]).must_equal "source_project_id"
+    _(job.config["copy"]["destinationTable"]["tableId"]).must_equal "target_table_id"
+    _(job.config["copy"]["createDisposition"]).must_equal "CREATE_IF_NEEDED"
   end
 
   it "can re-run itself" do
@@ -73,8 +73,8 @@ describe Google::Cloud::Bigquery::CopyJob, :mock_bigquery do
     mock.expect :insert_job, copy_job_gapi(job.job_id + "-rerun"), [project, rerun_job_gapi]
 
     new_job = job.rerun!
-    new_job.config["dryRun"].must_equal job.config["dryRun"]
-    new_job.job_id.wont_equal job.job_id
+    _(new_job.config["dryRun"]).must_equal job.config["dryRun"]
+    _(new_job.job_id).wont_equal job.job_id
     mock.verify
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -33,44 +33,44 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data = table.data
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.count.must_equal 3
-    data[0].must_be_kind_of Hash
-    data[0][:name].must_equal "Heidi"
-    data[0][:age].must_equal 36
-    data[0][:score].must_equal 7.65
-    data[0][:pi].must_equal BigDecimal("3.141592654")
-    data[0][:active].must_equal true
-    data[0][:avatar].must_be_kind_of StringIO
-    data[0][:avatar].read.must_equal "image data"
-    data[0][:started_at].must_equal Time.parse("2016-12-25 13:00:00 UTC")
-    data[0][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
-    data[0][:target_end].must_equal Time.parse("2017-01-01 00:00:00 UTC").to_datetime
-    data[0][:birthday].must_equal Date.parse("1968-10-20")
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.count).must_equal 3
+    _(data[0]).must_be_kind_of Hash
+    _(data[0][:name]).must_equal "Heidi"
+    _(data[0][:age]).must_equal 36
+    _(data[0][:score]).must_equal 7.65
+    _(data[0][:pi]).must_equal BigDecimal("3.141592654")
+    _(data[0][:active]).must_equal true
+    _(data[0][:avatar]).must_be_kind_of StringIO
+    _(data[0][:avatar].read).must_equal "image data"
+    _(data[0][:started_at]).must_equal Time.parse("2016-12-25 13:00:00 UTC")
+    _(data[0][:duration]).must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
+    _(data[0][:target_end]).must_equal Time.parse("2017-01-01 00:00:00 UTC").to_datetime
+    _(data[0][:birthday]).must_equal Date.parse("1968-10-20")
 
-    data[1].must_be_kind_of Hash
-    data[1][:name].must_equal "Aaron"
-    data[1][:age].must_equal 42
-    data[1][:score].must_equal 8.15
-    data[1][:pi].must_be :nil?
-    data[1][:active].must_equal false
-    data[1][:avatar].must_be :nil?
-    data[1][:started_at].must_be :nil?
-    data[1][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
-    data[1][:target_end].must_be :nil?
-    data[1][:birthday].must_be :nil?
+    _(data[1]).must_be_kind_of Hash
+    _(data[1][:name]).must_equal "Aaron"
+    _(data[1][:age]).must_equal 42
+    _(data[1][:score]).must_equal 8.15
+    _(data[1][:pi]).must_be :nil?
+    _(data[1][:active]).must_equal false
+    _(data[1][:avatar]).must_be :nil?
+    _(data[1][:started_at]).must_be :nil?
+    _(data[1][:duration]).must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
+    _(data[1][:target_end]).must_be :nil?
+    _(data[1][:birthday]).must_be :nil?
 
-    data[2].must_be_kind_of Hash
-    data[2][:name].must_equal "Sally"
-    data[2][:age].must_be :nil?
-    data[2][:score].must_be :nil?
-    data[2][:pi].must_be :nil?
-    data[2][:active].must_be :nil?
-    data[2][:avatar].must_be :nil?
-    data[2][:started_at].must_be :nil?
-    data[2][:duration].must_be :nil?
-    data[2][:target_end].must_be :nil?
-    data[2][:birthday].must_be :nil?
+    _(data[2]).must_be_kind_of Hash
+    _(data[2][:name]).must_equal "Sally"
+    _(data[2][:age]).must_be :nil?
+    _(data[2][:score]).must_be :nil?
+    _(data[2][:pi]).must_be :nil?
+    _(data[2][:active]).must_be :nil?
+    _(data[2][:avatar]).must_be :nil?
+    _(data[2][:started_at]).must_be :nil?
+    _(data[2][:duration]).must_be :nil?
+    _(data[2][:target_end]).must_be :nil?
+    _(data[2][:birthday]).must_be :nil?
   end
 
   it "knows the data metadata" do
@@ -83,19 +83,19 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data = table.data
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.kind.must_equal "bigquery#tableDataList"
-    data.etag.must_equal "etag1234567890"
-    data.token.must_equal "token1234567890"
-    data.total.must_equal 3
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.kind).must_equal "bigquery#tableDataList"
+    _(data.etag).must_equal "etag1234567890"
+    _(data.token).must_equal "token1234567890"
+    _(data.total).must_equal 3
 
-    data.statement_type.must_be :nil?
-    data.ddl?.must_equal false
-    data.dml?.must_equal false
-    data.ddl_operation_performed.must_be :nil?
-    data.ddl_target_routine.must_be :nil?
-    data.ddl_target_table.must_be :nil?
-    data.num_dml_affected_rows.must_be :nil?
+    _(data.statement_type).must_be :nil?
+    _(data.ddl?).must_equal false
+    _(data.dml?).must_equal false
+    _(data.ddl_operation_performed).must_be :nil?
+    _(data.ddl_target_routine).must_be :nil?
+    _(data.ddl_target_table).must_be :nil?
+    _(data.num_dml_affected_rows).must_be :nil?
   end
 
   it "knows schema, fields, and headers" do
@@ -108,11 +108,11 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data = table.data
     mock.verify
 
-    data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    data.schema.must_be :frozen?
-    data.fields.must_equal data.schema.fields
-    data.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    data.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(data.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(data.schema).must_be :frozen?
+    _(data.fields).must_equal data.schema.fields
+    _(data.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(data.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
   end
 
   it "handles missing rows and fields" do
@@ -125,8 +125,8 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     nil_data = table.data
     mock.verify
 
-    nil_data.class.must_equal Google::Cloud::Bigquery::Data
-    nil_data.count.must_equal 0
+    _(nil_data.class).must_equal Google::Cloud::Bigquery::Data
+    _(nil_data.count).must_equal 0
   end
 
   it "handles repeated scalars" do
@@ -165,10 +165,10 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     nested_data = nested_table.data
     mock.verify
 
-    nested_data.class.must_equal Google::Cloud::Bigquery::Data
-    nested_data.count.must_equal 1
+    _(nested_data.class).must_equal Google::Cloud::Bigquery::Data
+    _(nested_data.count).must_equal 1
 
-    nested_data.must_equal [{ nums: [1, 2, 3], scores: [100.0, 99.9, 0.001], msgs: ["hello", "world"], flags: [true, false] }]
+    _(nested_data).must_equal [{ nums: [1, 2, 3], scores: [100.0, 99.9, 0.001], msgs: ["hello", "world"], flags: [true, false] }]
   end
 
   it "handles nested, repeated records" do
@@ -210,10 +210,10 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     nested_data = nested_table.data
     mock.verify
 
-    nested_data.class.must_equal Google::Cloud::Bigquery::Data
-    nested_data.count.must_equal 1
+    _(nested_data.class).must_equal Google::Cloud::Bigquery::Data
+    _(nested_data.count).must_equal 1
 
-    nested_data.must_equal [{ name: "mike", foo: [{ bar: "hey", baz: { bif: 1 } }, { bar: "world", baz: { bif: 2 } }] }]
+    _(nested_data).must_equal [{ name: "mike", foo: [{ bar: "hey", baz: { bif: 1 } }, { bar: "world", baz: { bif: 2 } }] }]
   end
 
   it "paginates data" do
@@ -228,11 +228,11 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
 
     data1 = table.data
 
-    data1.class.must_equal Google::Cloud::Bigquery::Data
-    data1.token.wont_be :nil?
-    data1.token.must_equal "token1234567890"
+    _(data1.class).must_equal Google::Cloud::Bigquery::Data
+    _(data1.token).wont_be :nil?
+    _(data1.token).must_equal "token1234567890"
     data2 = table.data token: data1.token
-    data2.class.must_equal Google::Cloud::Bigquery::Data
+    _(data2.class).must_equal Google::Cloud::Bigquery::Data
     mock.verify
   end
 
@@ -248,13 +248,13 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
 
     data1 = table.data
 
-    data1.class.must_equal Google::Cloud::Bigquery::Data
-    data1.token.wont_be :nil?
-    data1.next?.must_equal true # can't use must_be :next?
+    _(data1.class).must_equal Google::Cloud::Bigquery::Data
+    _(data1.token).wont_be :nil?
+    _(data1.next?).must_equal true # can't use must_be :next?
     data2 = data1.next
-    data2.token.must_be :nil?
-    data2.next?.must_equal false
-    data2.class.must_equal Google::Cloud::Bigquery::Data
+    _(data2.token).must_be :nil?
+    _(data2.next?).must_equal false
+    _(data2.class).must_equal Google::Cloud::Bigquery::Data
     mock.verify
   end
 
@@ -270,8 +270,8 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
 
     data = table.data.all.to_a
 
-    data.count.must_equal 6
-    data.each { |d| d.class.must_equal Hash }
+    _(data.count).must_equal 6
+    data.each { |d| _(d.class).must_equal Hash }
     mock.verify
   end
 
@@ -287,7 +287,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
 
     data = table.data
 
-    data.all { |d| d.class.must_equal Hash }
+    data.all { |d| _(d.class).must_equal Hash }
     mock.verify
   end
 
@@ -303,8 +303,8 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
 
     data = table.data.all.take(5)
 
-    data.count.must_equal 5
-    data.each { |d| d.class.must_equal Hash }
+    _(data.count).must_equal 5
+    data.each { |d| _(d.class).must_equal Hash }
     mock.verify
   end
 
@@ -320,8 +320,8 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
 
     data = table.data.all(request_limit: 1).to_a
 
-    data.count.must_equal 6
-    data.each { |d| d.class.must_equal Hash }
+    _(data.count).must_equal 6
+    data.each { |d| _(d.class).must_equal Hash }
     mock.verify
   end
 
@@ -333,7 +333,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
                 [project, dataset_id, table_id, {  max_results: 3, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = table.data max: 3
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
   end
 
   it "paginates data with start set" do
@@ -346,6 +346,6 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data = table.data start: 25
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset/model_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset/model_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::Bigquery::Dataset, :model, :mock_bigquery do
 
     mock.verify
 
-    model.must_be_kind_of Google::Cloud::Bigquery::Model
-    model.model_id.must_equal found_model_id
+    _(model).must_be_kind_of Google::Cloud::Bigquery::Model
+    _(model.model_id).must_equal found_model_id
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset/models_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset/models_test.rb
@@ -29,8 +29,8 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
 
     mock.verify
 
-    models.size.must_equal 3
-    models.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Model }
+    _(models.size).must_equal 3
+    models.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Model }
   end
 
   it "lists models with max set" do
@@ -43,10 +43,10 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
 
     mock.verify
 
-    models.count.must_equal 3
-    models.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Model }
-    models.token.wont_be :nil?
-    models.token.must_equal "next_page_token"
+    _(models.count).must_equal 3
+    models.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Model }
+    _(models.token).wont_be :nil?
+    _(models.token).must_equal "next_page_token"
   end
 
   it "paginates models" do
@@ -62,14 +62,14 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
 
     mock.verify
 
-    first_models.count.must_equal 3
-    first_models.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Model }
-    first_models.token.wont_be :nil?
-    first_models.token.must_equal "next_page_token"
+    _(first_models.count).must_equal 3
+    first_models.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Model }
+    _(first_models.token).wont_be :nil?
+    _(first_models.token).must_equal "next_page_token"
 
-    second_models.count.must_equal 2
-    second_models.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Model }
-    second_models.token.must_be :nil?
+    _(second_models.count).must_equal 2
+    second_models.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Model }
+    _(second_models.token).must_be :nil?
   end
 
   it "paginates models with next? and next" do
@@ -85,14 +85,14 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
 
     mock.verify
 
-    first_models.count.must_equal 3
-    first_models.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Model }
-    first_models.token.wont_be :nil?
-    first_models.token.must_equal "next_page_token"
+    _(first_models.count).must_equal 3
+    first_models.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Model }
+    _(first_models.token).wont_be :nil?
+    _(first_models.token).must_equal "next_page_token"
 
-    second_models.count.must_equal 2
-    second_models.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Model }
-    second_models.token.must_be :nil?
+    _(second_models.count).must_equal 2
+    second_models.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Model }
+    _(second_models.token).must_be :nil?
   end
 
   it "paginates models with next? and next and max" do
@@ -108,13 +108,13 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
 
     mock.verify
 
-    first_models.count.must_equal 3
-    first_models.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Model }
-    first_models.next?.must_equal true
+    _(first_models.count).must_equal 3
+    first_models.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Model }
+    _(first_models.next?).must_equal true
 
-    second_models.count.must_equal 2
-    second_models.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Model }
-    second_models.next?.must_equal false
+    _(second_models.count).must_equal 2
+    second_models.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Model }
+    _(second_models.next?).must_equal false
   end
 
   it "paginates models with all" do
@@ -129,8 +129,8 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
 
     mock.verify
 
-    models.count.must_equal 5
-    models.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Model }
+    _(models.count).must_equal 5
+    models.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Model }
   end
 
   it "paginates models with all and max" do
@@ -145,8 +145,8 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
 
     mock.verify
 
-    models.count.must_equal 5
-    models.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Model }
+    _(models.count).must_equal 5
+    models.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Model }
   end
 
   it "iterates models with all using Enumerator" do
@@ -161,8 +161,8 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
 
     mock.verify
 
-    models.count.must_equal 5
-    models.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Model }
+    _(models.count).must_equal 5
+    models.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Model }
   end
 
   it "iterates models with all with request_limit set" do
@@ -177,7 +177,7 @@ describe Google::Cloud::Bigquery::Dataset, :models, :mock_bigquery do
 
     mock.verify
 
-    models.count.must_equal 6
-    models.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Model }
+    _(models.count).must_equal 6
+    models.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Model }
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset/routine_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset/routine_test.rb
@@ -38,8 +38,8 @@ describe Google::Cloud::Bigquery::Dataset, :routine, :mock_bigquery do
 
     mock.verify
 
-    routine.must_be_kind_of Google::Cloud::Bigquery::Routine
-    routine.routine_id.must_equal routine_id
+    _(routine).must_be_kind_of Google::Cloud::Bigquery::Routine
+    _(routine.routine_id).must_equal routine_id
   end
 
   it "creates a routine with attributes in a block" do
@@ -93,8 +93,8 @@ describe Google::Cloud::Bigquery::Dataset, :routine, :mock_bigquery do
 
     mock.verify
 
-    routine.must_be_kind_of Google::Cloud::Bigquery::Routine
-    routine.routine_id.must_equal routine_id
+    _(routine).must_be_kind_of Google::Cloud::Bigquery::Routine
+    _(routine.routine_id).must_equal routine_id
   end
 
   it "finds a routine" do
@@ -108,7 +108,7 @@ describe Google::Cloud::Bigquery::Dataset, :routine, :mock_bigquery do
 
     mock.verify
 
-    routine.must_be_kind_of Google::Cloud::Bigquery::Routine
-    routine.routine_id.must_equal found_routine_id
+    _(routine).must_be_kind_of Google::Cloud::Bigquery::Routine
+    _(routine.routine_id).must_equal found_routine_id
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset/routines_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset/routines_test.rb
@@ -30,8 +30,8 @@ describe Google::Cloud::Bigquery::Dataset, :routines, :mock_bigquery do
 
     mock.verify
 
-    routines.size.must_equal 3
-    routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(routines.size).must_equal 3
+    routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
   end
 
   it "lists routines with max set" do
@@ -44,10 +44,10 @@ describe Google::Cloud::Bigquery::Dataset, :routines, :mock_bigquery do
 
     mock.verify
 
-    routines.count.must_equal 3
-    routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
-    routines.token.wont_be :nil?
-    routines.token.must_equal "next_page_token"
+    _(routines.count).must_equal 3
+    routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(routines.token).wont_be :nil?
+    _(routines.token).must_equal "next_page_token"
   end
 
   it "lists routines with filter set" do
@@ -60,10 +60,10 @@ describe Google::Cloud::Bigquery::Dataset, :routines, :mock_bigquery do
 
     mock.verify
 
-    routines.count.must_equal 3
-    routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
-    routines.token.wont_be :nil?
-    routines.token.must_equal "next_page_token"
+    _(routines.count).must_equal 3
+    routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(routines.token).wont_be :nil?
+    _(routines.token).must_equal "next_page_token"
   end
 
   it "paginates routines" do
@@ -79,14 +79,14 @@ describe Google::Cloud::Bigquery::Dataset, :routines, :mock_bigquery do
 
     mock.verify
 
-    first_routines.count.must_equal 3
-    first_routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
-    first_routines.token.wont_be :nil?
-    first_routines.token.must_equal "next_page_token"
+    _(first_routines.count).must_equal 3
+    first_routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(first_routines.token).wont_be :nil?
+    _(first_routines.token).must_equal "next_page_token"
 
-    second_routines.count.must_equal 2
-    second_routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
-    second_routines.token.must_be :nil?
+    _(second_routines.count).must_equal 2
+    second_routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(second_routines.token).must_be :nil?
   end
 
   it "paginates routines with next? and next" do
@@ -102,14 +102,14 @@ describe Google::Cloud::Bigquery::Dataset, :routines, :mock_bigquery do
 
     mock.verify
 
-    first_routines.count.must_equal 3
-    first_routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
-    first_routines.token.wont_be :nil?
-    first_routines.token.must_equal "next_page_token"
+    _(first_routines.count).must_equal 3
+    first_routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(first_routines.token).wont_be :nil?
+    _(first_routines.token).must_equal "next_page_token"
 
-    second_routines.count.must_equal 2
-    second_routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
-    second_routines.token.must_be :nil?
+    _(second_routines.count).must_equal 2
+    second_routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(second_routines.token).must_be :nil?
   end
 
   it "paginates routines with next? and next and max" do
@@ -125,13 +125,13 @@ describe Google::Cloud::Bigquery::Dataset, :routines, :mock_bigquery do
 
     mock.verify
 
-    first_routines.count.must_equal 3
-    first_routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
-    first_routines.next?.must_equal true
+    _(first_routines.count).must_equal 3
+    first_routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(first_routines.next?).must_equal true
 
-    second_routines.count.must_equal 2
-    second_routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
-    second_routines.next?.must_equal false
+    _(second_routines.count).must_equal 2
+    second_routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(second_routines.next?).must_equal false
   end
 
   it "paginates routines with next? and next and filter" do
@@ -147,13 +147,13 @@ describe Google::Cloud::Bigquery::Dataset, :routines, :mock_bigquery do
 
     mock.verify
 
-    first_routines.count.must_equal 3
-    first_routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
-    first_routines.next?.must_equal true
+    _(first_routines.count).must_equal 3
+    first_routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(first_routines.next?).must_equal true
 
-    second_routines.count.must_equal 2
-    second_routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
-    second_routines.next?.must_equal false
+    _(second_routines.count).must_equal 2
+    second_routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(second_routines.next?).must_equal false
   end
 
   it "paginates routines with all" do
@@ -168,8 +168,8 @@ describe Google::Cloud::Bigquery::Dataset, :routines, :mock_bigquery do
 
     mock.verify
 
-    routines.count.must_equal 5
-    routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(routines.count).must_equal 5
+    routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
   end
 
   it "paginates routines with all and max" do
@@ -184,8 +184,8 @@ describe Google::Cloud::Bigquery::Dataset, :routines, :mock_bigquery do
 
     mock.verify
 
-    routines.count.must_equal 5
-    routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(routines.count).must_equal 5
+    routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
   end
 
   it "paginates routines with all and filter" do
@@ -200,8 +200,8 @@ describe Google::Cloud::Bigquery::Dataset, :routines, :mock_bigquery do
 
     mock.verify
 
-    routines.count.must_equal 5
-    routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(routines.count).must_equal 5
+    routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
   end
 
   it "iterates routines with all using Enumerator" do
@@ -216,8 +216,8 @@ describe Google::Cloud::Bigquery::Dataset, :routines, :mock_bigquery do
 
     mock.verify
 
-    routines.count.must_equal 5
-    routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(routines.count).must_equal 5
+    routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
   end
 
   it "iterates routines with all with request_limit set" do
@@ -232,7 +232,7 @@ describe Google::Cloud::Bigquery::Dataset, :routines, :mock_bigquery do
 
     mock.verify
 
-    routines.count.must_equal 6
-    routines.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Routine }
+    _(routines.count).must_equal 6
+    routines.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Routine }
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_access_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_access_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Bigquery::Dataset, :access, :mock_bigquery do
                                                       bigquery.service }
 
   it "gets the access rules" do
-    dataset.access.must_be :empty?
+    _(dataset.access).must_be :empty?
   end
 
   it "adds an access entry with specifying user scope" do
@@ -34,22 +34,22 @@ describe Google::Cloud::Bigquery::Dataset, :access, :mock_bigquery do
     patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access], etag: dataset_gapi.etag
     mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
-    dataset.access.must_be_kind_of Google::Cloud::Bigquery::Dataset::Access
-    dataset.access.must_be :frozen?
+    _(dataset.access).must_be_kind_of Google::Cloud::Bigquery::Dataset::Access
+    _(dataset.access).must_be :frozen?
 
     refute dataset.access.writer_user? "writer@example.com"
 
     dataset.access do |acl|
-      acl.must_be_kind_of Google::Cloud::Bigquery::Dataset::Access
-      acl.wont_be :frozen?
+      _(acl).must_be_kind_of Google::Cloud::Bigquery::Dataset::Access
+      _(acl).wont_be :frozen?
 
       refute acl.writer_user? "writer@example.com"
       acl.add_writer_user "writer@example.com"
       assert acl.writer_user? "writer@example.com"
     end
 
-    dataset.access.must_be_kind_of Google::Cloud::Bigquery::Dataset::Access
-    dataset.access.must_be :frozen?
+    _(dataset.access).must_be_kind_of Google::Cloud::Bigquery::Dataset::Access
+    _(dataset.access).must_be :frozen?
 
     assert dataset.access.writer_user? "writer@example.com"
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_attributes_test.rb
@@ -33,10 +33,10 @@ describe Google::Cloud::Bigquery::Dataset, :attributes, :mock_bigquery do
     bigquery.service.mocked_service = mock
     mock.expect :get_dataset, dataset_full_gapi, [project, dataset_id]
 
-    dataset.created_at.must_be_close_to ::Time.now, 1
+    _(dataset.created_at).must_be_close_to ::Time.now, 1
 
     # A second call to attribute does not make a second HTTP API call
-    dataset.created_at.must_be_close_to ::Time.now, 1
+    _(dataset.created_at).must_be_close_to ::Time.now, 1
     mock.verify
   end
 
@@ -45,10 +45,10 @@ describe Google::Cloud::Bigquery::Dataset, :attributes, :mock_bigquery do
     bigquery.service.mocked_service = mock
     mock.expect :get_dataset, dataset_full_gapi, [project, dataset_id]
 
-    dataset.modified_at.must_be_close_to ::Time.now, 1
+    _(dataset.modified_at).must_be_close_to ::Time.now, 1
 
     # A second call to attribute does not make a second HTTP API call
-    dataset.modified_at.must_be_close_to ::Time.now, 1
+    _(dataset.modified_at).must_be_close_to ::Time.now, 1
     mock.verify
   end
 
@@ -57,10 +57,10 @@ describe Google::Cloud::Bigquery::Dataset, :attributes, :mock_bigquery do
     bigquery.service.mocked_service = mock
     mock.expect :get_dataset, dataset_full_gapi, [project, dataset_id]
 
-    dataset.default_encryption.must_be_nil
+    _(dataset.default_encryption).must_be_nil
 
     # A second call to attribute does not make a second HTTP API call
-    dataset.default_encryption.must_be_nil
+    _(dataset.default_encryption).must_be_nil
     mock.verify
   end
 
@@ -70,10 +70,10 @@ describe Google::Cloud::Bigquery::Dataset, :attributes, :mock_bigquery do
       bigquery.service.mocked_service = mock
       mock.expect :get_dataset, dataset_full_gapi, [project, dataset_id]
 
-      dataset.send(attr).must_equal val
+      _(dataset.send(attr)).must_equal val
 
       # A second call to attribute does not make a second HTTP API call
-      dataset.send(attr).must_equal val
+      _(dataset.send(attr)).must_equal val
       mock.verify
     end
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_exists_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_exists_test.rb
@@ -24,19 +24,19 @@ describe Google::Cloud::Bigquery::Dataset, :exists, :mock_bigquery do
   it "knows if full resource exists when created with an HTTP method" do
     # The absence of a mock means this test will fail
     # if the method exists? makes an HTTP call.
-    dataset.wont_be :reference?
-    dataset.must_be :resource?
-    dataset.wont_be :resource_partial?
-    dataset.must_be :resource_full?
+    _(dataset).wont_be :reference?
+    _(dataset).must_be :resource?
+    _(dataset).wont_be :resource_partial?
+    _(dataset).must_be :resource_full?
 
-    dataset.must_be :exists?
-    dataset.wont_be :reference?
-    dataset.must_be :resource?
-    dataset.wont_be :resource_partial?
-    dataset.must_be :resource_full?
+    _(dataset).must_be :exists?
+    _(dataset).wont_be :reference?
+    _(dataset).must_be :resource?
+    _(dataset).wont_be :resource_partial?
+    _(dataset).must_be :resource_full?
 
     # Additional exists? calls do not make HTTP calls either
-    dataset.must_be :exists?
+    _(dataset).must_be :exists?
   end
 
   describe "partial dataset resource from list of a dataset that exists" do
@@ -46,19 +46,19 @@ describe Google::Cloud::Bigquery::Dataset, :exists, :mock_bigquery do
     it "knows if partial resource exists when created with an HTTP method" do
       # The absence of a mock means this test will fail
       # if the method exists? makes an HTTP call.
-      dataset.wont_be :reference?
-      dataset.must_be :resource?
-      dataset.must_be :resource_partial?
-      dataset.wont_be :resource_full?
+      _(dataset).wont_be :reference?
+      _(dataset).must_be :resource?
+      _(dataset).must_be :resource_partial?
+      _(dataset).wont_be :resource_full?
 
-      dataset.must_be :exists?
-      dataset.wont_be :reference?
-      dataset.must_be :resource?
-      dataset.must_be :resource_partial?
-      dataset.wont_be :resource_full?
+      _(dataset).must_be :exists?
+      _(dataset).wont_be :reference?
+      _(dataset).must_be :resource?
+      _(dataset).must_be :resource_partial?
+      _(dataset).wont_be :resource_full?
 
       # Additional exists? calls do not make HTTP calls
-      dataset.must_be :exists?
+      _(dataset).must_be :exists?
     end
   end
 
@@ -70,19 +70,19 @@ describe Google::Cloud::Bigquery::Dataset, :exists, :mock_bigquery do
       mock.expect :get_dataset, dataset_gapi, [project, dataset_id]
       dataset.service.mocked_service = mock
 
-      dataset.must_be :reference?
-      dataset.wont_be :resource?
-      dataset.wont_be :resource_partial?
-      dataset.wont_be :resource_full?
+      _(dataset).must_be :reference?
+      _(dataset).wont_be :resource?
+      _(dataset).wont_be :resource_partial?
+      _(dataset).wont_be :resource_full?
 
-      dataset.must_be :exists?
-      dataset.wont_be :reference?
-      dataset.must_be :resource?
-      dataset.wont_be :resource_partial?
-      dataset.must_be :resource_full?
+      _(dataset).must_be :exists?
+      _(dataset).wont_be :reference?
+      _(dataset).must_be :resource?
+      _(dataset).wont_be :resource_partial?
+      _(dataset).must_be :resource_full?
 
       # Additional exists? calls do not make HTTP calls
-      dataset.must_be :exists?
+      _(dataset).must_be :exists?
 
       mock.verify
     end
@@ -98,19 +98,19 @@ describe Google::Cloud::Bigquery::Dataset, :exists, :mock_bigquery do
       end
       dataset.service.mocked_service = stub
 
-      dataset.must_be :reference?
-      dataset.wont_be :resource?
-      dataset.wont_be :resource_partial?
-      dataset.wont_be :resource_full?
+      _(dataset).must_be :reference?
+      _(dataset).wont_be :resource?
+      _(dataset).wont_be :resource_partial?
+      _(dataset).wont_be :resource_full?
 
-      dataset.wont_be :exists?
-      dataset.must_be :reference?
-      dataset.wont_be :resource?
-      dataset.wont_be :resource_partial?
-      dataset.wont_be :resource_full?
+      _(dataset).wont_be :exists?
+      _(dataset).must_be :reference?
+      _(dataset).wont_be :resource?
+      _(dataset).wont_be :resource_partial?
+      _(dataset).wont_be :resource_full?
 
       # Additional exists? calls do not make HTTP calls
-      dataset.wont_be :exists?
+      _(dataset).wont_be :exists?
     end
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_external_test.rb
@@ -26,437 +26,437 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
   it "creates a simple external table" do
     external = dataset.external "gs://my-bucket/path/to/file.csv"
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-    external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
-    external.must_be :csv?
-    external.format.must_equal "CSV"
+    _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    _(external.urls).must_equal ["gs://my-bucket/path/to/file.csv"]
+    _(external).must_be :csv?
+    _(external.format).must_equal "CSV"
   end
 
   describe "CSV" do
     it "determines CSV from one URL" do
       external = dataset.external "gs://my-bucket/path/to/file.csv"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-      external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
-      external.must_be :csv?
-      external.format.must_equal "CSV"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      _(external.urls).must_equal ["gs://my-bucket/path/to/file.csv"]
+      _(external).must_be :csv?
+      _(external.format).must_equal "CSV"
     end
 
     it "determines CSV from multiple URL" do
       external = dataset.external ["some url", "gs://my-bucket/path/to/file.csv"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.csv"]
-      external.must_be :csv?
-      external.format.must_equal "CSV"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      _(external.urls).must_equal ["some url", "gs://my-bucket/path/to/file.csv"]
+      _(external).must_be :csv?
+      _(external.format).must_equal "CSV"
     end
 
     it "determines CSV from the format (:csv)" do
       external = dataset.external "some url", format: :csv
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-      external.urls.must_equal ["some url"]
-      external.must_be :csv?
-      external.format.must_equal "CSV"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :csv?
+      _(external.format).must_equal "CSV"
     end
 
     it "determines CSV from the format (csv)" do
       external = dataset.external "some url", format: "csv"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-      external.urls.must_equal ["some url"]
-      external.must_be :csv?
-      external.format.must_equal "CSV"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :csv?
+      _(external.format).must_equal "CSV"
     end
 
     it "determines CSV from the format (:CSV)" do
       external = dataset.external "some url", format: :CSV
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-      external.urls.must_equal ["some url"]
-      external.must_be :csv?
-      external.format.must_equal "CSV"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :csv?
+      _(external.format).must_equal "CSV"
     end
 
     it "determines CSV from the format (CSV)" do
       external = dataset.external "some url", format: "CSV"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-      external.urls.must_equal ["some url"]
-      external.must_be :csv?
-      external.format.must_equal "CSV"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :csv?
+      _(external.format).must_equal "CSV"
     end
   end
 
   describe "JSON" do
     it "determines JSON from one URL" do
       external = dataset.external "gs://my-bucket/path/to/file.json"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["gs://my-bucket/path/to/file.json"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["gs://my-bucket/path/to/file.json"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from multiple URL" do
       external = dataset.external ["some url", "gs://my-bucket/path/to/file.json"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.json"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url", "gs://my-bucket/path/to/file.json"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (:json)" do
       external = dataset.external "some url", format: :json
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (json)" do
       external = dataset.external "some url", format: "json"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (:JSON)" do
       external = dataset.external "some url", format: :JSON
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (JSON)" do
       external = dataset.external "some url", format: "JSON"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (:newline_delimited_json)" do
       external = dataset.external "some url", format: :newline_delimited_json
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (newline_delimited_json)" do
       external = dataset.external "some url", format: "newline_delimited_json"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (:NEWLINE_DELIMITED_JSON)" do
       external = dataset.external "some url", format: :NEWLINE_DELIMITED_JSON
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (NEWLINE_DELIMITED_JSON)" do
       external = dataset.external "some url", format: "NEWLINE_DELIMITED_JSON"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
   end
 
   describe "Google Sheets" do
     it "determines CSV from one URL" do
       external = dataset.external "https://docs.google.com/spreadsheets/d/1234567980"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["https://docs.google.com/spreadsheets/d/1234567980"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["https://docs.google.com/spreadsheets/d/1234567980"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines CSV from multiple URL" do
       external = dataset.external ["some url", "https://docs.google.com/spreadsheets/d/1234567980"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url", "https://docs.google.com/spreadsheets/d/1234567980"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url", "https://docs.google.com/spreadsheets/d/1234567980"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (:sheets)" do
       external = dataset.external "some url", format: :sheets
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (sheets)" do
       external = dataset.external "some url", format: "sheets"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (:SHEETS)" do
       external = dataset.external "some url", format: :SHEETS
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (SHEETS)" do
       external = dataset.external "some url", format: "SHEETS"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (:google_sheets)" do
       external = dataset.external "some url", format: :google_sheets
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (google_sheets)" do
       external = dataset.external "some url", format: "google_sheets"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (:GOOGLE_SHEETS)" do
       external = dataset.external "some url", format: :GOOGLE_SHEETS
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (GOOGLE_SHEETS)" do
       external = dataset.external "some url", format: "GOOGLE_SHEETS"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
   end
 
   describe "AVRO" do
     it "determines AVRO from one URL" do
       external = dataset.external "gs://my-bucket/path/to/file.avro"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["gs://my-bucket/path/to/file.avro"]
-      external.must_be :avro?
-      external.format.must_equal "AVRO"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["gs://my-bucket/path/to/file.avro"]
+      _(external).must_be :avro?
+      _(external.format).must_equal "AVRO"
     end
 
     it "determines AVRO from multiple URL" do
       external = dataset.external ["some url", "gs://my-bucket/path/to/file.avro"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.avro"]
-      external.must_be :avro?
-      external.format.must_equal "AVRO"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url", "gs://my-bucket/path/to/file.avro"]
+      _(external).must_be :avro?
+      _(external.format).must_equal "AVRO"
     end
 
     it "determines AVRO from the format (:avro)" do
       external = dataset.external "some url", format: :avro
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :avro?
-      external.format.must_equal "AVRO"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :avro?
+      _(external.format).must_equal "AVRO"
     end
 
     it "determines AVRO from the format (avro)" do
       external = dataset.external "some url", format: "avro"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :avro?
-      external.format.must_equal "AVRO"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :avro?
+      _(external.format).must_equal "AVRO"
     end
 
     it "determines AVRO from the format (:AVRO)" do
       external = dataset.external "some url", format: :AVRO
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :avro?
-      external.format.must_equal "AVRO"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :avro?
+      _(external.format).must_equal "AVRO"
     end
 
     it "determines AVRO from the format (AVRO)" do
       external = dataset.external "some url", format: "AVRO"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :avro?
-      external.format.must_equal "AVRO"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :avro?
+      _(external.format).must_equal "AVRO"
     end
   end
 
   describe "Datastore Backup" do
     it "determines BACKUP from one URL" do
       external = dataset.external "gs://my-bucket/path/to/file.backup_info"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["gs://my-bucket/path/to/file.backup_info"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["gs://my-bucket/path/to/file.backup_info"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from multiple URL" do
       external = dataset.external ["some url", "gs://my-bucket/path/to/file.backup_info"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.backup_info"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url", "gs://my-bucket/path/to/file.backup_info"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (:backup)" do
       external = dataset.external "some url", format: :backup
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (backup)" do
       external = dataset.external "some url", format: "backup"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (:BACKUP)" do
       external = dataset.external "some url", format: :BACKUP
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (BACKUP)" do
       external = dataset.external "some url", format: "BACKUP"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (:datastore)" do
       external = dataset.external "some url", format: :datastore
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (datastore)" do
       external = dataset.external "some url", format: "datastore"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (:DATASTORE)" do
       external = dataset.external "some url", format: :DATASTORE
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (DATASTORE)" do
       external = dataset.external "some url", format: "DATASTORE"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (:datastore_backup)" do
       external = dataset.external "some url", format: :datastore_backup
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (datastore_backup)" do
       external = dataset.external "some url", format: "datastore_backup"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (:DATASTORE_BACKUP)" do
       external = dataset.external "some url", format: :DATASTORE_BACKUP
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (DATASTORE_BACKUP)" do
       external = dataset.external "some url", format: "DATASTORE_BACKUP"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
   end
 
   describe "BIGTABLE" do
     it "determines BIGTABLE from one URL" do
       external = dataset.external "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
-      external.urls.must_equal ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
-      external.must_be :bigtable?
-      external.format.must_equal "BIGTABLE"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      _(external.urls).must_equal ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+      _(external).must_be :bigtable?
+      _(external.format).must_equal "BIGTABLE"
     end
 
     it "determines BIGTABLE from multiple URL" do
       external = dataset.external ["some url", "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
-      external.urls.must_equal ["some url", "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
-      external.must_be :bigtable?
-      external.format.must_equal "BIGTABLE"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      _(external.urls).must_equal ["some url", "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+      _(external).must_be :bigtable?
+      _(external.format).must_equal "BIGTABLE"
     end
 
     it "determines BIGTABLE from the format (:bigtable)" do
       external = dataset.external "some url", format: :bigtable
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
-      external.urls.must_equal ["some url"]
-      external.must_be :bigtable?
-      external.format.must_equal "BIGTABLE"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :bigtable?
+      _(external.format).must_equal "BIGTABLE"
     end
 
     it "determines BIGTABLE from the format (bigtable)" do
       external = dataset.external "some url", format: "bigtable"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
-      external.urls.must_equal ["some url"]
-      external.must_be :bigtable?
-      external.format.must_equal "BIGTABLE"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :bigtable?
+      _(external.format).must_equal "BIGTABLE"
     end
 
     it "determines BIGTABLE from the format (:BIGTABLE)" do
       external = dataset.external "some url", format: :BIGTABLE
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
-      external.urls.must_equal ["some url"]
-      external.must_be :bigtable?
-      external.format.must_equal "BIGTABLE"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :bigtable?
+      _(external.format).must_equal "BIGTABLE"
     end
 
     it "determines BIGTABLE from the format (BIGTABLE)" do
       external = dataset.external "some url", format: "BIGTABLE"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
-      external.urls.must_equal ["some url"]
-      external.must_be :bigtable?
-      external.format.must_equal "BIGTABLE"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :bigtable?
+      _(external.format).must_equal "BIGTABLE"
     end
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_async_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_async_test.rb
@@ -61,19 +61,19 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
     SecureRandom.stub :uuid, insert_id do
       inserter.insert rows.first
 
-      inserter.batch.rows.must_equal [rows.first]
+      _(inserter.batch.rows).must_equal [rows.first]
 
-      inserter.must_be :started?
-      inserter.wont_be :stopped?
+      _(inserter).must_be :started?
+      _(inserter).wont_be :stopped?
 
       # force the queued rows to be inserted
       inserter.flush
       inserter.stop.wait!
 
-      inserter.wont_be :started?
-      inserter.must_be :stopped?
+      _(inserter).wont_be :started?
+      _(inserter).must_be :stopped?
 
-      inserter.batch.must_be :nil?
+      _(inserter.batch).must_be :nil?
     end
 
     mock.verify
@@ -97,19 +97,19 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
       SecureRandom.stub :uuid, insert_id do
         inserter.insert rows.first
 
-        inserter.batch.rows.must_equal [rows.first]
+        _(inserter.batch.rows).must_equal [rows.first]
 
-        inserter.must_be :started?
-        inserter.wont_be :stopped?
+        _(inserter).must_be :started?
+        _(inserter).wont_be :stopped?
 
         # force the queued rows to be inserted
         inserter.flush
         inserter.stop.wait!
 
-        inserter.wont_be :started?
-        inserter.must_be :stopped?
+        _(inserter).wont_be :started?
+        _(inserter).must_be :stopped?
 
-        inserter.batch.must_be :nil?
+        _(inserter.batch).must_be :nil?
       end
 
       mock.verify
@@ -131,19 +131,19 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
     SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
-      inserter.batch.rows.must_equal rows
+      _(inserter.batch.rows).must_equal rows
 
-      inserter.must_be :started?
-      inserter.wont_be :stopped?
+      _(inserter).must_be :started?
+      _(inserter).wont_be :stopped?
 
       # force the queued rows to be inserted
       inserter.flush
       inserter.stop.wait!
 
-      inserter.wont_be :started?
-      inserter.must_be :stopped?
+      _(inserter).wont_be :started?
+      _(inserter).must_be :stopped?
 
-      inserter.batch.must_be :nil?
+      _(inserter.batch).must_be :nil?
     end
 
     mock.verify
@@ -166,19 +166,19 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
         inserter.insert row
       end
 
-      inserter.batch.rows.must_equal rows
+      _(inserter.batch.rows).must_equal rows
 
-      inserter.must_be :started?
-      inserter.wont_be :stopped?
+      _(inserter).must_be :started?
+      _(inserter).wont_be :stopped?
 
       # force the queued rows to be inserted
       inserter.flush
       inserter.stop.wait!
 
-      inserter.wont_be :started?
-      inserter.must_be :stopped?
+      _(inserter).wont_be :started?
+      _(inserter).must_be :stopped?
 
-      inserter.batch.must_be :nil?
+      _(inserter.batch).must_be :nil?
     end
 
     mock.verify
@@ -205,34 +205,34 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
     SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
-      inserter.batch.rows.must_equal rows
+      _(inserter.batch.rows).must_equal rows
 
-      inserter.must_be :started?
-      inserter.wont_be :stopped?
+      _(inserter).must_be :started?
+      _(inserter).wont_be :stopped?
 
       # force the queued rows to be inserted
       inserter.flush
       wait_until { callback_called == true }
       inserter.stop.wait!
 
-      inserter.wont_be :started?
-      inserter.must_be :stopped?
+      _(inserter).wont_be :started?
+      _(inserter).must_be :stopped?
 
-      inserter.batch.must_be :nil?
+      _(inserter.batch).must_be :nil?
     end
 
-    insert_result.wont_be_nil
-    insert_result.must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
-    insert_result.wont_be :error?
-    insert_result.error.must_be_nil
-    insert_result.must_be :success?
-    insert_result.insert_response.wont_be_nil
-    insert_result.insert_count.must_equal 3
-    insert_result.error_count.must_equal 0
-    insert_result.insert_errors.must_be_kind_of Array
-    insert_result.insert_errors.must_be :empty?
-    insert_result.error_rows.must_be_kind_of Array
-    insert_result.error_rows.must_be :empty?
+    _(insert_result).wont_be_nil
+    _(insert_result).must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
+    _(insert_result).wont_be :error?
+    _(insert_result.error).must_be_nil
+    _(insert_result).must_be :success?
+    _(insert_result.insert_response).wont_be_nil
+    _(insert_result.insert_count).must_equal 3
+    _(insert_result.error_count).must_equal 0
+    _(insert_result.insert_errors).must_be_kind_of Array
+    _(insert_result.insert_errors).must_be :empty?
+    _(insert_result.error_rows).must_be_kind_of Array
+    _(insert_result.error_rows).must_be :empty?
 
     mock.verify
   end
@@ -257,20 +257,20 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
     SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
-      inserter.batch.rows.must_equal [rows.last]
+      _(inserter.batch.rows).must_equal [rows.last]
 
-      inserter.must_be :started?
-      inserter.wont_be :stopped?
+      _(inserter).must_be :started?
+      _(inserter).wont_be :stopped?
 
       # force the queued rows to be inserted
       inserter.flush
       wait_until { callbacks == 2 }
       inserter.stop.wait!
 
-      inserter.wont_be :started?
-      inserter.must_be :stopped?
+      _(inserter).wont_be :started?
+      _(inserter).must_be :stopped?
 
-      inserter.batch.must_be :nil?
+      _(inserter.batch).must_be :nil?
     end
 
     mock.verify
@@ -296,20 +296,20 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
     SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
-      inserter.batch.rows.must_equal [rows.last]
+      _(inserter.batch.rows).must_equal [rows.last]
 
-      inserter.must_be :started?
-      inserter.wont_be :stopped?
+      _(inserter).must_be :started?
+      _(inserter).wont_be :stopped?
 
       # force the queued rows to be inserted
       inserter.flush
       wait_until { callbacks == 2 }
       inserter.stop.wait!
 
-      inserter.wont_be :started?
-      inserter.must_be :stopped?
+      _(inserter).wont_be :started?
+      _(inserter).must_be :stopped?
 
-      inserter.batch.must_be :nil?
+      _(inserter.batch).must_be :nil?
     end
 
     mock.verify
@@ -329,19 +329,19 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
 
     inserter.insert rows, insert_ids: insert_ids
 
-    inserter.batch.rows.must_equal rows
+    _(inserter.batch.rows).must_equal rows
 
-    inserter.must_be :started?
-    inserter.wont_be :stopped?
+    _(inserter).must_be :started?
+    _(inserter).wont_be :stopped?
 
     # force the queued rows to be inserted
     inserter.flush
     inserter.stop.wait!
 
-    inserter.wont_be :started?
-    inserter.must_be :stopped?
+    _(inserter).wont_be :started?
+    _(inserter).must_be :stopped?
 
-    inserter.batch.must_be :nil?
+    _(inserter.batch).must_be :nil?
 
     mock.verify
   end
@@ -362,19 +362,19 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
       inserter.insert row, insert_ids: insert_id
     end
 
-    inserter.batch.rows.must_equal rows
+    _(inserter.batch.rows).must_equal rows
 
-    inserter.must_be :started?
-    inserter.wont_be :stopped?
+    _(inserter).must_be :started?
+    _(inserter).wont_be :stopped?
 
     # force the queued rows to be inserted
     inserter.flush
     inserter.stop.wait!
 
-    inserter.wont_be :started?
-    inserter.must_be :stopped?
+    _(inserter).wont_be :started?
+    _(inserter).must_be :stopped?
 
-    inserter.batch.must_be :nil?
+    _(inserter.batch).must_be :nil?
 
     mock.verify
   end
@@ -389,17 +389,17 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
 
     expect { inserter.insert rows, insert_ids: insert_ids }.must_raise ArgumentError
 
-    inserter.batch.must_be :nil?
+    _(inserter.batch).must_be :nil?
 
-    inserter.must_be :started?
-    inserter.wont_be :stopped?
+    _(inserter).must_be :started?
+    _(inserter).wont_be :stopped?
 
     # force the queued rows to be inserted
     inserter.flush
     inserter.stop.wait!
 
-    inserter.wont_be :started?
-    inserter.must_be :stopped?
+    _(inserter).wont_be :started?
+    _(inserter).must_be :stopped?
 
     mock.verify
   end
@@ -418,19 +418,19 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
 
     inserter.insert rows, insert_ids: :skip
 
-    inserter.batch.rows.must_equal rows
+    _(inserter.batch.rows).must_equal rows
 
-    inserter.must_be :started?
-    inserter.wont_be :stopped?
+    _(inserter).must_be :started?
+    _(inserter).wont_be :stopped?
 
     # force the queued rows to be inserted
     inserter.flush
     inserter.stop.wait!
 
-    inserter.wont_be :started?
-    inserter.must_be :stopped?
+    _(inserter).wont_be :started?
+    _(inserter).must_be :stopped?
 
-    inserter.batch.must_be :nil?
+    _(inserter.batch).must_be :nil?
 
     mock.verify
   end
@@ -451,19 +451,19 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
       inserter.insert row, insert_ids: :skip
     end
 
-    inserter.batch.rows.must_equal rows
+    _(inserter.batch.rows).must_equal rows
 
-    inserter.must_be :started?
-    inserter.wont_be :stopped?
+    _(inserter).must_be :started?
+    _(inserter).wont_be :stopped?
 
     # force the queued rows to be inserted
     inserter.flush
     inserter.stop.wait!
 
-    inserter.wont_be :started?
-    inserter.must_be :stopped?
+    _(inserter).wont_be :started?
+    _(inserter).must_be :stopped?
 
-    inserter.batch.must_be :nil?
+    _(inserter.batch).must_be :nil?
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
@@ -64,9 +64,9 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 1
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 1
+    _(result.error_count).must_equal 0
   end
 
   describe "dataset reference" do
@@ -88,9 +88,9 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
       mock.verify
 
-      result.must_be :success?
-      result.insert_count.must_equal 1
-      result.error_count.must_equal 0
+      _(result).must_be :success?
+      _(result.insert_count).must_equal 1
+      _(result.error_count).must_equal 0
     end
   end
 
@@ -110,9 +110,9 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 3
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 3
+    _(result.error_count).must_equal 0
   end
 
   it "will indicate there was a problem with the data" do
@@ -131,46 +131,46 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.wont_be :success?
-    result.insert_count.must_equal 2
-    result.error_count.must_equal 1
-    result.insert_errors.count.must_equal 1
-    result.insert_errors.first.index.must_equal 0
-    result.insert_errors.first.row.must_equal rows.first
-    result.insert_errors.first.errors.count.must_equal 1
-    result.insert_errors.first.errors.first["reason"].must_equal "r34s0n"
-    result.insert_errors.first.errors.first["location"].must_equal "l0c4t10n"
-    result.insert_errors.first.errors.first["debugInfo"].must_equal "d3bugInf0"
-    result.insert_errors.first.errors.first["message"].must_equal "m3ss4g3"
+    _(result).wont_be :success?
+    _(result.insert_count).must_equal 2
+    _(result.error_count).must_equal 1
+    _(result.insert_errors.count).must_equal 1
+    _(result.insert_errors.first.index).must_equal 0
+    _(result.insert_errors.first.row).must_equal rows.first
+    _(result.insert_errors.first.errors.count).must_equal 1
+    _(result.insert_errors.first.errors.first["reason"]).must_equal "r34s0n"
+    _(result.insert_errors.first.errors.first["location"]).must_equal "l0c4t10n"
+    _(result.insert_errors.first.errors.first["debugInfo"]).must_equal "d3bugInf0"
+    _(result.insert_errors.first.errors.first["message"]).must_equal "m3ss4g3"
 
-    result.error_rows.first.must_equal rows.first
+    _(result.error_rows.first).must_equal rows.first
 
     first_row_insert_error = result.insert_error_for(rows.first)
-    first_row_insert_error.index.must_equal 0
-    first_row_insert_error.row.must_equal rows.first
-    first_row_insert_error.errors.first["reason"].must_equal "r34s0n"
-    first_row_insert_error.errors.first["location"].must_equal "l0c4t10n"
-    first_row_insert_error.errors.first["debugInfo"].must_equal "d3bugInf0"
-    first_row_insert_error.errors.first["message"].must_equal "m3ss4g3"
+    _(first_row_insert_error.index).must_equal 0
+    _(first_row_insert_error.row).must_equal rows.first
+    _(first_row_insert_error.errors.first["reason"]).must_equal "r34s0n"
+    _(first_row_insert_error.errors.first["location"]).must_equal "l0c4t10n"
+    _(first_row_insert_error.errors.first["debugInfo"]).must_equal "d3bugInf0"
+    _(first_row_insert_error.errors.first["message"]).must_equal "m3ss4g3"
 
     first_row_index = result.index_for(rows.first)
-    first_row_index.must_equal 0
+    _(first_row_index).must_equal 0
 
     first_row_errors = result.errors_for(rows.first)
-    first_row_errors.count.must_equal 1
-    first_row_errors.first["reason"].must_equal "r34s0n"
-    first_row_errors.first["location"].must_equal "l0c4t10n"
-    first_row_errors.first["debugInfo"].must_equal "d3bugInf0"
-    first_row_errors.first["message"].must_equal "m3ss4g3"
+    _(first_row_errors.count).must_equal 1
+    _(first_row_errors.first["reason"]).must_equal "r34s0n"
+    _(first_row_errors.first["location"]).must_equal "l0c4t10n"
+    _(first_row_errors.first["debugInfo"]).must_equal "d3bugInf0"
+    _(first_row_errors.first["message"]).must_equal "m3ss4g3"
 
     last_row_insert_error = result.insert_error_for(rows.last)
-    last_row_insert_error.must_be_nil
+    _(last_row_insert_error).must_be_nil
 
     last_row_index = result.index_for(rows.last)
-    last_row_index.must_be_nil
+    _(last_row_index).must_be_nil
 
     last_row_errors = result.errors_for(rows.last)
-    last_row_errors.count.must_equal 0
+    _(last_row_errors.count).must_equal 0
   end
 
   it "can specify skipping invalid rows" do
@@ -189,9 +189,9 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 3
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 3
+    _(result.error_count).must_equal 0
   end
 
   it "can specify ignoring unknown values" do
@@ -210,9 +210,9 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 3
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 3
+    _(result.error_count).must_equal 0
   end
 
   it "properly formats values when inserting" do
@@ -258,9 +258,9 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 1
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 1
+    _(result.error_count).must_equal 0
   end
 
   it "can specify insert_ids" do
@@ -276,9 +276,9 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 3
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 3
+    _(result.error_count).must_equal 0
   end
 
   it "raises if the insert_ids option is provided but size does not match rows" do
@@ -300,9 +300,9 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 3
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 3
+    _(result.error_count).must_equal 0
   end
 
   def success_table_insert_gapi

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_local_test.rb
@@ -35,7 +35,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
         [project, load_job_gapi(table_reference, "CSV"), upload_source: file, content_type: "text/csv"]
 
       job = dataset.load_job table_id, file, format: :csv
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
     end
     mock.verify
   end
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
       job = dataset.load_job table_id, file, format: :csv, jagged_rows: true, quoted_newlines: true, autodetect: true,
         encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",
         quote: "'", skip_leading: 1
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
     end
 
     mock.verify
@@ -70,7 +70,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
         [project, load_job_gapi(table_reference), upload_source: file, content_type: "application/json"]
 
       job = dataset.load_job table_id, file, format: "JSON"
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
     end
 
     mock.verify
@@ -84,7 +84,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
 
     local_json = "acceptance/data/kitten-test-data.json"
     job = dataset.load_job table_id, local_json
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -100,8 +100,8 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
         [project, job_gapi, upload_source: file, content_type: "application/json"]
 
       job = dataset.load_job table_id, file, format: "JSON", job_id: job_id
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-      job.job_id.must_equal job_id
+      _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      _(job.job_id).must_equal job_id
     end
 
     mock.verify
@@ -121,8 +121,8 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
         [project, job_gapi, upload_source: file, content_type: "application/json"]
 
       job = dataset.load_job table_id, file, format: "JSON", prefix: prefix
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-      job.job_id.must_equal job_id
+      _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      _(job.job_id).must_equal job_id
     end
 
     mock.verify
@@ -139,8 +139,8 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
         [project, job_gapi, upload_source: file, content_type: "application/json"]
 
       job = dataset.load_job table_id, file, format: "JSON", job_id: job_id, prefix: "IGNORED"
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-      job.job_id.must_equal job_id
+      _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      _(job.job_id).must_equal job_id
     end
 
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
@@ -115,13 +115,13 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
       expect { job.wait_until_done! }.must_raise RuntimeError
     end
 
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    job.schema_update_options.must_equal schema_update_options
-    job.range_partitioning?.must_equal true
-    job.range_partitioning_field.must_equal "age"
-    job.range_partitioning_start.must_equal 0
-    job.range_partitioning_interval.must_equal 10
-    job.range_partitioning_end.must_equal 100
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job.schema_update_options).must_equal schema_update_options
+    _(job.range_partitioning?).must_equal true
+    _(job.range_partitioning_field).must_equal "age"
+    _(job.range_partitioning_start).must_equal 0
+    _(job.range_partitioning_interval).must_equal 10
+    _(job.range_partitioning_end).must_equal 100
 
     mock.verify
   end
@@ -164,15 +164,15 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
       expect { job.wait_until_done! }.must_raise RuntimeError
     end
 
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    job.schema_update_options.must_equal schema_update_options
-    job.time_partitioning?.must_equal true
-    job.time_partitioning_type.must_equal "DAY"
-    job.time_partitioning_field.must_equal "dob"
-    job.time_partitioning_expiration.must_equal 86_400
-    job.time_partitioning_require_filter?.must_equal true
-    job.clustering?.must_equal true
-    job.clustering_fields.must_equal clustering_fields
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job.schema_update_options).must_equal schema_update_options
+    _(job.time_partitioning?).must_equal true
+    _(job.time_partitioning_type).must_equal "DAY"
+    _(job.time_partitioning_field).must_equal "dob"
+    _(job.time_partitioning_expiration).must_equal 86_400
+    _(job.time_partitioning_require_filter?).must_equal true
+    _(job.clustering?).must_equal true
+    _(job.clustering_fields).must_equal clustering_fields
 
     mock.verify
   end
@@ -196,21 +196,21 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
     schema.timestamp "dob", mode: :required
 
     job = dataset.load_job table_id, load_file, create: :needed, schema: schema
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    job.schema_update_options.must_be_kind_of Array
-    job.schema_update_options.must_be :empty?
-    job.range_partitioning?.must_equal false
-    job.range_partitioning_field.must_be_nil
-    job.range_partitioning_start.must_be_nil
-    job.range_partitioning_interval.must_be_nil
-    job.range_partitioning_end.must_be_nil
-    job.time_partitioning?.must_equal false
-    job.time_partitioning_type.must_be :nil?
-    job.time_partitioning_field.must_be :nil?
-    job.time_partitioning_expiration.must_be :nil?
-    job.time_partitioning_require_filter?.must_equal false
-    job.clustering?.must_equal false
-    job.clustering_fields.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job.schema_update_options).must_be_kind_of Array
+    _(job.schema_update_options).must_be :empty?
+    _(job.range_partitioning?).must_equal false
+    _(job.range_partitioning_field).must_be_nil
+    _(job.range_partitioning_start).must_be_nil
+    _(job.range_partitioning_interval).must_be_nil
+    _(job.range_partitioning_end).must_be_nil
+    _(job.time_partitioning?).must_equal false
+    _(job.time_partitioning_type).must_be :nil?
+    _(job.time_partitioning_field).must_be :nil?
+    _(job.time_partitioning_expiration).must_be :nil?
+    _(job.time_partitioning_require_filter?).must_equal false
+    _(job.clustering?).must_equal false
+    _(job.clustering_fields).must_be :nil?
 
     mock.verify
   end
@@ -239,8 +239,8 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
       schema.timestamp "dob", mode: :required
       schema.schema_update_options = schema_update_options
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    job.schema_update_options.must_equal schema_update_options
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job.schema_update_options).must_equal schema_update_options
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_storage_test.rb
@@ -46,7 +46,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -62,7 +62,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
       dataset.service.mocked_service = mock
 
       job = dataset.load_job table_id, load_file
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
       mock.verify
     end
@@ -80,7 +80,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, special_file, format: :csv
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -116,7 +116,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     job = dataset.load_job table_id, special_file, jagged_rows: true, quoted_newlines: true, autodetect: true,
       encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",
       quote: "'", skip_leading: 1
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -133,7 +133,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -150,7 +150,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -167,7 +167,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -184,7 +184,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -203,7 +203,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, special_file, projection_fields: projection_fields
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -216,7 +216,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_url
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -229,7 +229,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, URI(load_url)
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -243,7 +243,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, [URI(load_url), load_url2]
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -257,7 +257,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_url, dryrun: true
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -271,7 +271,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_url, create: "CREATE_NEVER"
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -285,7 +285,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_url, create: :never
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -299,7 +299,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_url, write: "WRITE_TRUNCATE"
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -313,7 +313,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_url, write: :truncate
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_local_test.rb
@@ -35,7 +35,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :local, :mock_bigquery do
         [project, load_job_gapi(table_reference, "CSV"), upload_source: file, content_type: "text/csv"]
 
       result = dataset.load table_id, file, format: :csv
-      result.must_equal true
+      _(result).must_equal true
     end
     mock.verify
   end
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :local, :mock_bigquery do
       result = dataset.load table_id, file, format: :csv, jagged_rows: true, quoted_newlines: true, autodetect: true,
         encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",
         quote: "'", skip_leading: 1
-      result.must_equal true
+      _(result).must_equal true
     end
 
     mock.verify
@@ -70,7 +70,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :local, :mock_bigquery do
         [project, load_job_gapi(table_reference), upload_source: file, content_type: "application/json"]
 
       result = dataset.load table_id, file, format: "JSON"
-      result.must_equal true
+      _(result).must_equal true
     end
 
     mock.verify
@@ -84,7 +84,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :local, :mock_bigquery do
 
     local_json = "acceptance/data/kitten-test-data.json"
     result = dataset.load table_id, local_json
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_schema_test.rb
@@ -75,7 +75,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :schema, :mock_bigquery do
       schema.boolean "active"
       schema.bytes "avatar"
     end
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :schema, :mock_bigquery do
     schema.bytes "avatar"
 
     result = dataset.load table_id, load_file, create: :needed, schema: schema
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -120,7 +120,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :schema, :mock_bigquery do
       schema.boolean "active"
       schema.bytes "avatar"
     end
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_storage_test.rb
@@ -46,7 +46,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, load_file
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -62,7 +62,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
       dataset.service.mocked_service = mock
 
       result = dataset.load table_id, load_file
-      result.must_equal true
+      _(result).must_equal true
 
       mock.verify
     end
@@ -80,7 +80,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, special_file, format: :csv
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, special_file
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -116,7 +116,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     result = dataset.load table_id, special_file, jagged_rows: true, quoted_newlines: true, autodetect: true,
       encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",
       quote: "'", skip_leading: 1
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -133,7 +133,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, special_file
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -150,7 +150,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, special_file
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -167,7 +167,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, special_file
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -184,7 +184,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, special_file
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -203,7 +203,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, special_file, projection_fields: projection_fields
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -216,7 +216,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, load_url
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -229,7 +229,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, URI(load_url)
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -243,7 +243,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, [URI(load_url), load_url2]
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -257,7 +257,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, load_url, create: "CREATE_NEVER"
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -271,7 +271,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, load_url, create: :never
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -285,7 +285,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, load_url, write: "WRITE_TRUNCATE"
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -299,7 +299,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, load_url, write: :truncate
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_external_test.rb
@@ -48,26 +48,26 @@ describe Google::Cloud::Bigquery::Dataset, :query, :external, :mock_bigquery do
     data = dataset.query query, external: { my_csv: external_csv }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
   def assert_valid_data data
-    data.count.must_equal 3
-    data[0].must_be_kind_of Hash
-    data[0][:name].must_equal "Heidi"
-    data[0][:age].must_equal 36
-    data[0][:score].must_equal 7.65
-    data[0][:active].must_equal true
-    data[1].must_be_kind_of Hash
-    data[1][:name].must_equal "Aaron"
-    data[1][:age].must_equal 42
-    data[1][:score].must_equal 8.15
-    data[1][:active].must_equal false
-    data[2].must_be_kind_of Hash
-    data[2][:name].must_equal "Sally"
-    data[2][:age].must_be :nil?
-    data[2][:score].must_be :nil?
-    data[2][:active].must_be :nil?
+    _(data.count).must_equal 3
+    _(data[0]).must_be_kind_of Hash
+    _(data[0][:name]).must_equal "Heidi"
+    _(data[0][:age]).must_equal 36
+    _(data[0][:score]).must_equal 7.65
+    _(data[0][:active]).must_equal true
+    _(data[1]).must_be_kind_of Hash
+    _(data[1][:name]).must_equal "Aaron"
+    _(data[1][:age]).must_equal 42
+    _(data[1][:score]).must_equal 8.15
+    _(data[1][:active]).must_equal false
+    _(data[2]).must_be_kind_of Hash
+    _(data[2][:name]).must_equal "Sally"
+    _(data[2][:age]).must_be :nil?
+    _(data[2][:score]).must_be :nil?
+    _(data[2][:active]).must_be :nil?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_external_test.rb
@@ -42,6 +42,6 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :external, :mock_bigquery
     job = dataset.query_job query, external: { my_csv: external_csv }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -50,7 +50,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE name = @name", params: { name: "Testy McTesterson" }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with an integer parameter" do
@@ -74,7 +74,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE age > @age", params: { age: 35 }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a float parameter" do
@@ -98,7 +98,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE score > @score", params: { score: 90.0 }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a numeric parameter" do
@@ -122,7 +122,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE pi = @pi", params: { pi: BigDecimal("3.141592654") }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a true parameter" do
@@ -146,7 +146,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE active = @active", params: { active: true }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a false parameter" do
@@ -170,7 +170,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE active = @active", params: { active: false }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a date parameter" do
@@ -196,7 +196,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE create_date = @day", params: { day: today }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a datetime parameter" do
@@ -222,7 +222,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE update_datetime < @when", params: { when: now }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a timestamp parameter" do
@@ -248,7 +248,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE update_timestamp < @when", params: { when: now }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a time parameter" do
@@ -274,7 +274,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE create_time = @time", params: { time: timeofday }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
     it "queries the data with a File parameter" do
@@ -300,7 +300,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
       job = dataset.query_job "#{query} WHERE avatar = @file", params: { file: file }
       mock.verify
 
-      job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+      _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
     end
 
     it "queries the data with a StringIO parameter" do
@@ -326,7 +326,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
       job = dataset.query_job "#{query} WHERE avatar = @file", params: { file: file }
       mock.verify
 
-      job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+      _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
     end
 
   it "queries the data with many parameters" do
@@ -417,7 +417,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with an array parameter" do
@@ -448,7 +448,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a struct parameter" do
@@ -491,6 +491,6 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -49,7 +49,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE name = ?", params: ["Testy McTesterson"]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with an integer parameter" do
@@ -72,7 +72,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE age > ?", params: [35]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a float parameter" do
@@ -95,7 +95,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE score > ?", params: [90.0]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a numeric parameter" do
@@ -118,7 +118,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE pi = ?", params: [BigDecimal("3.141592654")]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a true parameter" do
@@ -141,7 +141,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE active = ?", params: [true]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a false parameter" do
@@ -164,7 +164,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE active = ?", params: [false]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a date parameter" do
@@ -189,7 +189,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE create_date = ?", params: [today]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a datetime parameter" do
@@ -214,7 +214,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE update_datetime < ?", params: [now]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a timestamp parameter" do
@@ -239,7 +239,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE update_timestamp < ?", params: [now]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a time parameter" do
@@ -264,7 +264,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE create_time = ?", params: [timeofday]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a File parameter" do
@@ -289,7 +289,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE avatar = ?", params: [file]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a StringIO parameter" do
@@ -314,7 +314,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE avatar = ?", params: [file]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with many parameters" do
@@ -393,7 +393,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with an array parameter" do
@@ -423,7 +423,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE name IN ?", params: [%w{name1 name2 name3}]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a struct parameter" do
@@ -465,6 +465,6 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
@@ -58,7 +58,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   describe "dataset reference" do
@@ -78,7 +78,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
       job = dataset.query_job query
       mock.verify
 
-      job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+      _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
     end
   end
 
@@ -111,19 +111,19 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
                             maximum_bytes_billed: 12345678901234
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.range_partitioning?.must_equal false
-    job.range_partitioning_field.must_be_nil
-    job.range_partitioning_start.must_be_nil
-    job.range_partitioning_interval.must_be_nil
-    job.range_partitioning_end.must_be_nil
-    job.time_partitioning?.must_equal false
-    job.time_partitioning_type.must_be :nil?
-    job.time_partitioning_field.must_be :nil?
-    job.time_partitioning_expiration.must_be :nil?
-    job.time_partitioning_require_filter?.must_equal false
-    job.clustering?.must_equal false
-    job.clustering_fields.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.range_partitioning?).must_equal false
+    _(job.range_partitioning_field).must_be_nil
+    _(job.range_partitioning_start).must_be_nil
+    _(job.range_partitioning_interval).must_be_nil
+    _(job.range_partitioning_end).must_be_nil
+    _(job.time_partitioning?).must_equal false
+    _(job.time_partitioning_type).must_be :nil?
+    _(job.time_partitioning_field).must_be :nil?
+    _(job.time_partitioning_expiration).must_be :nil?
+    _(job.time_partitioning_require_filter?).must_equal false
+    _(job.clustering?).must_equal false
+    _(job.clustering_fields).must_be :nil?
   end
 
   it "queries the data with range_partitioning" do
@@ -152,12 +152,12 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.range_partitioning?.must_equal true
-    job.range_partitioning_field.must_equal "my_table_id"
-    job.range_partitioning_start.must_equal 0
-    job.range_partitioning_interval.must_equal 10
-    job.range_partitioning_end.must_equal 100
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.range_partitioning?).must_equal true
+    _(job.range_partitioning_field).must_equal "my_table_id"
+    _(job.range_partitioning_start).must_equal 0
+    _(job.range_partitioning_interval).must_equal 10
+    _(job.range_partitioning_end).must_equal 100
   end
 
   it "queries the data with time_partitioning and clustering" do
@@ -188,14 +188,14 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.time_partitioning?.must_equal true
-    job.time_partitioning_type.must_equal "DAY"
-    job.time_partitioning_field.must_equal "dob"
-    job.time_partitioning_expiration.must_equal 86_400
-    job.time_partitioning_require_filter?.must_equal true
-    job.clustering?.must_equal true
-    job.clustering_fields.must_equal clustering_fields
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.time_partitioning?).must_equal true
+    _(job.time_partitioning_type).must_equal "DAY"
+    _(job.time_partitioning_field).must_equal "dob"
+    _(job.time_partitioning_expiration).must_equal 86_400
+    _(job.time_partitioning_require_filter?).must_equal true
+    _(job.clustering?).must_equal true
+    _(job.clustering_fields).must_equal clustering_fields
   end
 
   it "queries the data with job_id option" do
@@ -214,8 +214,8 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query, job_id: job_id
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.job_id).must_equal job_id
   end
 
   it "queries the data with dryrun flag" do
@@ -233,11 +233,11 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query, dryrun: true
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.dryrun?.must_equal true
-    job.dryrun.must_equal true # alias
-    job.dry_run.must_equal true # alias
-    job.dry_run?.must_equal true # alias
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.dryrun?).must_equal true
+    _(job.dryrun).must_equal true # alias
+    _(job.dry_run).must_equal true # alias
+    _(job.dry_run?).must_equal true # alias
   end
 
   it "queries the data with prefix option" do
@@ -259,8 +259,8 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query, prefix: prefix
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.job_id).must_equal job_id
   end
 
   it "queries the data with job_id option if both job_id and prefix options are provided" do
@@ -279,8 +279,8 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query, job_id: job_id, prefix: "IGNORED"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.job_id).must_equal job_id
   end
 
   it "queries the data with the job labels option" do
@@ -298,8 +298,8 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query, labels: labels
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.labels.must_equal labels
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.labels).must_equal labels
   end
 
   it "queries the data with an array for the udfs option" do
@@ -317,8 +317,8 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query, udfs: udfs
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.udfs.must_equal udfs
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.udfs).must_equal udfs
   end
 
   it "queries the data with a string for the udfs option" do
@@ -336,7 +336,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query, udfs: "gs://my-bucket/my-lib.js"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.udfs.must_equal ["gs://my-bucket/my-lib.js"]
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.udfs).must_equal ["gs://my-bucket/my-lib.js"]
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_updater_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_updater_test.rb
@@ -59,7 +59,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with the job labels option" do
@@ -79,8 +79,8 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.labels.must_equal labels
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.labels).must_equal labels
   end
 
   it "queries the data with an array for the udfs option" do
@@ -100,8 +100,8 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.udfs.must_equal udfs
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.udfs).must_equal udfs
   end
 
   it "queries the data with a string for the udfs option" do
@@ -121,8 +121,8 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.udfs.must_equal ["gs://my-bucket/my-lib.js"]
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.udfs).must_equal ["gs://my-bucket/my-lib.js"]
   end
 
   it "queries the data with the encryption option" do
@@ -144,8 +144,8 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
-    job.encryption.kms_key.must_equal kms_key
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.encryption).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(job.encryption.kms_key).must_equal kms_key
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE name = @name", params: { name: "Testy McTesterson" }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -83,7 +83,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE age > @age", params: { age: 35 }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -115,7 +115,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE score > @score", params: { score: 90.0 }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -147,7 +147,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE pi = @pi", params: { pi: BigDecimal("3.141592654") }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -179,7 +179,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE active = @active", params: { active: true }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -211,7 +211,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE active = @active", params: { active: false }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -245,7 +245,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE create_date = @day", params: { day: today }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -279,7 +279,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE update_datetime < @when", params: { when: now }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -313,7 +313,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE update_timestamp < @when", params: { when: now }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -347,7 +347,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE create_time = @time", params: { time: timeofday }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -381,7 +381,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -415,7 +415,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -514,7 +514,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
 
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -553,7 +553,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -604,26 +604,26 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
   def assert_valid_data data
-    data.count.must_equal 3
-    data[0].must_be_kind_of Hash
-    data[0][:name].must_equal "Heidi"
-    data[0][:age].must_equal 36
-    data[0][:score].must_equal 7.65
-    data[0][:active].must_equal true
-    data[1].must_be_kind_of Hash
-    data[1][:name].must_equal "Aaron"
-    data[1][:age].must_equal 42
-    data[1][:score].must_equal 8.15
-    data[1][:active].must_equal false
-    data[2].must_be_kind_of Hash
-    data[2][:name].must_equal "Sally"
-    data[2][:age].must_be :nil?
-    data[2][:score].must_be :nil?
-    data[2][:active].must_be :nil?
+    _(data.count).must_equal 3
+    _(data[0]).must_be_kind_of Hash
+    _(data[0][:name]).must_equal "Heidi"
+    _(data[0][:age]).must_equal 36
+    _(data[0][:score]).must_equal 7.65
+    _(data[0][:active]).must_equal true
+    _(data[1]).must_be_kind_of Hash
+    _(data[1][:name]).must_equal "Aaron"
+    _(data[1][:age]).must_equal 42
+    _(data[1][:score]).must_equal 8.15
+    _(data[1][:active]).must_equal false
+    _(data[2]).must_be_kind_of Hash
+    _(data[2][:name]).must_equal "Sally"
+    _(data[2][:age]).must_be :nil?
+    _(data[2][:score]).must_be :nil?
+    _(data[2][:active]).must_be :nil?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE name = ?", params: ["Testy McTesterson"]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -82,7 +82,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE age > ?", params: [35]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -113,7 +113,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE score > ?", params: [90.0]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -144,7 +144,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE pi = ?", params: [BigDecimal("3.141592654")]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -175,7 +175,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE active = ?", params: [true]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -206,7 +206,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE active = ?", params: [false]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -239,7 +239,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE create_date = ?", params: [today]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -272,7 +272,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE update_datetime < ?", params: [now]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -305,7 +305,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE update_timestamp < ?", params: [now]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -338,7 +338,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE create_time = ?", params: [timeofday]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -371,7 +371,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
       data = dataset.query "#{query} WHERE avatar = ?", params: [file]
       mock.verify
 
-      data.class.must_equal Google::Cloud::Bigquery::Data
+      _(data.class).must_equal Google::Cloud::Bigquery::Data
       assert_valid_data data
     end
 
@@ -404,7 +404,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
       data = dataset.query "#{query} WHERE avatar = ?", params: [file]
       mock.verify
 
-      data.class.must_equal Google::Cloud::Bigquery::Data
+      _(data.class).must_equal Google::Cloud::Bigquery::Data
       assert_valid_data data
     end
 
@@ -491,7 +491,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
 
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -529,7 +529,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE name IN ?", params: [%w{name1 name2 name3}]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -579,26 +579,26 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
   def assert_valid_data data
-    data.count.must_equal 3
-    data[0].must_be_kind_of Hash
-    data[0][:name].must_equal "Heidi"
-    data[0][:age].must_equal 36
-    data[0][:score].must_equal 7.65
-    data[0][:active].must_equal true
-    data[1].must_be_kind_of Hash
-    data[1][:name].must_equal "Aaron"
-    data[1][:age].must_equal 42
-    data[1][:score].must_equal 8.15
-    data[1][:active].must_equal false
-    data[2].must_be_kind_of Hash
-    data[2][:name].must_equal "Sally"
-    data[2][:age].must_be :nil?
-    data[2][:score].must_be :nil?
-    data[2][:active].must_be :nil?
+    _(data.count).must_equal 3
+    _(data[0]).must_be_kind_of Hash
+    _(data[0][:name]).must_equal "Heidi"
+    _(data[0][:age]).must_equal 36
+    _(data[0][:score]).must_equal 7.65
+    _(data[0][:active]).must_equal true
+    _(data[1]).must_be_kind_of Hash
+    _(data[1][:name]).must_equal "Aaron"
+    _(data[1][:age]).must_equal 42
+    _(data[1][:score]).must_equal 8.15
+    _(data[1][:active]).must_equal false
+    _(data[2]).must_be_kind_of Hash
+    _(data[2][:name]).must_equal "Sally"
+    _(data[2][:age]).must_be :nil?
+    _(data[2][:score]).must_be :nil?
+    _(data[2][:active]).must_be :nil?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
@@ -38,8 +38,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :mock_bigquery do
                 [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query query
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.count.must_equal 3
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.count).must_equal 3
     mock.verify
   end
 
@@ -61,8 +61,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :mock_bigquery do
                   [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
       data = dataset.query query
-      data.class.must_equal Google::Cloud::Bigquery::Data
-      data.count.must_equal 3
+      _(data.class).must_equal Google::Cloud::Bigquery::Data
+      _(data.count).must_equal 3
       mock.verify
     end
   end
@@ -76,8 +76,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :mock_bigquery do
     mock.expect :insert_job, failed_query_job_resp_gapi(query, job_id: job_id, reason: "accessDenied"), [project, job_gapi]
 
     err = expect { dataset.query query }.must_raise Google::Cloud::PermissionDeniedError
-    err.message.must_equal "string"
-    err.cause.body.must_equal({
+    _(err.message).must_equal "string"
+    _(err.cause.body).must_equal({
       "debugInfo"=>"string",
       "location"=>"string",
       "message"=>"string",
@@ -102,8 +102,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :mock_bigquery do
     mock.expect :insert_job, failed_query_job_resp_gapi(query, job_id: job_id, reason: "backendError"), [project, job_gapi]
 
     err = expect { dataset.query query }.must_raise Google::Cloud::InternalError
-    err.message.must_equal "string"
-    err.cause.body.must_equal({
+    _(err.message).must_equal "string"
+    _(err.cause.body).must_equal({
       "debugInfo"=>"string",
       "location"=>"string",
       "message"=>"string",

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_test.rb
@@ -32,23 +32,23 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
   let(:dataset_gapi) { Google::Apis::BigqueryV2::Dataset.from_json dataset_hash.to_json }
 
   it "knows its attributes" do
-    dataset.dataset_id.must_equal dataset_id
-    dataset.project_id.must_equal project
-    dataset.dataset_ref.must_be_kind_of Hash
-    dataset.dataset_ref[:dataset_id].must_equal dataset_id
-    dataset.dataset_ref[:project_id].must_equal project
+    _(dataset.dataset_id).must_equal dataset_id
+    _(dataset.project_id).must_equal project
+    _(dataset.dataset_ref).must_be_kind_of Hash
+    _(dataset.dataset_ref[:dataset_id]).must_equal dataset_id
+    _(dataset.dataset_ref[:project_id]).must_equal project
 
-    dataset.name.must_be_nil
-    dataset.description.must_be_nil
-    dataset.default_expiration.must_be_nil
-    dataset.etag.must_be_nil
-    dataset.api_url.must_be_nil
-    dataset.location.must_be_nil
-    dataset.labels.must_be_nil
-    dataset.created_at.must_be_nil
-    dataset.modified_at.must_be_nil
+    _(dataset.name).must_be_nil
+    _(dataset.description).must_be_nil
+    _(dataset.default_expiration).must_be_nil
+    _(dataset.etag).must_be_nil
+    _(dataset.api_url).must_be_nil
+    _(dataset.location).must_be_nil
+    _(dataset.labels).must_be_nil
+    _(dataset.created_at).must_be_nil
+    _(dataset.modified_at).must_be_nil
 
-    dataset.default_encryption.must_be_nil
+    _(dataset.default_encryption).must_be_nil
   end
 
   it "can test its existence" do
@@ -56,7 +56,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
     mock.expect :get_dataset, dataset_gapi, [project, dataset_id]
     dataset.service.mocked_service = mock
 
-    dataset.exists?.must_equal true
+    _(dataset.exists?).must_equal true
 
     mock.verify
   end
@@ -66,7 +66,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
     mock.expect :get_dataset, dataset_gapi, [project, dataset_id]
     dataset.service.mocked_service = mock
 
-    dataset.exists?(force: true).must_equal true
+    _(dataset.exists?(force: true)).must_equal true
 
     mock.verify
   end
@@ -77,9 +77,9 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
       [project, dataset.dataset_id, delete_contents: nil]
     dataset.service.mocked_service = mock
 
-    dataset.delete.must_equal true
+    _(dataset.delete).must_equal true
 
-    dataset.exists?.must_equal false
+    _(dataset.exists?).must_equal false
 
     mock.verify
   end
@@ -90,9 +90,9 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
       [project, dataset.dataset_id, delete_contents: true]
     dataset.service.mocked_service = mock
 
-    dataset.delete(force: true).must_equal true
+    _(dataset.delete(force: true)).must_equal true
 
-    dataset.exists?.must_equal false
+    _(dataset.exists?).must_equal false
 
     mock.verify
   end
@@ -110,10 +110,10 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal table_id
-    table.must_be :table?
-    table.wont_be :view?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal table_id
+    _(table).must_be :table?
+    _(table).wont_be :view?
   end
 
   it "can create a empty view" do
@@ -136,14 +136,14 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal view_id
-    table.query.must_equal query
-    table.must_be :query_standard_sql?
-    table.wont_be :query_legacy_sql?
-    table.query_udfs.must_be :empty?
-    table.must_be :view?
-    table.wont_be :table?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal view_id
+    _(table.query).must_equal query
+    _(table).must_be :query_standard_sql?
+    _(table).wont_be :query_legacy_sql?
+    _(table.query_udfs).must_be :empty?
+    _(table).must_be :view?
+    _(table).wont_be :table?
   end
 
   it "lists tables" do
@@ -156,8 +156,8 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
 
     mock.verify
 
-    tables.size.must_equal 3
-    tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(tables.size).must_equal 3
+    tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
   end
 
   it "paginates tables" do
@@ -173,16 +173,16 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
 
     mock.verify
 
-    first_tables.count.must_equal 3
-    first_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
-    first_tables.token.wont_be :nil?
-    first_tables.token.must_equal "next_page_token"
-    first_tables.total.must_equal 5
+    _(first_tables.count).must_equal 3
+    first_tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(first_tables.token).wont_be :nil?
+    _(first_tables.token).must_equal "next_page_token"
+    _(first_tables.total).must_equal 5
 
-    second_tables.count.must_equal 2
-    second_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
-    second_tables.token.must_be :nil?
-    second_tables.total.must_equal 5
+    _(second_tables.count).must_equal 2
+    second_tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(second_tables.token).must_be :nil?
+    _(second_tables.total).must_equal 5
   end
 
   it "finds a table" do
@@ -196,8 +196,8 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal found_table_id
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal found_table_id
   end
 
   def create_table_gapi id, name = nil, description = nil

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_update_test.rb
@@ -34,11 +34,11 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :update, :mock_bigquery d
     patch_dataset_gapi = Google::Apis::BigqueryV2::Dataset.new friendly_name: new_dataset_name, etag: dataset_gapi.etag
     mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_dataset_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
-    dataset.name.must_be_nil
+    _(dataset.name).must_be_nil
 
     dataset.name = new_dataset_name
 
-    dataset.name.must_equal new_dataset_name
+    _(dataset.name).must_equal new_dataset_name
     mock.verify
   end
 
@@ -53,13 +53,13 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :update, :mock_bigquery d
     patch_gapi = Google::Apis::BigqueryV2::Dataset.new description: new_description, etag: dataset_gapi.etag
     mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
-    dataset.description.must_be_nil
+    _(dataset.description).must_be_nil
 
     dataset.description = new_description
 
-    dataset.name.must_equal dataset_name
-    dataset.description.must_equal new_description
-    dataset.default_expiration.must_equal default_expiration
+    _(dataset.name).must_equal dataset_name
+    _(dataset.description).must_equal new_description
+    _(dataset.default_expiration).must_equal default_expiration
     mock.verify
   end
 
@@ -74,13 +74,13 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :update, :mock_bigquery d
     patch_gapi = Google::Apis::BigqueryV2::Dataset.new default_table_expiration_ms: new_default_expiration, etag: dataset_gapi.etag
     mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
-    dataset.default_expiration.must_be_nil
+    _(dataset.default_expiration).must_be_nil
 
     dataset.default_expiration = new_default_expiration
 
-    dataset.name.must_equal dataset_name
-    dataset.description.must_equal description
-    dataset.default_expiration.must_equal new_default_expiration
+    _(dataset.name).must_equal dataset_name
+    _(dataset.description).must_equal description
+    _(dataset.default_expiration).must_equal new_default_expiration
     mock.verify
   end
 
@@ -95,11 +95,11 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :update, :mock_bigquery d
     patch_gapi = Google::Apis::BigqueryV2::Dataset.new labels: new_labels, etag: dataset_gapi.etag
     mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
-    dataset.labels.must_be_nil
+    _(dataset.labels).must_be_nil
 
     dataset.labels = new_labels
 
-    dataset.labels.must_equal new_labels
+    _(dataset.labels).must_equal new_labels
     mock.verify
   end
 
@@ -114,13 +114,13 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :update, :mock_bigquery d
     patch_gapi = Google::Apis::BigqueryV2::Dataset.new default_encryption_configuration: updated_gapi.default_encryption_configuration, etag: dataset_gapi.etag
     mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
-    dataset.default_encryption.must_be_nil
+    _(dataset.default_encryption).must_be_nil
 
     dataset.default_encryption = bigquery.encryption kms_key: kms_key
 
-    dataset.default_encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
-    dataset.default_encryption.kms_key.must_equal kms_key
-    dataset.default_encryption.must_be :frozen?
+    _(dataset.default_encryption).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(dataset.default_encryption.kms_key).must_equal kms_key
+    _(dataset.default_encryption).must_be :frozen?
     mock.verify
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reload_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reload_test.rb
@@ -26,16 +26,16 @@ describe Google::Cloud::Bigquery::Dataset, :reload, :mock_bigquery do
     mock.expect :get_dataset, dataset_gapi, [project, dataset_id]
     dataset.service.mocked_service = mock
 
-    dataset.wont_be :reference?
-    dataset.must_be :resource?
-    dataset.wont_be :resource_partial?
-    dataset.must_be :resource_full?
+    _(dataset).wont_be :reference?
+    _(dataset).must_be :resource?
+    _(dataset).wont_be :resource_partial?
+    _(dataset).must_be :resource_full?
 
     dataset.reload!
-    dataset.wont_be :reference?
-    dataset.must_be :resource?
-    dataset.wont_be :resource_partial?
-    dataset.must_be :resource_full?
+    _(dataset).wont_be :reference?
+    _(dataset).must_be :resource?
+    _(dataset).wont_be :resource_partial?
+    _(dataset).must_be :resource_full?
 
     mock.verify
   end
@@ -49,16 +49,16 @@ describe Google::Cloud::Bigquery::Dataset, :reload, :mock_bigquery do
       mock.expect :get_dataset, dataset_gapi, [project, dataset_id]
       dataset.service.mocked_service = mock
 
-      dataset.wont_be :reference?
-      dataset.must_be :resource?
-      dataset.must_be :resource_partial?
-      dataset.wont_be :resource_full?
+      _(dataset).wont_be :reference?
+      _(dataset).must_be :resource?
+      _(dataset).must_be :resource_partial?
+      _(dataset).wont_be :resource_full?
 
       dataset.reload!
-      dataset.wont_be :reference?
-      dataset.must_be :resource?
-      dataset.wont_be :resource_partial?
-      dataset.must_be :resource_full?
+      _(dataset).wont_be :reference?
+      _(dataset).must_be :resource?
+      _(dataset).wont_be :resource_partial?
+      _(dataset).must_be :resource_full?
 
       mock.verify
     end
@@ -72,16 +72,16 @@ describe Google::Cloud::Bigquery::Dataset, :reload, :mock_bigquery do
       mock.expect :get_dataset, dataset_gapi, [project, dataset_id]
       dataset.service.mocked_service = mock
 
-      dataset.must_be :reference?
-      dataset.wont_be :resource?
-      dataset.wont_be :resource_partial?
-      dataset.wont_be :resource_full?
+      _(dataset).must_be :reference?
+      _(dataset).wont_be :resource?
+      _(dataset).wont_be :resource_partial?
+      _(dataset).wont_be :resource_full?
 
       dataset.reload!
-      dataset.wont_be :reference?
-      dataset.must_be :resource?
-      dataset.wont_be :resource_partial?
-      dataset.must_be :resource_full?
+      _(dataset).wont_be :reference?
+      _(dataset).must_be :resource?
+      _(dataset).wont_be :resource_partial?
+      _(dataset).must_be :resource_full?
 
       mock.verify
     end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -73,28 +73,28 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   it "knows its attributes" do
-    dataset.name.must_equal dataset_name
-    dataset.description.must_equal dataset_description
-    dataset.default_expiration.must_equal default_expiration
-    dataset.etag.must_equal etag
-    dataset.api_url.must_equal api_url
-    dataset.location.must_equal location_code
-    dataset.labels.must_equal labels
-    dataset.labels.must_be :frozen?
+    _(dataset.name).must_equal dataset_name
+    _(dataset.description).must_equal dataset_description
+    _(dataset.default_expiration).must_equal default_expiration
+    _(dataset.etag).must_equal etag
+    _(dataset.api_url).must_equal api_url
+    _(dataset.location).must_equal location_code
+    _(dataset.labels).must_equal labels
+    _(dataset.labels).must_be :frozen?
   end
 
   it "knows its creation and modification times" do
     now = ::Time.now
 
     dataset.gapi.creation_time = time_millis
-    dataset.created_at.must_be_close_to now, 0.1
+    _(dataset.created_at).must_be_close_to now, 0.1
 
     dataset.gapi.last_modified_time = time_millis
-    dataset.modified_at.must_be_close_to now, 0.1
+    _(dataset.modified_at).must_be_close_to now, 0.1
   end
 
   it "can test its existence without reloading" do
-    dataset.exists?.must_equal true
+    _(dataset.exists?).must_equal true
   end
 
   it "can test its existence with force reload" do
@@ -102,7 +102,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.expect :get_dataset, dataset_gapi, [project, dataset_id]
     dataset.service.mocked_service = mock
 
-    dataset.exists?(force: true).must_equal true
+    _(dataset.exists?(force: true)).must_equal true
 
     mock.verify
   end
@@ -113,9 +113,9 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       [project, dataset.dataset_id, delete_contents: nil]
     dataset.service.mocked_service = mock
 
-    dataset.delete.must_equal true
+    _(dataset.delete).must_equal true
 
-    dataset.exists?.must_equal false
+    _(dataset.exists?).must_equal false
 
     mock.verify
   end
@@ -126,9 +126,9 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       [project, dataset.dataset_id, delete_contents: true]
     dataset.service.mocked_service = mock
 
-    dataset.delete(force: true).must_equal true
+    _(dataset.delete(force: true)).must_equal true
 
-    dataset.exists?.must_equal false
+    _(dataset.exists?).must_equal false
 
     mock.verify
   end
@@ -146,10 +146,10 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal table_id
-    table.must_be :table?
-    table.wont_be :view?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal table_id
+    _(table).must_be :table?
+    _(table).wont_be :view?
   end
 
   it "creates a table with a name, description options" do
@@ -171,13 +171,13 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal table_id
-    table.name.must_equal table_name
-    table.description.must_equal table_description
-    table.schema.must_be :empty?
-    table.must_be :table?
-    table.wont_be :view?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal table_id
+    _(table.name).must_equal table_name
+    _(table.description).must_equal table_description
+    _(table.schema).must_be :empty?
+    _(table).must_be :table?
+    _(table).wont_be :view?
   end
 
   it "creates a table with a name, description in a block" do
@@ -215,13 +215,13 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal table_id
-    table.name.must_equal table_name
-    table.description.must_equal table_description
-    table.schema.must_be :empty?
-    table.must_be :table?
-    table.wont_be :view?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal table_id
+    _(table.name).must_equal table_name
+    _(table.description).must_equal table_description
+    _(table.schema).must_be :empty?
+    _(table).must_be :table?
+    _(table).wont_be :view?
   end
 
   it "creates a table with time partitioning and clustering in a block" do
@@ -243,13 +243,13 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal table_id
-    table.time_partitioning?.must_equal true
-    table.time_partitioning_type.must_equal "DAY"
-    table.time_partitioning_field.must_equal "dob"
-    table.time_partitioning_expiration.must_equal 5
-    table.clustering_fields.must_equal clustering_fields
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal table_id
+    _(table.time_partitioning?).must_equal true
+    _(table.time_partitioning_type).must_equal "DAY"
+    _(table.time_partitioning_field).must_equal "dob"
+    _(table.time_partitioning_expiration).must_equal 5
+    _(table.clustering_fields).must_equal clustering_fields
   end
 
   it "creates a table with range partitioning in a block" do
@@ -270,13 +270,13 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal table_id
-    table.range_partitioning?.must_equal true
-    table.range_partitioning_field.must_equal "my_table_id"
-    table.range_partitioning_start.must_equal 0
-    table.range_partitioning_interval.must_equal 10
-    table.range_partitioning_end.must_equal 100
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal table_id
+    _(table.range_partitioning?).must_equal true
+    _(table.range_partitioning_field).must_equal "my_table_id"
+    _(table.range_partitioning_start).must_equal 0
+    _(table.range_partitioning_interval).must_equal 10
+    _(table.range_partitioning_end).must_equal 100
   end
 
   it "creates a table with require_partition_filter in a block" do
@@ -294,9 +294,9 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal table_id
-    table.require_partition_filter.must_equal true
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal table_id
+    _(table.require_partition_filter).must_equal true
   end
 
   it "creates a table with a schema inline" do
@@ -324,14 +324,14 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal table_id
-    table.name.must_equal table_name
-    table.description.must_equal table_description
-    table.schema.wont_be :empty?
-    table.schema.must_be :frozen?
-    table.must_be :table?
-    table.wont_be :view?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal table_id
+    _(table.name).must_equal table_name
+    _(table.description).must_equal table_description
+    _(table.schema).wont_be :empty?
+    _(table.schema).must_be :frozen?
+    _(table).must_be :table?
+    _(table).wont_be :view?
   end
 
   it "creates a table with a old schema syntax" do
@@ -378,14 +378,14 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal table_id
-    table.name.must_equal table_name
-    table.description.must_equal table_description
-    table.schema.wont_be :empty?
-    table.schema.must_be :frozen?
-    table.must_be :table?
-    table.wont_be :view?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal table_id
+    _(table.name).must_equal table_name
+    _(table.description).must_equal table_description
+    _(table.schema).wont_be :empty?
+    _(table.schema).must_be :frozen?
+    _(table).must_be :table?
+    _(table).wont_be :view?
   end
 
   it "creates a table with a schema in a block" do
@@ -415,14 +415,14 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal table_id
-    table.name.must_equal table_name
-    table.description.must_equal table_description
-    table.schema.wont_be :empty?
-    table.schema.must_be :frozen?
-    table.must_be :table?
-    table.wont_be :view?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal table_id
+    _(table.name).must_equal table_name
+    _(table.description).must_equal table_description
+    _(table.schema).wont_be :empty?
+    _(table.schema).must_be :frozen?
+    _(table).must_be :table?
+    _(table).wont_be :view?
   end
 
   it "can create a empty view" do
@@ -445,14 +445,14 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal view_id
-    table.query.must_equal query
-    table.must_be :query_standard_sql?
-    table.wont_be :query_legacy_sql?
-    table.query_udfs.must_be :empty?
-    table.must_be :view?
-    table.wont_be :table?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal view_id
+    _(table.query).must_equal query
+    _(table).must_be :query_standard_sql?
+    _(table).wont_be :query_legacy_sql?
+    _(table.query_udfs).must_be :empty?
+    _(table).must_be :view?
+    _(table).wont_be :table?
   end
 
   it "can create a view with a name and description" do
@@ -479,16 +479,16 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal view_id
-    table.query.must_equal query
-    table.name.must_equal view_name
-    table.description.must_equal view_description
-    table.must_be :query_standard_sql?
-    table.wont_be :query_legacy_sql?
-    table.query_udfs.must_be :empty?
-    table.must_be :view?
-    table.wont_be :table?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal view_id
+    _(table.query).must_equal query
+    _(table.name).must_equal view_name
+    _(table.description).must_equal view_description
+    _(table).must_be :query_standard_sql?
+    _(table).wont_be :query_legacy_sql?
+    _(table.query_udfs).must_be :empty?
+    _(table).must_be :view?
+    _(table).wont_be :table?
   end
 
   it "can create a view with standard_sql" do
@@ -511,14 +511,14 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal view_id
-    table.query.must_equal query
-    table.must_be :query_standard_sql?
-    table.wont_be :query_legacy_sql?
-    table.query_udfs.must_be :empty?
-    table.must_be :view?
-    table.wont_be :table?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal view_id
+    _(table.query).must_equal query
+    _(table).must_be :query_standard_sql?
+    _(table).wont_be :query_legacy_sql?
+    _(table.query_udfs).must_be :empty?
+    _(table).must_be :view?
+    _(table).wont_be :table?
   end
 
   it "can create a view with legacy_sql" do
@@ -541,16 +541,16 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal view_id
-    table.query.must_equal query
-    table.wont_be :query_standard_sql?
-    table.must_be :query_legacy_sql?
-    table.query_udfs.must_be :empty?
-    table.name.must_equal view_name
-    table.description.must_equal view_description
-    table.must_be :view?
-    table.wont_be :table?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal view_id
+    _(table.query).must_equal query
+    _(table).wont_be :query_standard_sql?
+    _(table).must_be :query_legacy_sql?
+    _(table.query_udfs).must_be :empty?
+    _(table.name).must_equal view_name
+    _(table.description).must_equal view_description
+    _(table).must_be :view?
+    _(table).wont_be :table?
   end
 
   it "can create a view with udfs (array)" do
@@ -576,14 +576,14 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal view_id
-    table.query.must_equal query
-    table.must_be :query_standard_sql?
-    table.wont_be :query_legacy_sql?
-    table.query_udfs.must_equal ["return x+1;", "gs://my-bucket/my-lib.js"]
-    table.must_be :view?
-    table.wont_be :table?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal view_id
+    _(table.query).must_equal query
+    _(table).must_be :query_standard_sql?
+    _(table).wont_be :query_legacy_sql?
+    _(table.query_udfs).must_equal ["return x+1;", "gs://my-bucket/my-lib.js"]
+    _(table).must_be :view?
+    _(table).wont_be :table?
   end
 
   it "can create a view with udfs (inline)" do
@@ -608,14 +608,14 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal view_id
-    table.query.must_equal query
-    table.must_be :query_standard_sql?
-    table.wont_be :query_legacy_sql?
-    table.query_udfs.must_equal ["return x+1;"]
-    table.must_be :view?
-    table.wont_be :table?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal view_id
+    _(table.query).must_equal query
+    _(table).must_be :query_standard_sql?
+    _(table).wont_be :query_legacy_sql?
+    _(table.query_udfs).must_equal ["return x+1;"]
+    _(table).must_be :view?
+    _(table).wont_be :table?
   end
 
   it "can create a view with udfs (url)" do
@@ -640,14 +640,14 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal view_id
-    table.query.must_equal query
-    table.must_be :query_standard_sql?
-    table.wont_be :query_legacy_sql?
-    table.query_udfs.must_equal ["gs://my-bucket/my-lib.js"]
-    table.must_be :view?
-    table.wont_be :table?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal view_id
+    _(table.query).must_equal query
+    _(table).must_be :query_standard_sql?
+    _(table).wont_be :query_legacy_sql?
+    _(table.query_udfs).must_equal ["gs://my-bucket/my-lib.js"]
+    _(table).must_be :view?
+    _(table).wont_be :table?
   end
 
   it "lists tables" do
@@ -660,8 +660,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    tables.size.must_equal 3
-    tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(tables.size).must_equal 3
+    tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
   end
 
   it "lists tables with max set" do
@@ -674,10 +674,10 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    tables.count.must_equal 3
-    tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
-    tables.token.wont_be :nil?
-    tables.token.must_equal "next_page_token"
+    _(tables.count).must_equal 3
+    tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(tables.token).wont_be :nil?
+    _(tables.token).must_equal "next_page_token"
   end
 
   it "paginates tables" do
@@ -693,16 +693,16 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    first_tables.count.must_equal 3
-    first_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
-    first_tables.token.wont_be :nil?
-    first_tables.token.must_equal "next_page_token"
-    first_tables.total.must_equal 5
+    _(first_tables.count).must_equal 3
+    first_tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(first_tables.token).wont_be :nil?
+    _(first_tables.token).must_equal "next_page_token"
+    _(first_tables.total).must_equal 5
 
-    second_tables.count.must_equal 2
-    second_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
-    second_tables.token.must_be :nil?
-    second_tables.total.must_equal 5
+    _(second_tables.count).must_equal 2
+    second_tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(second_tables.token).must_be :nil?
+    _(second_tables.total).must_equal 5
   end
 
   it "paginates tables with next? and next" do
@@ -718,16 +718,16 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    first_tables.count.must_equal 3
-    first_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
-    first_tables.token.wont_be :nil?
-    first_tables.token.must_equal "next_page_token"
-    first_tables.total.must_equal 5
+    _(first_tables.count).must_equal 3
+    first_tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(first_tables.token).wont_be :nil?
+    _(first_tables.token).must_equal "next_page_token"
+    _(first_tables.total).must_equal 5
 
-    second_tables.count.must_equal 2
-    second_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
-    second_tables.token.must_be :nil?
-    second_tables.total.must_equal 5
+    _(second_tables.count).must_equal 2
+    second_tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(second_tables.token).must_be :nil?
+    _(second_tables.total).must_equal 5
   end
 
   it "paginates tables with next? and next and max" do
@@ -743,15 +743,15 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    first_tables.count.must_equal 3
-    first_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
-    first_tables.next?.must_equal true
-    first_tables.total.must_equal 5
+    _(first_tables.count).must_equal 3
+    first_tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(first_tables.next?).must_equal true
+    _(first_tables.total).must_equal 5
 
-    second_tables.count.must_equal 2
-    second_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
-    second_tables.next?.must_equal false
-    second_tables.total.must_equal 5
+    _(second_tables.count).must_equal 2
+    second_tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(second_tables.next?).must_equal false
+    _(second_tables.total).must_equal 5
   end
 
   it "paginates tables with all" do
@@ -766,8 +766,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    tables.count.must_equal 5
-    tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(tables.count).must_equal 5
+    tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
   end
 
   it "paginates tables with all and max" do
@@ -782,8 +782,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    tables.count.must_equal 5
-    tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(tables.count).must_equal 5
+    tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
   end
 
   it "iterates tables with all using Enumerator" do
@@ -798,8 +798,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    tables.count.must_equal 5
-    tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(tables.count).must_equal 5
+    tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
   end
 
   it "iterates tables with all with request_limit set" do
@@ -814,8 +814,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    tables.count.must_equal 6
-    tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    _(tables.count).must_equal 6
+    tables.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Table }
   end
 
   it "finds a table" do
@@ -829,8 +829,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal found_table_id
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table.table_id).must_equal found_table_id
   end
 
   it "finds a table with skip_lookup option" do
@@ -839,11 +839,11 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     table = dataset.table table_id, skip_lookup: true
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.must_be :reference?
-    table.wont_be :resource?
-    table.wont_be :resource_partial?
-    table.wont_be :resource_full?
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table).must_be :reference?
+    _(table).wont_be :resource?
+    _(table).wont_be :resource_partial?
+    _(table).wont_be :resource_full?
   end
 
   it "finds a table with skip_lookup option if table_id is nil" do
@@ -853,7 +853,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     error = expect do
       dataset.table table_id, skip_lookup: true
     end.must_raise ArgumentError
-    error.message.must_equal "table_id is required"
+    _(error.message).must_equal "table_id is required"
   end
 
   def create_table_gapi id, name = nil, description = nil

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_update_test.rb
@@ -35,15 +35,15 @@ describe Google::Cloud::Bigquery::Dataset, :update, :mock_bigquery do
     patch_dataset_gapi = Google::Apis::BigqueryV2::Dataset.new friendly_name: new_dataset_name, etag: dataset_gapi.etag
     mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_dataset_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
-    dataset.name.must_equal dataset_name
-    dataset.description.must_equal description
-    dataset.default_expiration.must_equal default_expiration
+    _(dataset.name).must_equal dataset_name
+    _(dataset.description).must_equal description
+    _(dataset.default_expiration).must_equal default_expiration
 
     dataset.name = new_dataset_name
 
-    dataset.name.must_equal new_dataset_name
-    dataset.description.must_equal description
-    dataset.default_expiration.must_equal default_expiration
+    _(dataset.name).must_equal new_dataset_name
+    _(dataset.description).must_equal description
+    _(dataset.default_expiration).must_equal default_expiration
     mock.verify
   end
 
@@ -57,15 +57,15 @@ describe Google::Cloud::Bigquery::Dataset, :update, :mock_bigquery do
     patch_gapi = Google::Apis::BigqueryV2::Dataset.new description: new_description, etag: dataset_gapi.etag
     mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
-    dataset.name.must_equal dataset_name
-    dataset.description.must_equal description
-    dataset.default_expiration.must_equal default_expiration
+    _(dataset.name).must_equal dataset_name
+    _(dataset.description).must_equal description
+    _(dataset.default_expiration).must_equal default_expiration
 
     dataset.description = new_description
 
-    dataset.name.must_equal dataset_name
-    dataset.description.must_equal new_description
-    dataset.default_expiration.must_equal default_expiration
+    _(dataset.name).must_equal dataset_name
+    _(dataset.description).must_equal new_description
+    _(dataset.default_expiration).must_equal default_expiration
     mock.verify
   end
 
@@ -79,15 +79,15 @@ describe Google::Cloud::Bigquery::Dataset, :update, :mock_bigquery do
     patch_gapi = Google::Apis::BigqueryV2::Dataset.new default_table_expiration_ms: new_default_expiration, etag: dataset_gapi.etag
     mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
-    dataset.name.must_equal dataset_name
-    dataset.description.must_equal description
-    dataset.default_expiration.must_equal default_expiration
+    _(dataset.name).must_equal dataset_name
+    _(dataset.description).must_equal description
+    _(dataset.default_expiration).must_equal default_expiration
 
     dataset.default_expiration = new_default_expiration
 
-    dataset.name.must_equal dataset_name
-    dataset.description.must_equal description
-    dataset.default_expiration.must_equal new_default_expiration
+    _(dataset.name).must_equal dataset_name
+    _(dataset.description).must_equal description
+    _(dataset.default_expiration).must_equal new_default_expiration
     mock.verify
   end
 
@@ -101,11 +101,11 @@ describe Google::Cloud::Bigquery::Dataset, :update, :mock_bigquery do
     patch_gapi = Google::Apis::BigqueryV2::Dataset.new labels: new_labels, etag: dataset_gapi.etag
     mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
-    dataset.labels.must_equal labels
+    _(dataset.labels).must_equal labels
 
     dataset.labels = new_labels
 
-    dataset.labels.must_equal new_labels
+    _(dataset.labels).must_equal new_labels
     mock.verify
   end
 
@@ -119,13 +119,13 @@ describe Google::Cloud::Bigquery::Dataset, :update, :mock_bigquery do
     patch_gapi = Google::Apis::BigqueryV2::Dataset.new default_encryption_configuration: updated_gapi.default_encryption_configuration, etag: dataset_gapi.etag
     mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
-    dataset.default_encryption.must_be_nil
+    _(dataset.default_encryption).must_be_nil
 
     dataset.default_encryption = bigquery.encryption kms_key: kms_key
 
-    dataset.default_encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
-    dataset.default_encryption.kms_key.must_equal kms_key
-    dataset.default_encryption.must_be :frozen?
+    _(dataset.default_encryption).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(dataset.default_encryption.kms_key).must_equal kms_key
+    _(dataset.default_encryption).must_be :frozen?
     mock.verify
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/encryption_configuration_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/encryption_configuration_test.rb
@@ -23,21 +23,21 @@ describe Google::Cloud::Bigquery::EncryptionConfiguration do
       kms_key_name: "projects/a/locations/b/keyRings/c/cryptoKeys/d"
     )
 
-    config.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
-    config.kms_key.must_equal "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+    _(config).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(config.kms_key).must_equal "projects/a/locations/b/keyRings/c/cryptoKeys/d"
 
-    config.to_gapi.to_h.must_equal config_gapi.to_h
+    _(config.to_gapi.to_h).must_equal config_gapi.to_h
   end
 
   it "can set KMS keys" do
     config = Google::Cloud::Bigquery::EncryptionConfiguration.new
-    config.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(config).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
 
     config.kms_key=  "projects/a/locations/b/keyRings/c/cryptoKeys/d"
-    config.kms_key.must_equal "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+    _(config.kms_key).must_equal "projects/a/locations/b/keyRings/c/cryptoKeys/d"
 
     config.kms_key=  "projects/1/locations/2/keyRings/3/cryptoKeys/4"
-    config.kms_key.must_equal "projects/1/locations/2/keyRings/3/cryptoKeys/4"
+    _(config.kms_key).must_equal "projects/1/locations/2/keyRings/3/cryptoKeys/4"
   end
 
   it "can be converted from gapi" do
@@ -46,10 +46,10 @@ describe Google::Cloud::Bigquery::EncryptionConfiguration do
     )
     config = Google::Cloud::Bigquery::EncryptionConfiguration.from_gapi config_gapi
 
-    config.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
-    config.kms_key.must_equal "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+    _(config).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(config.kms_key).must_equal "projects/a/locations/b/keyRings/c/cryptoKeys/d"
 
-    config.to_gapi.to_h.must_equal config_gapi.to_h
+    _(config.to_gapi.to_h).must_equal config_gapi.to_h
   end
 
   it "can compare using equality" do
@@ -58,11 +58,11 @@ describe Google::Cloud::Bigquery::EncryptionConfiguration do
     config.kms_key =  "projects/a/locations/b/keyRings/c/cryptoKeys/d"
     config_other.kms_key =  "projects/a/locations/b/keyRings/c/cryptoKeys/d"
 
-    config.must_equal config_other
+    _(config).must_equal config_other
 
     config_other.kms_key =  "projects/1/locations/2/keyRings/3/cryptoKeys/4"
-    config.wont_equal config_other
+    _(config).wont_equal config_other
 
-    config.wont_equal "not a config"
+    _(config).wont_equal "not a config"
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_column_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_column_test.rb
@@ -21,50 +21,50 @@ describe Google::Cloud::Bigquery::External::BigtableSource::Column, :mock_bigque
 
   it "creates a simple external table" do
     external = bigquery.external "gs://my-bucket/path/to/file.csv"
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-    external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
-    external.format.must_equal "CSV"
+    _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    _(external.urls).must_equal ["gs://my-bucket/path/to/file.csv"]
+    _(external.format).must_equal "CSV"
   end
 
   it "determines CSV from one URL" do
     external = bigquery.external "gs://my-bucket/path/to/file.csv"
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-    external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
-    external.format.must_equal "CSV"
+    _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    _(external.urls).must_equal ["gs://my-bucket/path/to/file.csv"]
+    _(external.format).must_equal "CSV"
   end
 
   it "determines CSV from multiple URL" do
     external = bigquery.external ["some url", "gs://my-bucket/path/to/file.csv"]
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-    external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.csv"]
-    external.format.must_equal "CSV"
+    _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    _(external.urls).must_equal ["some url", "gs://my-bucket/path/to/file.csv"]
+    _(external.format).must_equal "CSV"
   end
 
   it "determines CSV from the format (:csv)" do
     external = bigquery.external "some url", format: :csv
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-    external.urls.must_equal ["some url"]
-    external.format.must_equal "CSV"
+    _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    _(external.urls).must_equal ["some url"]
+    _(external.format).must_equal "CSV"
   end
 
   it "determines CSV from the format (csv)" do
     external = bigquery.external "some url", format: "csv"
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-    external.urls.must_equal ["some url"]
-    external.format.must_equal "CSV"
+    _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    _(external.urls).must_equal ["some url"]
+    _(external.format).must_equal "CSV"
   end
 
   it "determines CSV from the format (:CSV)" do
     external = bigquery.external "some url", format: :CSV
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-    external.urls.must_equal ["some url"]
-    external.format.must_equal "CSV"
+    _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    _(external.urls).must_equal ["some url"]
+    _(external.format).must_equal "CSV"
   end
 
   it "determines CSV from the format (CSV)" do
     external = bigquery.external "some url", format: "CSV"
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-    external.urls.must_equal ["some url"]
-    external.format.must_equal "CSV"
+    _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    _(external.urls).must_equal ["some url"]
+    _(external.format).must_equal "CSV"
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_test.rb
@@ -28,18 +28,18 @@ describe Google::Cloud::Bigquery::External::BigtableSource do
       )
     )
 
-    table.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-    table.urls.must_equal ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
-    table.must_be :bigtable?
-    table.format.must_equal "BIGTABLE"
+    _(table).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+    _(table.urls).must_equal ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+    _(table).must_be :bigtable?
+    _(table.format).must_equal "BIGTABLE"
 
-    table.wont_be :csv?
-    table.wont_be :json?
-    table.wont_be :sheets?
-    table.wont_be :avro?
-    table.wont_be :backup?
+    _(table).wont_be :csv?
+    _(table).wont_be :json?
+    _(table).wont_be :sheets?
+    _(table).wont_be :avro?
+    _(table).wont_be :backup?
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets rowkey_as_string" do
@@ -56,13 +56,13 @@ describe Google::Cloud::Bigquery::External::BigtableSource do
       )
     )
 
-    table.rowkey_as_string.must_be :nil?
+    _(table.rowkey_as_string).must_be :nil?
 
     table.rowkey_as_string = true
 
-    table.rowkey_as_string.must_equal true
+    _(table.rowkey_as_string).must_equal true
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "adds column families using block" do
@@ -88,7 +88,7 @@ describe Google::Cloud::Bigquery::External::BigtableSource do
       )
     )
 
-    table.families.must_be :empty?
+    _(table.families).must_be :empty?
 
     table.add_family "user" do |u|
       u.add_string  "name"
@@ -98,28 +98,28 @@ describe Google::Cloud::Bigquery::External::BigtableSource do
       u.add_bytes   "avatar"
     end
 
-    table.families.wont_be :empty?
-    table.families.count.must_equal 1
-    table.families[0].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::ColumnFamily
-    table.families[0].family_id.must_equal "user"
-    table.families[0].columns.count.must_equal 5
-    table.families[0].columns[0].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
-    table.families[0].columns[0].qualifier.must_equal "name"
-    table.families[0].columns[0].type.must_equal "STRING"
-    table.families[0].columns[1].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
-    table.families[0].columns[1].qualifier.must_equal "age"
-    table.families[0].columns[1].type.must_equal "INTEGER"
-    table.families[0].columns[2].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
-    table.families[0].columns[2].qualifier.must_equal "score"
-    table.families[0].columns[2].type.must_equal "FLOAT"
-    table.families[0].columns[3].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
-    table.families[0].columns[3].qualifier.must_equal "active"
-    table.families[0].columns[3].type.must_equal "BOOLEAN"
-    table.families[0].columns[4].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
-    table.families[0].columns[4].qualifier.must_equal "avatar"
-    table.families[0].columns[4].type.must_equal "BYTES"
+    _(table.families).wont_be :empty?
+    _(table.families.count).must_equal 1
+    _(table.families[0]).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::ColumnFamily
+    _(table.families[0].family_id).must_equal "user"
+    _(table.families[0].columns.count).must_equal 5
+    _(table.families[0].columns[0]).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    _(table.families[0].columns[0].qualifier).must_equal "name"
+    _(table.families[0].columns[0].type).must_equal "STRING"
+    _(table.families[0].columns[1]).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    _(table.families[0].columns[1].qualifier).must_equal "age"
+    _(table.families[0].columns[1].type).must_equal "INTEGER"
+    _(table.families[0].columns[2]).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    _(table.families[0].columns[2].qualifier).must_equal "score"
+    _(table.families[0].columns[2].type).must_equal "FLOAT"
+    _(table.families[0].columns[3]).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    _(table.families[0].columns[3].qualifier).must_equal "active"
+    _(table.families[0].columns[3].type).must_equal "BOOLEAN"
+    _(table.families[0].columns[4]).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    _(table.families[0].columns[4].qualifier).must_equal "avatar"
+    _(table.families[0].columns[4].type).must_equal "BYTES"
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "adds column families inline" do
@@ -145,7 +145,7 @@ describe Google::Cloud::Bigquery::External::BigtableSource do
       )
     )
 
-    table.families.must_be :empty?
+    _(table.families).must_be :empty?
 
     family = table.add_family "user"
     family.add_string  "name"
@@ -154,27 +154,27 @@ describe Google::Cloud::Bigquery::External::BigtableSource do
     family.add_boolean "active"
     family.add_bytes   "avatar"
 
-    table.families.wont_be :empty?
-    table.families.count.must_equal 1
-    table.families[0].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::ColumnFamily
-    table.families[0].family_id.must_equal "user"
-    table.families[0].columns.count.must_equal 5
-    table.families[0].columns[0].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
-    table.families[0].columns[0].qualifier.must_equal "name"
-    table.families[0].columns[0].type.must_equal "STRING"
-    table.families[0].columns[1].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
-    table.families[0].columns[1].qualifier.must_equal "age"
-    table.families[0].columns[1].type.must_equal "INTEGER"
-    table.families[0].columns[2].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
-    table.families[0].columns[2].qualifier.must_equal "score"
-    table.families[0].columns[2].type.must_equal "FLOAT"
-    table.families[0].columns[3].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
-    table.families[0].columns[3].qualifier.must_equal "active"
-    table.families[0].columns[3].type.must_equal "BOOLEAN"
-    table.families[0].columns[4].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
-    table.families[0].columns[4].qualifier.must_equal "avatar"
-    table.families[0].columns[4].type.must_equal "BYTES"
+    _(table.families).wont_be :empty?
+    _(table.families.count).must_equal 1
+    _(table.families[0]).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::ColumnFamily
+    _(table.families[0].family_id).must_equal "user"
+    _(table.families[0].columns.count).must_equal 5
+    _(table.families[0].columns[0]).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    _(table.families[0].columns[0].qualifier).must_equal "name"
+    _(table.families[0].columns[0].type).must_equal "STRING"
+    _(table.families[0].columns[1]).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    _(table.families[0].columns[1].qualifier).must_equal "age"
+    _(table.families[0].columns[1].type).must_equal "INTEGER"
+    _(table.families[0].columns[2]).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    _(table.families[0].columns[2].qualifier).must_equal "score"
+    _(table.families[0].columns[2].type).must_equal "FLOAT"
+    _(table.families[0].columns[3]).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    _(table.families[0].columns[3].qualifier).must_equal "active"
+    _(table.families[0].columns[3].type).must_equal "BOOLEAN"
+    _(table.families[0].columns[4]).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    _(table.families[0].columns[4].qualifier).must_equal "avatar"
+    _(table.families[0].columns[4].type).must_equal "BYTES"
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_csv_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_csv_source_test.rb
@@ -26,18 +26,18 @@ describe Google::Cloud::Bigquery::External::CsvSource do
       csv_options: Google::Apis::BigqueryV2::CsvOptions.new
     )
 
-    table.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-    table.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
-    table.must_be :csv?
-    table.format.must_equal "CSV"
+    _(table).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+    _(table.urls).must_equal ["gs://my-bucket/path/to/file.csv"]
+    _(table).must_be :csv?
+    _(table.format).must_equal "CSV"
 
-    table.wont_be :json?
-    table.wont_be :sheets?
-    table.wont_be :avro?
-    table.wont_be :backup?
-    table.wont_be :bigtable?
+    _(table).wont_be :json?
+    _(table).wont_be :sheets?
+    _(table).wont_be :avro?
+    _(table).wont_be :backup?
+    _(table).wont_be :bigtable?
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets jagged_rows" do
@@ -53,13 +53,13 @@ describe Google::Cloud::Bigquery::External::CsvSource do
       )
     )
 
-    table.jagged_rows.must_be :nil?
+    _(table.jagged_rows).must_be :nil?
 
     table.jagged_rows = true
 
-    table.jagged_rows.must_equal true
+    _(table.jagged_rows).must_equal true
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets quoted_newlines" do
@@ -75,13 +75,13 @@ describe Google::Cloud::Bigquery::External::CsvSource do
       )
     )
 
-    table.quoted_newlines.must_be :nil?
+    _(table.quoted_newlines).must_be :nil?
 
     table.quoted_newlines = true
 
-    table.quoted_newlines.must_equal true
+    _(table.quoted_newlines).must_equal true
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets encoding" do
@@ -97,23 +97,23 @@ describe Google::Cloud::Bigquery::External::CsvSource do
       )
     )
 
-    table.encoding.must_be :nil?
-    table.must_be :utf8? # default is UTF-8, even when encoding is not specifically set
-    table.wont_be :iso8859_1?
+    _(table.encoding).must_be :nil?
+    _(table).must_be :utf8? # default is UTF-8, even when encoding is not specifically set
+    _(table).wont_be :iso8859_1?
 
     table.encoding = "ISO-8859-1"
 
-    table.encoding.must_equal "ISO-8859-1"
-    table.wont_be :utf8?
-    table.must_be :iso8859_1?
+    _(table.encoding).must_equal "ISO-8859-1"
+    _(table).wont_be :utf8?
+    _(table).must_be :iso8859_1?
 
     table.encoding = "UTF-8"
 
-    table.encoding.must_equal "UTF-8"
-    table.must_be :utf8?
-    table.wont_be :iso8859_1?
+    _(table.encoding).must_equal "UTF-8"
+    _(table).must_be :utf8?
+    _(table).wont_be :iso8859_1?
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets delimiter" do
@@ -129,13 +129,13 @@ describe Google::Cloud::Bigquery::External::CsvSource do
       )
     )
 
-    table.delimiter.must_be :nil?
+    _(table.delimiter).must_be :nil?
 
     table.delimiter = "|"
 
-    table.delimiter.must_equal "|"
+    _(table.delimiter).must_equal "|"
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets quote" do
@@ -151,13 +151,13 @@ describe Google::Cloud::Bigquery::External::CsvSource do
       )
     )
 
-    table.quote.must_be :nil?
+    _(table.quote).must_be :nil?
 
     table.quote = "'"
 
-    table.quote.must_equal "'"
+    _(table.quote).must_equal "'"
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets skip_leading_rows" do
@@ -173,13 +173,13 @@ describe Google::Cloud::Bigquery::External::CsvSource do
       )
     )
 
-    table.skip_leading_rows.must_be :nil?
+    _(table.skip_leading_rows).must_be :nil?
 
     table.skip_leading_rows = true
 
-    table.skip_leading_rows.must_equal true
+    _(table.skip_leading_rows).must_equal true
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets schema using block" do
@@ -205,8 +205,8 @@ describe Google::Cloud::Bigquery::External::CsvSource do
       csv_options: Google::Apis::BigqueryV2::CsvOptions.new
     )
 
-    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    table.schema.must_be :empty?
+    _(table.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(table.schema).must_be :empty?
 
     table.schema do |s|
       s.string "name", mode: :required
@@ -221,14 +221,14 @@ describe Google::Cloud::Bigquery::External::CsvSource do
       s.date "birthday"
     end
 
-    table.schema.wont_be :empty?
-    table.fields.must_equal table.schema.fields
-    table.headers.must_equal table.schema.headers
-    table.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    table.param_types.must_equal table.schema.param_types
-    table.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(table.schema).wont_be :empty?
+    _(table.fields).must_equal table.schema.fields
+    _(table.headers).must_equal table.schema.headers
+    _(table.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(table.param_types).must_equal table.schema.param_types
+    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets schema using object" do
@@ -254,8 +254,8 @@ describe Google::Cloud::Bigquery::External::CsvSource do
       csv_options: Google::Apis::BigqueryV2::CsvOptions.new
     )
 
-    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    table.schema.must_be :empty?
+    _(table.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(table.schema).must_be :empty?
 
     # this object is usually created by calling bigquery.schema
     schema = Google::Cloud::Bigquery::Schema.from_gapi
@@ -272,13 +272,13 @@ describe Google::Cloud::Bigquery::External::CsvSource do
 
     table.schema = schema
 
-    table.schema.wont_be :empty?
-    table.fields.must_equal table.schema.fields
-    table.headers.must_equal table.schema.headers
-    table.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    table.param_types.must_equal table.schema.param_types
-    table.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(table.schema).wont_be :empty?
+    _(table.fields).must_equal table.schema.fields
+    _(table.headers).must_equal table.schema.headers
+    _(table.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(table.param_types).must_equal table.schema.param_types
+    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_data_souce_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_data_souce_test.rb
@@ -25,18 +25,18 @@ describe Google::Cloud::Bigquery::External::DataSource do
       source_format: "AVRO"
     )
 
-    table.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-    table.urls.must_equal ["gs://my-bucket/path/to/file.avro"]
-    table.must_be :avro?
-    table.format.must_equal "AVRO"
+    _(table).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+    _(table.urls).must_equal ["gs://my-bucket/path/to/file.avro"]
+    _(table).must_be :avro?
+    _(table.format).must_equal "AVRO"
 
-    table.wont_be :csv?
-    table.wont_be :json?
-    table.wont_be :sheets?
-    table.wont_be :backup?
-    table.wont_be :bigtable?
+    _(table).wont_be :csv?
+    _(table).wont_be :json?
+    _(table).wont_be :sheets?
+    _(table).wont_be :backup?
+    _(table).wont_be :bigtable?
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "can be used for DATASTORE_BACKUP" do
@@ -49,18 +49,18 @@ describe Google::Cloud::Bigquery::External::DataSource do
       source_format: "DATASTORE_BACKUP"
     )
 
-    table.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-    table.urls.must_equal ["gs://my-bucket/path/to/file.backup_info"]
-    table.must_be :backup?
-    table.format.must_equal "DATASTORE_BACKUP"
+    _(table).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+    _(table.urls).must_equal ["gs://my-bucket/path/to/file.backup_info"]
+    _(table).must_be :backup?
+    _(table.format).must_equal "DATASTORE_BACKUP"
 
-    table.wont_be :csv?
-    table.wont_be :json?
-    table.wont_be :sheets?
-    table.wont_be :avro?
-    table.wont_be :bigtable?
+    _(table).wont_be :csv?
+    _(table).wont_be :json?
+    _(table).wont_be :sheets?
+    _(table).wont_be :avro?
+    _(table).wont_be :bigtable?
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets autodetect" do
@@ -74,13 +74,13 @@ describe Google::Cloud::Bigquery::External::DataSource do
       autodetect: true
     )
 
-    table.autodetect.must_be :nil?
+    _(table.autodetect).must_be :nil?
 
     table.autodetect = true
 
-    table.autodetect.must_equal true
+    _(table.autodetect).must_equal true
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets compression" do
@@ -94,13 +94,13 @@ describe Google::Cloud::Bigquery::External::DataSource do
       compression: "GZIP"
     )
 
-    table.compression.must_be :nil?
+    _(table.compression).must_be :nil?
 
     table.compression = "GZIP"
 
-    table.compression.must_equal "GZIP"
+    _(table.compression).must_equal "GZIP"
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets ignore_unknown" do
@@ -114,13 +114,13 @@ describe Google::Cloud::Bigquery::External::DataSource do
       ignore_unknown_values: true
     )
 
-    table.ignore_unknown.must_be :nil?
+    _(table.ignore_unknown).must_be :nil?
 
     table.ignore_unknown = true
 
-    table.ignore_unknown.must_equal true
+    _(table.ignore_unknown).must_equal true
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets max_bad_records" do
@@ -134,12 +134,12 @@ describe Google::Cloud::Bigquery::External::DataSource do
       max_bad_records: 10
     )
 
-    table.max_bad_records.must_be :nil?
+    _(table.max_bad_records).must_be :nil?
 
     table.max_bad_records = 10
 
-    table.max_bad_records.must_equal 10
+    _(table.max_bad_records).must_equal 10
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_json_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_json_source_test.rb
@@ -25,18 +25,18 @@ describe Google::Cloud::Bigquery::External::JsonSource do
       source_format: "NEWLINE_DELIMITED_JSON"
     )
 
-    table.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-    table.urls.must_equal ["gs://my-bucket/path/to/file.json"]
-    table.must_be :json?
-    table.format.must_equal "NEWLINE_DELIMITED_JSON"
+    _(table).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+    _(table.urls).must_equal ["gs://my-bucket/path/to/file.json"]
+    _(table).must_be :json?
+    _(table.format).must_equal "NEWLINE_DELIMITED_JSON"
 
-    table.wont_be :csv?
-    table.wont_be :sheets?
-    table.wont_be :avro?
-    table.wont_be :backup?
-    table.wont_be :bigtable?
+    _(table).wont_be :csv?
+    _(table).wont_be :sheets?
+    _(table).wont_be :avro?
+    _(table).wont_be :backup?
+    _(table).wont_be :bigtable?
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets schema using block" do
@@ -61,8 +61,8 @@ describe Google::Cloud::Bigquery::External::JsonSource do
       ])
     )
 
-    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    table.schema.must_be :empty?
+    _(table.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(table.schema).must_be :empty?
 
     table.schema do |s|
       s.string "name", mode: :required
@@ -77,14 +77,14 @@ describe Google::Cloud::Bigquery::External::JsonSource do
       s.date "birthday"
     end
 
-    table.schema.wont_be :empty?
-    table.fields.must_equal table.schema.fields
-    table.headers.must_equal table.schema.headers
-    table.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    table.param_types.must_equal table.schema.param_types
-    table.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(table.schema).wont_be :empty?
+    _(table.fields).must_equal table.schema.fields
+    _(table.headers).must_equal table.schema.headers
+    _(table.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(table.param_types).must_equal table.schema.param_types
+    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets schema using object" do
@@ -109,8 +109,8 @@ describe Google::Cloud::Bigquery::External::JsonSource do
       ])
     )
 
-    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    table.schema.must_be :empty?
+    _(table.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(table.schema).must_be :empty?
 
     # this object is usually created by calling bigquery.schema
     schema = Google::Cloud::Bigquery::Schema.from_gapi
@@ -127,13 +127,13 @@ describe Google::Cloud::Bigquery::External::JsonSource do
 
     table.schema = schema
 
-    table.schema.wont_be :empty?
-    table.fields.must_equal table.schema.fields
-    table.headers.must_equal table.schema.headers
-    table.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    table.param_types.must_equal table.schema.param_types
-    table.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(table.schema).wont_be :empty?
+    _(table.fields).must_equal table.schema.fields
+    _(table.headers).must_equal table.schema.headers
+    _(table.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(table.param_types).must_equal table.schema.param_types
+    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_sheets_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_sheets_source_test.rb
@@ -26,18 +26,18 @@ describe Google::Cloud::Bigquery::External::SheetsSource do
       google_sheets_options: Google::Apis::BigqueryV2::GoogleSheetsOptions.new
     )
 
-    table.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-    table.urls.must_equal ["https://docs.google.com/spreadsheets/d/1234567980"]
-    table.must_be :sheets?
-    table.format.must_equal "GOOGLE_SHEETS"
+    _(table).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+    _(table.urls).must_equal ["https://docs.google.com/spreadsheets/d/1234567980"]
+    _(table).must_be :sheets?
+    _(table.format).must_equal "GOOGLE_SHEETS"
 
-    table.wont_be :csv?
-    table.wont_be :json?
-    table.wont_be :avro?
-    table.wont_be :backup?
-    table.wont_be :bigtable?
+    _(table).wont_be :csv?
+    _(table).wont_be :json?
+    _(table).wont_be :avro?
+    _(table).wont_be :backup?
+    _(table).wont_be :bigtable?
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets skip_leading_rows" do
@@ -53,13 +53,13 @@ describe Google::Cloud::Bigquery::External::SheetsSource do
       )
     )
 
-    table.skip_leading_rows.must_be :nil?
+    _(table.skip_leading_rows).must_be :nil?
 
     table.skip_leading_rows = true
 
-    table.skip_leading_rows.must_equal true
+    _(table.skip_leading_rows).must_equal true
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
   it "sets range" do
@@ -75,12 +75,12 @@ describe Google::Cloud::Bigquery::External::SheetsSource do
       )
     )
 
-    table.range.must_be :nil?
+    _(table.range).must_be :nil?
 
     table.range = "sheet1!A1:B20"
 
-    table.range.must_equal "sheet1!A1:B20"
+    _(table.range).must_equal "sheet1!A1:B20"
 
-    table.to_gapi.to_h.must_equal table_gapi.to_h
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/extract_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/extract_job_test.rb
@@ -22,13 +22,13 @@ describe Google::Cloud::Bigquery::ExtractJob, :mock_bigquery do
   let(:job_id) { job.job_id }
 
   it "knows it is extract job" do
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "knows its destination uris" do
-    job.destinations.must_be_kind_of Array
-    job.destinations.count.must_equal 1
-    job.destinations.first.must_equal "gs://bucket/file-*.ext"
+    _(job.destinations).must_be_kind_of Array
+    _(job.destinations.count).must_equal 1
+    _(job.destinations.first).must_equal "gs://bucket/file-*.ext"
   end
 
   it "knows its source table" do
@@ -38,40 +38,40 @@ describe Google::Cloud::Bigquery::ExtractJob, :mock_bigquery do
     mock.expect :get_table, source_table_gapi, ["source_project_id", "source_dataset_id", "source_table_id"]
 
     source = job.source
-    source.must_be_kind_of Google::Cloud::Bigquery::Table
-    source.project_id.must_equal "source_project_id"
-    source.dataset_id.must_equal "source_dataset_id"
-    source.table_id.must_equal   "source_table_id"
+    _(source).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(source.project_id).must_equal "source_project_id"
+    _(source.dataset_id).must_equal "source_dataset_id"
+    _(source.table_id).must_equal   "source_table_id"
     mock.verify
   end
 
   it "knows its attributes" do
-    job.must_be :compression?
-    job.must_be :json?
-    job.wont_be :csv?
-    job.wont_be :avro?
-    job.delimiter.must_equal ","
-    job.must_be :print_header?
-    job.must_be :use_avro_logical_types?
+    _(job).must_be :compression?
+    _(job).must_be :json?
+    _(job).wont_be :csv?
+    _(job).wont_be :avro?
+    _(job.delimiter).must_equal ","
+    _(job).must_be :print_header?
+    _(job).must_be :use_avro_logical_types?
   end
 
   it "knows its extract config" do
-    job.config.must_be_kind_of Hash
-    job.config["extract"]["sourceTable"]["projectId"].must_equal "source_project_id"
-    job.config["extract"]["compression"].must_equal "GZIP"
-    job.config["extract"]["fieldDelimiter"].must_equal ","
+    _(job.config).must_be_kind_of Hash
+    _(job.config["extract"]["sourceTable"]["projectId"]).must_equal "source_project_id"
+    _(job.config["extract"]["compression"]).must_equal "GZIP"
+    _(job.config["extract"]["fieldDelimiter"]).must_equal ","
   end
 
   it "knows its statistics attributes" do
     # stats convenience method
-    job.destinations_file_counts.must_be_kind_of Array
-    job.destinations_file_counts.count.must_equal 1
-    job.destinations_file_counts.first.must_equal 123
+    _(job.destinations_file_counts).must_be_kind_of Array
+    _(job.destinations_file_counts.count).must_equal 1
+    _(job.destinations_file_counts.first).must_equal 123
 
     # hash of the uris and the file counts
-    job.destinations_counts.must_be_kind_of Hash
-    job.destinations_counts.count.must_equal 1
-    job.destinations_counts["gs://bucket/file-*.ext"].must_equal 123
+    _(job.destinations_counts).must_be_kind_of Hash
+    _(job.destinations_counts.count).must_equal 1
+    _(job.destinations_counts["gs://bucket/file-*.ext"]).must_equal 123
   end
 
   def extract_job_gapi

--- a/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
@@ -52,64 +52,64 @@ describe Google::Cloud::Bigquery::Job, :mock_bigquery do
   let(:failed_job_id) { failed_job.job_id }
 
   it "knows its attributes" do
-    job.job_id.wont_be :nil?
-    job.job_id.must_equal job_gapi.job_reference.job_id
-    job.location.must_equal region
-    job.labels.must_equal labels
-    job.labels.must_be :frozen?
-    job.user_email.must_equal "user@example.com"
-    job.num_child_jobs.must_equal 2
-    job.parent_job_id.must_equal "2222222222"
+    _(job.job_id).wont_be :nil?
+    _(job.job_id).must_equal job_gapi.job_reference.job_id
+    _(job.location).must_equal region
+    _(job.labels).must_equal labels
+    _(job.labels).must_be :frozen?
+    _(job.user_email).must_equal "user@example.com"
+    _(job.num_child_jobs).must_equal 2
+    _(job.parent_job_id).must_equal "2222222222"
   end
 
   it "knows its state" do
-    job.state.must_equal "running"
-    job.must_be :running?
-    job.wont_be :pending?
-    job.wont_be :done?
-    job.wont_be :failed?
+    _(job.state).must_equal "running"
+    _(job).must_be :running?
+    _(job).wont_be :pending?
+    _(job).wont_be :done?
+    _(job).wont_be :failed?
 
     job.gapi.status.state = "RUNNING"
-    job.state.must_equal "RUNNING"
-    job.must_be :running?
-    job.wont_be :pending?
-    job.wont_be :done?
-    job.wont_be :failed?
+    _(job.state).must_equal "RUNNING"
+    _(job).must_be :running?
+    _(job).wont_be :pending?
+    _(job).wont_be :done?
+    _(job).wont_be :failed?
 
     job.gapi.status.state = "pending"
-    job.state.must_equal "pending"
-    job.wont_be :running?
-    job.must_be :pending?
-    job.wont_be :done?
-    job.wont_be :failed?
+    _(job.state).must_equal "pending"
+    _(job).wont_be :running?
+    _(job).must_be :pending?
+    _(job).wont_be :done?
+    _(job).wont_be :failed?
 
     job.gapi.status.state = "PENDING"
-    job.state.must_equal "PENDING"
-    job.wont_be :running?
-    job.must_be :pending?
-    job.wont_be :done?
-    job.wont_be :failed?
+    _(job.state).must_equal "PENDING"
+    _(job).wont_be :running?
+    _(job).must_be :pending?
+    _(job).wont_be :done?
+    _(job).wont_be :failed?
 
     job.gapi.status.state = "done"
-    job.state.must_equal "done"
-    job.wont_be :running?
-    job.wont_be :pending?
-    job.must_be :done?
-    job.wont_be :failed?
+    _(job.state).must_equal "done"
+    _(job).wont_be :running?
+    _(job).wont_be :pending?
+    _(job).must_be :done?
+    _(job).wont_be :failed?
 
     job.gapi.status.state = "DONE"
-    job.state.must_equal "DONE"
-    job.wont_be :running?
-    job.wont_be :pending?
-    job.must_be :done?
-    job.wont_be :failed?
+    _(job.state).must_equal "DONE"
+    _(job).wont_be :running?
+    _(job).wont_be :pending?
+    _(job).must_be :done?
+    _(job).wont_be :failed?
 
     job.gapi.status.state = nil
-    job.state.must_be :nil?
-    job.wont_be :running?
-    job.wont_be :pending?
-    job.wont_be :done?
-    job.wont_be :failed?
+    _(job.state).must_be :nil?
+    _(job).wont_be :running?
+    _(job).wont_be :pending?
+    _(job).wont_be :done?
+    _(job).wont_be :failed?
   end
 
   it "knows its creation and modification times" do
@@ -117,9 +117,9 @@ describe Google::Cloud::Bigquery::Job, :mock_bigquery do
     job.gapi.statistics.start_time = nil
     job.gapi.statistics.end_time = nil
 
-    job.created_at.must_be :nil?
-    job.started_at.must_be :nil?
-    job.ended_at.must_be :nil?
+    _(job.created_at).must_be :nil?
+    _(job.started_at).must_be :nil?
+    _(job.ended_at).must_be :nil?
 
     nowish = ::Time.now
     timestamp = time_millis
@@ -128,59 +128,59 @@ describe Google::Cloud::Bigquery::Job, :mock_bigquery do
     job.gapi.statistics.start_time = timestamp
     job.gapi.statistics.end_time = timestamp
 
-    job.created_at.must_be_close_to nowish, 1
-    job.started_at.must_be_close_to nowish, 1
-    job.ended_at.must_be_close_to nowish, 1
+    _(job.created_at).must_be_close_to nowish, 1
+    _(job.started_at).must_be_close_to nowish, 1
+    _(job.ended_at).must_be_close_to nowish, 1
   end
 
   it "knows its configuration" do
-    job.config.must_be_kind_of Hash
-    job.config["dryRun"].must_equal false
-    job.configuration.must_be_kind_of Hash
-    job.configuration["dryRun"].must_equal false
+    _(job.config).must_be_kind_of Hash
+    _(job.config["dryRun"]).must_equal false
+    _(job.configuration).must_be_kind_of Hash
+    _(job.configuration["dryRun"]).must_equal false
   end
 
   it "knows its statistics config" do
-    job.statistics.must_be_kind_of Hash
-    job.statistics["creationTime"].wont_be :nil?
-    job.stats.must_be_kind_of Hash
-    job.stats["creationTime"].wont_be :nil?
+    _(job.statistics).must_be_kind_of Hash
+    _(job.statistics["creationTime"]).wont_be :nil?
+    _(job.stats).must_be_kind_of Hash
+    _(job.stats["creationTime"]).wont_be :nil?
   end
 
   it "knows its script statistics" do
-    job.script_statistics.must_be_kind_of Google::Cloud::Bigquery::Job::ScriptStatistics
-    job.script_statistics.evaluation_kind.must_equal "EXPRESSION"
-    job.script_statistics.stack_frames.wont_be :nil?
-    job.script_statistics.stack_frames.must_be_kind_of Array
-    job.script_statistics.stack_frames.count.must_equal 1
-    job.script_statistics.stack_frames[0].must_be_kind_of Google::Cloud::Bigquery::Job::ScriptStackFrame
-    job.script_statistics.stack_frames[0].start_line.must_equal 5
-    job.script_statistics.stack_frames[0].start_column.must_equal 29
-    job.script_statistics.stack_frames[0].end_line.must_equal 9
-    job.script_statistics.stack_frames[0].end_column.must_equal 14
-    job.script_statistics.stack_frames[0].text.must_equal "QUERY TEXT"
+    _(job.script_statistics).must_be_kind_of Google::Cloud::Bigquery::Job::ScriptStatistics
+    _(job.script_statistics.evaluation_kind).must_equal "EXPRESSION"
+    _(job.script_statistics.stack_frames).wont_be :nil?
+    _(job.script_statistics.stack_frames).must_be_kind_of Array
+    _(job.script_statistics.stack_frames.count).must_equal 1
+    _(job.script_statistics.stack_frames[0]).must_be_kind_of Google::Cloud::Bigquery::Job::ScriptStackFrame
+    _(job.script_statistics.stack_frames[0].start_line).must_equal 5
+    _(job.script_statistics.stack_frames[0].start_column).must_equal 29
+    _(job.script_statistics.stack_frames[0].end_line).must_equal 9
+    _(job.script_statistics.stack_frames[0].end_column).must_equal 14
+    _(job.script_statistics.stack_frames[0].text).must_equal "QUERY TEXT"
   end
 
   it "knows its error info if it has not failed" do
-    job.wont_be :failed?
-    job.error.must_be :nil?
-    job.errors.count.must_equal 0
+    _(job).wont_be :failed?
+    _(job.error).must_be :nil?
+    _(job.errors.count).must_equal 0
   end
 
   it "knows if it has failed" do
-    failed_job.state.must_equal "DONE"
-    failed_job.must_be :failed?
-    failed_job.error.must_be_kind_of Hash
-    failed_job.error.wont_be :empty?
-    failed_job.error["reason"].must_equal "r34s0n"
-    failed_job.error["location"].must_equal "l0c4t10n"
-    failed_job.error["debugInfo"].must_equal "d3bugInf0"
-    failed_job.error["message"].must_equal "m3ss4g3"
-    failed_job.errors.count.must_equal 1
-    failed_job.errors.first["reason"].must_equal "r34s0n"
-    failed_job.errors.first["location"].must_equal "l0c4t10n"
-    failed_job.errors.first["debugInfo"].must_equal "d3bugInf0"
-    failed_job.errors.first["message"].must_equal "m3ss4g3"
+    _(failed_job.state).must_equal "DONE"
+    _(failed_job).must_be :failed?
+    _(failed_job.error).must_be_kind_of Hash
+    _(failed_job.error).wont_be :empty?
+    _(failed_job.error["reason"]).must_equal "r34s0n"
+    _(failed_job.error["location"]).must_equal "l0c4t10n"
+    _(failed_job.error["debugInfo"]).must_equal "d3bugInf0"
+    _(failed_job.error["message"]).must_equal "m3ss4g3"
+    _(failed_job.errors.count).must_equal 1
+    _(failed_job.errors.first["reason"]).must_equal "r34s0n"
+    _(failed_job.errors.first["location"]).must_equal "l0c4t10n"
+    _(failed_job.errors.first["debugInfo"]).must_equal "d3bugInf0"
+    _(failed_job.errors.first["message"]).must_equal "m3ss4g3"
   end
 
   it "can reload itself" do
@@ -190,9 +190,9 @@ describe Google::Cloud::Bigquery::Job, :mock_bigquery do
                 Google::Apis::BigqueryV2::Job.from_json(random_job_hash(job_id, "done").to_json),
                 [project, job_id, {location: "US"}]
 
-    job.must_be :running?
+    _(job).must_be :running?
     job.reload!
-    job.must_be :done?
+    _(job).must_be :done?
     mock.verify
   end
 
@@ -220,9 +220,9 @@ describe Google::Cloud::Bigquery::Job, :mock_bigquery do
     def job.sleep *args
     end
 
-    job.must_be :running?
+    _(job).must_be :running?
     job.wait_until_done!
-    job.must_be :done?
+    _(job).must_be :done?
     mock.verify
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
@@ -24,13 +24,13 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
   let(:job_id) { job.job_id }
 
   it "knows it is load job" do
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
   end
 
   it "knows its source uris" do
-    job.sources.must_be_kind_of Array
-    job.sources.count.must_equal 1
-    job.sources.first.must_equal "gs://bucket/file.ext"
+    _(job.sources).must_be_kind_of Array
+    _(job.sources.count).must_equal 1
+    _(job.sources.first).must_equal "gs://bucket/file.ext"
   end
 
   it "knows its destination table" do
@@ -41,68 +41,68 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
     job.service.mocked_service = mock
 
     table = job.destination
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    _(table).must_be_kind_of Google::Cloud::Bigquery::Table
 
     mock.verify
 
-    table.project_id.must_equal "target_project_id"
-    table.dataset_id.must_equal "target_dataset_id"
-    table.table_id.must_equal   "target_table_id"
+    _(table.project_id).must_equal "target_project_id"
+    _(table.dataset_id).must_equal "target_dataset_id"
+    _(table.table_id).must_equal   "target_table_id"
   end
 
   it "knows its default attributes" do
-    job_defaults.delimiter.must_equal ","
-    job_defaults.skip_leading_rows.must_equal 0
-    job_defaults.must_be :utf8?
-    job_defaults.wont_be :iso8859_1?
-    job_defaults.quote.must_equal "\""
-    job_defaults.max_bad_records.must_equal 0
-    job_defaults.null_marker.must_equal ""
-    job_defaults.wont_be :quoted_newlines?
-    job_defaults.wont_be :autodetect?
-    job_defaults.must_be :json?
-    job_defaults.wont_be :csv?
-    job_defaults.wont_be :backup?
-    job_defaults.wont_be :allow_jagged_rows?
-    job_defaults.wont_be :ignore_unknown_values?
+    _(job_defaults.delimiter).must_equal ","
+    _(job_defaults.skip_leading_rows).must_equal 0
+    _(job_defaults).must_be :utf8?
+    _(job_defaults).wont_be :iso8859_1?
+    _(job_defaults.quote).must_equal "\""
+    _(job_defaults.max_bad_records).must_equal 0
+    _(job_defaults.null_marker).must_equal ""
+    _(job_defaults).wont_be :quoted_newlines?
+    _(job_defaults).wont_be :autodetect?
+    _(job_defaults).must_be :json?
+    _(job_defaults).wont_be :csv?
+    _(job_defaults).wont_be :backup?
+    _(job_defaults).wont_be :allow_jagged_rows?
+    _(job_defaults).wont_be :ignore_unknown_values?
   end
 
   it "knows its full attributes" do
-    job.delimiter.must_equal ","
-    job.skip_leading_rows.must_equal 0
-    job.must_be :utf8?
-    job.wont_be :iso8859_1?
-    job.quote.must_equal "\""
-    job.max_bad_records.must_equal 0
-    job.null_marker.must_equal "\N"
-    job.must_be :quoted_newlines?
-    job.must_be :autodetect?
-    job.must_be :json?
-    job.wont_be :csv?
-    job.wont_be :backup?
-    job.must_be :allow_jagged_rows?
-    job.must_be :ignore_unknown_values?
+    _(job.delimiter).must_equal ","
+    _(job.skip_leading_rows).must_equal 0
+    _(job).must_be :utf8?
+    _(job).wont_be :iso8859_1?
+    _(job.quote).must_equal "\""
+    _(job.max_bad_records).must_equal 0
+    _(job.null_marker).must_equal "\N"
+    _(job).must_be :quoted_newlines?
+    _(job).must_be :autodetect?
+    _(job).must_be :json?
+    _(job).wont_be :csv?
+    _(job).wont_be :backup?
+    _(job).must_be :allow_jagged_rows?
+    _(job).must_be :ignore_unknown_values?
   end
 
   it "knows its statistics data" do
-    job.input_files.must_equal 3
-    job.input_file_bytes.must_equal 456
-    job.output_rows.must_equal 5
-    job.output_bytes.must_equal 789
+    _(job.input_files).must_equal 3
+    _(job.input_file_bytes).must_equal 456
+    _(job.output_rows).must_equal 5
+    _(job.output_bytes).must_equal 789
   end
 
   it "knows its schema" do
-    job.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    job.schema.must_be :frozen?
-    job.schema.fields.wont_be :empty?
-    job.schema.fields.map(&:name).must_equal ["name", "age", "score", "pi", "active", "avatar", "started_at", "duration", "target_end", "birthday"]
+    _(job.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(job.schema).must_be :frozen?
+    _(job.schema.fields).wont_be :empty?
+    _(job.schema.fields.map(&:name)).must_equal ["name", "age", "score", "pi", "active", "avatar", "started_at", "duration", "target_end", "birthday"]
   end
 
   it "knows its load config" do
-    job.config.must_be_kind_of Hash
-    job.config["load"]["destinationTable"]["tableId"].must_equal "target_table_id"
-    job.config["load"]["createDisposition"].must_equal "CREATE_IF_NEEDED"
-    job.config["load"]["encoding"].must_equal "UTF-8"
+    _(job.config).must_be_kind_of Hash
+    _(job.config["load"]["destinationTable"]["tableId"]).must_equal "target_table_id"
+    _(job.config["load"]["createDisposition"]).must_equal "CREATE_IF_NEEDED"
+    _(job.config["load"]["encoding"]).must_equal "UTF-8"
   end
 
   def load_job_defaults_hash

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_updater_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_updater_test.rb
@@ -30,60 +30,60 @@ describe Google::Cloud::Bigquery::LoadJob::Updater do
     updater = new_updater
     updater.format = "csv"
     job_gapi = updater.to_gapi
-    job_gapi.configuration.load.source_format.must_equal "CSV"
+    _(job_gapi.configuration.load.source_format).must_equal "CSV"
 
     updater.format = "json"
     job_gapi = updater.to_gapi
-    job_gapi.configuration.load.source_format.must_equal "NEWLINE_DELIMITED_JSON"
+    _(job_gapi.configuration.load.source_format).must_equal "NEWLINE_DELIMITED_JSON"
 
     updater.format = "avro"
     job_gapi = updater.to_gapi
-    job_gapi.configuration.load.source_format.must_equal "AVRO"
+    _(job_gapi.configuration.load.source_format).must_equal "AVRO"
 
     updater.format = "orc"
     job_gapi = updater.to_gapi
-    job_gapi.configuration.load.source_format.must_equal "ORC"
+    _(job_gapi.configuration.load.source_format).must_equal "ORC"
 
     updater.format = "parquet"
     job_gapi = updater.to_gapi
-    job_gapi.configuration.load.source_format.must_equal "PARQUET"
+    _(job_gapi.configuration.load.source_format).must_equal "PARQUET"
 
     updater.format = "SOME_NEW_UNSUPPORTED_FORMAT"
     job_gapi = updater.to_gapi
-    job_gapi.configuration.load.source_format.must_equal "SOME_NEW_UNSUPPORTED_FORMAT"
+    _(job_gapi.configuration.load.source_format).must_equal "SOME_NEW_UNSUPPORTED_FORMAT"
   end
 
   it "can set the create disposition" do
     updater = new_updater
     updater.create = "needed"
     job_gapi = updater.to_gapi
-    job_gapi.configuration.load.create_disposition.must_equal "CREATE_IF_NEEDED"
+    _(job_gapi.configuration.load.create_disposition).must_equal "CREATE_IF_NEEDED"
 
     updater.create = "never"
     job_gapi = updater.to_gapi
-    job_gapi.configuration.load.create_disposition.must_equal "CREATE_NEVER"
+    _(job_gapi.configuration.load.create_disposition).must_equal "CREATE_NEVER"
 
     updater.create = "SOME_NEW_UNSUPPORTED_DISPOSITION"
     job_gapi = updater.to_gapi
-    job_gapi.configuration.load.create_disposition.must_equal "SOME_NEW_UNSUPPORTED_DISPOSITION"
+    _(job_gapi.configuration.load.create_disposition).must_equal "SOME_NEW_UNSUPPORTED_DISPOSITION"
   end
 
   it "can set the write disposition" do
     updater = new_updater
     updater.write = "append"
     job_gapi = updater.to_gapi
-    job_gapi.configuration.load.write_disposition.must_equal "WRITE_APPEND"
+    _(job_gapi.configuration.load.write_disposition).must_equal "WRITE_APPEND"
 
     updater.write = "truncate"
     job_gapi = updater.to_gapi
-    job_gapi.configuration.load.write_disposition.must_equal "WRITE_TRUNCATE"
+    _(job_gapi.configuration.load.write_disposition).must_equal "WRITE_TRUNCATE"
 
     updater.write = "empty"
     job_gapi = updater.to_gapi
-    job_gapi.configuration.load.write_disposition.must_equal "WRITE_EMPTY"
+    _(job_gapi.configuration.load.write_disposition).must_equal "WRITE_EMPTY"
 
     updater.write = "SOME_NEW_UNSUPPORTED_DISPOSITION"
     job_gapi = updater.to_gapi
-    job_gapi.configuration.load.write_disposition.must_equal "SOME_NEW_UNSUPPORTED_DISPOSITION"
+    _(job_gapi.configuration.load.write_disposition).must_equal "SOME_NEW_UNSUPPORTED_DISPOSITION"
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/columns_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/columns_test.rb
@@ -25,20 +25,20 @@ describe Google::Cloud::Bigquery::Model, :columns, :mock_bigquery do
   let(:model) { Google::Cloud::Bigquery::Model.from_gapi_json model_full_hash, bigquery.service }
 
   it "maps columns to primitive ruby values" do
-    model.feature_columns.count.must_equal 1
-    model.feature_columns[0].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    model.feature_columns[0].name.must_equal "f1"
-    model.feature_columns[0].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    model.feature_columns[0].type.type_kind.must_equal "STRING"
-    model.feature_columns[0].type.array_element_type.must_be_nil
-    model.feature_columns[0].type.struct_type.must_be_nil
+    _(model.feature_columns.count).must_equal 1
+    _(model.feature_columns[0]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(model.feature_columns[0].name).must_equal "f1"
+    _(model.feature_columns[0].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(model.feature_columns[0].type.type_kind).must_equal "STRING"
+    _(model.feature_columns[0].type.array_element_type).must_be_nil
+    _(model.feature_columns[0].type.struct_type).must_be_nil
 
-    model.label_columns.count.must_equal 1
-    model.label_columns[0].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    model.label_columns[0].name.must_equal "predicted_label"
-    model.label_columns[0].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    model.label_columns[0].type.type_kind.must_equal "FLOAT64"
-    model.label_columns[0].type.array_element_type.must_be_nil
-    model.label_columns[0].type.struct_type.must_be_nil
+    _(model.label_columns.count).must_equal 1
+    _(model.label_columns[0]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(model.label_columns[0].name).must_equal "predicted_label"
+    _(model.label_columns[0].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(model.label_columns[0].type.type_kind).must_equal "FLOAT64"
+    _(model.label_columns[0].type.array_element_type).must_be_nil
+    _(model.label_columns[0].type.struct_type).must_be_nil
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/metrics_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/metrics_test.rb
@@ -25,36 +25,36 @@ describe Google::Cloud::Bigquery::Model, :metrics, :mock_bigquery do
   let(:model) { Google::Cloud::Bigquery::Model.from_gapi_json model_full_hash, bigquery.service }
 
   it "exposes training runs" do
-    model.training_runs.count.must_equal 1
+    _(model.training_runs.count).must_equal 1
 
-    Time.parse(model.training_runs.first[:startTime]).must_be_close_to ::Time.now, 1
+    _(Time.parse(model.training_runs.first[:startTime])).must_be_close_to ::Time.now, 1
 
-    model.training_runs.first[:evaluationMetrics].must_be_kind_of Hash
-    model.training_runs.first[:evaluationMetrics][:regressionMetrics].must_be_kind_of Hash
-    model.training_runs.first[:evaluationMetrics][:regressionMetrics][:meanAbsoluteError].must_equal 0.58
-    model.training_runs.first[:evaluationMetrics][:regressionMetrics][:meanSquaredError].must_equal 0.628
-    model.training_runs.first[:evaluationMetrics][:regressionMetrics][:meanSquaredLogError].must_equal 0.035
-    model.training_runs.first[:evaluationMetrics][:regressionMetrics][:medianAbsoluteError].must_equal 0.04
-    model.training_runs.first[:evaluationMetrics][:regressionMetrics][:rSquared].must_equal 0.225
+    _(model.training_runs.first[:evaluationMetrics]).must_be_kind_of Hash
+    _(model.training_runs.first[:evaluationMetrics][:regressionMetrics]).must_be_kind_of Hash
+    _(model.training_runs.first[:evaluationMetrics][:regressionMetrics][:meanAbsoluteError]).must_equal 0.58
+    _(model.training_runs.first[:evaluationMetrics][:regressionMetrics][:meanSquaredError]).must_equal 0.628
+    _(model.training_runs.first[:evaluationMetrics][:regressionMetrics][:meanSquaredLogError]).must_equal 0.035
+    _(model.training_runs.first[:evaluationMetrics][:regressionMetrics][:medianAbsoluteError]).must_equal 0.04
+    _(model.training_runs.first[:evaluationMetrics][:regressionMetrics][:rSquared]).must_equal 0.225
 
-    model.training_runs.first[:results].count.must_equal 1
-    model.training_runs.first[:results].first.must_be_kind_of Hash
-    model.training_runs.first[:results].first[:durationMs].must_equal 2531
-    model.training_runs.first[:results].first[:evalLoss].must_be_nil
-    model.training_runs.first[:results].first[:index].must_equal 0
-    model.training_runs.first[:results].first[:trainingLoss].must_equal 0.628
+    _(model.training_runs.first[:results].count).must_equal 1
+    _(model.training_runs.first[:results].first).must_be_kind_of Hash
+    _(model.training_runs.first[:results].first[:durationMs]).must_equal 2531
+    _(model.training_runs.first[:results].first[:evalLoss]).must_be_nil
+    _(model.training_runs.first[:results].first[:index]).must_equal 0
+    _(model.training_runs.first[:results].first[:trainingLoss]).must_equal 0.628
 
-    model.training_runs.first[:trainingOptions].must_be_kind_of Hash
-    model.training_runs.first[:trainingOptions].must_be_kind_of Hash
-    model.training_runs.first[:trainingOptions][:earlyStop].must_equal true
-    model.training_runs.first[:trainingOptions][:l1Regularization].must_equal 0
-    model.training_runs.first[:trainingOptions][:l2Regularization].must_equal 0
-    model.training_runs.first[:trainingOptions][:learnRate].must_equal 0.4
-    model.training_runs.first[:trainingOptions][:learnRateStrategy].must_equal "CONSTANT"
-    model.training_runs.first[:trainingOptions][:lossType].must_equal "MEAN_SQUARED_LOSS"
-    model.training_runs.first[:trainingOptions][:maxIterations].must_equal 1
-    model.training_runs.first[:trainingOptions][:minRelativeProgress].must_equal 0.01
-    model.training_runs.first[:trainingOptions][:optimizationStrategy].must_equal "BATCH_GRADIENT_DESCENT"
-    model.training_runs.first[:trainingOptions][:warmStart].must_equal false
+    _(model.training_runs.first[:trainingOptions]).must_be_kind_of Hash
+    _(model.training_runs.first[:trainingOptions]).must_be_kind_of Hash
+    _(model.training_runs.first[:trainingOptions][:earlyStop]).must_equal true
+    _(model.training_runs.first[:trainingOptions][:l1Regularization]).must_equal 0
+    _(model.training_runs.first[:trainingOptions][:l2Regularization]).must_equal 0
+    _(model.training_runs.first[:trainingOptions][:learnRate]).must_equal 0.4
+    _(model.training_runs.first[:trainingOptions][:learnRateStrategy]).must_equal "CONSTANT"
+    _(model.training_runs.first[:trainingOptions][:lossType]).must_equal "MEAN_SQUARED_LOSS"
+    _(model.training_runs.first[:trainingOptions][:maxIterations]).must_equal 1
+    _(model.training_runs.first[:trainingOptions][:minRelativeProgress]).must_equal 0.01
+    _(model.training_runs.first[:trainingOptions][:optimizationStrategy]).must_equal "BATCH_GRADIENT_DESCENT"
+    _(model.training_runs.first[:trainingOptions][:warmStart]).must_equal false
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/partial/attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/partial/attributes_test.rb
@@ -31,24 +31,24 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
   let(:model) { Google::Cloud::Bigquery::Model.from_gapi_json model_hash, bigquery.service }
 
   it "knows its attributes" do
-    model.model_id.must_equal model_id
-    model.dataset_id.must_equal dataset
-    model.project_id.must_equal project
+    _(model.model_id).must_equal model_id
+    _(model.dataset_id).must_equal dataset
+    _(model.project_id).must_equal project
     # model_ref is private
-    model.model_ref.must_be_kind_of Google::Apis::BigqueryV2::ModelReference
-    model.model_ref.model_id.must_equal model_id
-    model.model_ref.dataset_id.must_equal dataset
-    model.model_ref.project_id.must_equal project
+    _(model.model_ref).must_be_kind_of Google::Apis::BigqueryV2::ModelReference
+    _(model.model_ref.model_id).must_equal model_id
+    _(model.model_ref.dataset_id).must_equal dataset
+    _(model.model_ref.project_id).must_equal project
 
     # Only the following fields are populated:
     # modelReference, modelType, creationTime, lastModifiedTime and labels
-    model.model_type.must_equal model_type
-    model.created_at.must_be_close_to ::Time.now, 1
-    model.modified_at.must_be_close_to ::Time.now, 1
-    model.labels.must_equal labels
-    model.labels.must_be :frozen?
+    _(model.model_type).must_equal model_type
+    _(model.created_at).must_be_close_to ::Time.now, 1
+    _(model.modified_at).must_be_close_to ::Time.now, 1
+    _(model.labels).must_equal labels
+    _(model.labels).must_be :frozen?
 
-    model.encryption.must_be_nil
+    _(model.encryption).must_be_nil
   end
 
   it "gets full data for name" do
@@ -57,7 +57,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
       [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
-    model.name.must_equal model_name
+    _(model.name).must_equal model_name
 
     mock.verify
 
@@ -71,7 +71,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
       [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
-    model.description.must_equal description
+    _(model.description).must_equal description
 
     mock.verify
 
@@ -85,7 +85,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
       [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
-    model.etag.must_equal etag
+    _(model.etag).must_equal etag
 
     mock.verify
 
@@ -99,7 +99,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
       [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
-    model.location.must_equal location_code
+    _(model.location).must_equal location_code
 
     mock.verify
 
@@ -113,7 +113,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
       [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
-    model.expires_at.must_be_close_to ::Time.now, 1
+    _(model.expires_at).must_be_close_to ::Time.now, 1
 
     mock.verify
 
@@ -129,7 +129,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
       [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
-    model.expires_at.must_be :nil?
+    _(model.expires_at).must_be :nil?
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/partial/delete_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/partial/delete_test.rb
@@ -29,9 +29,9 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
       [project, dataset, model_id]
     model.service.mocked_service = mock
 
-    model.delete.must_equal true
+    _(model.delete).must_equal true
 
-    model.exists?.must_equal false
+    _(model.exists?).must_equal false
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/partial/exists_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/partial/exists_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
   let(:model) { Google::Cloud::Bigquery::Model.from_gapi_json model_hash, bigquery.service }
 
   it "can test its existence" do
-    model.exists?.must_equal true
+    _(model.exists?).must_equal true
   end
 
   it "can test its existence with force to load resource" do
@@ -32,7 +32,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :attributes, :mock_bigquery d
     mock.expect :get_model, model_hash.to_json, [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
-    model.exists?(force: true).must_equal true
+    _(model.exists?(force: true)).must_equal true
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/partial/update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/partial/update_test.rb
@@ -44,7 +44,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :update, :mock_bigquery do
 
     mock.verify
 
-    model.name.must_equal new_model_name
+    _(model.name).must_equal new_model_name
   end
 
   it "updates its description" do
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :update, :mock_bigquery do
 
     mock.verify
 
-    model.description.must_equal new_description
+    _(model.description).must_equal new_description
   end
 
   it "updates its labels" do
@@ -84,7 +84,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :update, :mock_bigquery do
 
     mock.verify
 
-    model.labels.must_equal new_labels
+    _(model.labels).must_equal new_labels
   end
 
   it "updates its expires time" do
@@ -105,7 +105,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :update, :mock_bigquery do
 
     mock.verify
 
-    model.expires_at.must_be_close_to one_hour_from_now, 1
+    _(model.expires_at).must_be_close_to one_hour_from_now, 1
   end
 
   it "updates its expires time to nil" do
@@ -124,7 +124,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :update, :mock_bigquery do
 
     mock.verify
 
-    model.expires_at.must_be_nil
+    _(model.expires_at).must_be_nil
   end
 
   it "updates its encryption" do
@@ -141,7 +141,7 @@ describe Google::Cloud::Bigquery::Model, :partial, :update, :mock_bigquery do
     mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
-    model.encryption.must_be :nil?
+    _(model.encryption).must_be :nil?
 
     encrypt_config = bigquery.encryption kms_key: kms_key
 
@@ -149,8 +149,8 @@ describe Google::Cloud::Bigquery::Model, :partial, :update, :mock_bigquery do
 
     mock.verify
 
-    model.encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
-    model.encryption.kms_key.must_equal kms_key
-    model.encryption.must_be :frozen?
+    _(model.encryption).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(model.encryption.kms_key).must_equal kms_key
+    _(model.encryption).must_be :frozen?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/reference/attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/reference/attributes_test.rb
@@ -32,26 +32,26 @@ describe Google::Cloud::Bigquery::Model, :reference, :attributes, :mock_bigquery
   let(:model_gapi) { Google::Apis::BigqueryV2::Model.from_json model_full_hash.to_json }
 
   it "knows its attributes" do
-    model.model_id.must_equal model_id
-    model.dataset_id.must_equal dataset
-    model.project_id.must_equal project
+    _(model.model_id).must_equal model_id
+    _(model.dataset_id).must_equal dataset
+    _(model.project_id).must_equal project
     # model_ref is private
-    model.model_ref.must_be_kind_of Google::Apis::BigqueryV2::ModelReference
-    model.model_ref.model_id.must_equal model_id
-    model.model_ref.dataset_id.must_equal dataset
-    model.model_ref.project_id.must_equal project
+    _(model.model_ref).must_be_kind_of Google::Apis::BigqueryV2::ModelReference
+    _(model.model_ref.model_id).must_equal model_id
+    _(model.model_ref.dataset_id).must_equal dataset
+    _(model.model_ref.project_id).must_equal project
 
-    model.model_type.must_be_nil
-    model.created_at.must_be_nil
-    model.modified_at.must_be_nil
-    model.labels.must_be_nil
+    _(model.model_type).must_be_nil
+    _(model.created_at).must_be_nil
+    _(model.modified_at).must_be_nil
+    _(model.labels).must_be_nil
 
-    model.name.must_be_nil
-    model.description.must_be_nil
-    model.etag.must_be_nil
-    model.location.must_be_nil
-    model.expires_at.must_be_nil
+    _(model.name).must_be_nil
+    _(model.description).must_be_nil
+    _(model.etag).must_be_nil
+    _(model.location).must_be_nil
+    _(model.expires_at).must_be_nil
 
-    model.encryption.must_be_nil
+    _(model.encryption).must_be_nil
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/reference/delete_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/reference/delete_test.rb
@@ -28,9 +28,9 @@ describe Google::Cloud::Bigquery::Model, :reference, :attributes, :mock_bigquery
       [project, dataset, model_id]
     model.service.mocked_service = mock
 
-    model.delete.must_equal true
+    _(model.delete).must_equal true
 
-    model.exists?.must_equal false
+    _(model.exists?).must_equal false
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/reference/exists_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/reference/exists_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Bigquery::Model, :reference, :attributes, :mock_bigquery
     mock.expect :get_model, model_hash.to_json, [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
-    model.exists?.must_equal true
+    _(model.exists?).must_equal true
 
     mock.verify
   end
@@ -38,7 +38,7 @@ describe Google::Cloud::Bigquery::Model, :reference, :attributes, :mock_bigquery
     mock.expect :get_model, model_hash.to_json, [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
-    model.exists?(force: true).must_equal true
+    _(model.exists?(force: true)).must_equal true
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/reference/update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/reference/update_test.rb
@@ -43,7 +43,7 @@ describe Google::Cloud::Bigquery::Model, :reference, :update, :mock_bigquery do
 
     mock.verify
 
-    model.name.must_equal new_model_name
+    _(model.name).must_equal new_model_name
   end
 
   it "updates its description" do
@@ -62,7 +62,7 @@ describe Google::Cloud::Bigquery::Model, :reference, :update, :mock_bigquery do
 
     mock.verify
 
-    model.description.must_equal new_description
+    _(model.description).must_equal new_description
   end
 
   it "updates its labels" do
@@ -83,7 +83,7 @@ describe Google::Cloud::Bigquery::Model, :reference, :update, :mock_bigquery do
 
     mock.verify
 
-    model.labels.must_equal new_labels
+    _(model.labels).must_equal new_labels
   end
 
   it "updates its expires time" do
@@ -104,7 +104,7 @@ describe Google::Cloud::Bigquery::Model, :reference, :update, :mock_bigquery do
 
     mock.verify
 
-    model.expires_at.must_be_close_to one_hour_from_now, 1
+    _(model.expires_at).must_be_close_to one_hour_from_now, 1
   end
 
   it "updates its expires time to nil" do
@@ -123,7 +123,7 @@ describe Google::Cloud::Bigquery::Model, :reference, :update, :mock_bigquery do
 
     mock.verify
 
-    model.expires_at.must_be_nil
+    _(model.expires_at).must_be_nil
   end
 
   it "updates its encryption" do
@@ -140,7 +140,7 @@ describe Google::Cloud::Bigquery::Model, :reference, :update, :mock_bigquery do
     mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
-    model.encryption.must_be :nil?
+    _(model.encryption).must_be :nil?
 
     encrypt_config = bigquery.encryption kms_key: kms_key
 
@@ -148,8 +148,8 @@ describe Google::Cloud::Bigquery::Model, :reference, :update, :mock_bigquery do
 
     mock.verify
 
-    model.encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
-    model.encryption.kms_key.must_equal kms_key
-    model.encryption.must_be :frozen?
+    _(model.encryption).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(model.encryption.kms_key).must_equal kms_key
+    _(model.encryption).must_be :frozen?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/resource/attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/resource/attributes_test.rb
@@ -31,58 +31,58 @@ describe Google::Cloud::Bigquery::Model, :resource, :attributes, :mock_bigquery 
   let(:model) { Google::Cloud::Bigquery::Model.from_gapi_json model_hash, bigquery.service }
 
   it "knows its attributes" do
-    model.model_id.must_equal model_id
-    model.dataset_id.must_equal dataset
-    model.project_id.must_equal project
+    _(model.model_id).must_equal model_id
+    _(model.dataset_id).must_equal dataset
+    _(model.project_id).must_equal project
     # model_ref is private
-    model.model_ref.must_be_kind_of Google::Apis::BigqueryV2::ModelReference
-    model.model_ref.model_id.must_equal model_id
-    model.model_ref.dataset_id.must_equal dataset
-    model.model_ref.project_id.must_equal project
+    _(model.model_ref).must_be_kind_of Google::Apis::BigqueryV2::ModelReference
+    _(model.model_ref.model_id).must_equal model_id
+    _(model.model_ref.dataset_id).must_equal dataset
+    _(model.model_ref.project_id).must_equal project
 
     # Only the following fields are populated:
     # modelReference, modelType, creationTime, lastModifiedTime and labels
-    model.model_type.must_equal model_type
-    model.created_at.must_be_close_to ::Time.now, 1
-    model.modified_at.must_be_close_to ::Time.now, 1
-    model.labels.must_equal labels
-    model.labels.must_be :frozen?
+    _(model.model_type).must_equal model_type
+    _(model.created_at).must_be_close_to ::Time.now, 1
+    _(model.modified_at).must_be_close_to ::Time.now, 1
+    _(model.labels).must_equal labels
+    _(model.labels).must_be :frozen?
 
-    model.name.must_equal model_name
-    model.description.must_equal description
-    model.etag.must_equal etag
-    model.location.must_equal location_code
-    model.expires_at.must_be_close_to ::Time.now, 1
+    _(model.name).must_equal model_name
+    _(model.description).must_equal description
+    _(model.etag).must_equal etag
+    _(model.location).must_equal location_code
+    _(model.expires_at).must_be_close_to ::Time.now, 1
 
-    model.encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
-    model.encryption.kms_key.must_equal kms_key
-    model.encryption.must_be :frozen?
+    _(model.encryption).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(model.encryption.kms_key).must_equal kms_key
+    _(model.encryption).must_be :frozen?
   end
 
   it "handles nil for optional expires_at" do
     model.gapi_json.delete :expirationTime
 
-    model.model_id.must_equal model_id
-    model.dataset_id.must_equal dataset
-    model.project_id.must_equal project
+    _(model.model_id).must_equal model_id
+    _(model.dataset_id).must_equal dataset
+    _(model.project_id).must_equal project
     # model_ref is private
-    model.model_ref.must_be_kind_of Google::Apis::BigqueryV2::ModelReference
-    model.model_ref.model_id.must_equal model_id
-    model.model_ref.dataset_id.must_equal dataset
-    model.model_ref.project_id.must_equal project
+    _(model.model_ref).must_be_kind_of Google::Apis::BigqueryV2::ModelReference
+    _(model.model_ref.model_id).must_equal model_id
+    _(model.model_ref.dataset_id).must_equal dataset
+    _(model.model_ref.project_id).must_equal project
 
     # Only the following fields are populated:
     # modelReference, modelType, creationTime, lastModifiedTime and labels
-    model.model_type.must_equal model_type
-    model.created_at.must_be_close_to ::Time.now, 1
-    model.modified_at.must_be_close_to ::Time.now, 1
-    model.labels.must_equal labels
-    model.labels.must_be :frozen?
+    _(model.model_type).must_equal model_type
+    _(model.created_at).must_be_close_to ::Time.now, 1
+    _(model.modified_at).must_be_close_to ::Time.now, 1
+    _(model.labels).must_equal labels
+    _(model.labels).must_be :frozen?
 
-    model.name.must_equal model_name
-    model.description.must_equal description
-    model.etag.must_equal etag
-    model.location.must_equal location_code
-    model.expires_at.must_be_nil
+    _(model.name).must_equal model_name
+    _(model.description).must_equal description
+    _(model.etag).must_equal etag
+    _(model.location).must_equal location_code
+    _(model.expires_at).must_be_nil
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/resource/delete_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/resource/delete_test.rb
@@ -29,9 +29,9 @@ describe Google::Cloud::Bigquery::Model, :resource, :attributes, :mock_bigquery 
       [project, dataset, model_id]
     model.service.mocked_service = mock
 
-    model.delete.must_equal true
+    _(model.delete).must_equal true
 
-    model.exists?.must_equal false
+    _(model.exists?).must_equal false
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/resource/exists_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/resource/exists_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Bigquery::Model, :resource, :attributes, :mock_bigquery 
   let(:model) { Google::Cloud::Bigquery::Model.from_gapi_json model_hash, bigquery.service }
 
   it "can test its existence" do
-    model.exists?.must_equal true
+    _(model.exists?).must_equal true
   end
 
   it "can test its existence with force to load resource" do
@@ -32,7 +32,7 @@ describe Google::Cloud::Bigquery::Model, :resource, :attributes, :mock_bigquery 
     mock.expect :get_model, model_hash.to_json, [model.project_id, model.dataset_id, model.model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
-    model.exists?(force: true).must_equal true
+    _(model.exists?(force: true)).must_equal true
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/model/resource/update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/model/resource/update_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Bigquery::Model, :resource, :update, :mock_bigquery do
   let(:model) {Google::Cloud::Bigquery::Model.from_gapi_json model_hash, bigquery.service }
 
   it "updates its name" do
-    model.name.must_equal model_name
+    _(model.name).must_equal model_name
 
     new_model_name = "My Updated Model"
 
@@ -45,11 +45,11 @@ describe Google::Cloud::Bigquery::Model, :resource, :update, :mock_bigquery do
 
     mock.verify
 
-    model.name.must_equal new_model_name
+    _(model.name).must_equal new_model_name
   end
 
   it "updates its description" do
-    model.description.must_equal description
+    _(model.description).must_equal description
 
     new_description = "This is my updated model"
 
@@ -65,11 +65,11 @@ describe Google::Cloud::Bigquery::Model, :resource, :update, :mock_bigquery do
 
     mock.verify
 
-    model.description.must_equal new_description
+    _(model.description).must_equal new_description
   end
 
   it "updates its labels" do
-    model.labels.must_equal labels
+    _(model.labels).must_equal labels
 
     new_labels = { bar: "baz" }
 
@@ -87,11 +87,11 @@ describe Google::Cloud::Bigquery::Model, :resource, :update, :mock_bigquery do
 
     mock.verify
 
-    model.labels.must_equal new_labels
+    _(model.labels).must_equal new_labels
   end
 
   it "updates its expires time" do
-    model.expires_at.must_be_close_to ::Time.now, 1
+    _(model.expires_at).must_be_close_to ::Time.now, 1
 
     one_hour_from_now = Time.now + 60*60
 
@@ -109,11 +109,11 @@ describe Google::Cloud::Bigquery::Model, :resource, :update, :mock_bigquery do
 
     mock.verify
 
-    model.expires_at.must_be_close_to one_hour_from_now, 1
+    _(model.expires_at).must_be_close_to one_hour_from_now, 1
   end
 
   it "updates its expires time to nil" do
-    model.expires_at.must_be_close_to ::Time.now, 1
+    _(model.expires_at).must_be_close_to ::Time.now, 1
 
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
@@ -129,7 +129,7 @@ describe Google::Cloud::Bigquery::Model, :resource, :update, :mock_bigquery do
 
     mock.verify
 
-    model.expires_at.must_be_nil
+    _(model.expires_at).must_be_nil
   end
 
   it "updates its encryption" do
@@ -145,7 +145,7 @@ describe Google::Cloud::Bigquery::Model, :resource, :update, :mock_bigquery do
     mock.expect :get_model, model_hash.to_json, [project, dataset, model_id, options: { skip_deserialization: true }]
     model.service.mocked_service = mock
 
-    model.encryption.must_be :nil?
+    _(model.encryption).must_be :nil?
 
     encrypt_config = bigquery.encryption kms_key: kms_key
 
@@ -153,9 +153,9 @@ describe Google::Cloud::Bigquery::Model, :resource, :update, :mock_bigquery do
 
     mock.verify
 
-    model.encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
-    model.encryption.kms_key.must_equal kms_key
-    model.encryption.must_be :frozen?
+    _(model.encryption).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(model.encryption.kms_key).must_equal kms_key
+    _(model.encryption).must_be :frozen?
   end
 
   def return_model model_hash

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project/jobs_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project/jobs_test.rb
@@ -38,8 +38,8 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.size.must_equal 3
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.size).must_equal 3
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
   end
 
   it "lists jobs with max set" do
@@ -52,10 +52,10 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 3
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    jobs.token.wont_be :nil?
-    jobs.token.must_equal "next_page_token"
+    _(jobs.count).must_equal 3
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.token).wont_be :nil?
+    _(jobs.token).must_equal "next_page_token"
   end
 
   it "lists jobs with filter set" do
@@ -68,10 +68,10 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 3
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    jobs.token.wont_be :nil?
-    jobs.token.must_equal "next_page_token"
+    _(jobs.count).must_equal 3
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.token).wont_be :nil?
+    _(jobs.token).must_equal "next_page_token"
   end
 
   it "lists jobs with only min_created_at set" do
@@ -84,10 +84,10 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 3
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    jobs.token.wont_be :nil?
-    jobs.token.must_equal "next_page_token"
+    _(jobs.count).must_equal 3
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.token).wont_be :nil?
+    _(jobs.token).must_equal "next_page_token"
   end
 
   it "lists jobs with only max_created_at set" do
@@ -100,10 +100,10 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 3
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    jobs.token.wont_be :nil?
-    jobs.token.must_equal "next_page_token"
+    _(jobs.count).must_equal 3
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.token).wont_be :nil?
+    _(jobs.token).must_equal "next_page_token"
   end
 
   it "lists jobs with created_at set" do
@@ -116,10 +116,10 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 3
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    jobs.token.wont_be :nil?
-    jobs.token.must_equal "next_page_token"
+    _(jobs.count).must_equal 3
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.token).wont_be :nil?
+    _(jobs.token).must_equal "next_page_token"
   end
 
   it "lists jobs with parent_job set to a string" do
@@ -132,10 +132,10 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 3
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    jobs.token.wont_be :nil?
-    jobs.token.must_equal "next_page_token"
+    _(jobs.count).must_equal 3
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.token).wont_be :nil?
+    _(jobs.token).must_equal "next_page_token"
   end
 
   it "lists jobs with parent_job set to a job" do
@@ -148,10 +148,10 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 3
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    jobs.token.wont_be :nil?
-    jobs.token.must_equal "next_page_token"
+    _(jobs.count).must_equal 3
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.token).wont_be :nil?
+    _(jobs.token).must_equal "next_page_token"
   end
 
   it "lists jobs with filter and created_at set" do
@@ -164,10 +164,10 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 3
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    jobs.token.wont_be :nil?
-    jobs.token.must_equal "next_page_token"
+    _(jobs.count).must_equal 3
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.token).wont_be :nil?
+    _(jobs.token).must_equal "next_page_token"
   end
 
   it "paginates jobs" do
@@ -183,14 +183,14 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    first_jobs.count.must_equal 3
-    first_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    first_jobs.token.wont_be :nil?
-    first_jobs.token.must_equal "next_page_token"
+    _(first_jobs.count).must_equal 3
+    first_jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(first_jobs.token).wont_be :nil?
+    _(first_jobs.token).must_equal "next_page_token"
 
-    second_jobs.count.must_equal 2
-    second_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    second_jobs.token.must_be :nil?
+    _(second_jobs.count).must_equal 2
+    second_jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(second_jobs.token).must_be :nil?
   end
 
   it "paginates jobs using next? and next" do
@@ -206,13 +206,13 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    first_jobs.count.must_equal 3
-    first_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    first_jobs.next?.must_equal true
+    _(first_jobs.count).must_equal 3
+    first_jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(first_jobs.next?).must_equal true
 
-    second_jobs.count.must_equal 2
-    second_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    second_jobs.next?.must_equal false
+    _(second_jobs.count).must_equal 2
+    second_jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(second_jobs.next?).must_equal false
   end
 
   it "paginates jobs with next? and next and filter set" do
@@ -228,13 +228,13 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    first_jobs.count.must_equal 3
-    first_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    first_jobs.next?.must_equal true
+    _(first_jobs.count).must_equal 3
+    first_jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(first_jobs.next?).must_equal true
 
-    second_jobs.count.must_equal 2
-    second_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    second_jobs.next?.must_equal false
+    _(second_jobs.count).must_equal 2
+    second_jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(second_jobs.next?).must_equal false
   end
 
   it "paginates jobs with next? and next and created_at set" do
@@ -250,13 +250,13 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    first_jobs.count.must_equal 3
-    first_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    first_jobs.next?.must_equal true
+    _(first_jobs.count).must_equal 3
+    first_jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(first_jobs.next?).must_equal true
 
-    second_jobs.count.must_equal 2
-    second_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    second_jobs.next?.must_equal false
+    _(second_jobs.count).must_equal 2
+    second_jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(second_jobs.next?).must_equal false
   end
 
   it "paginates jobs with next? and next and parent_job_id set" do
@@ -272,13 +272,13 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    first_jobs.count.must_equal 3
-    first_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    first_jobs.next?.must_equal true
+    _(first_jobs.count).must_equal 3
+    first_jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(first_jobs.next?).must_equal true
 
-    second_jobs.count.must_equal 2
-    second_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    second_jobs.next?.must_equal false
+    _(second_jobs.count).must_equal 2
+    second_jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(second_jobs.next?).must_equal false
   end
 
   it "paginates jobs with next? and next and filter and created_at set" do
@@ -294,13 +294,13 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    first_jobs.count.must_equal 3
-    first_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    first_jobs.next?.must_equal true
+    _(first_jobs.count).must_equal 3
+    first_jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(first_jobs.next?).must_equal true
 
-    second_jobs.count.must_equal 2
-    second_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
-    second_jobs.next?.must_equal false
+    _(second_jobs.count).must_equal 2
+    second_jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(second_jobs.next?).must_equal false
   end
 
   it "paginates jobs with all" do
@@ -315,8 +315,8 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 5
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.count).must_equal 5
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
   end
 
   it "paginates jobs with all and filter set" do
@@ -331,8 +331,8 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 5
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.count).must_equal 5
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
   end
 
   it "paginates jobs with all and created_at set" do
@@ -347,8 +347,8 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 5
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.count).must_equal 5
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
   end
 
   it "paginates jobs with all and parent_job_id set" do
@@ -363,8 +363,8 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 5
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.count).must_equal 5
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
   end
 
   it "paginates jobs with all and filter and created_at set" do
@@ -379,8 +379,8 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 5
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.count).must_equal 5
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
   end
 
   it "iterates jobs with all using Enumerator" do
@@ -395,8 +395,8 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 5
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.count).must_equal 5
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
   end
 
   it "iterates jobs with all with request_limit set" do
@@ -411,8 +411,8 @@ describe Google::Cloud::Bigquery::Project, :jobs, :mock_bigquery do
 
     mock.verify
 
-    jobs.count.must_equal 6
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    _(jobs.count).must_equal 6
+    jobs.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Job }
   end
 
   def list_jobs_gapi count = 2, token = nil

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_copy_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_copy_job_test.rb
@@ -54,7 +54,7 @@ describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
     job = bigquery.copy_job source_table, target_table
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy to a table identified by a string" do
@@ -67,7 +67,7 @@ describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
     job = bigquery.copy_job source_table, "target-project:target_dataset.target_table_id"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy to a dataset ID and table name string only" do
@@ -87,7 +87,7 @@ describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
     job = bigquery.copy_job source_table, "source_dataset.new_target_table_id"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy a table with create disposition" do
@@ -101,7 +101,7 @@ describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
     job = bigquery.copy_job source_table, target_table, create: "CREATE_NEVER"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy a table with create disposition symbol" do
@@ -115,7 +115,7 @@ describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
     job = bigquery.copy_job source_table, target_table, create: :never
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
 
@@ -130,7 +130,7 @@ describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
     job = bigquery.copy_job source_table, target_table, write: "WRITE_TRUNCATE"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy a table with write disposition symbol" do
@@ -144,7 +144,7 @@ describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
     job = bigquery.copy_job source_table, target_table, write: :truncate
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy a table with job_id option" do
@@ -158,8 +158,8 @@ describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
     job = bigquery.copy_job source_table, target_table, job_id: job_id
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job.job_id).must_equal job_id
   end
 
   it "can copy a table with prefix option" do
@@ -176,8 +176,8 @@ describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
     job = bigquery.copy_job source_table, target_table, prefix: prefix
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job.job_id).must_equal job_id
   end
 
   it "can copy a table with job_id option if both job_id and prefix options are provided" do
@@ -191,8 +191,8 @@ describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
     job = bigquery.copy_job source_table, target_table, job_id: job_id, prefix: "IGNORED"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job.job_id).must_equal job_id
   end
 
   it "can copy a table with the job labels option" do
@@ -205,8 +205,8 @@ describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
     job = bigquery.copy_job source_table, target_table, labels: labels
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    job.labels.must_equal labels
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job.labels).must_equal labels
   end
 
   it "can copy a table with the location option" do
@@ -227,7 +227,7 @@ describe Google::Cloud::Bigquery::Project, :copy_job, :mock_bigquery do
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    job.location.must_equal region
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job.location).must_equal region
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_copy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_copy_test.rb
@@ -54,7 +54,7 @@ describe Google::Cloud::Bigquery::Project, :copy, :mock_bigquery do
     result = bigquery.copy source_table, target_table
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can copy to a table identified by a string" do
@@ -69,7 +69,7 @@ describe Google::Cloud::Bigquery::Project, :copy, :mock_bigquery do
     result = bigquery.copy source_table, "target-project:target_dataset.target_table_id"
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can copy to a dataset ID and table name string only" do
@@ -91,7 +91,7 @@ describe Google::Cloud::Bigquery::Project, :copy, :mock_bigquery do
     result = bigquery.copy source_table, "source_dataset.new_target_table_id"
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can copy a table with create disposition" do
@@ -107,7 +107,7 @@ describe Google::Cloud::Bigquery::Project, :copy, :mock_bigquery do
     result = bigquery.copy source_table, target_table, create: "CREATE_NEVER"
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can copy a table with create disposition symbol" do
@@ -123,7 +123,7 @@ describe Google::Cloud::Bigquery::Project, :copy, :mock_bigquery do
     result = bigquery.copy source_table, target_table, create: :never
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
 
@@ -140,7 +140,7 @@ describe Google::Cloud::Bigquery::Project, :copy, :mock_bigquery do
     result = bigquery.copy source_table, target_table, write: "WRITE_TRUNCATE"
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can copy a table with write disposition symbol" do
@@ -156,6 +156,6 @@ describe Google::Cloud::Bigquery::Project, :copy, :mock_bigquery do
     result = bigquery.copy source_table, target_table, write: :truncate
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_external_test.rb
@@ -21,437 +21,437 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
   it "creates a simple external table" do
     external = bigquery.external "gs://my-bucket/path/to/file.csv"
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-    external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
-    external.must_be :csv?
-    external.format.must_equal "CSV"
+    _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    _(external.urls).must_equal ["gs://my-bucket/path/to/file.csv"]
+    _(external).must_be :csv?
+    _(external.format).must_equal "CSV"
   end
 
   describe "CSV" do
     it "determines CSV from one URL" do
       external = bigquery.external "gs://my-bucket/path/to/file.csv"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-      external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
-      external.must_be :csv?
-      external.format.must_equal "CSV"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      _(external.urls).must_equal ["gs://my-bucket/path/to/file.csv"]
+      _(external).must_be :csv?
+      _(external.format).must_equal "CSV"
     end
 
     it "determines CSV from multiple URL" do
       external = bigquery.external ["some url", "gs://my-bucket/path/to/file.csv"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.csv"]
-      external.must_be :csv?
-      external.format.must_equal "CSV"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      _(external.urls).must_equal ["some url", "gs://my-bucket/path/to/file.csv"]
+      _(external).must_be :csv?
+      _(external.format).must_equal "CSV"
     end
 
     it "determines CSV from the format (:csv)" do
       external = bigquery.external "some url", format: :csv
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-      external.urls.must_equal ["some url"]
-      external.must_be :csv?
-      external.format.must_equal "CSV"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :csv?
+      _(external.format).must_equal "CSV"
     end
 
     it "determines CSV from the format (csv)" do
       external = bigquery.external "some url", format: "csv"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-      external.urls.must_equal ["some url"]
-      external.must_be :csv?
-      external.format.must_equal "CSV"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :csv?
+      _(external.format).must_equal "CSV"
     end
 
     it "determines CSV from the format (:CSV)" do
       external = bigquery.external "some url", format: :CSV
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-      external.urls.must_equal ["some url"]
-      external.must_be :csv?
-      external.format.must_equal "CSV"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :csv?
+      _(external.format).must_equal "CSV"
     end
 
     it "determines CSV from the format (CSV)" do
       external = bigquery.external "some url", format: "CSV"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-      external.urls.must_equal ["some url"]
-      external.must_be :csv?
-      external.format.must_equal "CSV"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :csv?
+      _(external.format).must_equal "CSV"
     end
   end
 
   describe "JSON" do
     it "determines JSON from one URL" do
       external = bigquery.external "gs://my-bucket/path/to/file.json"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["gs://my-bucket/path/to/file.json"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["gs://my-bucket/path/to/file.json"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from multiple URL" do
       external = bigquery.external ["some url", "gs://my-bucket/path/to/file.json"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.json"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url", "gs://my-bucket/path/to/file.json"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (:json)" do
       external = bigquery.external "some url", format: :json
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (json)" do
       external = bigquery.external "some url", format: "json"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (:JSON)" do
       external = bigquery.external "some url", format: :JSON
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (JSON)" do
       external = bigquery.external "some url", format: "JSON"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (:newline_delimited_json)" do
       external = bigquery.external "some url", format: :newline_delimited_json
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (newline_delimited_json)" do
       external = bigquery.external "some url", format: "newline_delimited_json"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (:NEWLINE_DELIMITED_JSON)" do
       external = bigquery.external "some url", format: :NEWLINE_DELIMITED_JSON
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
 
     it "determines JSON from the format (NEWLINE_DELIMITED_JSON)" do
       external = bigquery.external "some url", format: "NEWLINE_DELIMITED_JSON"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-      external.urls.must_equal ["some url"]
-      external.must_be :json?
-      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :json?
+      _(external.format).must_equal "NEWLINE_DELIMITED_JSON"
     end
   end
 
   describe "Google Sheets" do
     it "determines CSV from one URL" do
       external = bigquery.external "https://docs.google.com/spreadsheets/d/1234567980"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["https://docs.google.com/spreadsheets/d/1234567980"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["https://docs.google.com/spreadsheets/d/1234567980"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines CSV from multiple URL" do
       external = bigquery.external ["some url", "https://docs.google.com/spreadsheets/d/1234567980"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url", "https://docs.google.com/spreadsheets/d/1234567980"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url", "https://docs.google.com/spreadsheets/d/1234567980"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (:sheets)" do
       external = bigquery.external "some url", format: :sheets
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (sheets)" do
       external = bigquery.external "some url", format: "sheets"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (:SHEETS)" do
       external = bigquery.external "some url", format: :SHEETS
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (SHEETS)" do
       external = bigquery.external "some url", format: "SHEETS"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (:google_sheets)" do
       external = bigquery.external "some url", format: :google_sheets
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (google_sheets)" do
       external = bigquery.external "some url", format: "google_sheets"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (:GOOGLE_SHEETS)" do
       external = bigquery.external "some url", format: :GOOGLE_SHEETS
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
 
     it "determines SHEETS from the format (GOOGLE_SHEETS)" do
       external = bigquery.external "some url", format: "GOOGLE_SHEETS"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
-      external.urls.must_equal ["some url"]
-      external.must_be :sheets?
-      external.format.must_equal "GOOGLE_SHEETS"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :sheets?
+      _(external.format).must_equal "GOOGLE_SHEETS"
     end
   end
 
   describe "AVRO" do
     it "determines AVRO from one URL" do
       external = bigquery.external "gs://my-bucket/path/to/file.avro"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["gs://my-bucket/path/to/file.avro"]
-      external.must_be :avro?
-      external.format.must_equal "AVRO"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["gs://my-bucket/path/to/file.avro"]
+      _(external).must_be :avro?
+      _(external.format).must_equal "AVRO"
     end
 
     it "determines AVRO from multiple URL" do
       external = bigquery.external ["some url", "gs://my-bucket/path/to/file.avro"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.avro"]
-      external.must_be :avro?
-      external.format.must_equal "AVRO"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url", "gs://my-bucket/path/to/file.avro"]
+      _(external).must_be :avro?
+      _(external.format).must_equal "AVRO"
     end
 
     it "determines AVRO from the format (:avro)" do
       external = bigquery.external "some url", format: :avro
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :avro?
-      external.format.must_equal "AVRO"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :avro?
+      _(external.format).must_equal "AVRO"
     end
 
     it "determines AVRO from the format (avro)" do
       external = bigquery.external "some url", format: "avro"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :avro?
-      external.format.must_equal "AVRO"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :avro?
+      _(external.format).must_equal "AVRO"
     end
 
     it "determines AVRO from the format (:AVRO)" do
       external = bigquery.external "some url", format: :AVRO
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :avro?
-      external.format.must_equal "AVRO"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :avro?
+      _(external.format).must_equal "AVRO"
     end
 
     it "determines AVRO from the format (AVRO)" do
       external = bigquery.external "some url", format: "AVRO"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :avro?
-      external.format.must_equal "AVRO"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :avro?
+      _(external.format).must_equal "AVRO"
     end
   end
 
   describe "Datastore Backup" do
     it "determines BACKUP from one URL" do
       external = bigquery.external "gs://my-bucket/path/to/file.backup_info"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["gs://my-bucket/path/to/file.backup_info"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["gs://my-bucket/path/to/file.backup_info"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from multiple URL" do
       external = bigquery.external ["some url", "gs://my-bucket/path/to/file.backup_info"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.backup_info"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url", "gs://my-bucket/path/to/file.backup_info"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (:backup)" do
       external = bigquery.external "some url", format: :backup
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (backup)" do
       external = bigquery.external "some url", format: "backup"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (:BACKUP)" do
       external = bigquery.external "some url", format: :BACKUP
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (BACKUP)" do
       external = bigquery.external "some url", format: "BACKUP"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (:datastore)" do
       external = bigquery.external "some url", format: :datastore
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (datastore)" do
       external = bigquery.external "some url", format: "datastore"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (:DATASTORE)" do
       external = bigquery.external "some url", format: :DATASTORE
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (DATASTORE)" do
       external = bigquery.external "some url", format: "DATASTORE"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (:datastore_backup)" do
       external = bigquery.external "some url", format: :datastore_backup
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (datastore_backup)" do
       external = bigquery.external "some url", format: "datastore_backup"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (:DATASTORE_BACKUP)" do
       external = bigquery.external "some url", format: :DATASTORE_BACKUP
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
 
     it "determines BACKUP from the format (DATASTORE_BACKUP)" do
       external = bigquery.external "some url", format: "DATASTORE_BACKUP"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
-      external.urls.must_equal ["some url"]
-      external.must_be :backup?
-      external.format.must_equal "DATASTORE_BACKUP"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :backup?
+      _(external.format).must_equal "DATASTORE_BACKUP"
     end
   end
 
   describe "BIGTABLE" do
     it "determines BIGTABLE from one URL" do
       external = bigquery.external "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
-      external.urls.must_equal ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
-      external.must_be :bigtable?
-      external.format.must_equal "BIGTABLE"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      _(external.urls).must_equal ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+      _(external).must_be :bigtable?
+      _(external.format).must_equal "BIGTABLE"
     end
 
     it "determines BIGTABLE from multiple URL" do
       external = bigquery.external ["some url", "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
-      external.urls.must_equal ["some url", "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
-      external.must_be :bigtable?
-      external.format.must_equal "BIGTABLE"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      _(external.urls).must_equal ["some url", "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+      _(external).must_be :bigtable?
+      _(external.format).must_equal "BIGTABLE"
     end
 
     it "determines BIGTABLE from the format (:bigtable)" do
       external = bigquery.external "some url", format: :bigtable
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
-      external.urls.must_equal ["some url"]
-      external.must_be :bigtable?
-      external.format.must_equal "BIGTABLE"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :bigtable?
+      _(external.format).must_equal "BIGTABLE"
     end
 
     it "determines BIGTABLE from the format (bigtable)" do
       external = bigquery.external "some url", format: "bigtable"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
-      external.urls.must_equal ["some url"]
-      external.must_be :bigtable?
-      external.format.must_equal "BIGTABLE"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :bigtable?
+      _(external.format).must_equal "BIGTABLE"
     end
 
     it "determines BIGTABLE from the format (:BIGTABLE)" do
       external = bigquery.external "some url", format: :BIGTABLE
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
-      external.urls.must_equal ["some url"]
-      external.must_be :bigtable?
-      external.format.must_equal "BIGTABLE"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :bigtable?
+      _(external.format).must_equal "BIGTABLE"
     end
 
     it "determines BIGTABLE from the format (BIGTABLE)" do
       external = bigquery.external "some url", format: "BIGTABLE"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
-      external.urls.must_equal ["some url"]
-      external.must_be :bigtable?
-      external.format.must_equal "BIGTABLE"
+      _(external).must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      _(external.urls).must_equal ["some url"]
+      _(external).must_be :bigtable?
+      _(external.format).must_equal "BIGTABLE"
     end
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_job_test.rb
@@ -50,7 +50,7 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table_id_standard_sql, extract_file
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract a table to a storage file using a Legacy SQL table id" do
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table_id_legacy_sql, extract_file
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract a table to a storage file" do
@@ -76,7 +76,7 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table, extract_file
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract a table to a storage url" do
@@ -89,7 +89,7 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table, extract_url
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract a table and determine the csv format" do
@@ -104,7 +104,7 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table, "#{extract_url}.csv"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract a table and specify the csv format" do
@@ -118,7 +118,7 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table, extract_url, format: :csv
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract a table and specify the csv format and options" do
@@ -135,7 +135,7 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table, extract_url, format: :csv, compression: "GZIP", delimiter: "\t", header: false
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract a table and determine the json format" do
@@ -150,7 +150,7 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table, "#{extract_url}.json"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract a table and specify the json format" do
@@ -164,7 +164,7 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table, extract_url, format: :json
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract a table and determine the avro format" do
@@ -179,7 +179,7 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table, "#{extract_url}.avro"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract a table and determine the avro format with options" do
@@ -202,7 +202,7 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract a table and specify the avro format" do
@@ -216,7 +216,7 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table, extract_url, format: :avro
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract a table and specify the avro format and options" do
@@ -234,7 +234,7 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract a table with job_id option" do
@@ -248,8 +248,8 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table, extract_url, job_id: job_id
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job.job_id).must_equal job_id
   end
 
   it "can extract a table with prefix option" do
@@ -266,8 +266,8 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table, extract_url, prefix: prefix
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job.job_id).must_equal job_id
   end
 
   it "can extract a table with job_id option if both job_id and prefix options are provided" do
@@ -281,8 +281,8 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table, extract_url, job_id: job_id, prefix: "IGNORED"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job.job_id).must_equal job_id
   end
 
   it "can extract a table with the job labels option" do
@@ -296,8 +296,8 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     job = bigquery.extract_job table, extract_file, labels: labels
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-    job.labels.must_equal labels
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job.labels).must_equal labels
   end
 
   it "can extract a table with the location option" do
@@ -315,8 +315,8 @@ describe Google::Cloud::Bigquery::Project, :extract_job, :mock_bigquery do
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-    job.location.must_equal region
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job.location).must_equal region
   end
 
   # Borrowed from MockStorage, extract to a common module?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_extract_test.rb
@@ -50,7 +50,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
     result = bigquery.extract table_id_standard_sql, extract_file
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract a table to a storage file using a Legacy SQL table id" do
@@ -65,7 +65,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
     result = bigquery.extract table_id_legacy_sql, extract_file
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract a table to a storage file" do
@@ -80,7 +80,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
     result = bigquery.extract table, extract_file
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract a table to a storage url" do
@@ -95,7 +95,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
     result = bigquery.extract table, extract_url
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract a table and determine the csv format" do
@@ -112,7 +112,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
     result = bigquery.extract table, "#{extract_url}.csv"
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract a table and specify the csv format" do
@@ -128,7 +128,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
     result = bigquery.extract table, extract_url, format: :csv
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract a table and specify the csv format and options" do
@@ -147,7 +147,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
     result = bigquery.extract table, extract_url, format: :csv, compression: "GZIP", delimiter: "\t", header: false
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract a table and determine the json format" do
@@ -164,7 +164,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
     result = bigquery.extract table, "#{extract_url}.json"
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract a table and specify the json format" do
@@ -180,7 +180,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
     result = bigquery.extract table, extract_url, format: :json
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract a table and determine the avro format" do
@@ -197,7 +197,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
     result = bigquery.extract table, "#{extract_url}.avro"
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract a table and determine the avro format with options" do
@@ -217,7 +217,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
     end
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract a table and specify the avro format" do
@@ -233,7 +233,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
     result = bigquery.extract table, extract_url, format: :avro
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract a table and specify the avro format with options" do
@@ -253,7 +253,7 @@ describe Google::Cloud::Bigquery::Project, :extract, :mock_bigquery do
     end
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   # Borrowed from MockStorage, extract to a common module?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_external_test.rb
@@ -47,26 +47,26 @@ describe Google::Cloud::Bigquery::Project, :query, :external, :mock_bigquery do
     data = bigquery.query query, external: { my_csv: external_csv }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
   def assert_valid_data data
-    data.count.must_equal 3
-    data[0].must_be_kind_of Hash
-    data[0][:name].must_equal "Heidi"
-    data[0][:age].must_equal 36
-    data[0][:score].must_equal 7.65
-    data[0][:active].must_equal true
-    data[1].must_be_kind_of Hash
-    data[1][:name].must_equal "Aaron"
-    data[1][:age].must_equal 42
-    data[1][:score].must_equal 8.15
-    data[1][:active].must_equal false
-    data[2].must_be_kind_of Hash
-    data[2][:name].must_equal "Sally"
-    data[2][:age].must_be :nil?
-    data[2][:score].must_be :nil?
-    data[2][:active].must_be :nil?
+    _(data.count).must_equal 3
+    _(data[0]).must_be_kind_of Hash
+    _(data[0][:name]).must_equal "Heidi"
+    _(data[0][:age]).must_equal 36
+    _(data[0][:score]).must_equal 7.65
+    _(data[0][:active]).must_equal true
+    _(data[1]).must_be_kind_of Hash
+    _(data[1][:name]).must_equal "Aaron"
+    _(data[1][:age]).must_equal 42
+    _(data[1][:score]).must_equal 8.15
+    _(data[1][:active]).must_equal false
+    _(data[2]).must_be_kind_of Hash
+    _(data[2][:name]).must_equal "Sally"
+    _(data[2][:age]).must_be :nil?
+    _(data[2][:score]).must_be :nil?
+    _(data[2][:active]).must_be :nil?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_external_test.rb
@@ -41,6 +41,6 @@ describe Google::Cloud::Bigquery::Project, :query_job, :external, :mock_bigquery
     job = bigquery.query_job query, external: { my_csv: external_csv }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -53,7 +53,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE name = @name", params: { name: "Testy McTesterson" }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with an integer parameter" do
@@ -77,7 +77,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE age > @age", params: { age: 35 }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a float parameter" do
@@ -101,7 +101,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE score > @score", params: { score: 90.0 }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a numeric parameter" do
@@ -125,7 +125,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE pi = @pi", params: { pi: BigDecimal("3.141592654") }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a true parameter" do
@@ -149,7 +149,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE active = @active", params: { active: true }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a false parameter" do
@@ -173,7 +173,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE active = @active", params: { active: false }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a date parameter" do
@@ -199,7 +199,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE create_date = @day", params: { day: today }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a datetime parameter" do
@@ -225,7 +225,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE update_datetime < @when", params: { when: now }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a timestamp parameter" do
@@ -251,7 +251,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE update_timestamp < @when", params: { when: now }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a time parameter" do
@@ -277,7 +277,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE create_time = @time", params: { time: timeofday }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a File parameter" do
@@ -303,7 +303,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a StringIO parameter" do
@@ -329,7 +329,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with many parameters" do
@@ -420,7 +420,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with an array parameter" do
@@ -451,7 +451,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a struct parameter" do
@@ -494,6 +494,6 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -52,7 +52,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE name = ?", params: ["Testy McTesterson"]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with an integer parameter" do
@@ -75,7 +75,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE age > ?", params: [35]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a float parameter" do
@@ -98,7 +98,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE score > ?", params: [90.0]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a numeric parameter" do
@@ -121,7 +121,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE pi = ?", params: [BigDecimal("3.141592654")]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a true parameter" do
@@ -144,7 +144,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE active = ?", params: [true]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a false parameter" do
@@ -167,7 +167,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE active = ?", params: [false]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a date parameter" do
@@ -192,7 +192,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE create_date = ?", params: [today]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a datetime parameter" do
@@ -217,7 +217,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE update_datetime < ?", params: [now]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a timestamp parameter" do
@@ -242,7 +242,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE update_timestamp < ?", params: [now]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a time parameter" do
@@ -267,7 +267,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE create_time = ?", params: [timeofday]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a File parameter" do
@@ -292,7 +292,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE avatar = ?", params: [file]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a StringIO parameter" do
@@ -317,7 +317,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE avatar = ?", params: [file]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with many parameters" do
@@ -396,7 +396,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with an array parameter" do
@@ -426,7 +426,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE name = ?", params: [%w{name1 name2 name3}]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with a struct parameter" do
@@ -468,6 +468,6 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
@@ -38,19 +38,19 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
 
     # Sometimes statistics.query is nil in the returned job, test for that behavior here.
-    job.cache_hit?.must_equal true
-    job.bytes_processed.must_equal 123456
-    job.query_plan.wont_be :nil?
-    job.statement_type.must_equal "SELECT"
-    job.ddl?.must_equal false
-    job.dml?.must_equal false
-    job.ddl_operation_performed.must_be :nil?
-    job.ddl_target_routine.must_be :nil?
-    job.ddl_target_table.must_be :nil?
-    job.num_dml_affected_rows.must_be :nil?
+    _(job.cache_hit?).must_equal true
+    _(job.bytes_processed).must_equal 123456
+    _(job.query_plan).wont_be :nil?
+    _(job.statement_type).must_equal "SELECT"
+    _(job.ddl?).must_equal false
+    _(job.dml?).must_equal false
+    _(job.ddl_operation_performed).must_be :nil?
+    _(job.ddl_target_routine).must_be :nil?
+    _(job.ddl_target_table).must_be :nil?
+    _(job.num_dml_affected_rows).must_be :nil?
   end
 
   it "queries the data with options set" do
@@ -65,7 +65,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, priority: :batch, cache: false
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with table options" do
@@ -93,7 +93,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
                                 maximum_bytes_billed: 12345678901234
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with dataset option as a Dataset" do
@@ -110,7 +110,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, dataset: dataset
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with dataset and project options" do
@@ -127,7 +127,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, dataset: "some_random_dataset", project: "some_random_project"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with job_id option" do
@@ -142,8 +142,8 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, job_id: job_id
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.job_id).must_equal job_id
   end
 
   it "queries the data with dryrun flag" do
@@ -157,11 +157,11 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, dryrun: true
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.dryrun?.must_equal true
-    job.dryrun.must_equal true # alias
-    job.dry_run.must_equal true # alias
-    job.dry_run?.must_equal true # alias
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.dryrun?).must_equal true
+    _(job.dryrun).must_equal true # alias
+    _(job.dry_run).must_equal true # alias
+    _(job.dry_run?).must_equal true # alias
   end
 
   it "queries the data with prefix option" do
@@ -179,8 +179,8 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, prefix: prefix
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.job_id).must_equal job_id
   end
 
   it "queries the data with job_id option if both job_id and prefix options are provided" do
@@ -195,8 +195,8 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, job_id: job_id, prefix: "IGNORED"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.job_id).must_equal job_id
   end
 
   it "queries the data with the job labels option" do
@@ -210,8 +210,8 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, labels: labels
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.labels.must_equal labels
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.labels).must_equal labels
   end
 
   it "queries the data with an array for the udfs option" do
@@ -225,8 +225,8 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, udfs: udfs
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.udfs.must_equal udfs
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.udfs).must_equal udfs
   end
 
   it "queries the data with a string for the udfs option" do
@@ -240,7 +240,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, udfs: "gs://my-bucket/my-lib.js"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.udfs.must_equal ["gs://my-bucket/my-lib.js"]
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.udfs).must_equal ["gs://my-bucket/my-lib.js"]
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_updater_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_updater_test.rb
@@ -41,8 +41,8 @@ describe Google::Cloud::Bigquery::Project, :query_job, :updater, :mock_bigquery 
     job = bigquery.query_job query, job_id: job_id
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.job_id).must_equal job_id
   end
 
   it "queries the data with prefix option" do
@@ -60,8 +60,8 @@ describe Google::Cloud::Bigquery::Project, :query_job, :updater, :mock_bigquery 
     job = bigquery.query_job query, prefix: prefix
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.job_id).must_equal job_id
   end
 
   it "queries the data with options set" do
@@ -84,7 +84,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with table options" do
@@ -114,7 +114,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with dataset option" do
@@ -133,7 +133,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "queries the data with the job labels option" do
@@ -149,8 +149,8 @@ describe Google::Cloud::Bigquery::Project, :query_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.labels.must_equal labels
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.labels).must_equal labels
   end
 
   it "queries the data with an array for the udfs option" do
@@ -166,8 +166,8 @@ describe Google::Cloud::Bigquery::Project, :query_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.udfs.must_equal udfs
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.udfs).must_equal udfs
   end
 
   it "queries the data with a string for the udfs option" do
@@ -183,8 +183,8 @@ describe Google::Cloud::Bigquery::Project, :query_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.udfs.must_equal ["gs://my-bucket/my-lib.js"]
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.udfs).must_equal ["gs://my-bucket/my-lib.js"]
   end
 
   it "queries the data with the encryption option" do
@@ -202,9 +202,9 @@ describe Google::Cloud::Bigquery::Project, :query_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
-    job.encryption.kms_key.must_equal kms_key
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.encryption).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(job.encryption.kms_key).must_equal kms_key
   end
 
   it "queries the data with the location option" do
@@ -216,13 +216,13 @@ describe Google::Cloud::Bigquery::Project, :query_job, :updater, :mock_bigquery 
     mock.expect :insert_job, return_job_gapi, [project, insert_job_gapi]
 
     job = bigquery.query_job query do |j|
-      j.location.must_be :nil?
+      _(j.location).must_be :nil?
       j.location = region
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.location.must_equal region
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.location).must_equal region
   end
 
   it "queries the data with setting location to nil" do
@@ -234,12 +234,12 @@ describe Google::Cloud::Bigquery::Project, :query_job, :updater, :mock_bigquery 
     mock.expect :insert_job, return_job_gapi, [project, insert_job_gapi]
 
     job = bigquery.query_job query do |j|
-      j.location.must_be :nil?
+      _(j.location).must_be :nil?
       j.location = nil
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
-    job.location.must_equal "US"
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.location).must_equal "US"
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -54,7 +54,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE name = @name", params: { name: "Testy McTesterson" }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -86,7 +86,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE age > @age", params: { age: 35 }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -118,7 +118,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE score > @score", params: { score: 90.0 }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -150,7 +150,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE pi = @pi", params: { pi: BigDecimal("3.141592654") }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -182,7 +182,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE active = @active", params: { active: true }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -214,7 +214,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE active = @active", params: { active: false }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -248,7 +248,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE create_date = @day", params: { day: today }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -282,7 +282,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE update_datetime < @when", params: { when: now }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -316,7 +316,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE update_timestamp < @when", params: { when: now }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -350,7 +350,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE create_time = @time", params: { time: timeofday }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -384,7 +384,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -418,7 +418,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -517,7 +517,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
 
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -556,7 +556,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -607,26 +607,26 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
   def assert_valid_data data
-    data.count.must_equal 3
-    data[0].must_be_kind_of Hash
-    data[0][:name].must_equal "Heidi"
-    data[0][:age].must_equal 36
-    data[0][:score].must_equal 7.65
-    data[0][:active].must_equal true
-    data[1].must_be_kind_of Hash
-    data[1][:name].must_equal "Aaron"
-    data[1][:age].must_equal 42
-    data[1][:score].must_equal 8.15
-    data[1][:active].must_equal false
-    data[2].must_be_kind_of Hash
-    data[2][:name].must_equal "Sally"
-    data[2][:age].must_be :nil?
-    data[2][:score].must_be :nil?
-    data[2][:active].must_be :nil?
+    _(data.count).must_equal 3
+    _(data[0]).must_be_kind_of Hash
+    _(data[0][:name]).must_equal "Heidi"
+    _(data[0][:age]).must_equal 36
+    _(data[0][:score]).must_equal 7.65
+    _(data[0][:active]).must_equal true
+    _(data[1]).must_be_kind_of Hash
+    _(data[1][:name]).must_equal "Aaron"
+    _(data[1][:age]).must_equal 42
+    _(data[1][:score]).must_equal 8.15
+    _(data[1][:active]).must_equal false
+    _(data[2]).must_be_kind_of Hash
+    _(data[2][:name]).must_equal "Sally"
+    _(data[2][:age]).must_be :nil?
+    _(data[2][:score]).must_be :nil?
+    _(data[2][:active]).must_be :nil?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -54,7 +54,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE name = ?", params: ["Testy McTesterson"]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -85,7 +85,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE age > ?", params: [35]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -116,7 +116,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE score > ?", params: [90.0]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -147,7 +147,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE pi = ?", params: [BigDecimal("3.141592654")]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -178,7 +178,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE active = ?", params: [true]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -209,7 +209,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE active = ?", params: [false]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -242,7 +242,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE create_date = ?", params: [today]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -275,7 +275,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE update_datetime < ?", params: [now]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -308,7 +308,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE update_timestamp < ?", params: [now]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -341,7 +341,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE create_time = ?", params: [timeofday]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -374,7 +374,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE avatar = ?", params: [file]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -407,7 +407,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE avatar = ?", params: [file]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -494,7 +494,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
 
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -532,7 +532,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE name IN ?", params: [%w{name1 name2 name3}]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
@@ -582,26 +582,26 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
     assert_valid_data data
   end
 
   def assert_valid_data data
-    data.count.must_equal 3
-    data[0].must_be_kind_of Hash
-    data[0][:name].must_equal "Heidi"
-    data[0][:age].must_equal 36
-    data[0][:score].must_equal 7.65
-    data[0][:active].must_equal true
-    data[1].must_be_kind_of Hash
-    data[1][:name].must_equal "Aaron"
-    data[1][:age].must_equal 42
-    data[1][:score].must_equal 8.15
-    data[1][:active].must_equal false
-    data[2].must_be_kind_of Hash
-    data[2][:name].must_equal "Sally"
-    data[2][:age].must_be :nil?
-    data[2][:score].must_be :nil?
-    data[2][:active].must_be :nil?
+    _(data.count).must_equal 3
+    _(data[0]).must_be_kind_of Hash
+    _(data[0][:name]).must_equal "Heidi"
+    _(data[0][:age]).must_equal 36
+    _(data[0][:score]).must_equal 7.65
+    _(data[0][:active]).must_equal true
+    _(data[1]).must_be_kind_of Hash
+    _(data[1][:name]).must_equal "Aaron"
+    _(data[1][:age]).must_equal 42
+    _(data[1][:score]).must_equal 8.15
+    _(data[1][:active]).must_equal false
+    _(data[2]).must_be_kind_of Hash
+    _(data[2][:name]).must_equal "Sally"
+    _(data[2][:age]).must_be :nil?
+    _(data[2][:score]).must_be :nil?
+    _(data[2][:active]).must_be :nil?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
@@ -45,23 +45,23 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
     data = bigquery.query query
     mock.verify
     # data.must_be_kind_of Google::Cloud::Bigquery::Data
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.count.must_equal 3
-    data[0].must_be_kind_of Hash
-    data[0][:name].must_equal "Heidi"
-    data[0][:age].must_equal 36
-    data[0][:score].must_equal 7.65
-    data[0][:active].must_equal true
-    data[1].must_be_kind_of Hash
-    data[1][:name].must_equal "Aaron"
-    data[1][:age].must_equal 42
-    data[1][:score].must_equal 8.15
-    data[1][:active].must_equal false
-    data[2].must_be_kind_of Hash
-    data[2][:name].must_equal "Sally"
-    data[2][:age].must_be :nil?
-    data[2][:score].must_be :nil?
-    data[2][:active].must_be :nil?
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.count).must_equal 3
+    _(data[0]).must_be_kind_of Hash
+    _(data[0][:name]).must_equal "Heidi"
+    _(data[0][:age]).must_equal 36
+    _(data[0][:score]).must_equal 7.65
+    _(data[0][:active]).must_equal true
+    _(data[1]).must_be_kind_of Hash
+    _(data[1][:name]).must_equal "Aaron"
+    _(data[1][:age]).must_equal 42
+    _(data[1][:score]).must_equal 8.15
+    _(data[1][:active]).must_equal false
+    _(data[2]).must_be_kind_of Hash
+    _(data[2][:name]).must_equal "Sally"
+    _(data[2][:age]).must_be :nil?
+    _(data[2][:score]).must_be :nil?
+    _(data[2][:active]).must_be :nil?
   end
 
   it "executes a DDL statement" do
@@ -75,18 +75,18 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
     data = bigquery.query ddl_query
     mock.verify
     # data.must_be_kind_of Google::Cloud::Bigquery::Data
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.count.must_equal 0
-    data.total.must_be :nil?
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.count).must_equal 0
+    _(data.total).must_be :nil?
 
-    data.statement_type.must_equal "CREATE_TABLE"
-    data.ddl?.must_equal true
-    data.dml?.must_equal false
-    data.ddl_operation_performed.must_equal "CREATE"
-    data.ddl_target_table.wont_be :nil?
-    data.num_dml_affected_rows.must_be :nil?
+    _(data.statement_type).must_equal "CREATE_TABLE"
+    _(data.ddl?).must_equal true
+    _(data.dml?).must_equal false
+    _(data.ddl_operation_performed).must_equal "CREATE"
+    _(data.ddl_target_table).wont_be :nil?
+    _(data.num_dml_affected_rows).must_be :nil?
     # in real life this example does not create a routine, but test the attribute here anyway
-    data.ddl_target_routine.wont_be :nil?
+    _(data.ddl_target_routine).wont_be :nil?
   end
 
   it "executes a DML statement" do
@@ -100,15 +100,15 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
     data = bigquery.query dml_query
     mock.verify
     # data.must_be_kind_of Google::Cloud::Bigquery::Data
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.count.must_equal 0
-    data.total.must_be :nil?
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.count).must_equal 0
+    _(data.total).must_be :nil?
 
-    data.statement_type.must_equal "UPDATE"
-    data.ddl?.must_equal false
-    data.dml?.must_equal true
-    data.ddl_operation_performed.must_be :nil?
-    data.num_dml_affected_rows.must_equal 50
+    _(data.statement_type).must_equal "UPDATE"
+    _(data.ddl?).must_equal false
+    _(data.dml?).must_equal true
+    _(data.ddl_operation_performed).must_be :nil?
+    _(data.num_dml_affected_rows).must_equal 50
   end
 
   it "paginates the data" do
@@ -129,14 +129,14 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
 
     data = bigquery.query query
     # data.must_be_kind_of Google::Cloud::Bigquery::Data
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.count.must_equal 3
-    data.token.must_equal "token1234567890"
-    data.next?.must_equal true
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.count).must_equal 3
+    _(data.token).must_equal "token1234567890"
+    _(data.next?).must_equal true
 
     data2 = data.next
-    data2.class.must_equal Google::Cloud::Bigquery::Data
-    data2.count.must_equal 3
+    _(data2.class).must_equal Google::Cloud::Bigquery::Data
+    _(data2.count).must_equal 3
     mock.verify
   end
 
@@ -154,8 +154,8 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
                 [project, "target_dataset_id", "target_table_id", {  max_results: 42, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query query, max: 42
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.count.must_equal 3
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.count).must_equal 3
     mock.verify
   end
 
@@ -176,8 +176,8 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
                 [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query query, dataset: "some_random_dataset"
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.count.must_equal 3
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.count).must_equal 3
     mock.verify
   end
 
@@ -199,8 +199,8 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
 
     data = bigquery.query query, dataset: "some_random_dataset",
                                  project: "some_random_project"
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.count.must_equal 3
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.count).must_equal 3
     mock.verify
   end
 
@@ -221,8 +221,8 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
 
 
     data = bigquery.query query, cache: false
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.count.must_equal 3
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.count).must_equal 3
     mock.verify
   end
 
@@ -234,8 +234,8 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
     mock.expect :insert_job, failed_query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
 
     err = expect { bigquery.query query }.must_raise Google::Cloud::PermissionDeniedError
-    err.message.must_equal "string"
-    err.cause.body.must_equal({
+    _(err.message).must_equal "string"
+    _(err.cause.body).must_equal({
       "debugInfo"=>"string",
       "location"=>"string",
       "message"=>"string",
@@ -259,8 +259,8 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
     mock.expect :insert_job, failed_query_job_resp_gapi(query, job_id: job_id, reason: "backendError"), [project, job_gapi]
 
     err = expect { bigquery.query query }.must_raise Google::Cloud::InternalError
-    err.message.must_equal "string"
-    err.cause.body.must_equal({
+    _(err.message).must_equal "string"
+    _(err.cause.body).must_equal({
       "debugInfo"=>"string",
       "location"=>"string",
       "message"=>"string",

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
@@ -26,8 +26,8 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.expect :get_project_service_account, service_account_resp, [project]
     bigquery.service.mocked_service = mock
 
-    bigquery.service_account_email.must_equal email
-    bigquery.service_account_email.must_equal email # memoized, no request
+    _(bigquery.service_account_email).must_equal email
+    _(bigquery.service_account_email).must_equal email # memoized, no request
 
     mock.verify
   end
@@ -46,7 +46,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(dataset).must_be_kind_of Google::Cloud::Bigquery::Dataset
   end
 
   it "creates a dataset with options" do
@@ -74,11 +74,11 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
-    dataset.name.must_equal name
-    dataset.description.must_equal description
-    dataset.default_expiration.must_equal default_expiration
-    dataset.location.must_equal location
+    _(dataset).must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(dataset.name).must_equal name
+    _(dataset.description).must_equal description
+    _(dataset.default_expiration).must_equal default_expiration
+    _(dataset.location).must_equal location
   end
 
   it "creates a dataset and access rules using a block" do
@@ -104,8 +104,8 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
-    dataset.access.wont_be :empty?
+    _(dataset).must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(dataset.access).wont_be :empty?
   end
 
   it "creates a dataset with options and access rules using a block" do
@@ -163,13 +163,13 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
-    dataset.name.must_equal name
-    dataset.description.must_equal description
-    dataset.default_expiration.must_equal default_expiration
-    dataset.labels.must_equal labels
-    dataset.location.must_equal location
-    dataset.access.wont_be :empty?
+    _(dataset).must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(dataset.name).must_equal name
+    _(dataset.description).must_equal description
+    _(dataset.default_expiration).must_equal default_expiration
+    _(dataset.labels).must_equal labels
+    _(dataset.location).must_equal location
+    _(dataset.access).wont_be :empty?
   end
 
   it "creates a dataset with block options and access rules not using a block" do
@@ -203,12 +203,12 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
-    dataset.name.must_equal name
-    dataset.description.must_equal description
-    dataset.default_expiration.must_equal default_expiration
-    dataset.location.must_equal location
-    dataset.access.wont_be :empty?
+    _(dataset).must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(dataset.name).must_equal name
+    _(dataset.description).must_equal description
+    _(dataset.default_expiration).must_equal default_expiration
+    _(dataset.location).must_equal location
+    _(dataset.access).wont_be :empty?
   end
 
   it "raises when creating a dataset with a blank id" do
@@ -233,13 +233,13 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    datasets.size.must_equal 3
+    _(datasets.size).must_equal 3
     datasets.each do |ds|
-      ds.must_be_kind_of Google::Cloud::Bigquery::Dataset
-      ds.wont_be :reference?
-      ds.must_be :resource?
-      ds.must_be :resource_partial?
-      ds.wont_be :resource_full?
+      _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset
+      _(ds).wont_be :reference?
+      _(ds).must_be :resource?
+      _(ds).must_be :resource_partial?
+      _(ds).wont_be :resource_full?
     end
   end
 
@@ -253,10 +253,10 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    datasets.count.must_equal 3
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
-    datasets.token.wont_be :nil?
-    datasets.token.must_equal "next_page_token"
+    _(datasets.count).must_equal 3
+    datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(datasets.token).wont_be :nil?
+    _(datasets.token).must_equal "next_page_token"
   end
 
   it "paginates datasets with filter set" do
@@ -269,10 +269,10 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    datasets.count.must_equal 3
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
-    datasets.token.wont_be :nil?
-    datasets.token.must_equal "next_page_token"
+    _(datasets.count).must_equal 3
+    datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(datasets.token).wont_be :nil?
+    _(datasets.token).must_equal "next_page_token"
   end
 
   it "paginates datasets with max set" do
@@ -285,10 +285,10 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    datasets.count.must_equal 3
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
-    datasets.token.wont_be :nil?
-    datasets.token.must_equal "next_page_token"
+    _(datasets.count).must_equal 3
+    datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(datasets.token).wont_be :nil?
+    _(datasets.token).must_equal "next_page_token"
   end
 
   it "paginates datasets" do
@@ -304,14 +304,14 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    first_datasets.count.must_equal 3
-    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
-    first_datasets.token.wont_be :nil?
-    first_datasets.token.must_equal "next_page_token"
+    _(first_datasets.count).must_equal 3
+    first_datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(first_datasets.token).wont_be :nil?
+    _(first_datasets.token).must_equal "next_page_token"
 
-    second_datasets.count.must_equal 2
-    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
-    second_datasets.token.must_be :nil?
+    _(second_datasets.count).must_equal 2
+    second_datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(second_datasets.token).must_be :nil?
   end
 
   it "paginates datasets with next? and next" do
@@ -327,13 +327,13 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    first_datasets.count.must_equal 3
-    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
-    first_datasets.next?.must_equal true
+    _(first_datasets.count).must_equal 3
+    first_datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(first_datasets.next?).must_equal true
 
-    second_datasets.count.must_equal 2
-    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
-    second_datasets.next?.must_equal false
+    _(second_datasets.count).must_equal 2
+    second_datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(second_datasets.next?).must_equal false
   end
 
   it "paginates datasets with next? and next with all/hidden set" do
@@ -349,13 +349,13 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    first_datasets.count.must_equal 3
-    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
-    first_datasets.next?.must_equal true
+    _(first_datasets.count).must_equal 3
+    first_datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(first_datasets.next?).must_equal true
 
-    second_datasets.count.must_equal 2
-    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
-    second_datasets.next?.must_equal false
+    _(second_datasets.count).must_equal 2
+    second_datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(second_datasets.next?).must_equal false
   end
 
   it "paginates datasets with next? and next with filter set" do
@@ -371,13 +371,13 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    first_datasets.count.must_equal 3
-    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
-    first_datasets.next?.must_equal true
+    _(first_datasets.count).must_equal 3
+    first_datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(first_datasets.next?).must_equal true
 
-    second_datasets.count.must_equal 2
-    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
-    second_datasets.next?.must_equal false
+    _(second_datasets.count).must_equal 2
+    second_datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(second_datasets.next?).must_equal false
   end
 
   it "paginates datasets with next? and next with max set" do
@@ -393,13 +393,13 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    first_datasets.count.must_equal 3
-    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
-    first_datasets.next?.must_equal true
+    _(first_datasets.count).must_equal 3
+    first_datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(first_datasets.next?).must_equal true
 
-    second_datasets.count.must_equal 2
-    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
-    second_datasets.next?.must_equal false
+    _(second_datasets.count).must_equal 2
+    second_datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(second_datasets.next?).must_equal false
   end
 
   it "paginates datasets with all" do
@@ -414,8 +414,8 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    datasets.count.must_equal 5
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(datasets.count).must_equal 5
+    datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
   end
 
   it "paginates datasets with all with all/hidden set" do
@@ -430,8 +430,8 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    datasets.count.must_equal 5
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(datasets.count).must_equal 5
+    datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
   end
 
   it "paginates datasets with all with filter set" do
@@ -446,8 +446,8 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    datasets.count.must_equal 5
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(datasets.count).must_equal 5
+    datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
   end
 
   it "paginates datasets with all with max set" do
@@ -462,8 +462,8 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    datasets.count.must_equal 5
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(datasets.count).must_equal 5
+    datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
   end
 
   it "iterates datasets with all using Enumerator" do
@@ -478,8 +478,8 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    datasets.count.must_equal 5
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(datasets.count).must_equal 5
+    datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
   end
 
   it "iterates datasets with all with request_limit set" do
@@ -494,8 +494,8 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    datasets.count.must_equal 6
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    _(datasets.count).must_equal 6
+    datasets.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Dataset }
   end
 
   it "finds a dataset" do
@@ -511,9 +511,9 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
-    dataset.dataset_id.must_equal dataset_id
-    dataset.name.must_equal dataset_name
+    _(dataset).must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(dataset.dataset_id).must_equal dataset_id
+    _(dataset.name).must_equal dataset_name
   end
 
   it "finds a dataset with skip_lookup option" do
@@ -522,11 +522,11 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     dataset = bigquery.dataset dataset_id, skip_lookup: true
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
-    dataset.must_be :reference?
-    dataset.wont_be :resource?
-    dataset.wont_be :resource_partial?
-    dataset.wont_be :resource_full?
+    _(dataset).must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(dataset).must_be :reference?
+    _(dataset).wont_be :resource?
+    _(dataset).wont_be :resource_partial?
+    _(dataset).wont_be :resource_full?
   end
 
   it "finds a dataset with skip_lookup option and then reloads it" do
@@ -540,19 +540,19 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     dataset = bigquery.dataset dataset_id, skip_lookup: true
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
-    dataset.must_be :reference?
-    dataset.wont_be :resource?
-    dataset.wont_be :resource_partial?
-    dataset.wont_be :resource_full?
-    dataset.dataset_id.must_equal dataset_id # does not call reload! internally
+    _(dataset).must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(dataset).must_be :reference?
+    _(dataset).wont_be :resource?
+    _(dataset).wont_be :resource_partial?
+    _(dataset).wont_be :resource_full?
+    _(dataset.dataset_id).must_equal dataset_id # does not call reload! internally
 
     dataset.reload!
-    dataset.name.must_equal dataset_name
-    dataset.wont_be :reference?
-    dataset.must_be :resource?
-    dataset.wont_be :resource_partial?
-    dataset.must_be :resource_full?
+    _(dataset.name).must_equal dataset_name
+    _(dataset).wont_be :reference?
+    _(dataset).must_be :resource?
+    _(dataset).wont_be :resource_partial?
+    _(dataset).must_be :resource_full?
 
     mock.verify
   end
@@ -568,22 +568,22 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     dataset = bigquery.dataset dataset_id, skip_lookup: true
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
-    dataset.must_be :reference?
-    dataset.project_id.must_equal project # does not call reload! internally
-    dataset.dataset_id.must_equal dataset_id # does not call reload! internally
-    dataset.dataset_ref.wont_be_nil
-    dataset.must_be :reference?
-    dataset.wont_be :resource?
-    dataset.wont_be :resource_partial?
-    dataset.wont_be :resource_full?
+    _(dataset).must_be_kind_of Google::Cloud::Bigquery::Dataset
+    _(dataset).must_be :reference?
+    _(dataset.project_id).must_equal project # does not call reload! internally
+    _(dataset.dataset_id).must_equal dataset_id # does not call reload! internally
+    _(dataset.dataset_ref).wont_be_nil
+    _(dataset).must_be :reference?
+    _(dataset).wont_be :resource?
+    _(dataset).wont_be :resource_partial?
+    _(dataset).wont_be :resource_full?
 
     dataset.exists? # calls reload! internally
-    dataset.wont_be :reference?
-    dataset.must_be :resource?
-    dataset.wont_be :resource_partial?
-    dataset.must_be :resource_full?
-    dataset.name.must_equal dataset_name
+    _(dataset).wont_be :reference?
+    _(dataset).must_be :resource?
+    _(dataset).wont_be :resource_partial?
+    _(dataset).must_be :resource_full?
+    _(dataset.name).must_equal dataset_name
 
     mock.verify
   end
@@ -594,7 +594,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     error = expect do
       bigquery.dataset dataset_id, skip_lookup: true
     end.must_raise ArgumentError
-    error.message.must_equal "dataset_id is required"
+    _(error.message).must_equal "dataset_id is required"
   end
 
   it "finds a job" do
@@ -608,8 +608,8 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::Job
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::Job
+    _(job.job_id).must_equal job_id
   end
 
   it "finds a job with location" do
@@ -624,9 +624,9 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::Job
-    job.job_id.must_equal job_id
-    job.location.must_equal region
+    _(job).must_be_kind_of Google::Cloud::Bigquery::Job
+    _(job.job_id).must_equal job_id
+    _(job.location).must_equal region
   end
 
   it "lists projects" do
@@ -639,12 +639,12 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    projects.size.must_equal 3
+    _(projects.size).must_equal 3
     projects.each do |project|
-      project.must_be_kind_of Google::Cloud::Bigquery::Project
-      project.name.must_equal "project-name"
-      project.numeric_id.must_equal 1234567890
-      project.project.must_equal "project-id-12345"
+      _(project).must_be_kind_of Google::Cloud::Bigquery::Project
+      _(project.name).must_equal "project-name"
+      _(project.numeric_id).must_equal 1234567890
+      _(project.project).must_equal "project-id-12345"
     end
   end
 
@@ -658,10 +658,10 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    projects.count.must_equal 3
-    projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
-    projects.token.wont_be :nil?
-    projects.token.must_equal "next_page_token"
+    _(projects.count).must_equal 3
+    projects.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Project }
+    _(projects.token).wont_be :nil?
+    _(projects.token).must_equal "next_page_token"
   end
 
   it "paginates projects" do
@@ -677,14 +677,14 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    first_projects.count.must_equal 3
-    first_projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
-    first_projects.token.wont_be :nil?
-    first_projects.token.must_equal "next_page_token"
+    _(first_projects.count).must_equal 3
+    first_projects.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Project }
+    _(first_projects.token).wont_be :nil?
+    _(first_projects.token).must_equal "next_page_token"
 
-    second_projects.count.must_equal 2
-    second_projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
-    second_projects.token.must_be :nil?
+    _(second_projects.count).must_equal 2
+    second_projects.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Project }
+    _(second_projects.token).must_be :nil?
   end
 
   it "paginates projects using next? and next" do
@@ -700,13 +700,13 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    first_projects.count.must_equal 3
-    first_projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
-    first_projects.next?.must_equal true
+    _(first_projects.count).must_equal 3
+    first_projects.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Project }
+    _(first_projects.next?).must_equal true
 
-    second_projects.count.must_equal 2
-    second_projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
-    second_projects.next?.must_equal false
+    _(second_projects.count).must_equal 2
+    second_projects.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Project }
+    _(second_projects.next?).must_equal false
   end
 
   it "paginates projects with all" do
@@ -721,8 +721,8 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    projects.count.must_equal 5
-    projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
+    _(projects.count).must_equal 5
+    projects.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Project }
   end
 
   it "iterates projects with all using Enumerator" do
@@ -737,8 +737,8 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    projects.count.must_equal 5
-    projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
+    _(projects.count).must_equal 5
+    projects.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Project }
   end
 
   it "iterates projects with all with request_limit set" do
@@ -753,27 +753,27 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    projects.count.must_equal 6
-    projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
+    _(projects.count).must_equal 6
+    projects.each { |ds| _(ds).must_be_kind_of Google::Cloud::Bigquery::Project }
   end
 
   it "creates a schema" do
     schema = bigquery.schema
-    schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    schema.wont_be :frozen?
-    schema.fields.must_be :empty?
+    _(schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(schema).wont_be :frozen?
+    _(schema.fields).must_be :empty?
   end
 
   it "creates a schema with configuration in a block" do
     schema = bigquery.schema do |s|
       s.string "first_name", mode: :required
     end
-    schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    schema.wont_be :frozen?
-    schema.fields.wont_be :empty?
-    schema.fields.size.must_equal 1
-    schema.fields[0].name.must_equal "first_name"
-    schema.fields[0].mode.must_equal "REQUIRED"
+    _(schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(schema).wont_be :frozen?
+    _(schema.fields).wont_be :empty?
+    _(schema.fields.size).must_equal 1
+    _(schema.fields[0].name).must_equal "first_name"
+    _(schema.fields[0].mode).must_equal "REQUIRED"
   end
 
   def create_dataset_gapi id, name = nil, description = nil, default_expiration = nil, location = "US"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_data_test.rb
@@ -31,48 +31,48 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
                 table_data_gapi.to_json,
                 [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options:{skip_deserialization: true} }]
 
-    job.must_be :done?
+    _(job).must_be :done?
     data = job.data
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.count.must_equal 3
-    data[0].must_be_kind_of Hash
-    data[0][:name].must_equal "Heidi"
-    data[0][:age].must_equal 36
-    data[0][:score].must_equal 7.65
-    data[0][:pi].must_equal BigDecimal("3.141592654")
-    data[0][:active].must_equal true
-    data[0][:avatar].must_be_kind_of StringIO
-    data[0][:avatar].read.must_equal "image data"
-    data[0][:started_at].must_equal Time.parse("2016-12-25 13:00:00 UTC")
-    data[0][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
-    data[0][:target_end].must_equal Time.parse("2017-01-01 00:00:00 UTC").to_datetime
-    data[0][:birthday].must_equal Date.parse("1968-10-20")
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.count).must_equal 3
+    _(data[0]).must_be_kind_of Hash
+    _(data[0][:name]).must_equal "Heidi"
+    _(data[0][:age]).must_equal 36
+    _(data[0][:score]).must_equal 7.65
+    _(data[0][:pi]).must_equal BigDecimal("3.141592654")
+    _(data[0][:active]).must_equal true
+    _(data[0][:avatar]).must_be_kind_of StringIO
+    _(data[0][:avatar].read).must_equal "image data"
+    _(data[0][:started_at]).must_equal Time.parse("2016-12-25 13:00:00 UTC")
+    _(data[0][:duration]).must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
+    _(data[0][:target_end]).must_equal Time.parse("2017-01-01 00:00:00 UTC").to_datetime
+    _(data[0][:birthday]).must_equal Date.parse("1968-10-20")
 
-    data[1].must_be_kind_of Hash
-    data[1][:name].must_equal "Aaron"
-    data[1][:age].must_equal 42
-    data[1][:score].must_equal 8.15
-    data[1][:pi].must_be :nil?
-    data[1][:active].must_equal false
-    data[1][:avatar].must_be :nil?
-    data[1][:started_at].must_be :nil?
-    data[1][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
-    data[1][:target_end].must_be :nil?
-    data[1][:birthday].must_be :nil?
+    _(data[1]).must_be_kind_of Hash
+    _(data[1][:name]).must_equal "Aaron"
+    _(data[1][:age]).must_equal 42
+    _(data[1][:score]).must_equal 8.15
+    _(data[1][:pi]).must_be :nil?
+    _(data[1][:active]).must_equal false
+    _(data[1][:avatar]).must_be :nil?
+    _(data[1][:started_at]).must_be :nil?
+    _(data[1][:duration]).must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
+    _(data[1][:target_end]).must_be :nil?
+    _(data[1][:birthday]).must_be :nil?
 
-    data[2].must_be_kind_of Hash
-    data[2][:name].must_equal "Sally"
-    data[2][:age].must_be :nil?
-    data[2][:score].must_be :nil?
-    data[2][:pi].must_be :nil?
-    data[2][:active].must_be :nil?
-    data[2][:avatar].must_be :nil?
-    data[2][:started_at].must_be :nil?
-    data[2][:duration].must_be :nil?
-    data[2][:target_end].must_be :nil?
-    data[2][:birthday].must_be :nil?
+    _(data[2]).must_be_kind_of Hash
+    _(data[2][:name]).must_equal "Sally"
+    _(data[2][:age]).must_be :nil?
+    _(data[2][:score]).must_be :nil?
+    _(data[2][:pi]).must_be :nil?
+    _(data[2][:active]).must_be :nil?
+    _(data[2][:avatar]).must_be :nil?
+    _(data[2][:started_at]).must_be :nil?
+    _(data[2][:duration]).must_be :nil?
+    _(data[2][:target_end]).must_be :nil?
+    _(data[2][:birthday]).must_be :nil?
     end
 
   it "can retrieve query results when it already has destination_schema" do
@@ -84,48 +84,48 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
 
     job.instance_variable_set :@destination_schema_gapi, query_data_gapi.schema
 
-    job.must_be :done?
+    _(job).must_be :done?
     data = job.data
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.count.must_equal 3
-    data[0].must_be_kind_of Hash
-    data[0][:name].must_equal "Heidi"
-    data[0][:age].must_equal 36
-    data[0][:score].must_equal 7.65
-    data[0][:pi].must_equal BigDecimal("3.141592654")
-    data[0][:active].must_equal true
-    data[0][:avatar].must_be_kind_of StringIO
-    data[0][:avatar].read.must_equal "image data"
-    data[0][:started_at].must_equal Time.parse("2016-12-25 13:00:00 UTC")
-    data[0][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
-    data[0][:target_end].must_equal Time.parse("2017-01-01 00:00:00 UTC").to_datetime
-    data[0][:birthday].must_equal Date.parse("1968-10-20")
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.count).must_equal 3
+    _(data[0]).must_be_kind_of Hash
+    _(data[0][:name]).must_equal "Heidi"
+    _(data[0][:age]).must_equal 36
+    _(data[0][:score]).must_equal 7.65
+    _(data[0][:pi]).must_equal BigDecimal("3.141592654")
+    _(data[0][:active]).must_equal true
+    _(data[0][:avatar]).must_be_kind_of StringIO
+    _(data[0][:avatar].read).must_equal "image data"
+    _(data[0][:started_at]).must_equal Time.parse("2016-12-25 13:00:00 UTC")
+    _(data[0][:duration]).must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
+    _(data[0][:target_end]).must_equal Time.parse("2017-01-01 00:00:00 UTC").to_datetime
+    _(data[0][:birthday]).must_equal Date.parse("1968-10-20")
 
-    data[1].must_be_kind_of Hash
-    data[1][:name].must_equal "Aaron"
-    data[1][:age].must_equal 42
-    data[1][:score].must_equal 8.15
-    data[1][:pi].must_be :nil?
-    data[1][:active].must_equal false
-    data[1][:avatar].must_be :nil?
-    data[1][:started_at].must_be :nil?
-    data[1][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
-    data[1][:target_end].must_be :nil?
-    data[1][:birthday].must_be :nil?
+    _(data[1]).must_be_kind_of Hash
+    _(data[1][:name]).must_equal "Aaron"
+    _(data[1][:age]).must_equal 42
+    _(data[1][:score]).must_equal 8.15
+    _(data[1][:pi]).must_be :nil?
+    _(data[1][:active]).must_equal false
+    _(data[1][:avatar]).must_be :nil?
+    _(data[1][:started_at]).must_be :nil?
+    _(data[1][:duration]).must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
+    _(data[1][:target_end]).must_be :nil?
+    _(data[1][:birthday]).must_be :nil?
 
-    data[2].must_be_kind_of Hash
-    data[2][:name].must_equal "Sally"
-    data[2][:age].must_be :nil?
-    data[2][:score].must_be :nil?
-    data[2][:pi].must_be :nil?
-    data[2][:active].must_be :nil?
-    data[2][:avatar].must_be :nil?
-    data[2][:started_at].must_be :nil?
-    data[2][:duration].must_be :nil?
-    data[2][:target_end].must_be :nil?
-    data[2][:birthday].must_be :nil?
+    _(data[2]).must_be_kind_of Hash
+    _(data[2][:name]).must_equal "Sally"
+    _(data[2][:age]).must_be :nil?
+    _(data[2][:score]).must_be :nil?
+    _(data[2][:pi]).must_be :nil?
+    _(data[2][:active]).must_be :nil?
+    _(data[2][:avatar]).must_be :nil?
+    _(data[2][:started_at]).must_be :nil?
+    _(data[2][:duration]).must_be :nil?
+    _(data[2][:target_end]).must_be :nil?
+    _(data[2][:birthday]).must_be :nil?
   end
 
   it "paginates data" do
@@ -143,11 +143,11 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
 
     data1 = job.data
 
-    data1.class.must_equal Google::Cloud::Bigquery::Data
-    data1.token.wont_be :nil?
-    data1.token.must_equal "token1234567890"
+    _(data1.class).must_equal Google::Cloud::Bigquery::Data
+    _(data1.token).wont_be :nil?
+    _(data1.token).must_equal "token1234567890"
     data2 = job.data token: data1.token
-    data2.class.must_equal Google::Cloud::Bigquery::Data
+    _(data2.class).must_equal Google::Cloud::Bigquery::Data
     mock.verify
   end
 
@@ -166,13 +166,13 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
 
     data1 = job.data
 
-    data1.class.must_equal Google::Cloud::Bigquery::Data
-    data1.token.wont_be :nil?
-    data1.next?.must_equal true # can't use must_be :next?
+    _(data1.class).must_equal Google::Cloud::Bigquery::Data
+    _(data1.token).wont_be :nil?
+    _(data1.next?).must_equal true # can't use must_be :next?
     data2 = data1.next
-    data2.token.must_be :nil?
-    data2.next?.must_equal false
-    data2.class.must_equal Google::Cloud::Bigquery::Data
+    _(data2.token).must_be :nil?
+    _(data2.next?).must_equal false
+    _(data2.class).must_equal Google::Cloud::Bigquery::Data
     mock.verify
   end
 
@@ -191,8 +191,8 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
 
     data = job.data.all.to_a
 
-    data.count.must_equal 6
-    data.each { |d| d.class.must_equal Hash }
+    _(data.count).must_equal 6
+    data.each { |d| _(d.class).must_equal Hash }
     mock.verify
   end
 
@@ -211,7 +211,7 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
 
     data = job.data
 
-    data.all { |d| d.class.must_equal Hash }
+    data.all { |d| _(d.class).must_equal Hash }
     mock.verify
   end
 
@@ -230,8 +230,8 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
 
     data = job.data.all.take(5)
 
-    data.count.must_equal 5
-    data.each { |d| d.class.must_equal Hash }
+    _(data.count).must_equal 5
+    data.each { |d| _(d.class).must_equal Hash }
     mock.verify
   end
 
@@ -250,8 +250,8 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
 
     data = job.data.all(request_limit: 1).to_a
 
-    data.count.must_equal 6
-    data.each { |d| d.class.must_equal Hash }
+    _(data.count).must_equal 6
+    data.each { |d| _(d.class).must_equal Hash }
     mock.verify
   end
 
@@ -266,7 +266,7 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
                 [project, dataset_id, table_id, {  max_results: 3, page_token: nil, start_index: nil, options:{skip_deserialization: true} }]
 
     data = job.data max: 3
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
   end
 
   it "paginates data with start set" do
@@ -282,7 +282,7 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
     data = job.data start: 25
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
   end
 
   def query_job_gapi

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
   let(:job_id) { job.job_id }
 
   it "knows it is query job" do
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
   it "knows its destination table" do
@@ -33,88 +33,88 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
     mock.expect :get_table, destination_table_gapi, ["target_project_id", "target_dataset_id", "target_table_id"]
 
     destination = job.destination
-    destination.must_be_kind_of Google::Cloud::Bigquery::Table
-    destination.project_id.must_equal "target_project_id"
-    destination.dataset_id.must_equal "target_dataset_id"
-    destination.table_id.must_equal   "target_table_id"
+    _(destination).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(destination.project_id).must_equal "target_project_id"
+    _(destination.dataset_id).must_equal "target_dataset_id"
+    _(destination.table_id).must_equal   "target_table_id"
     mock.verify
   end
 
   it "knows its attributes" do
-    job.must_be :batch?
-    job.wont_be :interactive?
-    job.must_be :large_results?
-    job.must_be :cache?
-    job.must_be :flatten?
-    job.wont_be :legacy_sql?
-    job.must_be :standard_sql?
-    job.maximum_billing_tier.must_equal 2
-    job.maximum_bytes_billed.must_equal 12345678901234
+    _(job).must_be :batch?
+    _(job).wont_be :interactive?
+    _(job).must_be :large_results?
+    _(job).must_be :cache?
+    _(job).must_be :flatten?
+    _(job).wont_be :legacy_sql?
+    _(job).must_be :standard_sql?
+    _(job.maximum_billing_tier).must_equal 2
+    _(job.maximum_bytes_billed).must_equal 12345678901234
   end
 
   it "knows its statistics data" do
-    job.bytes_processed.must_equal 123456
-    job.cache_hit?.must_equal true
-    job.ddl_operation_performed.must_equal "CREATE"
-    job.ddl_target_table.must_be_kind_of Google::Cloud::Bigquery::Table
-    job.ddl_target_table.project_id.must_equal "target_project_id"
-    job.ddl_target_table.dataset_id.must_equal "target_dataset_id"
-    job.ddl_target_table.table_id.must_equal "target_table_id"
-    job.num_dml_affected_rows.must_equal 50
-    job.statement_type.must_equal "CREATE_TABLE"
-    job.ddl?.must_equal true
-    job.dml?.must_equal false
+    _(job.bytes_processed).must_equal 123456
+    _(job.cache_hit?).must_equal true
+    _(job.ddl_operation_performed).must_equal "CREATE"
+    _(job.ddl_target_table).must_be_kind_of Google::Cloud::Bigquery::Table
+    _(job.ddl_target_table.project_id).must_equal "target_project_id"
+    _(job.ddl_target_table.dataset_id).must_equal "target_dataset_id"
+    _(job.ddl_target_table.table_id).must_equal "target_table_id"
+    _(job.num_dml_affected_rows).must_equal 50
+    _(job.statement_type).must_equal "CREATE_TABLE"
+    _(job.ddl?).must_equal true
+    _(job.dml?).must_equal false
     # in real life this example does not create a routine, but test the attribute here anyway
-    job.ddl_target_routine.must_be_kind_of Google::Cloud::Bigquery::Routine
-    job.ddl_target_routine.project_id.must_equal "target_project_id"
-    job.ddl_target_routine.dataset_id.must_equal "target_dataset_id"
-    job.ddl_target_routine.routine_id.must_equal "target_routine_id"
+    _(job.ddl_target_routine).must_be_kind_of Google::Cloud::Bigquery::Routine
+    _(job.ddl_target_routine.project_id).must_equal "target_project_id"
+    _(job.ddl_target_routine.dataset_id).must_equal "target_dataset_id"
+    _(job.ddl_target_routine.routine_id).must_equal "target_routine_id"
   end
 
   it "knows its query config" do
-    job.config.must_be_kind_of Hash
-    job.config["query"]["destinationTable"]["tableId"].must_equal "target_table_id"
-    job.config["query"]["createDisposition"].must_equal "CREATE_IF_NEEDED"
-    job.config["query"]["priority"].must_equal "BATCH"
+    _(job.config).must_be_kind_of Hash
+    _(job.config["query"]["destinationTable"]["tableId"]).must_equal "target_table_id"
+    _(job.config["query"]["createDisposition"]).must_equal "CREATE_IF_NEEDED"
+    _(job.config["query"]["priority"]).must_equal "BATCH"
   end
 
   it "knows its query plan attributes" do
-    job.query_plan.wont_be_nil
-    job.query_plan.must_be_kind_of Array
-    job.query_plan.count.must_equal 1
+    _(job.query_plan).wont_be_nil
+    _(job.query_plan).must_be_kind_of Array
+    _(job.query_plan.count).must_equal 1
     stage = job.query_plan.first
-    stage.must_be_kind_of Google::Cloud::Bigquery::QueryJob::Stage
-    stage.compute_ratio_avg.must_equal 1.0
-    stage.compute_ratio_max.must_equal 1.0
-    stage.id.must_equal 1
-    stage.name.must_equal "Stage 1"
-    stage.read_ratio_avg.must_equal 0.2710832227382326
-    stage.read_ratio_max.must_equal 0.2710832227382326
-    stage.records_read.must_equal 164656
-    stage.records_written.must_equal 1
-    stage.status.must_equal "COMPLETE"
-    stage.wait_ratio_avg.must_equal 0.007876711656047392
-    stage.wait_ratio_max.must_equal 0.007876711656047392
-    stage.write_ratio_avg.must_equal 0.05389444608201358
-    stage.write_ratio_max.must_equal 0.05389444608201358
+    _(stage).must_be_kind_of Google::Cloud::Bigquery::QueryJob::Stage
+    _(stage.compute_ratio_avg).must_equal 1.0
+    _(stage.compute_ratio_max).must_equal 1.0
+    _(stage.id).must_equal 1
+    _(stage.name).must_equal "Stage 1"
+    _(stage.read_ratio_avg).must_equal 0.2710832227382326
+    _(stage.read_ratio_max).must_equal 0.2710832227382326
+    _(stage.records_read).must_equal 164656
+    _(stage.records_written).must_equal 1
+    _(stage.status).must_equal "COMPLETE"
+    _(stage.wait_ratio_avg).must_equal 0.007876711656047392
+    _(stage.wait_ratio_max).must_equal 0.007876711656047392
+    _(stage.write_ratio_avg).must_equal 0.05389444608201358
+    _(stage.write_ratio_max).must_equal 0.05389444608201358
 
-    stage.steps.wont_be_nil
-    stage.steps.must_be_kind_of Array
-    stage.steps.count.must_equal 1
+    _(stage.steps).wont_be_nil
+    _(stage.steps).must_be_kind_of Array
+    _(stage.steps.count).must_equal 1
     step = stage.steps.first
-    step.must_be_kind_of Google::Cloud::Bigquery::QueryJob::Step
-    step.kind.must_equal "READ"
-    step.substeps.wont_be_nil
-    step.substeps.must_be_kind_of Array
-    step.substeps.must_equal [ "word", "FROM bigquery-public-data:samples.shakespeare" ]
+    _(step).must_be_kind_of Google::Cloud::Bigquery::QueryJob::Step
+    _(step.kind).must_equal "READ"
+    _(step.substeps).wont_be_nil
+    _(step.substeps).must_be_kind_of Array
+    _(step.substeps).must_equal [ "word", "FROM bigquery-public-data:samples.shakespeare" ]
   end
 
   it "knows its user defined function resources" do
-    job.udfs.wont_be_nil
-    job.udfs.must_be_kind_of Array
-    job.udfs.count.must_equal 2
-    job.udfs.first.must_equal "return x+1;"
-    job.udfs.last.must_equal "gs://my-bucket/my-lib.js"
+    _(job.udfs).wont_be_nil
+    _(job.udfs).must_be_kind_of Array
+    _(job.udfs.count).must_equal 2
+    _(job.udfs.first).must_equal "return x+1;"
+    _(job.udfs.last).must_equal "gs://my-bucket/my-lib.js"
   end
 
   def query_job_gapi target_routine: false, target_table: false, statement_type: nil, num_dml_affected_rows: nil, ddl_operation_performed: nil

--- a/google-cloud-bigquery/test/google/cloud/bigquery/routine/partial/routine_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/routine/partial/routine_test.rb
@@ -80,30 +80,30 @@ describe Google::Cloud::Bigquery::Routine, :mock_bigquery do
   let(:routine) { Google::Cloud::Bigquery::Routine.from_gapi routine_partial_gapi, bigquery.service }
 
   it "knows its attributes" do
-    routine.routine_id.must_equal routine_id
-    routine.dataset_id.must_equal dataset
-    routine.project_id.must_equal project
+    _(routine.routine_id).must_equal routine_id
+    _(routine.dataset_id).must_equal dataset
+    _(routine.project_id).must_equal project
     # routine_ref is private
-    routine.routine_ref.must_be_kind_of Google::Apis::BigqueryV2::RoutineReference
-    routine.routine_ref.routine_id.must_equal routine_id
-    routine.routine_ref.dataset_id.must_equal dataset
-    routine.routine_ref.project_id.must_equal project
+    _(routine.routine_ref).must_be_kind_of Google::Apis::BigqueryV2::RoutineReference
+    _(routine.routine_ref.routine_id).must_equal routine_id
+    _(routine.routine_ref.dataset_id).must_equal dataset
+    _(routine.routine_ref.project_id).must_equal project
 
     # Only the following fields are populated:
     # etag, routineReference, routineType, creationTime, lastModifiedTime and language
-    routine.etag.must_equal etag
-    routine.routine_type.must_equal "SCALAR_FUNCTION"
-    routine.procedure?.must_equal false
-    routine.scalar_function?.must_equal true
-    routine.created_at.must_be_close_to now, 1
-    routine.modified_at.must_be_close_to now, 1
-    routine.language.must_equal "SQL"
-    routine.javascript?.must_equal false
-    routine.sql?.must_equal true
+    _(routine.etag).must_equal etag
+    _(routine.routine_type).must_equal "SCALAR_FUNCTION"
+    _(routine.procedure?).must_equal false
+    _(routine.scalar_function?).must_equal true
+    _(routine.created_at).must_be_close_to now, 1
+    _(routine.modified_at).must_be_close_to now, 1
+    _(routine.language).must_equal "SQL"
+    _(routine.javascript?).must_equal false
+    _(routine.sql?).must_equal true
   end
 
   it "can test its existence" do
-    routine.exists?.must_equal true
+    _(routine.exists?).must_equal true
   end
 
   it "can test its existence with force to load resource" do
@@ -111,7 +111,7 @@ describe Google::Cloud::Bigquery::Routine, :mock_bigquery do
     mock.expect :get_routine, routine_gapi, [routine.project_id, routine.dataset_id, routine.routine_id]
     routine.service.mocked_service = mock
 
-    routine.exists?(force: true).must_equal true
+    _(routine.exists?(force: true)).must_equal true
 
     mock.verify
   end
@@ -121,9 +121,9 @@ describe Google::Cloud::Bigquery::Routine, :mock_bigquery do
     mock.expect :delete_routine, nil, [project, dataset, routine_id]
     routine.service.mocked_service = mock
 
-    routine.delete.must_equal true
+    _(routine.delete).must_equal true
 
-    routine.exists?.must_equal false
+    _(routine.exists?).must_equal false
 
     mock.verify
   end
@@ -139,7 +139,7 @@ describe Google::Cloud::Bigquery::Routine, :mock_bigquery do
 
     mock.verify
 
-    routine.description.must_equal new_description
+    _(routine.description).must_equal new_description
   end
 
   it "updates its routine_type" do
@@ -155,7 +155,7 @@ describe Google::Cloud::Bigquery::Routine, :mock_bigquery do
 
     mock.verify
 
-    routine.routine_type.must_equal new_routine_type
+    _(routine.routine_type).must_equal new_routine_type
   end
 
   it "updates its language" do
@@ -171,7 +171,7 @@ describe Google::Cloud::Bigquery::Routine, :mock_bigquery do
 
     mock.verify
 
-    routine.language.must_equal new_language
+    _(routine.language).must_equal new_language
   end
 
   it "updates its arguments" do
@@ -187,7 +187,7 @@ describe Google::Cloud::Bigquery::Routine, :mock_bigquery do
 
     mock.verify
 
-    routine.arguments.size.must_equal new_arguments.size
+    _(routine.arguments.size).must_equal new_arguments.size
   end
 
   it "updates its return_type" do
@@ -205,7 +205,7 @@ describe Google::Cloud::Bigquery::Routine, :mock_bigquery do
 
     mock.verify
 
-    routine.return_type.type_kind.must_equal new_return_type.type_kind
+    _(routine.return_type.type_kind).must_equal new_return_type.type_kind
   end
 
   it "updates its return_type with a string" do
@@ -221,7 +221,7 @@ describe Google::Cloud::Bigquery::Routine, :mock_bigquery do
 
     mock.verify
 
-    routine.return_type.type_kind.must_equal "STRING"
+    _(routine.return_type.type_kind).must_equal "STRING"
   end
 
   it "updates its return_type to nil" do
@@ -239,7 +239,7 @@ describe Google::Cloud::Bigquery::Routine, :mock_bigquery do
 
     mock.verify
 
-    routine.return_type.must_be :nil?
+    _(routine.return_type).must_be :nil?
   end
   
   it "updates its imported_libraries" do
@@ -255,7 +255,7 @@ describe Google::Cloud::Bigquery::Routine, :mock_bigquery do
 
     mock.verify
 
-    routine.imported_libraries.must_equal new_imported_libraries
+    _(routine.imported_libraries).must_equal new_imported_libraries
   end
   
   it "updates its body" do
@@ -271,7 +271,7 @@ describe Google::Cloud::Bigquery::Routine, :mock_bigquery do
 
     mock.verify
 
-    routine.body.must_equal new_body
+    _(routine.body).must_equal new_body
   end
 
   it "updates its description" do
@@ -287,7 +287,7 @@ describe Google::Cloud::Bigquery::Routine, :mock_bigquery do
 
     mock.verify
 
-    routine.description.must_equal new_description
+    _(routine.description).must_equal new_description
   end
 
   it "updates its attributes in a block" do
@@ -318,13 +318,13 @@ describe Google::Cloud::Bigquery::Routine, :mock_bigquery do
 
     mock.verify
 
-    routine.routine_type.must_equal new_routine_type
-    routine.language.must_equal new_language
-    routine.arguments.size.must_equal new_arguments.size
-    routine.return_type.type_kind.must_equal new_return_type.type_kind
-    routine.imported_libraries.must_equal new_imported_libraries
-    routine.body.must_equal new_body
-    routine.description.must_equal new_description
+    _(routine.routine_type).must_equal new_routine_type
+    _(routine.language).must_equal new_language
+    _(routine.arguments.size).must_equal new_arguments.size
+    _(routine.return_type.type_kind).must_equal new_return_type.type_kind
+    _(routine.imported_libraries).must_equal new_imported_libraries
+    _(routine.body).must_equal new_body
+    _(routine.description).must_equal new_description
   end
 
   it "skips update when no updates are made in a block" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/routine/reference/routine_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/routine/reference/routine_test.rb
@@ -77,24 +77,24 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
   let(:routine) { Google::Cloud::Bigquery::Routine.new_reference project, dataset, routine_id, bigquery.service }
 
   it "knows its attributes" do
-    routine.routine_id.must_equal routine_id
-    routine.dataset_id.must_equal dataset
-    routine.project_id.must_equal project
+    _(routine.routine_id).must_equal routine_id
+    _(routine.dataset_id).must_equal dataset
+    _(routine.project_id).must_equal project
     # routine_ref is private
-    routine.routine_ref.must_be_kind_of Google::Apis::BigqueryV2::RoutineReference
-    routine.routine_ref.routine_id.must_equal routine_id
-    routine.routine_ref.dataset_id.must_equal dataset
-    routine.routine_ref.project_id.must_equal project
+    _(routine.routine_ref).must_be_kind_of Google::Apis::BigqueryV2::RoutineReference
+    _(routine.routine_ref.routine_id).must_equal routine_id
+    _(routine.routine_ref.dataset_id).must_equal dataset
+    _(routine.routine_ref.project_id).must_equal project
 
-    routine.etag.must_be_nil
-    routine.routine_type.must_be_nil
-    routine.created_at.must_be_nil
-    routine.modified_at.must_be_nil
-    routine.language.must_be_nil
-    routine.arguments.must_be_nil
-    routine.return_type.must_be_nil
-    routine.body.must_be_nil
-    routine.description.must_be_nil
+    _(routine.etag).must_be_nil
+    _(routine.routine_type).must_be_nil
+    _(routine.created_at).must_be_nil
+    _(routine.modified_at).must_be_nil
+    _(routine.language).must_be_nil
+    _(routine.arguments).must_be_nil
+    _(routine.return_type).must_be_nil
+    _(routine.body).must_be_nil
+    _(routine.description).must_be_nil
   end
 
   it "can test its existence" do
@@ -102,7 +102,7 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
     mock.expect :get_routine, routine_gapi, [routine.project_id, routine.dataset_id, routine.routine_id]
     routine.service.mocked_service = mock
 
-    routine.exists?.must_equal true
+    _(routine.exists?).must_equal true
 
     mock.verify
   end
@@ -112,7 +112,7 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
     mock.expect :get_routine, routine_gapi, [routine.project_id, routine.dataset_id, routine.routine_id]
     routine.service.mocked_service = mock
 
-    routine.exists?(force: true).must_equal true
+    _(routine.exists?(force: true)).must_equal true
 
     mock.verify
   end
@@ -122,9 +122,9 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
     mock.expect :delete_routine, nil, [project, dataset, routine_id]
     routine.service.mocked_service = mock
 
-    routine.delete.must_equal true
+    _(routine.delete).must_equal true
 
-    routine.exists?.must_equal false
+    _(routine.exists?).must_equal false
 
     mock.verify
   end
@@ -136,12 +136,12 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
       [project, dataset, routine_id]
     routine.service.mocked_service = mock
 
-    routine.description.must_be_nil
+    _(routine.description).must_be_nil
     routine.reload!
 
     mock.verify
 
-    routine.description.must_equal new_description
+    _(routine.description).must_equal new_description
   end
 
   it "updates its routine_type" do
@@ -157,7 +157,7 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
 
     mock.verify
 
-    routine.routine_type.must_equal new_routine_type
+    _(routine.routine_type).must_equal new_routine_type
   end
 
   it "updates its language" do
@@ -173,7 +173,7 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
 
     mock.verify
 
-    routine.language.must_equal new_language
+    _(routine.language).must_equal new_language
   end
 
   it "updates its arguments" do
@@ -189,7 +189,7 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
 
     mock.verify
 
-    routine.arguments.size.must_equal new_arguments.size
+    _(routine.arguments.size).must_equal new_arguments.size
   end
 
   it "updates its return_type" do
@@ -205,7 +205,7 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
 
     mock.verify
 
-    routine.return_type.type_kind.must_equal new_return_type.type_kind
+    _(routine.return_type.type_kind).must_equal new_return_type.type_kind
   end
 
   it "updates its return_type with a string" do
@@ -221,7 +221,7 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
 
     mock.verify
 
-    routine.return_type.type_kind.must_equal new_return_type.type_kind
+    _(routine.return_type.type_kind).must_equal new_return_type.type_kind
   end
 
   it "updates its return_type to nil" do
@@ -239,7 +239,7 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
 
     mock.verify
 
-    routine.return_type.must_be :nil?
+    _(routine.return_type).must_be :nil?
   end
   
   it "updates its imported_libraries" do
@@ -255,7 +255,7 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
 
     mock.verify
 
-    routine.imported_libraries.must_equal new_imported_libraries
+    _(routine.imported_libraries).must_equal new_imported_libraries
   end
   
   it "updates its body" do
@@ -271,7 +271,7 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
 
     mock.verify
 
-    routine.body.must_equal new_body
+    _(routine.body).must_equal new_body
   end
 
   it "updates its description" do
@@ -287,7 +287,7 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
 
     mock.verify
 
-    routine.description.must_equal new_description
+    _(routine.description).must_equal new_description
   end
 
   it "updates its attributes in a block" do
@@ -318,13 +318,13 @@ describe Google::Cloud::Bigquery::Routine, :reference, :mock_bigquery do
 
     mock.verify
 
-    routine.routine_type.must_equal new_routine_type
-    routine.language.must_equal new_language
-    routine.arguments.size.must_equal new_arguments.size
-    routine.return_type.type_kind.must_equal new_return_type.type_kind
-    routine.imported_libraries.must_equal new_imported_libraries
-    routine.body.must_equal new_body
-    routine.description.must_equal new_description
+    _(routine.routine_type).must_equal new_routine_type
+    _(routine.language).must_equal new_language
+    _(routine.arguments.size).must_equal new_arguments.size
+    _(routine.return_type.type_kind).must_equal new_return_type.type_kind
+    _(routine.imported_libraries).must_equal new_imported_libraries
+    _(routine.body).must_equal new_body
+    _(routine.description).must_equal new_description
   end
 
   it "skips update when no updates are made in a block" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/routine/resource/routine_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/routine/resource/routine_test.rb
@@ -70,72 +70,72 @@ describe Google::Cloud::Bigquery::Routine, :resource, :mock_bigquery do
   let(:routine) { Google::Cloud::Bigquery::Routine.from_gapi routine_gapi, bigquery.service }
 
   it "knows its attributes" do
-    routine.routine_id.must_equal routine_id
-    routine.dataset_id.must_equal dataset
-    routine.project_id.must_equal project
+    _(routine.routine_id).must_equal routine_id
+    _(routine.dataset_id).must_equal dataset
+    _(routine.project_id).must_equal project
     # routine_ref is private
-    routine.routine_ref.must_be_kind_of Google::Apis::BigqueryV2::RoutineReference
-    routine.routine_ref.routine_id.must_equal routine_id
-    routine.routine_ref.dataset_id.must_equal dataset
-    routine.routine_ref.project_id.must_equal project
+    _(routine.routine_ref).must_be_kind_of Google::Apis::BigqueryV2::RoutineReference
+    _(routine.routine_ref.routine_id).must_equal routine_id
+    _(routine.routine_ref.dataset_id).must_equal dataset
+    _(routine.routine_ref.project_id).must_equal project
 
-    routine.etag.must_equal etag
-    routine.routine_type.must_equal "SCALAR_FUNCTION"
-    routine.procedure?.must_equal false
-    routine.scalar_function?.must_equal true
-    routine.created_at.must_be_close_to now, 1
-    routine.modified_at.must_be_close_to now, 1
-    routine.language.must_equal "SQL"
-    routine.javascript?.must_equal false
-    routine.sql?.must_equal true
+    _(routine.etag).must_equal etag
+    _(routine.routine_type).must_equal "SCALAR_FUNCTION"
+    _(routine.procedure?).must_equal false
+    _(routine.scalar_function?).must_equal true
+    _(routine.created_at).must_be_close_to now, 1
+    _(routine.modified_at).must_be_close_to now, 1
+    _(routine.language).must_equal "SQL"
+    _(routine.javascript?).must_equal false
+    _(routine.sql?).must_equal true
 
-    routine.arguments.must_be_kind_of Array
-    routine.arguments.must_be :frozen?
-    routine.arguments.size.must_equal 2
-    routine.arguments[0].must_be_kind_of Google::Cloud::Bigquery::Argument
-    routine.arguments[0].name.must_equal "arr"
-    routine.arguments[0].argument_kind.must_equal "FIXED_TYPE"
-    routine.arguments[0].fixed_type?.must_equal true
-    routine.arguments[0].any_type?.must_equal false
-    routine.arguments[0].mode.must_equal "IN"
-    routine.arguments[0].in?.must_equal true
-    routine.arguments[0].out?.must_equal false
-    routine.arguments[0].inout?.must_equal false
-    routine.arguments[0].data_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    routine.arguments[0].data_type.type_kind.must_equal "ARRAY"
-    routine.arguments[0].data_type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    routine.arguments[0].data_type.array_element_type.type_kind.must_equal "STRUCT"
-    routine.arguments[0].data_type.array_element_type.struct_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
-    routine.arguments[0].data_type.array_element_type.struct_type.fields.must_be_kind_of Array
-    routine.arguments[0].data_type.array_element_type.struct_type.fields.must_be :frozen?
-    routine.arguments[0].data_type.array_element_type.struct_type.fields.size.must_equal 2
-    routine.arguments[0].data_type.array_element_type.struct_type.fields[0].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    routine.arguments[0].data_type.array_element_type.struct_type.fields[0].name.must_equal "my-struct-name"
-    routine.arguments[0].data_type.array_element_type.struct_type.fields[0].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    routine.arguments[0].data_type.array_element_type.struct_type.fields[0].type.type_kind.must_equal "STRING"
-    routine.arguments[0].data_type.array_element_type.struct_type.fields[1].name.must_equal "my-struct-val"
-    routine.arguments[0].data_type.array_element_type.struct_type.fields[1].type.type_kind.must_equal "INT64"
-    routine.arguments[1].name.must_equal "out"
-    routine.arguments[1].argument_kind.must_equal "ANY_TYPE"
-    routine.arguments[1].fixed_type?.must_equal false
-    routine.arguments[1].any_type?.must_equal true
-    routine.arguments[1].mode.must_equal "OUT"
-    routine.arguments[1].in?.must_equal false
-    routine.arguments[1].out?.must_equal true
-    routine.arguments[1].inout?.must_equal false
-    routine.arguments[1].data_type.type_kind.must_equal "STRING"
+    _(routine.arguments).must_be_kind_of Array
+    _(routine.arguments).must_be :frozen?
+    _(routine.arguments.size).must_equal 2
+    _(routine.arguments[0]).must_be_kind_of Google::Cloud::Bigquery::Argument
+    _(routine.arguments[0].name).must_equal "arr"
+    _(routine.arguments[0].argument_kind).must_equal "FIXED_TYPE"
+    _(routine.arguments[0].fixed_type?).must_equal true
+    _(routine.arguments[0].any_type?).must_equal false
+    _(routine.arguments[0].mode).must_equal "IN"
+    _(routine.arguments[0].in?).must_equal true
+    _(routine.arguments[0].out?).must_equal false
+    _(routine.arguments[0].inout?).must_equal false
+    _(routine.arguments[0].data_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(routine.arguments[0].data_type.type_kind).must_equal "ARRAY"
+    _(routine.arguments[0].data_type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(routine.arguments[0].data_type.array_element_type.type_kind).must_equal "STRUCT"
+    _(routine.arguments[0].data_type.array_element_type.struct_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
+    _(routine.arguments[0].data_type.array_element_type.struct_type.fields).must_be_kind_of Array
+    _(routine.arguments[0].data_type.array_element_type.struct_type.fields).must_be :frozen?
+    _(routine.arguments[0].data_type.array_element_type.struct_type.fields.size).must_equal 2
+    _(routine.arguments[0].data_type.array_element_type.struct_type.fields[0]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(routine.arguments[0].data_type.array_element_type.struct_type.fields[0].name).must_equal "my-struct-name"
+    _(routine.arguments[0].data_type.array_element_type.struct_type.fields[0].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(routine.arguments[0].data_type.array_element_type.struct_type.fields[0].type.type_kind).must_equal "STRING"
+    _(routine.arguments[0].data_type.array_element_type.struct_type.fields[1].name).must_equal "my-struct-val"
+    _(routine.arguments[0].data_type.array_element_type.struct_type.fields[1].type.type_kind).must_equal "INT64"
+    _(routine.arguments[1].name).must_equal "out"
+    _(routine.arguments[1].argument_kind).must_equal "ANY_TYPE"
+    _(routine.arguments[1].fixed_type?).must_equal false
+    _(routine.arguments[1].any_type?).must_equal true
+    _(routine.arguments[1].mode).must_equal "OUT"
+    _(routine.arguments[1].in?).must_equal false
+    _(routine.arguments[1].out?).must_equal true
+    _(routine.arguments[1].inout?).must_equal false
+    _(routine.arguments[1].data_type.type_kind).must_equal "STRING"
 
-    routine.return_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    routine.return_type.type_kind.must_equal "INT64"
+    _(routine.return_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(routine.return_type.type_kind).must_equal "INT64"
 
-    routine.imported_libraries.must_equal ["gs://cloud-samples-data/bigquery/udfs/max-value.js"]
-    routine.imported_libraries.must_be :frozen?
-    routine.body.must_equal "x * 3"
-    routine.description.must_equal description
+    _(routine.imported_libraries).must_equal ["gs://cloud-samples-data/bigquery/udfs/max-value.js"]
+    _(routine.imported_libraries).must_be :frozen?
+    _(routine.body).must_equal "x * 3"
+    _(routine.description).must_equal description
   end
 
   it "can test its existence" do
-    routine.exists?.must_equal true
+    _(routine.exists?).must_equal true
   end
 
   it "can test its existence with force to load resource" do
@@ -143,7 +143,7 @@ describe Google::Cloud::Bigquery::Routine, :resource, :mock_bigquery do
     mock.expect :get_routine, routine_gapi, [routine.project_id, routine.dataset_id, routine.routine_id]
     routine.service.mocked_service = mock
 
-    routine.exists?(force: true).must_equal true
+    _(routine.exists?(force: true)).must_equal true
 
     mock.verify
   end
@@ -153,9 +153,9 @@ describe Google::Cloud::Bigquery::Routine, :resource, :mock_bigquery do
     mock.expect :delete_routine, nil, [project, dataset, routine_id]
     routine.service.mocked_service = mock
 
-    routine.delete.must_equal true
+    _(routine.delete).must_equal true
 
-    routine.exists?.must_equal false
+    _(routine.exists?).must_equal false
 
     mock.verify
   end
@@ -169,16 +169,16 @@ describe Google::Cloud::Bigquery::Routine, :resource, :mock_bigquery do
       [project, dataset, routine_id]
     routine.service.mocked_service = mock
 
-    routine.description.must_equal description
+    _(routine.description).must_equal description
     routine.reload!
 
     mock.verify
 
-    routine.description.must_equal new_description
+    _(routine.description).must_equal new_description
   end
 
   it "updates its routine_type" do
-    routine.routine_type.must_equal routine_type
+    _(routine.routine_type).must_equal routine_type
 
     mock = Minitest::Mock.new
     updated_routine_gapi = routine_gapi.dup
@@ -191,11 +191,11 @@ describe Google::Cloud::Bigquery::Routine, :resource, :mock_bigquery do
 
     mock.verify
 
-    routine.routine_type.must_equal new_routine_type
+    _(routine.routine_type).must_equal new_routine_type
   end
 
   it "updates its language" do
-    routine.language.must_equal language
+    _(routine.language).must_equal language
 
     mock = Minitest::Mock.new
     updated_routine_gapi = routine_gapi.dup
@@ -208,11 +208,11 @@ describe Google::Cloud::Bigquery::Routine, :resource, :mock_bigquery do
 
     mock.verify
 
-    routine.language.must_equal new_language
+    _(routine.language).must_equal new_language
   end
 
   it "updates its arguments" do
-    routine.arguments.size.must_equal routine_gapi.arguments.size
+    _(routine.arguments.size).must_equal routine_gapi.arguments.size
 
     mock = Minitest::Mock.new
     updated_routine_gapi = routine_gapi.dup
@@ -225,11 +225,11 @@ describe Google::Cloud::Bigquery::Routine, :resource, :mock_bigquery do
 
     mock.verify
 
-    routine.arguments.size.must_equal new_arguments.size
+    _(routine.arguments.size).must_equal new_arguments.size
   end
 
   it "updates its return_type" do
-    routine.return_type.type_kind.must_equal return_type.type_kind
+    _(routine.return_type.type_kind).must_equal return_type.type_kind
 
     mock = Minitest::Mock.new
     updated_routine_gapi = routine_gapi.dup
@@ -242,11 +242,11 @@ describe Google::Cloud::Bigquery::Routine, :resource, :mock_bigquery do
 
     mock.verify
 
-    routine.return_type.type_kind.must_equal new_return_type.type_kind
+    _(routine.return_type.type_kind).must_equal new_return_type.type_kind
   end
 
   it "updates its return_type with a string" do
-    routine.return_type.type_kind.must_equal return_type.type_kind
+    _(routine.return_type.type_kind).must_equal return_type.type_kind
 
     mock = Minitest::Mock.new
     updated_routine_gapi = routine_gapi.dup
@@ -259,11 +259,11 @@ describe Google::Cloud::Bigquery::Routine, :resource, :mock_bigquery do
 
     mock.verify
 
-    routine.return_type.type_kind.must_equal new_return_type.type_kind
+    _(routine.return_type.type_kind).must_equal new_return_type.type_kind
   end
 
   it "updates its return_type to nil" do
-    routine.return_type.type_kind.must_equal return_type.type_kind
+    _(routine.return_type.type_kind).must_equal return_type.type_kind
 
     mock = Minitest::Mock.new
     updated_routine_gapi = routine_gapi.dup
@@ -276,11 +276,11 @@ describe Google::Cloud::Bigquery::Routine, :resource, :mock_bigquery do
 
     mock.verify
 
-    routine.return_type.must_be :nil?
+    _(routine.return_type).must_be :nil?
   end
   
   it "updates its imported_libraries" do
-    routine.imported_libraries.must_equal imported_libraries
+    _(routine.imported_libraries).must_equal imported_libraries
 
     mock = Minitest::Mock.new
     updated_routine_gapi = routine_gapi.dup
@@ -293,11 +293,11 @@ describe Google::Cloud::Bigquery::Routine, :resource, :mock_bigquery do
 
     mock.verify
 
-    routine.imported_libraries.must_equal new_imported_libraries
+    _(routine.imported_libraries).must_equal new_imported_libraries
   end
   
   it "updates its body" do
-    routine.body.must_equal body
+    _(routine.body).must_equal body
 
     mock = Minitest::Mock.new
     updated_routine_gapi = routine_gapi.dup
@@ -310,11 +310,11 @@ describe Google::Cloud::Bigquery::Routine, :resource, :mock_bigquery do
 
     mock.verify
 
-    routine.body.must_equal new_body
+    _(routine.body).must_equal new_body
   end
 
   it "updates its description" do
-    routine.description.must_equal description
+    _(routine.description).must_equal description
 
     mock = Minitest::Mock.new
     updated_routine_gapi = routine_gapi.dup
@@ -327,11 +327,11 @@ describe Google::Cloud::Bigquery::Routine, :resource, :mock_bigquery do
 
     mock.verify
 
-    routine.description.must_equal new_description
+    _(routine.description).must_equal new_description
   end
 
   it "updates its attributes in a block" do
-    routine.description.must_equal description
+    _(routine.description).must_equal description
 
     mock = Minitest::Mock.new
     updated_routine_gapi = routine_gapi.dup
@@ -358,13 +358,13 @@ describe Google::Cloud::Bigquery::Routine, :resource, :mock_bigquery do
 
     mock.verify
 
-    routine.routine_type.must_equal new_routine_type
-    routine.language.must_equal new_language
-    routine.arguments.size.must_equal new_arguments.size
-    routine.return_type.type_kind.must_equal new_return_type.type_kind
-    routine.imported_libraries.must_equal new_imported_libraries
-    routine.body.must_equal new_body
-    routine.description.must_equal new_description
+    _(routine.routine_type).must_equal new_routine_type
+    _(routine.language).must_equal new_language
+    _(routine.arguments.size).must_equal new_arguments.size
+    _(routine.return_type.type_kind).must_equal new_return_type.type_kind
+    _(routine.imported_libraries).must_equal new_imported_libraries
+    _(routine.body).must_equal new_body
+    _(routine.description).must_equal new_description
   end
 
   it "skips update when no updates are made in a block" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/schema_test.rb
@@ -119,400 +119,400 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
   end
 
   it "has basic values" do
-    schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    schema.fields.wont_be :empty?
-    schema.fields.map(&:name).must_equal ["name", "age", "score", "pi", "active", "avatar", "started_at", "duration", "target_end", "birthday", "alts"]
+    _(schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(schema.fields).wont_be :empty?
+    _(schema.fields.map(&:name)).must_equal ["name", "age", "score", "pi", "active", "avatar", "started_at", "duration", "target_end", "birthday", "alts"]
   end
 
   it "can access fields with a symbol" do
-    schema.field(:name).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:name).name.must_equal "name"
-    schema.field(:name).type.must_equal "STRING"
-    schema.field(:name).mode.must_equal "REQUIRED"
-    schema.field(:name).must_be :string?
-    schema.field(:name).must_be :required?
+    _(schema.field(:name)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:name).name).must_equal "name"
+    _(schema.field(:name).type).must_equal "STRING"
+    _(schema.field(:name).mode).must_equal "REQUIRED"
+    _(schema.field(:name)).must_be :string?
+    _(schema.field(:name)).must_be :required?
 
-    schema.field(:age).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:age).name.must_equal "age"
-    schema.field(:age).type.must_equal "INTEGER"
-    schema.field(:age).mode.must_equal "NULLABLE"
-    schema.field(:age).must_be :integer?
-    schema.field(:age).must_be :nullable?
+    _(schema.field(:age)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:age).name).must_equal "age"
+    _(schema.field(:age).type).must_equal "INTEGER"
+    _(schema.field(:age).mode).must_equal "NULLABLE"
+    _(schema.field(:age)).must_be :integer?
+    _(schema.field(:age)).must_be :nullable?
 
-    schema.field(:score).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:score).name.must_equal "score"
-    schema.field(:score).type.must_equal "FLOAT"
-    schema.field(:score).mode.must_equal "NULLABLE"
-    schema.field(:score).must_be :float?
-    schema.field(:score).must_be :nullable?
+    _(schema.field(:score)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:score).name).must_equal "score"
+    _(schema.field(:score).type).must_equal "FLOAT"
+    _(schema.field(:score).mode).must_equal "NULLABLE"
+    _(schema.field(:score)).must_be :float?
+    _(schema.field(:score)).must_be :nullable?
 
-    schema.field(:pi).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:pi).name.must_equal "pi"
-    schema.field(:pi).type.must_equal "NUMERIC"
-    schema.field(:pi).mode.must_equal "NULLABLE"
-    schema.field(:pi).must_be :numeric?
-    schema.field(:pi).must_be :nullable?
+    _(schema.field(:pi)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:pi).name).must_equal "pi"
+    _(schema.field(:pi).type).must_equal "NUMERIC"
+    _(schema.field(:pi).mode).must_equal "NULLABLE"
+    _(schema.field(:pi)).must_be :numeric?
+    _(schema.field(:pi)).must_be :nullable?
 
-    schema.field(:active).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:active).name.must_equal "active"
-    schema.field(:active).type.must_equal "BOOLEAN"
-    schema.field(:active).mode.must_equal "NULLABLE"
-    schema.field(:active).must_be :boolean?
-    schema.field(:active).must_be :nullable?
+    _(schema.field(:active)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:active).name).must_equal "active"
+    _(schema.field(:active).type).must_equal "BOOLEAN"
+    _(schema.field(:active).mode).must_equal "NULLABLE"
+    _(schema.field(:active)).must_be :boolean?
+    _(schema.field(:active)).must_be :nullable?
 
-    schema.field(:avatar).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:avatar).name.must_equal "avatar"
-    schema.field(:avatar).type.must_equal "BYTES"
-    schema.field(:avatar).mode.must_equal "NULLABLE"
-    schema.field(:avatar).must_be :bytes?
-    schema.field(:avatar).must_be :nullable?
+    _(schema.field(:avatar)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:avatar).name).must_equal "avatar"
+    _(schema.field(:avatar).type).must_equal "BYTES"
+    _(schema.field(:avatar).mode).must_equal "NULLABLE"
+    _(schema.field(:avatar)).must_be :bytes?
+    _(schema.field(:avatar)).must_be :nullable?
 
-    schema.field(:started_at).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:started_at).name.must_equal "started_at"
-    schema.field(:started_at).type.must_equal "TIMESTAMP"
-    schema.field(:started_at).mode.must_equal "NULLABLE"
-    schema.field(:started_at).must_be :timestamp?
-    schema.field(:started_at).must_be :nullable?
+    _(schema.field(:started_at)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:started_at).name).must_equal "started_at"
+    _(schema.field(:started_at).type).must_equal "TIMESTAMP"
+    _(schema.field(:started_at).mode).must_equal "NULLABLE"
+    _(schema.field(:started_at)).must_be :timestamp?
+    _(schema.field(:started_at)).must_be :nullable?
 
-    schema.field(:duration).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:duration).name.must_equal "duration"
-    schema.field(:duration).type.must_equal "TIME"
-    schema.field(:duration).mode.must_equal "NULLABLE"
-    schema.field(:duration).must_be :time?
-    schema.field(:duration).must_be :nullable?
+    _(schema.field(:duration)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:duration).name).must_equal "duration"
+    _(schema.field(:duration).type).must_equal "TIME"
+    _(schema.field(:duration).mode).must_equal "NULLABLE"
+    _(schema.field(:duration)).must_be :time?
+    _(schema.field(:duration)).must_be :nullable?
 
-    schema.field(:target_end).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:target_end).name.must_equal "target_end"
-    schema.field(:target_end).type.must_equal "DATETIME"
-    schema.field(:target_end).mode.must_equal "NULLABLE"
-    schema.field(:target_end).must_be :datetime?
-    schema.field(:target_end).must_be :nullable?
+    _(schema.field(:target_end)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:target_end).name).must_equal "target_end"
+    _(schema.field(:target_end).type).must_equal "DATETIME"
+    _(schema.field(:target_end).mode).must_equal "NULLABLE"
+    _(schema.field(:target_end)).must_be :datetime?
+    _(schema.field(:target_end)).must_be :nullable?
 
-    schema.field(:birthday).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:birthday).name.must_equal "birthday"
-    schema.field(:birthday).type.must_equal "DATE"
-    schema.field(:birthday).mode.must_equal "NULLABLE"
-    schema.field(:birthday).must_be :date?
-    schema.field(:birthday).must_be :nullable?
+    _(schema.field(:birthday)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:birthday).name).must_equal "birthday"
+    _(schema.field(:birthday).type).must_equal "DATE"
+    _(schema.field(:birthday).mode).must_equal "NULLABLE"
+    _(schema.field(:birthday)).must_be :date?
+    _(schema.field(:birthday)).must_be :nullable?
 
-    schema.field(:alts).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:alts).name.must_equal "alts"
-    schema.field(:alts).type.must_equal "RECORD"
-    schema.field(:alts).mode.must_equal "REPEATED"
-    schema.field(:alts).must_be :record?
-    schema.field(:alts).must_be :repeated?
+    _(schema.field(:alts)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:alts).name).must_equal "alts"
+    _(schema.field(:alts).type).must_equal "RECORD"
+    _(schema.field(:alts).mode).must_equal "REPEATED"
+    _(schema.field(:alts)).must_be :record?
+    _(schema.field(:alts)).must_be :repeated?
 
-    schema.field(:alts).field(:age).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:alts).field(:age).name.must_equal "age"
-    schema.field(:alts).field(:age).type.must_equal "INT64"
-    schema.field(:alts).field(:age).mode.must_be :nil?
-    schema.field(:alts).field(:age).must_be :integer?
+    _(schema.field(:alts).field(:age)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:alts).field(:age).name).must_equal "age"
+    _(schema.field(:alts).field(:age).type).must_equal "INT64"
+    _(schema.field(:alts).field(:age).mode).must_be :nil?
+    _(schema.field(:alts).field(:age)).must_be :integer?
 
-    schema.field(:alts).field(:score).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:alts).field(:score).name.must_equal "score"
-    schema.field(:alts).field(:score).type.must_equal "FLOAT64"
-    schema.field(:alts).field(:score).mode.must_be :nil?
-    schema.field(:alts).field(:score).must_be :float?
+    _(schema.field(:alts).field(:score)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:alts).field(:score).name).must_equal "score"
+    _(schema.field(:alts).field(:score).type).must_equal "FLOAT64"
+    _(schema.field(:alts).field(:score).mode).must_be :nil?
+    _(schema.field(:alts).field(:score)).must_be :float?
 
-    schema.field(:alts).field(:active).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:alts).field(:active).name.must_equal "active"
-    schema.field(:alts).field(:active).type.must_equal "BOOL"
-    schema.field(:alts).field(:active).mode.must_be :nil?
-    schema.field(:alts).field(:active).must_be :boolean?
+    _(schema.field(:alts).field(:active)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:alts).field(:active).name).must_equal "active"
+    _(schema.field(:alts).field(:active).type).must_equal "BOOL"
+    _(schema.field(:alts).field(:active).mode).must_be :nil?
+    _(schema.field(:alts).field(:active)).must_be :boolean?
 
-    schema.field(:alts).field(:alt).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:alts).field(:alt).name.must_equal "alt"
-    schema.field(:alts).field(:alt).type.must_equal "STRUCT"
-    schema.field(:alts).field(:alt).mode.must_be :nil?
-    schema.field(:alts).field(:alt).must_be :record?
+    _(schema.field(:alts).field(:alt)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:alts).field(:alt).name).must_equal "alt"
+    _(schema.field(:alts).field(:alt).type).must_equal "STRUCT"
+    _(schema.field(:alts).field(:alt).mode).must_be :nil?
+    _(schema.field(:alts).field(:alt)).must_be :record?
 
-    schema.field(:alts).field(:alt).field(:name).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:alts).field(:alt).field(:name).name.must_equal "name"
-    schema.field(:alts).field(:alt).field(:name).type.must_equal "STRING"
-    schema.field(:alts).field(:alt).field(:name).mode.must_be :nil?
-    schema.field(:alts).field(:alt).field(:name).must_be :string?
+    _(schema.field(:alts).field(:alt).field(:name)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:alts).field(:alt).field(:name).name).must_equal "name"
+    _(schema.field(:alts).field(:alt).field(:name).type).must_equal "STRING"
+    _(schema.field(:alts).field(:alt).field(:name).mode).must_be :nil?
+    _(schema.field(:alts).field(:alt).field(:name)).must_be :string?
   end
 
   it "can access fields with a string" do
-    schema.field("name").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("name").name.must_equal "name"
-    schema.field("name").type.must_equal "STRING"
-    schema.field("name").mode.must_equal "REQUIRED"
-    schema.field("name").must_be :string?
-    schema.field("name").must_be :required?
+    _(schema.field("name")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("name").name).must_equal "name"
+    _(schema.field("name").type).must_equal "STRING"
+    _(schema.field("name").mode).must_equal "REQUIRED"
+    _(schema.field("name")).must_be :string?
+    _(schema.field("name")).must_be :required?
 
-    schema.field("age").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("age").name.must_equal "age"
-    schema.field("age").type.must_equal "INTEGER"
-    schema.field("age").mode.must_equal "NULLABLE"
-    schema.field("age").must_be :integer?
-    schema.field("age").must_be :nullable?
+    _(schema.field("age")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("age").name).must_equal "age"
+    _(schema.field("age").type).must_equal "INTEGER"
+    _(schema.field("age").mode).must_equal "NULLABLE"
+    _(schema.field("age")).must_be :integer?
+    _(schema.field("age")).must_be :nullable?
 
-    schema.field("score").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("score").name.must_equal "score"
-    schema.field("score").type.must_equal "FLOAT"
-    schema.field("score").mode.must_equal "NULLABLE"
-    schema.field("score").must_be :float?
-    schema.field("score").must_be :nullable?
+    _(schema.field("score")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("score").name).must_equal "score"
+    _(schema.field("score").type).must_equal "FLOAT"
+    _(schema.field("score").mode).must_equal "NULLABLE"
+    _(schema.field("score")).must_be :float?
+    _(schema.field("score")).must_be :nullable?
 
-    schema.field("pi").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("pi").name.must_equal "pi"
-    schema.field("pi").type.must_equal "NUMERIC"
-    schema.field("pi").mode.must_equal "NULLABLE"
-    schema.field("pi").must_be :numeric?
-    schema.field("pi").must_be :nullable?
+    _(schema.field("pi")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("pi").name).must_equal "pi"
+    _(schema.field("pi").type).must_equal "NUMERIC"
+    _(schema.field("pi").mode).must_equal "NULLABLE"
+    _(schema.field("pi")).must_be :numeric?
+    _(schema.field("pi")).must_be :nullable?
 
-    schema.field("active").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("active").name.must_equal "active"
-    schema.field("active").type.must_equal "BOOLEAN"
-    schema.field("active").mode.must_equal "NULLABLE"
-    schema.field("active").must_be :boolean?
-    schema.field("active").must_be :nullable?
+    _(schema.field("active")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("active").name).must_equal "active"
+    _(schema.field("active").type).must_equal "BOOLEAN"
+    _(schema.field("active").mode).must_equal "NULLABLE"
+    _(schema.field("active")).must_be :boolean?
+    _(schema.field("active")).must_be :nullable?
 
-    schema.field("avatar").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("avatar").name.must_equal "avatar"
-    schema.field("avatar").type.must_equal "BYTES"
-    schema.field("avatar").mode.must_equal "NULLABLE"
-    schema.field("avatar").must_be :bytes?
-    schema.field("avatar").must_be :nullable?
+    _(schema.field("avatar")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("avatar").name).must_equal "avatar"
+    _(schema.field("avatar").type).must_equal "BYTES"
+    _(schema.field("avatar").mode).must_equal "NULLABLE"
+    _(schema.field("avatar")).must_be :bytes?
+    _(schema.field("avatar")).must_be :nullable?
 
-    schema.field("started_at").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("started_at").name.must_equal "started_at"
-    schema.field("started_at").type.must_equal "TIMESTAMP"
-    schema.field("started_at").mode.must_equal "NULLABLE"
-    schema.field("started_at").must_be :timestamp?
-    schema.field("started_at").must_be :nullable?
+    _(schema.field("started_at")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("started_at").name).must_equal "started_at"
+    _(schema.field("started_at").type).must_equal "TIMESTAMP"
+    _(schema.field("started_at").mode).must_equal "NULLABLE"
+    _(schema.field("started_at")).must_be :timestamp?
+    _(schema.field("started_at")).must_be :nullable?
 
-    schema.field("duration").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("duration").name.must_equal "duration"
-    schema.field("duration").type.must_equal "TIME"
-    schema.field("duration").mode.must_equal "NULLABLE"
-    schema.field("duration").must_be :time?
-    schema.field("duration").must_be :nullable?
+    _(schema.field("duration")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("duration").name).must_equal "duration"
+    _(schema.field("duration").type).must_equal "TIME"
+    _(schema.field("duration").mode).must_equal "NULLABLE"
+    _(schema.field("duration")).must_be :time?
+    _(schema.field("duration")).must_be :nullable?
 
-    schema.field("target_end").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("target_end").name.must_equal "target_end"
-    schema.field("target_end").type.must_equal "DATETIME"
-    schema.field("target_end").mode.must_equal "NULLABLE"
-    schema.field("target_end").must_be :datetime?
-    schema.field("target_end").must_be :nullable?
+    _(schema.field("target_end")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("target_end").name).must_equal "target_end"
+    _(schema.field("target_end").type).must_equal "DATETIME"
+    _(schema.field("target_end").mode).must_equal "NULLABLE"
+    _(schema.field("target_end")).must_be :datetime?
+    _(schema.field("target_end")).must_be :nullable?
 
-    schema.field("birthday").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("birthday").name.must_equal "birthday"
-    schema.field("birthday").type.must_equal "DATE"
-    schema.field("birthday").mode.must_equal "NULLABLE"
-    schema.field("birthday").must_be :date?
-    schema.field("birthday").must_be :nullable?
+    _(schema.field("birthday")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("birthday").name).must_equal "birthday"
+    _(schema.field("birthday").type).must_equal "DATE"
+    _(schema.field("birthday").mode).must_equal "NULLABLE"
+    _(schema.field("birthday")).must_be :date?
+    _(schema.field("birthday")).must_be :nullable?
 
-    schema.field("alts").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("alts").name.must_equal "alts"
-    schema.field("alts").type.must_equal "RECORD"
-    schema.field("alts").mode.must_equal "REPEATED"
-    schema.field("alts").must_be :record?
-    schema.field("alts").must_be :repeated?
+    _(schema.field("alts")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("alts").name).must_equal "alts"
+    _(schema.field("alts").type).must_equal "RECORD"
+    _(schema.field("alts").mode).must_equal "REPEATED"
+    _(schema.field("alts")).must_be :record?
+    _(schema.field("alts")).must_be :repeated?
 
-    schema.field("alts").field("age").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("alts").field("age").name.must_equal "age"
-    schema.field("alts").field("age").type.must_equal "INT64"
-    schema.field("alts").field("age").mode.must_be :nil?
-    schema.field("alts").field("age").must_be :integer?
+    _(schema.field("alts").field("age")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("alts").field("age").name).must_equal "age"
+    _(schema.field("alts").field("age").type).must_equal "INT64"
+    _(schema.field("alts").field("age").mode).must_be :nil?
+    _(schema.field("alts").field("age")).must_be :integer?
 
-    schema.field("alts").field("score").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("alts").field("score").name.must_equal "score"
-    schema.field("alts").field("score").type.must_equal "FLOAT64"
-    schema.field("alts").field("score").mode.must_be :nil?
-    schema.field("alts").field("score").must_be :float?
+    _(schema.field("alts").field("score")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("alts").field("score").name).must_equal "score"
+    _(schema.field("alts").field("score").type).must_equal "FLOAT64"
+    _(schema.field("alts").field("score").mode).must_be :nil?
+    _(schema.field("alts").field("score")).must_be :float?
 
-    schema.field("alts").field("active").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("alts").field("active").name.must_equal "active"
-    schema.field("alts").field("active").type.must_equal "BOOL"
-    schema.field("alts").field("active").mode.must_be :nil?
-    schema.field("alts").field("active").must_be :boolean?
+    _(schema.field("alts").field("active")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("alts").field("active").name).must_equal "active"
+    _(schema.field("alts").field("active").type).must_equal "BOOL"
+    _(schema.field("alts").field("active").mode).must_be :nil?
+    _(schema.field("alts").field("active")).must_be :boolean?
 
-    schema.field("alts").field("alt").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("alts").field("alt").name.must_equal "alt"
-    schema.field("alts").field("alt").type.must_equal "STRUCT"
-    schema.field("alts").field("alt").mode.must_be :nil?
-    schema.field("alts").field("alt").must_be :record?
+    _(schema.field("alts").field("alt")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("alts").field("alt").name).must_equal "alt"
+    _(schema.field("alts").field("alt").type).must_equal "STRUCT"
+    _(schema.field("alts").field("alt").mode).must_be :nil?
+    _(schema.field("alts").field("alt")).must_be :record?
 
-    schema.field("alts").field("alt").field("name").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field("alts").field("alt").field("name").name.must_equal "name"
-    schema.field("alts").field("alt").field("name").type.must_equal "STRING"
-    schema.field("alts").field("alt").field("name").mode.must_be :nil?
-    schema.field("alts").field("alt").field("name").must_be :string?
+    _(schema.field("alts").field("alt").field("name")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("alts").field("alt").field("name").name).must_equal "name"
+    _(schema.field("alts").field("alt").field("name").type).must_equal "STRING"
+    _(schema.field("alts").field("alt").field("name").mode).must_be :nil?
+    _(schema.field("alts").field("alt").field("name")).must_be :string?
   end
 
   it "can load the schema from a File" do
     io = StringIO.new(kittens_schema_json)
     schema.load io
 
-    schema.wont_be :empty?
-    schema.fields.map(&:name).must_equal %w[id breed name dob features]
+    _(schema).wont_be :empty?
+    _(schema.fields.map(&:name)).must_equal %w[id breed name dob features]
 
-    schema.field(:id).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:id).name.must_equal "id"
-    schema.field(:id).type.must_equal "INTEGER"
-    schema.field(:id).description.must_equal "id description"
-    schema.field(:id).mode.must_equal "REQUIRED"
-    schema.field(:id).must_be :integer?
-    schema.field(:id).must_be :required?
+    _(schema.field(:id)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:id).name).must_equal "id"
+    _(schema.field(:id).type).must_equal "INTEGER"
+    _(schema.field(:id).description).must_equal "id description"
+    _(schema.field(:id).mode).must_equal "REQUIRED"
+    _(schema.field(:id)).must_be :integer?
+    _(schema.field(:id)).must_be :required?
 
-    schema.field(:breed).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:breed).name.must_equal "breed"
-    schema.field(:breed).type.must_equal "STRING"
-    schema.field(:breed).description.must_equal "breed description"
-    schema.field(:breed).mode.must_equal "REQUIRED"
-    schema.field(:breed).must_be :string?
-    schema.field(:breed).must_be :required?
+    _(schema.field(:breed)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:breed).name).must_equal "breed"
+    _(schema.field(:breed).type).must_equal "STRING"
+    _(schema.field(:breed).description).must_equal "breed description"
+    _(schema.field(:breed).mode).must_equal "REQUIRED"
+    _(schema.field(:breed)).must_be :string?
+    _(schema.field(:breed)).must_be :required?
 
-    schema.field(:name).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:name).name.must_equal "name"
-    schema.field(:name).type.must_equal "STRING"
-    schema.field(:name).description.must_equal "name description"
-    schema.field(:name).mode.must_equal "REQUIRED"
-    schema.field(:name).must_be :string?
-    schema.field(:name).must_be :required?
+    _(schema.field(:name)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:name).name).must_equal "name"
+    _(schema.field(:name).type).must_equal "STRING"
+    _(schema.field(:name).description).must_equal "name description"
+    _(schema.field(:name).mode).must_equal "REQUIRED"
+    _(schema.field(:name)).must_be :string?
+    _(schema.field(:name)).must_be :required?
 
-    schema.field(:dob).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:dob).name.must_equal "dob"
-    schema.field(:dob).type.must_equal "TIMESTAMP"
-    schema.field(:dob).description.must_equal "dob description"
-    schema.field(:dob).mode.must_equal "NULLABLE"
-    schema.field(:dob).must_be :timestamp?
+    _(schema.field(:dob)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:dob).name).must_equal "dob"
+    _(schema.field(:dob).type).must_equal "TIMESTAMP"
+    _(schema.field(:dob).description).must_equal "dob description"
+    _(schema.field(:dob).mode).must_equal "NULLABLE"
+    _(schema.field(:dob)).must_be :timestamp?
 
-    schema.field(:features).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:features).name.must_equal "features"
-    schema.field(:features).type.must_equal "RECORD"
-    schema.field(:features).description.must_equal "features description"
-    schema.field(:features).mode.must_equal "REPEATED"
-    schema.field(:features).must_be :record?
-    schema.field(:features).must_be :repeated?
+    _(schema.field(:features)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:features).name).must_equal "features"
+    _(schema.field(:features).type).must_equal "RECORD"
+    _(schema.field(:features).description).must_equal "features description"
+    _(schema.field(:features).mode).must_equal "REPEATED"
+    _(schema.field(:features)).must_be :record?
+    _(schema.field(:features)).must_be :repeated?
 
     features = schema.field(:features)
-    features.fields.map(&:name).must_equal %w[feature]
+    _(features.fields.map(&:name)).must_equal %w[feature]
 
-    features.field(:feature).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    features.field(:feature).name.must_equal "feature"
-    features.field(:feature).type.must_equal "STRING"
-    features.field(:feature).description.must_equal "feature description"
-    features.field(:feature).mode.must_equal "REQUIRED"
-    features.field(:feature).must_be :string?
-    features.field(:feature).must_be :required?
+    _(features.field(:feature)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(features.field(:feature).name).must_equal "feature"
+    _(features.field(:feature).type).must_equal "STRING"
+    _(features.field(:feature).description).must_equal "feature description"
+    _(features.field(:feature).mode).must_equal "REQUIRED"
+    _(features.field(:feature)).must_be :string?
+    _(features.field(:feature)).must_be :required?
   end
 
   it "can load the schema from a JSON string" do
     schema.load kittens_schema_json
 
-    schema.wont_be :empty?
-    schema.fields.map(&:name).must_equal %w[id breed name dob features]
+    _(schema).wont_be :empty?
+    _(schema.fields.map(&:name)).must_equal %w[id breed name dob features]
 
-    schema.field(:id).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:id).name.must_equal "id"
-    schema.field(:id).type.must_equal "INTEGER"
-    schema.field(:id).description.must_equal "id description"
-    schema.field(:id).mode.must_equal "REQUIRED"
-    schema.field(:id).must_be :integer?
-    schema.field(:id).must_be :required?
+    _(schema.field(:id)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:id).name).must_equal "id"
+    _(schema.field(:id).type).must_equal "INTEGER"
+    _(schema.field(:id).description).must_equal "id description"
+    _(schema.field(:id).mode).must_equal "REQUIRED"
+    _(schema.field(:id)).must_be :integer?
+    _(schema.field(:id)).must_be :required?
 
-    schema.field(:breed).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:breed).name.must_equal "breed"
-    schema.field(:breed).type.must_equal "STRING"
-    schema.field(:breed).description.must_equal "breed description"
-    schema.field(:breed).mode.must_equal "REQUIRED"
-    schema.field(:breed).must_be :string?
-    schema.field(:breed).must_be :required?
+    _(schema.field(:breed)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:breed).name).must_equal "breed"
+    _(schema.field(:breed).type).must_equal "STRING"
+    _(schema.field(:breed).description).must_equal "breed description"
+    _(schema.field(:breed).mode).must_equal "REQUIRED"
+    _(schema.field(:breed)).must_be :string?
+    _(schema.field(:breed)).must_be :required?
 
-    schema.field(:name).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:name).name.must_equal "name"
-    schema.field(:name).type.must_equal "STRING"
-    schema.field(:name).description.must_equal "name description"
-    schema.field(:name).mode.must_equal "REQUIRED"
-    schema.field(:name).must_be :string?
-    schema.field(:name).must_be :required?
+    _(schema.field(:name)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:name).name).must_equal "name"
+    _(schema.field(:name).type).must_equal "STRING"
+    _(schema.field(:name).description).must_equal "name description"
+    _(schema.field(:name).mode).must_equal "REQUIRED"
+    _(schema.field(:name)).must_be :string?
+    _(schema.field(:name)).must_be :required?
 
-    schema.field(:dob).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:dob).name.must_equal "dob"
-    schema.field(:dob).type.must_equal "TIMESTAMP"
-    schema.field(:dob).description.must_equal "dob description"
-    schema.field(:dob).mode.must_equal "NULLABLE"
-    schema.field(:dob).must_be :timestamp?
+    _(schema.field(:dob)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:dob).name).must_equal "dob"
+    _(schema.field(:dob).type).must_equal "TIMESTAMP"
+    _(schema.field(:dob).description).must_equal "dob description"
+    _(schema.field(:dob).mode).must_equal "NULLABLE"
+    _(schema.field(:dob)).must_be :timestamp?
 
-    schema.field(:features).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:features).name.must_equal "features"
-    schema.field(:features).type.must_equal "RECORD"
-    schema.field(:features).description.must_equal "features description"
-    schema.field(:features).mode.must_equal "REPEATED"
-    schema.field(:features).must_be :record?
-    schema.field(:features).must_be :repeated?
+    _(schema.field(:features)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:features).name).must_equal "features"
+    _(schema.field(:features).type).must_equal "RECORD"
+    _(schema.field(:features).description).must_equal "features description"
+    _(schema.field(:features).mode).must_equal "REPEATED"
+    _(schema.field(:features)).must_be :record?
+    _(schema.field(:features)).must_be :repeated?
 
     features = schema.field(:features)
-    features.fields.map(&:name).must_equal %w[feature]
+    _(features.fields.map(&:name)).must_equal %w[feature]
 
-    features.field(:feature).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    features.field(:feature).name.must_equal "feature"
-    features.field(:feature).type.must_equal "STRING"
-    features.field(:feature).description.must_equal "feature description"
-    features.field(:feature).mode.must_equal "REQUIRED"
-    features.field(:feature).must_be :string?
-    features.field(:feature).must_be :required?
+    _(features.field(:feature)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(features.field(:feature).name).must_equal "feature"
+    _(features.field(:feature).type).must_equal "STRING"
+    _(features.field(:feature).description).must_equal "feature description"
+    _(features.field(:feature).mode).must_equal "REQUIRED"
+    _(features.field(:feature)).must_be :string?
+    _(features.field(:feature)).must_be :required?
   end
 
   it "can load the schema from an Array of Hashes" do
     json = JSON.parse(kittens_schema_json)
     schema.load json
 
-    schema.wont_be :empty?
-    schema.fields.map(&:name).must_equal %w[id breed name dob features]
+    _(schema).wont_be :empty?
+    _(schema.fields.map(&:name)).must_equal %w[id breed name dob features]
 
-    schema.field(:id).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:id).name.must_equal "id"
-    schema.field(:id).type.must_equal "INTEGER"
-    schema.field(:id).description.must_equal "id description"
-    schema.field(:id).mode.must_equal "REQUIRED"
-    schema.field(:id).must_be :integer?
-    schema.field(:id).must_be :required?
+    _(schema.field(:id)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:id).name).must_equal "id"
+    _(schema.field(:id).type).must_equal "INTEGER"
+    _(schema.field(:id).description).must_equal "id description"
+    _(schema.field(:id).mode).must_equal "REQUIRED"
+    _(schema.field(:id)).must_be :integer?
+    _(schema.field(:id)).must_be :required?
 
-    schema.field(:breed).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:breed).name.must_equal "breed"
-    schema.field(:breed).type.must_equal "STRING"
-    schema.field(:breed).description.must_equal "breed description"
-    schema.field(:breed).mode.must_equal "REQUIRED"
-    schema.field(:breed).must_be :string?
-    schema.field(:breed).must_be :required?
+    _(schema.field(:breed)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:breed).name).must_equal "breed"
+    _(schema.field(:breed).type).must_equal "STRING"
+    _(schema.field(:breed).description).must_equal "breed description"
+    _(schema.field(:breed).mode).must_equal "REQUIRED"
+    _(schema.field(:breed)).must_be :string?
+    _(schema.field(:breed)).must_be :required?
 
-    schema.field(:name).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:name).name.must_equal "name"
-    schema.field(:name).type.must_equal "STRING"
-    schema.field(:name).description.must_equal "name description"
-    schema.field(:name).mode.must_equal "REQUIRED"
-    schema.field(:name).must_be :string?
-    schema.field(:name).must_be :required?
+    _(schema.field(:name)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:name).name).must_equal "name"
+    _(schema.field(:name).type).must_equal "STRING"
+    _(schema.field(:name).description).must_equal "name description"
+    _(schema.field(:name).mode).must_equal "REQUIRED"
+    _(schema.field(:name)).must_be :string?
+    _(schema.field(:name)).must_be :required?
 
-    schema.field(:dob).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:dob).name.must_equal "dob"
-    schema.field(:dob).type.must_equal "TIMESTAMP"
-    schema.field(:dob).description.must_equal "dob description"
-    schema.field(:dob).mode.must_equal "NULLABLE"
-    schema.field(:dob).must_be :timestamp?
+    _(schema.field(:dob)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:dob).name).must_equal "dob"
+    _(schema.field(:dob).type).must_equal "TIMESTAMP"
+    _(schema.field(:dob).description).must_equal "dob description"
+    _(schema.field(:dob).mode).must_equal "NULLABLE"
+    _(schema.field(:dob)).must_be :timestamp?
 
-    schema.field(:features).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    schema.field(:features).name.must_equal "features"
-    schema.field(:features).type.must_equal "RECORD"
-    schema.field(:features).description.must_equal "features description"
-    schema.field(:features).mode.must_equal "REPEATED"
-    schema.field(:features).must_be :record?
-    schema.field(:features).must_be :repeated?
+    _(schema.field(:features)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:features).name).must_equal "features"
+    _(schema.field(:features).type).must_equal "RECORD"
+    _(schema.field(:features).description).must_equal "features description"
+    _(schema.field(:features).mode).must_equal "REPEATED"
+    _(schema.field(:features)).must_be :record?
+    _(schema.field(:features)).must_be :repeated?
 
     features = schema.field(:features)
-    features.fields.map(&:name).must_equal %w[feature]
+    _(features.fields.map(&:name)).must_equal %w[feature]
 
-    features.field(:feature).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
-    features.field(:feature).name.must_equal "feature"
-    features.field(:feature).type.must_equal "STRING"
-    features.field(:feature).description.must_equal "feature description"
-    features.field(:feature).mode.must_equal "REQUIRED"
-    features.field(:feature).must_be :string?
-    features.field(:feature).must_be :required?
+    _(features.field(:feature)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(features.field(:feature).name).must_equal "feature"
+    _(features.field(:feature).type).must_equal "STRING"
+    _(features.field(:feature).description).must_equal "feature description"
+    _(features.field(:feature).mode).must_equal "REQUIRED"
+    _(features.field(:feature)).must_be :string?
+    _(features.field(:feature)).must_be :required?
   end
 
   it "can dump the schema as JSON to a File" do
@@ -528,71 +528,71 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
         file.delete
       end
     end
-    json.length.must_equal 11
+    _(json.length).must_equal 11
 
     name = json.find { |record| record["name"] == "name" }
-    name["type"].must_equal "STRING"
-    name["mode"].must_equal "REQUIRED"
+    _(name["type"]).must_equal "STRING"
+    _(name["mode"]).must_equal "REQUIRED"
 
     age = json.find { |record| record["name"] == "age" }
-    age["type"].must_equal "INTEGER"
-    age["mode"].must_equal "NULLABLE"
+    _(age["type"]).must_equal "INTEGER"
+    _(age["mode"]).must_equal "NULLABLE"
 
     score = json.find { |record| record["name"] == "score" }
-    score["type"].must_equal "FLOAT"
-    score["mode"].must_equal "NULLABLE"
+    _(score["type"]).must_equal "FLOAT"
+    _(score["mode"]).must_equal "NULLABLE"
 
     score = json.find { |record| record["name"] == "pi" }
-    score["type"].must_equal "NUMERIC"
-    score["mode"].must_equal "NULLABLE"
+    _(score["type"]).must_equal "NUMERIC"
+    _(score["mode"]).must_equal "NULLABLE"
 
     active = json.find { |record| record["name"] == "active" }
-    active["type"].must_equal "BOOLEAN"
-    active["mode"].must_equal "NULLABLE"
+    _(active["type"]).must_equal "BOOLEAN"
+    _(active["mode"]).must_equal "NULLABLE"
 
     avatar = json.find { |record| record["name"] == "avatar" }
-    avatar["type"].must_equal "BYTES"
-    avatar["mode"].must_equal "NULLABLE"
+    _(avatar["type"]).must_equal "BYTES"
+    _(avatar["mode"]).must_equal "NULLABLE"
 
     started_at = json.find { |record| record["name"] == "started_at" }
-    started_at["type"].must_equal "TIMESTAMP"
-    started_at["mode"].must_equal "NULLABLE"
+    _(started_at["type"]).must_equal "TIMESTAMP"
+    _(started_at["mode"]).must_equal "NULLABLE"
 
     duration = json.find { |record| record["name"] == "duration" }
-    duration["type"].must_equal "TIME"
-    duration["mode"].must_equal "NULLABLE"
+    _(duration["type"]).must_equal "TIME"
+    _(duration["mode"]).must_equal "NULLABLE"
 
     target_end = json.find { |record| record["name"] == "target_end" }
-    target_end["type"].must_equal "DATETIME"
-    target_end["mode"].must_equal "NULLABLE"
+    _(target_end["type"]).must_equal "DATETIME"
+    _(target_end["mode"]).must_equal "NULLABLE"
 
     birthday = json.find { |record| record["name"] == "birthday" }
-    birthday["type"].must_equal "DATE"
-    birthday["mode"].must_equal "NULLABLE"
+    _(birthday["type"]).must_equal "DATE"
+    _(birthday["mode"]).must_equal "NULLABLE"
 
     alts = json.find { |record| record["name"] == "alts" }
-    alts["type"].must_equal "RECORD"
-    alts["mode"].must_equal "REPEATED"
+    _(alts["type"]).must_equal "RECORD"
+    _(alts["mode"]).must_equal "REPEATED"
 
     age = alts["fields"].find { |record| record["name"] == "age"}
-    age["type"].must_equal "INT64"
-    age["mode"].must_be :nil?
+    _(age["type"]).must_equal "INT64"
+    _(age["mode"]).must_be :nil?
 
     score = alts["fields"].find { |record| record["name"] == "score"}
-    score["type"].must_equal "FLOAT64"
-    score["mode"].must_be :nil?
+    _(score["type"]).must_equal "FLOAT64"
+    _(score["mode"]).must_be :nil?
 
     active = alts["fields"].find { |record| record["name"] == "active"}
-    active["type"].must_equal "BOOL"
-    active["mode"].must_be :nil?
+    _(active["type"]).must_equal "BOOL"
+    _(active["mode"]).must_be :nil?
 
     alt = alts["fields"].find { |record| record["name"] == "alt"}
-    alt["type"].must_equal "STRUCT"
-    alt["mode"].must_be :nil?
+    _(alt["type"]).must_equal "STRUCT"
+    _(alt["mode"]).must_be :nil?
 
     name = alt["fields"].find { |record| record["name"] == "name"}
-    name["type"].must_equal "STRING"
-    name["mode"].must_be :nil?
+    _(name["type"]).must_equal "STRING"
+    _(name["mode"]).must_be :nil?
   end
 
   it "can dump the schema as JSON to a filename" do
@@ -608,79 +608,79 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
         file.delete
       end
     end
-    json.length.must_equal 11
+    _(json.length).must_equal 11
 
     name = json.find { |record| record["name"] == "name" }
-    name["type"].must_equal "STRING"
-    name["mode"].must_equal "REQUIRED"
+    _(name["type"]).must_equal "STRING"
+    _(name["mode"]).must_equal "REQUIRED"
 
     age = json.find { |record| record["name"] == "age" }
-    age["type"].must_equal "INTEGER"
-    age["mode"].must_equal "NULLABLE"
+    _(age["type"]).must_equal "INTEGER"
+    _(age["mode"]).must_equal "NULLABLE"
 
     score = json.find { |record| record["name"] == "score" }
-    score["type"].must_equal "FLOAT"
-    score["mode"].must_equal "NULLABLE"
+    _(score["type"]).must_equal "FLOAT"
+    _(score["mode"]).must_equal "NULLABLE"
 
     score = json.find { |record| record["name"] == "pi" }
-    score["type"].must_equal "NUMERIC"
-    score["mode"].must_equal "NULLABLE"
+    _(score["type"]).must_equal "NUMERIC"
+    _(score["mode"]).must_equal "NULLABLE"
 
     active = json.find { |record| record["name"] == "active" }
-    active["type"].must_equal "BOOLEAN"
-    active["mode"].must_equal "NULLABLE"
+    _(active["type"]).must_equal "BOOLEAN"
+    _(active["mode"]).must_equal "NULLABLE"
 
     avatar = json.find { |record| record["name"] == "avatar" }
-    avatar["type"].must_equal "BYTES"
-    avatar["mode"].must_equal "NULLABLE"
+    _(avatar["type"]).must_equal "BYTES"
+    _(avatar["mode"]).must_equal "NULLABLE"
 
     started_at = json.find { |record| record["name"] == "started_at" }
-    started_at["type"].must_equal "TIMESTAMP"
-    started_at["mode"].must_equal "NULLABLE"
+    _(started_at["type"]).must_equal "TIMESTAMP"
+    _(started_at["mode"]).must_equal "NULLABLE"
 
     duration = json.find { |record| record["name"] == "duration" }
-    duration["type"].must_equal "TIME"
-    duration["mode"].must_equal "NULLABLE"
+    _(duration["type"]).must_equal "TIME"
+    _(duration["mode"]).must_equal "NULLABLE"
 
     target_end = json.find { |record| record["name"] == "target_end" }
-    target_end["type"].must_equal "DATETIME"
-    target_end["mode"].must_equal "NULLABLE"
+    _(target_end["type"]).must_equal "DATETIME"
+    _(target_end["mode"]).must_equal "NULLABLE"
 
     birthday = json.find { |record| record["name"] == "birthday" }
-    birthday["type"].must_equal "DATE"
-    birthday["mode"].must_equal "NULLABLE"
+    _(birthday["type"]).must_equal "DATE"
+    _(birthday["mode"]).must_equal "NULLABLE"
 
     alts = json.find { |record| record["name"] == "alts" }
-    alts["type"].must_equal "RECORD"
-    alts["mode"].must_equal "REPEATED"
+    _(alts["type"]).must_equal "RECORD"
+    _(alts["mode"]).must_equal "REPEATED"
 
     age = alts["fields"].find { |record| record["name"] == "age"}
-    age["type"].must_equal "INT64"
-    age["mode"].must_be :nil?
+    _(age["type"]).must_equal "INT64"
+    _(age["mode"]).must_be :nil?
 
     score = alts["fields"].find { |record| record["name"] == "score"}
-    score["type"].must_equal "FLOAT64"
-    score["mode"].must_be :nil?
+    _(score["type"]).must_equal "FLOAT64"
+    _(score["mode"]).must_be :nil?
 
     active = alts["fields"].find { |record| record["name"] == "active"}
-    active["type"].must_equal "BOOL"
-    active["mode"].must_be :nil?
+    _(active["type"]).must_equal "BOOL"
+    _(active["mode"]).must_be :nil?
 
     alt = alts["fields"].find { |record| record["name"] == "alt"}
-    alt["type"].must_equal "STRUCT"
-    alt["mode"].must_be :nil?
+    _(alt["type"]).must_equal "STRUCT"
+    _(alt["mode"]).must_be :nil?
 
     name = alt["fields"].find { |record| record["name"] == "name"}
-    name["type"].must_equal "STRING"
-    name["mode"].must_be :nil?
+    _(name["type"]).must_equal "STRING"
+    _(name["mode"]).must_be :nil?
   end
 
   it "can load a schema with the class method" do
     io = StringIO.new(kittens_schema_json)
     schema = Google::Cloud::Bigquery::Schema.load io
 
-    schema.wont_be :empty?
-    schema.fields.map(&:name).must_equal %w[id breed name dob features]
+    _(schema).wont_be :empty?
+    _(schema.fields.map(&:name)).must_equal %w[id breed name dob features]
   end
 
   it "can dump a schema with the class method" do
@@ -696,10 +696,10 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
         file.delete
       end
     end
-    json.length.must_equal 11
+    _(json.length).must_equal 11
 
     fields = json.map { |record| record["name"] }
-    fields.wont_be :empty?
-    fields.must_equal %w[name age score pi active avatar started_at duration target_end birthday alts]
+    _(fields).wont_be :empty?
+    _(fields).must_equal %w[name age score pi active avatar started_at duration target_end birthday alts]
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/service_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/service_test.rb
@@ -28,79 +28,79 @@ describe Google::Cloud::Bigquery::Service do
 
   it "returns table ref from standard sql format with project, dataset, table and no default ref" do
     table_ref = Service.table_ref_from_s "#{project_id}.#{dataset_id}.#{table_id}"
-    table_ref.must_be_kind_of Google::Apis::BigqueryV2::TableReference
-    table_ref.project_id.must_equal project_id
-    table_ref.dataset_id.must_equal dataset_id
-    table_ref.table_id.must_equal table_id
+    _(table_ref).must_be_kind_of Google::Apis::BigqueryV2::TableReference
+    _(table_ref.project_id).must_equal project_id
+    _(table_ref.dataset_id).must_equal dataset_id
+    _(table_ref.table_id).must_equal table_id
   end
 
   it "returns table ref from legacy sql format with project, dataset, table and no default ref" do
     table_ref = Service.table_ref_from_s "#{project_id}:#{dataset_id}.#{table_id}"
-    table_ref.project_id.must_equal project_id
-    table_ref.dataset_id.must_equal dataset_id
-    table_ref.table_id.must_equal table_id
+    _(table_ref.project_id).must_equal project_id
+    _(table_ref.dataset_id).must_equal dataset_id
+    _(table_ref.table_id).must_equal table_id
   end
 
   it "returns table ref from standard sql format with project, dataset, table and project default ref" do
     table_ref = Service.table_ref_from_s "#{project_id}.#{dataset_id}.#{table_id}", default_ref: project_default_ref
-    table_ref.project_id.must_equal project_id
-    table_ref.dataset_id.must_equal dataset_id
-    table_ref.table_id.must_equal table_id
+    _(table_ref.project_id).must_equal project_id
+    _(table_ref.dataset_id).must_equal dataset_id
+    _(table_ref.table_id).must_equal table_id
   end
 
   it "returns table ref from standard sql format with project, dataset, table and dataset default ref" do
     table_ref = Service.table_ref_from_s "#{project_id}.#{dataset_id}.#{table_id}", default_ref: dataset_default_ref
-    table_ref.project_id.must_equal project_id
-    table_ref.dataset_id.must_equal dataset_id
-    table_ref.table_id.must_equal table_id
+    _(table_ref.project_id).must_equal project_id
+    _(table_ref.dataset_id).must_equal dataset_id
+    _(table_ref.table_id).must_equal table_id
   end
 
   it "returns table ref from standard sql format with project, dataset, table and table default ref" do
     table_ref = Service.table_ref_from_s "#{project_id}.#{dataset_id}.#{table_id}", default_ref: table_default_ref
-    table_ref.project_id.must_equal project_id
-    table_ref.dataset_id.must_equal dataset_id
-    table_ref.table_id.must_equal table_id
+    _(table_ref.project_id).must_equal project_id
+    _(table_ref.dataset_id).must_equal dataset_id
+    _(table_ref.table_id).must_equal table_id
   end
 
   it "returns table ref from standard sql format with dataset, table and project default ref" do
     table_ref = Service.table_ref_from_s "#{dataset_id}.#{table_id}", default_ref: project_default_ref
-    table_ref.project_id.must_equal project_id_default
-    table_ref.dataset_id.must_equal dataset_id
-    table_ref.table_id.must_equal table_id
+    _(table_ref.project_id).must_equal project_id_default
+    _(table_ref.dataset_id).must_equal dataset_id
+    _(table_ref.table_id).must_equal table_id
   end
 
   it "returns table ref from standard sql format with dataset, table and dataset default ref" do
     table_ref = Service.table_ref_from_s "#{dataset_id}.#{table_id}", default_ref: dataset_default_ref
-    table_ref.project_id.must_equal project_id_default
-    table_ref.dataset_id.must_equal dataset_id
-    table_ref.table_id.must_equal table_id
+    _(table_ref.project_id).must_equal project_id_default
+    _(table_ref.dataset_id).must_equal dataset_id
+    _(table_ref.table_id).must_equal table_id
   end
 
   it "returns table ref from standard sql format with dataset, table and table default ref" do
     table_ref = Service.table_ref_from_s "#{dataset_id}.#{table_id}", default_ref: table_default_ref
-    table_ref.project_id.must_equal project_id_default
-    table_ref.dataset_id.must_equal dataset_id
-    table_ref.table_id.must_equal table_id
+    _(table_ref.project_id).must_equal project_id_default
+    _(table_ref.dataset_id).must_equal dataset_id
+    _(table_ref.table_id).must_equal table_id
   end
 
   it "raises from standard sql format with table and project default ref" do
     err = expect do
       Service.table_ref_from_s table_id, default_ref: project_default_ref
     end.must_raise ArgumentError
-    err.message.must_equal "TableReference is missing dataset_id"
+    _(err.message).must_equal "TableReference is missing dataset_id"
   end
 
   it "returns table ref from standard sql format with table and dataset default ref" do
     table_ref = Service.table_ref_from_s table_id, default_ref: dataset_default_ref
-    table_ref.project_id.must_equal project_id_default
-    table_ref.dataset_id.must_equal dataset_id_default
-    table_ref.table_id.must_equal table_id
+    _(table_ref.project_id).must_equal project_id_default
+    _(table_ref.dataset_id).must_equal dataset_id_default
+    _(table_ref.table_id).must_equal table_id
   end
 
   it "returns table ref from standard sql format with table and table default ref" do
     table_ref = Service.table_ref_from_s table_id, default_ref: table_default_ref
-    table_ref.project_id.must_equal project_id_default
-    table_ref.dataset_id.must_equal dataset_id_default
-    table_ref.table_id.must_equal table_id
+    _(table_ref.project_id).must_equal project_id_default
+    _(table_ref.dataset_id).must_equal dataset_id_default
+    _(table_ref.table_id).must_equal table_id
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/standard_sql/array_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/standard_sql/array_test.rb
@@ -18,309 +18,309 @@ describe Google::Cloud::Bigquery::StandardSql, :array do
   it "represents a INT64 Array field" do
     field = array_field "int_array_col", "INT64"
 
-    field.name.must_equal "int_array_col"
+    _(field.name).must_equal "int_array_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "ARRAY"
-    field.type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.array_element_type.type_kind.must_equal "INT64"
-    field.type.array_element_type.array_element_type.must_be_nil
-    field.type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "ARRAY"
+    _(field.type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.array_element_type.type_kind).must_equal "INT64"
+    _(field.type.array_element_type.array_element_type).must_be_nil
+    _(field.type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.must_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).must_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a FLOAT64 Array field" do
     field = array_field "float_array_col", "FLOAT64"
 
-    field.name.must_equal "float_array_col"
+    _(field.name).must_equal "float_array_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "ARRAY"
-    field.type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.array_element_type.type_kind.must_equal "FLOAT64"
-    field.type.array_element_type.array_element_type.must_be_nil
-    field.type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "ARRAY"
+    _(field.type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.array_element_type.type_kind).must_equal "FLOAT64"
+    _(field.type.array_element_type.array_element_type).must_be_nil
+    _(field.type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.must_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).must_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a NUMERIC Array field" do
     field = array_field "num_array_col", "NUMERIC"
 
-    field.name.must_equal "num_array_col"
+    _(field.name).must_equal "num_array_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "ARRAY"
-    field.type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.array_element_type.type_kind.must_equal "NUMERIC"
-    field.type.array_element_type.array_element_type.must_be_nil
-    field.type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "ARRAY"
+    _(field.type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.array_element_type.type_kind).must_equal "NUMERIC"
+    _(field.type.array_element_type.array_element_type).must_be_nil
+    _(field.type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.must_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).must_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a BOOL Array field" do
     field = array_field "bool_array_col", "BOOL"
 
-    field.name.must_equal "bool_array_col"
+    _(field.name).must_equal "bool_array_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "ARRAY"
-    field.type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.array_element_type.type_kind.must_equal "BOOL"
-    field.type.array_element_type.array_element_type.must_be_nil
-    field.type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "ARRAY"
+    _(field.type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.array_element_type.type_kind).must_equal "BOOL"
+    _(field.type.array_element_type.array_element_type).must_be_nil
+    _(field.type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.must_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).must_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a STRING Array field" do
     field = array_field "str_array_col", "STRING"
 
-    field.name.must_equal "str_array_col"
+    _(field.name).must_equal "str_array_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "ARRAY"
-    field.type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.array_element_type.type_kind.must_equal "STRING"
-    field.type.array_element_type.array_element_type.must_be_nil
-    field.type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "ARRAY"
+    _(field.type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.array_element_type.type_kind).must_equal "STRING"
+    _(field.type.array_element_type.array_element_type).must_be_nil
+    _(field.type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.must_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).must_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a BYTES Array field" do
     field = array_field "bytes_array_col", "BYTES"
 
-    field.name.must_equal "bytes_array_col"
+    _(field.name).must_equal "bytes_array_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "ARRAY"
-    field.type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.array_element_type.type_kind.must_equal "BYTES"
-    field.type.array_element_type.array_element_type.must_be_nil
-    field.type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "ARRAY"
+    _(field.type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.array_element_type.type_kind).must_equal "BYTES"
+    _(field.type.array_element_type.array_element_type).must_be_nil
+    _(field.type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.must_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).must_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a DATE Array field" do
     field = array_field "date_array_col", "DATE"
 
-    field.name.must_equal "date_array_col"
+    _(field.name).must_equal "date_array_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "ARRAY"
-    field.type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.array_element_type.type_kind.must_equal "DATE"
-    field.type.array_element_type.array_element_type.must_be_nil
-    field.type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "ARRAY"
+    _(field.type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.array_element_type.type_kind).must_equal "DATE"
+    _(field.type.array_element_type.array_element_type).must_be_nil
+    _(field.type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.must_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).must_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a DATETIME Array field" do
     field = array_field "datetime_array_col", "DATETIME"
 
-    field.name.must_equal "datetime_array_col"
+    _(field.name).must_equal "datetime_array_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "ARRAY"
-    field.type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.array_element_type.type_kind.must_equal "DATETIME"
-    field.type.array_element_type.array_element_type.must_be_nil
-    field.type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "ARRAY"
+    _(field.type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.array_element_type.type_kind).must_equal "DATETIME"
+    _(field.type.array_element_type.array_element_type).must_be_nil
+    _(field.type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.must_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).must_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a GEOGRAPHY Array field" do
     field = array_field "geo_array_col", "GEOGRAPHY"
 
-    field.name.must_equal "geo_array_col"
+    _(field.name).must_equal "geo_array_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "ARRAY"
-    field.type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.array_element_type.type_kind.must_equal "GEOGRAPHY"
-    field.type.array_element_type.array_element_type.must_be_nil
-    field.type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "ARRAY"
+    _(field.type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.array_element_type.type_kind).must_equal "GEOGRAPHY"
+    _(field.type.array_element_type.array_element_type).must_be_nil
+    _(field.type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.must_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).must_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a TIME Array field" do
     field = array_field "time_array_col", "TIME"
 
-    field.name.must_equal "time_array_col"
+    _(field.name).must_equal "time_array_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "ARRAY"
-    field.type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.array_element_type.type_kind.must_equal "TIME"
-    field.type.array_element_type.array_element_type.must_be_nil
-    field.type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "ARRAY"
+    _(field.type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.array_element_type.type_kind).must_equal "TIME"
+    _(field.type.array_element_type.array_element_type).must_be_nil
+    _(field.type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.must_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).must_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a TIMESTAMP Array field" do
     field = array_field "ts_array_col", "TIMESTAMP"
 
-    field.name.must_equal "ts_array_col"
+    _(field.name).must_equal "ts_array_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "ARRAY"
-    field.type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.array_element_type.type_kind.must_equal "TIMESTAMP"
-    field.type.array_element_type.array_element_type.must_be_nil
-    field.type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "ARRAY"
+    _(field.type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.array_element_type.type_kind).must_equal "TIMESTAMP"
+    _(field.type.array_element_type.array_element_type).must_be_nil
+    _(field.type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.must_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).must_be :array?
+    _(field.type).wont_be :struct?
   end
 
   def array_field name, type_kind

--- a/google-cloud-bigquery/test/google/cloud/bigquery/standard_sql/struct_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/standard_sql/struct_test.rb
@@ -22,49 +22,49 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     struct_data_type = Google::Cloud::Bigquery::StandardSql::DataType.new type_kind: "STRUCT", struct_type: struct_type
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "struct_col", type: struct_data_type
 
-    field.name.must_equal "struct_col"
+    _(field.name).must_equal "struct_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "STRUCT"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.wont_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "STRUCT"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).wont_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.must_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).must_be :struct?
 
-    field.type.struct_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
-    field.type.struct_type.fields.count.must_equal 1
+    _(field.type.struct_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
+    _(field.type.struct_type.fields.count).must_equal 1
 
-    field.type.struct_type.fields[0].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[0].name.must_equal "int_col"
-    field.type.struct_type.fields[0].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[0].type.type_kind.must_equal "INT64"
-    field.type.struct_type.fields[0].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[0].type.struct_type.must_be_nil
-    field.type.struct_type.fields[0].type.must_be :int?
-    field.type.struct_type.fields[0].type.wont_be :float?
-    field.type.struct_type.fields[0].type.wont_be :numeric?
-    field.type.struct_type.fields[0].type.wont_be :boolean?
-    field.type.struct_type.fields[0].type.wont_be :string?
-    field.type.struct_type.fields[0].type.wont_be :bytes?
-    field.type.struct_type.fields[0].type.wont_be :date?
-    field.type.struct_type.fields[0].type.wont_be :datetime?
-    field.type.struct_type.fields[0].type.wont_be :geography?
-    field.type.struct_type.fields[0].type.wont_be :time?
-    field.type.struct_type.fields[0].type.wont_be :timestamp?
-    field.type.struct_type.fields[0].type.wont_be :array?
-    field.type.struct_type.fields[0].type.wont_be :struct?
+    _(field.type.struct_type.fields[0]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[0].name).must_equal "int_col"
+    _(field.type.struct_type.fields[0].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[0].type.type_kind).must_equal "INT64"
+    _(field.type.struct_type.fields[0].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[0].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[0].type).must_be :int?
+    _(field.type.struct_type.fields[0].type).wont_be :float?
+    _(field.type.struct_type.fields[0].type).wont_be :numeric?
+    _(field.type.struct_type.fields[0].type).wont_be :boolean?
+    _(field.type.struct_type.fields[0].type).wont_be :string?
+    _(field.type.struct_type.fields[0].type).wont_be :bytes?
+    _(field.type.struct_type.fields[0].type).wont_be :date?
+    _(field.type.struct_type.fields[0].type).wont_be :datetime?
+    _(field.type.struct_type.fields[0].type).wont_be :geography?
+    _(field.type.struct_type.fields[0].type).wont_be :time?
+    _(field.type.struct_type.fields[0].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[0].type).wont_be :array?
+    _(field.type.struct_type.fields[0].type).wont_be :struct?
   end
 
   it "represents an anonymous STRUCT field (missing)" do
@@ -74,49 +74,49 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     struct_data_type = Google::Cloud::Bigquery::StandardSql::DataType.new type_kind: "STRUCT", struct_type: struct_type
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "struct_col", type: struct_data_type
 
-    field.name.must_equal "struct_col"
+    _(field.name).must_equal "struct_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "STRUCT"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.wont_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "STRUCT"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).wont_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.must_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).must_be :struct?
 
-    field.type.struct_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
-    field.type.struct_type.fields.count.must_equal 1
+    _(field.type.struct_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
+    _(field.type.struct_type.fields.count).must_equal 1
 
-    field.type.struct_type.fields[0].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[0].name.must_be_nil
-    field.type.struct_type.fields[0].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[0].type.type_kind.must_equal "INT64"
-    field.type.struct_type.fields[0].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[0].type.struct_type.must_be_nil
-    field.type.struct_type.fields[0].type.must_be :int?
-    field.type.struct_type.fields[0].type.wont_be :float?
-    field.type.struct_type.fields[0].type.wont_be :numeric?
-    field.type.struct_type.fields[0].type.wont_be :boolean?
-    field.type.struct_type.fields[0].type.wont_be :string?
-    field.type.struct_type.fields[0].type.wont_be :bytes?
-    field.type.struct_type.fields[0].type.wont_be :date?
-    field.type.struct_type.fields[0].type.wont_be :datetime?
-    field.type.struct_type.fields[0].type.wont_be :geography?
-    field.type.struct_type.fields[0].type.wont_be :time?
-    field.type.struct_type.fields[0].type.wont_be :timestamp?
-    field.type.struct_type.fields[0].type.wont_be :array?
-    field.type.struct_type.fields[0].type.wont_be :struct?
+    _(field.type.struct_type.fields[0]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[0].name).must_be_nil
+    _(field.type.struct_type.fields[0].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[0].type.type_kind).must_equal "INT64"
+    _(field.type.struct_type.fields[0].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[0].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[0].type).must_be :int?
+    _(field.type.struct_type.fields[0].type).wont_be :float?
+    _(field.type.struct_type.fields[0].type).wont_be :numeric?
+    _(field.type.struct_type.fields[0].type).wont_be :boolean?
+    _(field.type.struct_type.fields[0].type).wont_be :string?
+    _(field.type.struct_type.fields[0].type).wont_be :bytes?
+    _(field.type.struct_type.fields[0].type).wont_be :date?
+    _(field.type.struct_type.fields[0].type).wont_be :datetime?
+    _(field.type.struct_type.fields[0].type).wont_be :geography?
+    _(field.type.struct_type.fields[0].type).wont_be :time?
+    _(field.type.struct_type.fields[0].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[0].type).wont_be :array?
+    _(field.type.struct_type.fields[0].type).wont_be :struct?
   end
 
   it "represents an anonymous STRUCT field (empty)" do
@@ -126,49 +126,49 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     struct_data_type = Google::Cloud::Bigquery::StandardSql::DataType.new type_kind: "STRUCT", struct_type: struct_type
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "struct_col", type: struct_data_type
 
-    field.name.must_equal "struct_col"
+    _(field.name).must_equal "struct_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "STRUCT"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.wont_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "STRUCT"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).wont_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.must_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).must_be :struct?
 
-    field.type.struct_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
-    field.type.struct_type.fields.count.must_equal 1
+    _(field.type.struct_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
+    _(field.type.struct_type.fields.count).must_equal 1
 
-    field.type.struct_type.fields[0].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[0].name.must_be_nil
-    field.type.struct_type.fields[0].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[0].type.type_kind.must_equal "INT64"
-    field.type.struct_type.fields[0].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[0].type.struct_type.must_be_nil
-    field.type.struct_type.fields[0].type.must_be :int?
-    field.type.struct_type.fields[0].type.wont_be :float?
-    field.type.struct_type.fields[0].type.wont_be :numeric?
-    field.type.struct_type.fields[0].type.wont_be :boolean?
-    field.type.struct_type.fields[0].type.wont_be :string?
-    field.type.struct_type.fields[0].type.wont_be :bytes?
-    field.type.struct_type.fields[0].type.wont_be :date?
-    field.type.struct_type.fields[0].type.wont_be :datetime?
-    field.type.struct_type.fields[0].type.wont_be :geography?
-    field.type.struct_type.fields[0].type.wont_be :time?
-    field.type.struct_type.fields[0].type.wont_be :timestamp?
-    field.type.struct_type.fields[0].type.wont_be :array?
-    field.type.struct_type.fields[0].type.wont_be :struct?
+    _(field.type.struct_type.fields[0]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[0].name).must_be_nil
+    _(field.type.struct_type.fields[0].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[0].type.type_kind).must_equal "INT64"
+    _(field.type.struct_type.fields[0].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[0].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[0].type).must_be :int?
+    _(field.type.struct_type.fields[0].type).wont_be :float?
+    _(field.type.struct_type.fields[0].type).wont_be :numeric?
+    _(field.type.struct_type.fields[0].type).wont_be :boolean?
+    _(field.type.struct_type.fields[0].type).wont_be :string?
+    _(field.type.struct_type.fields[0].type).wont_be :bytes?
+    _(field.type.struct_type.fields[0].type).wont_be :date?
+    _(field.type.struct_type.fields[0].type).wont_be :datetime?
+    _(field.type.struct_type.fields[0].type).wont_be :geography?
+    _(field.type.struct_type.fields[0].type).wont_be :time?
+    _(field.type.struct_type.fields[0].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[0].type).wont_be :array?
+    _(field.type.struct_type.fields[0].type).wont_be :struct?
   end
 
   it "represents an emtpy STRUCT field" do
@@ -176,29 +176,29 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     struct_data_type = Google::Cloud::Bigquery::StandardSql::DataType.new type_kind: "STRUCT", struct_type: struct_type
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "struct_col", type: struct_data_type
 
-    field.name.must_equal "struct_col"
+    _(field.name).must_equal "struct_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "STRUCT"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.wont_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "STRUCT"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).wont_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.must_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).must_be :struct?
 
-    field.type.struct_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
-    field.type.struct_type.fields.count.must_equal 0
+    _(field.type.struct_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
+    _(field.type.struct_type.fields.count).must_equal 0
   end
 
   it "represents nested STRUCT fields" do
@@ -212,69 +212,69 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     struct_data_type = Google::Cloud::Bigquery::StandardSql::DataType.new type_kind: "STRUCT", struct_type: struct_type
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "struct_col", type: struct_data_type
 
-    field.name.must_equal "struct_col"
+    _(field.name).must_equal "struct_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "STRUCT"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.wont_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "STRUCT"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).wont_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.must_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).must_be :struct?
 
-    field.type.struct_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
-    field.type.struct_type.fields.count.must_equal 1
+    _(field.type.struct_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
+    _(field.type.struct_type.fields.count).must_equal 1
 
-    field.type.struct_type.fields[0].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[0].name.must_equal "nested_col"
-    field.type.struct_type.fields[0].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[0].type.type_kind.must_equal "STRUCT"
-    field.type.struct_type.fields[0].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[0].type.struct_type.wont_be_nil
-    field.type.struct_type.fields[0].type.wont_be :int?
-    field.type.struct_type.fields[0].type.wont_be :float?
-    field.type.struct_type.fields[0].type.wont_be :numeric?
-    field.type.struct_type.fields[0].type.wont_be :boolean?
-    field.type.struct_type.fields[0].type.wont_be :string?
-    field.type.struct_type.fields[0].type.wont_be :bytes?
-    field.type.struct_type.fields[0].type.wont_be :date?
-    field.type.struct_type.fields[0].type.wont_be :datetime?
-    field.type.struct_type.fields[0].type.wont_be :geography?
-    field.type.struct_type.fields[0].type.wont_be :time?
-    field.type.struct_type.fields[0].type.wont_be :timestamp?
-    field.type.struct_type.fields[0].type.wont_be :array?
-    field.type.struct_type.fields[0].type.must_be :struct?
+    _(field.type.struct_type.fields[0]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[0].name).must_equal "nested_col"
+    _(field.type.struct_type.fields[0].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[0].type.type_kind).must_equal "STRUCT"
+    _(field.type.struct_type.fields[0].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[0].type.struct_type).wont_be_nil
+    _(field.type.struct_type.fields[0].type).wont_be :int?
+    _(field.type.struct_type.fields[0].type).wont_be :float?
+    _(field.type.struct_type.fields[0].type).wont_be :numeric?
+    _(field.type.struct_type.fields[0].type).wont_be :boolean?
+    _(field.type.struct_type.fields[0].type).wont_be :string?
+    _(field.type.struct_type.fields[0].type).wont_be :bytes?
+    _(field.type.struct_type.fields[0].type).wont_be :date?
+    _(field.type.struct_type.fields[0].type).wont_be :datetime?
+    _(field.type.struct_type.fields[0].type).wont_be :geography?
+    _(field.type.struct_type.fields[0].type).wont_be :time?
+    _(field.type.struct_type.fields[0].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[0].type).wont_be :array?
+    _(field.type.struct_type.fields[0].type).must_be :struct?
 
-    field.type.struct_type.fields[0].type.struct_type.fields[0].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[0].type.struct_type.fields[0].name.must_equal "int_col"
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.type_kind.must_equal "INT64"
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.struct_type.must_be_nil
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.must_be :int?
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.wont_be :float?
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.wont_be :numeric?
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.wont_be :boolean?
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.wont_be :string?
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.wont_be :bytes?
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.wont_be :date?
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.wont_be :datetime?
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.wont_be :geography?
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.wont_be :time?
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.wont_be :timestamp?
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.wont_be :array?
-    field.type.struct_type.fields[0].type.struct_type.fields[0].type.wont_be :struct?
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].name).must_equal "int_col"
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type.type_kind).must_equal "INT64"
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).must_be :int?
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :float?
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :numeric?
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :boolean?
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :string?
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :bytes?
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :date?
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :datetime?
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :geography?
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :time?
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :array?
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :struct?
   end
 
   it "represents all types of value fields" do
@@ -296,249 +296,249 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     struct_data_type = Google::Cloud::Bigquery::StandardSql::DataType.new type_kind: "STRUCT", struct_type: struct_type
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "struct_col", type: struct_data_type
 
-    field.name.must_equal "struct_col"
+    _(field.name).must_equal "struct_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "STRUCT"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.wont_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "STRUCT"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).wont_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.must_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).must_be :struct?
 
-    field.type.struct_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
-    field.type.struct_type.fields.count.must_equal 11
+    _(field.type.struct_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
+    _(field.type.struct_type.fields.count).must_equal 11
 
-    field.type.struct_type.fields[0].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[0].name.must_equal "int_col"
-    field.type.struct_type.fields[0].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[0].type.type_kind.must_equal "INT64"
-    field.type.struct_type.fields[0].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[0].type.struct_type.must_be_nil
-    field.type.struct_type.fields[0].type.must_be :int?
-    field.type.struct_type.fields[0].type.wont_be :float?
-    field.type.struct_type.fields[0].type.wont_be :numeric?
-    field.type.struct_type.fields[0].type.wont_be :boolean?
-    field.type.struct_type.fields[0].type.wont_be :string?
-    field.type.struct_type.fields[0].type.wont_be :bytes?
-    field.type.struct_type.fields[0].type.wont_be :date?
-    field.type.struct_type.fields[0].type.wont_be :datetime?
-    field.type.struct_type.fields[0].type.wont_be :geography?
-    field.type.struct_type.fields[0].type.wont_be :time?
-    field.type.struct_type.fields[0].type.wont_be :timestamp?
-    field.type.struct_type.fields[0].type.wont_be :array?
-    field.type.struct_type.fields[0].type.wont_be :struct?
+    _(field.type.struct_type.fields[0]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[0].name).must_equal "int_col"
+    _(field.type.struct_type.fields[0].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[0].type.type_kind).must_equal "INT64"
+    _(field.type.struct_type.fields[0].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[0].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[0].type).must_be :int?
+    _(field.type.struct_type.fields[0].type).wont_be :float?
+    _(field.type.struct_type.fields[0].type).wont_be :numeric?
+    _(field.type.struct_type.fields[0].type).wont_be :boolean?
+    _(field.type.struct_type.fields[0].type).wont_be :string?
+    _(field.type.struct_type.fields[0].type).wont_be :bytes?
+    _(field.type.struct_type.fields[0].type).wont_be :date?
+    _(field.type.struct_type.fields[0].type).wont_be :datetime?
+    _(field.type.struct_type.fields[0].type).wont_be :geography?
+    _(field.type.struct_type.fields[0].type).wont_be :time?
+    _(field.type.struct_type.fields[0].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[0].type).wont_be :array?
+    _(field.type.struct_type.fields[0].type).wont_be :struct?
 
-    field.type.struct_type.fields[1].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[1].name.must_equal "float_col"
-    field.type.struct_type.fields[1].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[1].type.type_kind.must_equal "FLOAT64"
-    field.type.struct_type.fields[1].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[1].type.struct_type.must_be_nil
-    field.type.struct_type.fields[1].type.wont_be :int?
-    field.type.struct_type.fields[1].type.must_be :float?
-    field.type.struct_type.fields[1].type.wont_be :numeric?
-    field.type.struct_type.fields[1].type.wont_be :boolean?
-    field.type.struct_type.fields[1].type.wont_be :string?
-    field.type.struct_type.fields[1].type.wont_be :bytes?
-    field.type.struct_type.fields[1].type.wont_be :date?
-    field.type.struct_type.fields[1].type.wont_be :datetime?
-    field.type.struct_type.fields[1].type.wont_be :geography?
-    field.type.struct_type.fields[1].type.wont_be :time?
-    field.type.struct_type.fields[1].type.wont_be :timestamp?
-    field.type.struct_type.fields[1].type.wont_be :array?
-    field.type.struct_type.fields[1].type.wont_be :struct?
+    _(field.type.struct_type.fields[1]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[1].name).must_equal "float_col"
+    _(field.type.struct_type.fields[1].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[1].type.type_kind).must_equal "FLOAT64"
+    _(field.type.struct_type.fields[1].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[1].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[1].type).wont_be :int?
+    _(field.type.struct_type.fields[1].type).must_be :float?
+    _(field.type.struct_type.fields[1].type).wont_be :numeric?
+    _(field.type.struct_type.fields[1].type).wont_be :boolean?
+    _(field.type.struct_type.fields[1].type).wont_be :string?
+    _(field.type.struct_type.fields[1].type).wont_be :bytes?
+    _(field.type.struct_type.fields[1].type).wont_be :date?
+    _(field.type.struct_type.fields[1].type).wont_be :datetime?
+    _(field.type.struct_type.fields[1].type).wont_be :geography?
+    _(field.type.struct_type.fields[1].type).wont_be :time?
+    _(field.type.struct_type.fields[1].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[1].type).wont_be :array?
+    _(field.type.struct_type.fields[1].type).wont_be :struct?
 
-    field.type.struct_type.fields[2].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[2].name.must_equal "num_col"
-    field.type.struct_type.fields[2].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[2].type.type_kind.must_equal "NUMERIC"
-    field.type.struct_type.fields[2].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[2].type.struct_type.must_be_nil
-    field.type.struct_type.fields[2].type.wont_be :int?
-    field.type.struct_type.fields[2].type.wont_be :float?
-    field.type.struct_type.fields[2].type.must_be :numeric?
-    field.type.struct_type.fields[2].type.wont_be :boolean?
-    field.type.struct_type.fields[2].type.wont_be :string?
-    field.type.struct_type.fields[2].type.wont_be :bytes?
-    field.type.struct_type.fields[2].type.wont_be :date?
-    field.type.struct_type.fields[2].type.wont_be :datetime?
-    field.type.struct_type.fields[2].type.wont_be :geography?
-    field.type.struct_type.fields[2].type.wont_be :time?
-    field.type.struct_type.fields[2].type.wont_be :timestamp?
-    field.type.struct_type.fields[2].type.wont_be :array?
-    field.type.struct_type.fields[2].type.wont_be :struct?
+    _(field.type.struct_type.fields[2]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[2].name).must_equal "num_col"
+    _(field.type.struct_type.fields[2].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[2].type.type_kind).must_equal "NUMERIC"
+    _(field.type.struct_type.fields[2].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[2].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[2].type).wont_be :int?
+    _(field.type.struct_type.fields[2].type).wont_be :float?
+    _(field.type.struct_type.fields[2].type).must_be :numeric?
+    _(field.type.struct_type.fields[2].type).wont_be :boolean?
+    _(field.type.struct_type.fields[2].type).wont_be :string?
+    _(field.type.struct_type.fields[2].type).wont_be :bytes?
+    _(field.type.struct_type.fields[2].type).wont_be :date?
+    _(field.type.struct_type.fields[2].type).wont_be :datetime?
+    _(field.type.struct_type.fields[2].type).wont_be :geography?
+    _(field.type.struct_type.fields[2].type).wont_be :time?
+    _(field.type.struct_type.fields[2].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[2].type).wont_be :array?
+    _(field.type.struct_type.fields[2].type).wont_be :struct?
 
-    field.type.struct_type.fields[3].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[3].name.must_equal "bool_col"
-    field.type.struct_type.fields[3].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[3].type.type_kind.must_equal "BOOL"
-    field.type.struct_type.fields[3].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[3].type.struct_type.must_be_nil
-    field.type.struct_type.fields[3].type.wont_be :int?
-    field.type.struct_type.fields[3].type.wont_be :float?
-    field.type.struct_type.fields[3].type.wont_be :numeric?
-    field.type.struct_type.fields[3].type.must_be :boolean?
-    field.type.struct_type.fields[3].type.wont_be :string?
-    field.type.struct_type.fields[3].type.wont_be :bytes?
-    field.type.struct_type.fields[3].type.wont_be :date?
-    field.type.struct_type.fields[3].type.wont_be :datetime?
-    field.type.struct_type.fields[3].type.wont_be :geography?
-    field.type.struct_type.fields[3].type.wont_be :time?
-    field.type.struct_type.fields[3].type.wont_be :timestamp?
-    field.type.struct_type.fields[3].type.wont_be :array?
-    field.type.struct_type.fields[3].type.wont_be :struct?
+    _(field.type.struct_type.fields[3]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[3].name).must_equal "bool_col"
+    _(field.type.struct_type.fields[3].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[3].type.type_kind).must_equal "BOOL"
+    _(field.type.struct_type.fields[3].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[3].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[3].type).wont_be :int?
+    _(field.type.struct_type.fields[3].type).wont_be :float?
+    _(field.type.struct_type.fields[3].type).wont_be :numeric?
+    _(field.type.struct_type.fields[3].type).must_be :boolean?
+    _(field.type.struct_type.fields[3].type).wont_be :string?
+    _(field.type.struct_type.fields[3].type).wont_be :bytes?
+    _(field.type.struct_type.fields[3].type).wont_be :date?
+    _(field.type.struct_type.fields[3].type).wont_be :datetime?
+    _(field.type.struct_type.fields[3].type).wont_be :geography?
+    _(field.type.struct_type.fields[3].type).wont_be :time?
+    _(field.type.struct_type.fields[3].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[3].type).wont_be :array?
+    _(field.type.struct_type.fields[3].type).wont_be :struct?
 
-    field.type.struct_type.fields[4].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[4].name.must_equal "str_col"
-    field.type.struct_type.fields[4].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[4].type.type_kind.must_equal "STRING"
-    field.type.struct_type.fields[4].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[4].type.struct_type.must_be_nil
-    field.type.struct_type.fields[4].type.wont_be :int?
-    field.type.struct_type.fields[4].type.wont_be :float?
-    field.type.struct_type.fields[4].type.wont_be :numeric?
-    field.type.struct_type.fields[4].type.wont_be :boolean?
-    field.type.struct_type.fields[4].type.must_be :string?
-    field.type.struct_type.fields[4].type.wont_be :bytes?
-    field.type.struct_type.fields[4].type.wont_be :date?
-    field.type.struct_type.fields[4].type.wont_be :datetime?
-    field.type.struct_type.fields[4].type.wont_be :geography?
-    field.type.struct_type.fields[4].type.wont_be :time?
-    field.type.struct_type.fields[4].type.wont_be :timestamp?
-    field.type.struct_type.fields[4].type.wont_be :array?
-    field.type.struct_type.fields[4].type.wont_be :struct?
+    _(field.type.struct_type.fields[4]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[4].name).must_equal "str_col"
+    _(field.type.struct_type.fields[4].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[4].type.type_kind).must_equal "STRING"
+    _(field.type.struct_type.fields[4].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[4].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[4].type).wont_be :int?
+    _(field.type.struct_type.fields[4].type).wont_be :float?
+    _(field.type.struct_type.fields[4].type).wont_be :numeric?
+    _(field.type.struct_type.fields[4].type).wont_be :boolean?
+    _(field.type.struct_type.fields[4].type).must_be :string?
+    _(field.type.struct_type.fields[4].type).wont_be :bytes?
+    _(field.type.struct_type.fields[4].type).wont_be :date?
+    _(field.type.struct_type.fields[4].type).wont_be :datetime?
+    _(field.type.struct_type.fields[4].type).wont_be :geography?
+    _(field.type.struct_type.fields[4].type).wont_be :time?
+    _(field.type.struct_type.fields[4].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[4].type).wont_be :array?
+    _(field.type.struct_type.fields[4].type).wont_be :struct?
 
-    field.type.struct_type.fields[5].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[5].name.must_equal "bytes_col"
-    field.type.struct_type.fields[5].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[5].type.type_kind.must_equal "BYTES"
-    field.type.struct_type.fields[5].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[5].type.struct_type.must_be_nil
-    field.type.struct_type.fields[5].type.wont_be :int?
-    field.type.struct_type.fields[5].type.wont_be :float?
-    field.type.struct_type.fields[5].type.wont_be :numeric?
-    field.type.struct_type.fields[5].type.wont_be :boolean?
-    field.type.struct_type.fields[5].type.wont_be :string?
-    field.type.struct_type.fields[5].type.must_be :bytes?
-    field.type.struct_type.fields[5].type.wont_be :date?
-    field.type.struct_type.fields[5].type.wont_be :datetime?
-    field.type.struct_type.fields[5].type.wont_be :geography?
-    field.type.struct_type.fields[5].type.wont_be :time?
-    field.type.struct_type.fields[5].type.wont_be :timestamp?
-    field.type.struct_type.fields[5].type.wont_be :array?
-    field.type.struct_type.fields[5].type.wont_be :struct?
+    _(field.type.struct_type.fields[5]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[5].name).must_equal "bytes_col"
+    _(field.type.struct_type.fields[5].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[5].type.type_kind).must_equal "BYTES"
+    _(field.type.struct_type.fields[5].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[5].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[5].type).wont_be :int?
+    _(field.type.struct_type.fields[5].type).wont_be :float?
+    _(field.type.struct_type.fields[5].type).wont_be :numeric?
+    _(field.type.struct_type.fields[5].type).wont_be :boolean?
+    _(field.type.struct_type.fields[5].type).wont_be :string?
+    _(field.type.struct_type.fields[5].type).must_be :bytes?
+    _(field.type.struct_type.fields[5].type).wont_be :date?
+    _(field.type.struct_type.fields[5].type).wont_be :datetime?
+    _(field.type.struct_type.fields[5].type).wont_be :geography?
+    _(field.type.struct_type.fields[5].type).wont_be :time?
+    _(field.type.struct_type.fields[5].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[5].type).wont_be :array?
+    _(field.type.struct_type.fields[5].type).wont_be :struct?
 
-    field.type.struct_type.fields[6].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[6].name.must_equal "date_col"
-    field.type.struct_type.fields[6].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[6].type.type_kind.must_equal "DATE"
-    field.type.struct_type.fields[6].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[6].type.struct_type.must_be_nil
-    field.type.struct_type.fields[6].type.wont_be :int?
-    field.type.struct_type.fields[6].type.wont_be :float?
-    field.type.struct_type.fields[6].type.wont_be :numeric?
-    field.type.struct_type.fields[6].type.wont_be :boolean?
-    field.type.struct_type.fields[6].type.wont_be :string?
-    field.type.struct_type.fields[6].type.wont_be :bytes?
-    field.type.struct_type.fields[6].type.must_be :date?
-    field.type.struct_type.fields[6].type.wont_be :datetime?
-    field.type.struct_type.fields[6].type.wont_be :geography?
-    field.type.struct_type.fields[6].type.wont_be :time?
-    field.type.struct_type.fields[6].type.wont_be :timestamp?
-    field.type.struct_type.fields[6].type.wont_be :array?
-    field.type.struct_type.fields[6].type.wont_be :struct?
+    _(field.type.struct_type.fields[6]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[6].name).must_equal "date_col"
+    _(field.type.struct_type.fields[6].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[6].type.type_kind).must_equal "DATE"
+    _(field.type.struct_type.fields[6].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[6].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[6].type).wont_be :int?
+    _(field.type.struct_type.fields[6].type).wont_be :float?
+    _(field.type.struct_type.fields[6].type).wont_be :numeric?
+    _(field.type.struct_type.fields[6].type).wont_be :boolean?
+    _(field.type.struct_type.fields[6].type).wont_be :string?
+    _(field.type.struct_type.fields[6].type).wont_be :bytes?
+    _(field.type.struct_type.fields[6].type).must_be :date?
+    _(field.type.struct_type.fields[6].type).wont_be :datetime?
+    _(field.type.struct_type.fields[6].type).wont_be :geography?
+    _(field.type.struct_type.fields[6].type).wont_be :time?
+    _(field.type.struct_type.fields[6].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[6].type).wont_be :array?
+    _(field.type.struct_type.fields[6].type).wont_be :struct?
 
-    field.type.struct_type.fields[7].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[7].name.must_equal "datetime_col"
-    field.type.struct_type.fields[7].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[7].type.type_kind.must_equal "DATETIME"
-    field.type.struct_type.fields[7].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[7].type.struct_type.must_be_nil
-    field.type.struct_type.fields[7].type.wont_be :int?
-    field.type.struct_type.fields[7].type.wont_be :float?
-    field.type.struct_type.fields[7].type.wont_be :numeric?
-    field.type.struct_type.fields[7].type.wont_be :boolean?
-    field.type.struct_type.fields[7].type.wont_be :string?
-    field.type.struct_type.fields[7].type.wont_be :bytes?
-    field.type.struct_type.fields[7].type.wont_be :date?
-    field.type.struct_type.fields[7].type.must_be :datetime?
-    field.type.struct_type.fields[7].type.wont_be :geography?
-    field.type.struct_type.fields[7].type.wont_be :time?
-    field.type.struct_type.fields[7].type.wont_be :timestamp?
-    field.type.struct_type.fields[7].type.wont_be :array?
-    field.type.struct_type.fields[7].type.wont_be :struct?
+    _(field.type.struct_type.fields[7]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[7].name).must_equal "datetime_col"
+    _(field.type.struct_type.fields[7].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[7].type.type_kind).must_equal "DATETIME"
+    _(field.type.struct_type.fields[7].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[7].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[7].type).wont_be :int?
+    _(field.type.struct_type.fields[7].type).wont_be :float?
+    _(field.type.struct_type.fields[7].type).wont_be :numeric?
+    _(field.type.struct_type.fields[7].type).wont_be :boolean?
+    _(field.type.struct_type.fields[7].type).wont_be :string?
+    _(field.type.struct_type.fields[7].type).wont_be :bytes?
+    _(field.type.struct_type.fields[7].type).wont_be :date?
+    _(field.type.struct_type.fields[7].type).must_be :datetime?
+    _(field.type.struct_type.fields[7].type).wont_be :geography?
+    _(field.type.struct_type.fields[7].type).wont_be :time?
+    _(field.type.struct_type.fields[7].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[7].type).wont_be :array?
+    _(field.type.struct_type.fields[7].type).wont_be :struct?
 
-    field.type.struct_type.fields[8].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[8].name.must_equal "geo_col"
-    field.type.struct_type.fields[8].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[8].type.type_kind.must_equal "GEOGRAPHY"
-    field.type.struct_type.fields[8].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[8].type.struct_type.must_be_nil
-    field.type.struct_type.fields[8].type.wont_be :int?
-    field.type.struct_type.fields[8].type.wont_be :float?
-    field.type.struct_type.fields[8].type.wont_be :numeric?
-    field.type.struct_type.fields[8].type.wont_be :boolean?
-    field.type.struct_type.fields[8].type.wont_be :string?
-    field.type.struct_type.fields[8].type.wont_be :bytes?
-    field.type.struct_type.fields[8].type.wont_be :date?
-    field.type.struct_type.fields[8].type.wont_be :datetime?
-    field.type.struct_type.fields[8].type.must_be :geography?
-    field.type.struct_type.fields[8].type.wont_be :time?
-    field.type.struct_type.fields[8].type.wont_be :timestamp?
-    field.type.struct_type.fields[8].type.wont_be :array?
-    field.type.struct_type.fields[8].type.wont_be :struct?
+    _(field.type.struct_type.fields[8]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[8].name).must_equal "geo_col"
+    _(field.type.struct_type.fields[8].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[8].type.type_kind).must_equal "GEOGRAPHY"
+    _(field.type.struct_type.fields[8].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[8].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[8].type).wont_be :int?
+    _(field.type.struct_type.fields[8].type).wont_be :float?
+    _(field.type.struct_type.fields[8].type).wont_be :numeric?
+    _(field.type.struct_type.fields[8].type).wont_be :boolean?
+    _(field.type.struct_type.fields[8].type).wont_be :string?
+    _(field.type.struct_type.fields[8].type).wont_be :bytes?
+    _(field.type.struct_type.fields[8].type).wont_be :date?
+    _(field.type.struct_type.fields[8].type).wont_be :datetime?
+    _(field.type.struct_type.fields[8].type).must_be :geography?
+    _(field.type.struct_type.fields[8].type).wont_be :time?
+    _(field.type.struct_type.fields[8].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[8].type).wont_be :array?
+    _(field.type.struct_type.fields[8].type).wont_be :struct?
 
-    field.type.struct_type.fields[9].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[9].name.must_equal "time_col"
-    field.type.struct_type.fields[9].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[9].type.type_kind.must_equal "TIME"
-    field.type.struct_type.fields[9].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[9].type.struct_type.must_be_nil
-    field.type.struct_type.fields[9].type.wont_be :int?
-    field.type.struct_type.fields[9].type.wont_be :float?
-    field.type.struct_type.fields[9].type.wont_be :numeric?
-    field.type.struct_type.fields[9].type.wont_be :boolean?
-    field.type.struct_type.fields[9].type.wont_be :string?
-    field.type.struct_type.fields[9].type.wont_be :bytes?
-    field.type.struct_type.fields[9].type.wont_be :date?
-    field.type.struct_type.fields[9].type.wont_be :datetime?
-    field.type.struct_type.fields[9].type.wont_be :geography?
-    field.type.struct_type.fields[9].type.must_be :time?
-    field.type.struct_type.fields[9].type.wont_be :timestamp?
-    field.type.struct_type.fields[9].type.wont_be :array?
-    field.type.struct_type.fields[9].type.wont_be :struct?
+    _(field.type.struct_type.fields[9]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[9].name).must_equal "time_col"
+    _(field.type.struct_type.fields[9].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[9].type.type_kind).must_equal "TIME"
+    _(field.type.struct_type.fields[9].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[9].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[9].type).wont_be :int?
+    _(field.type.struct_type.fields[9].type).wont_be :float?
+    _(field.type.struct_type.fields[9].type).wont_be :numeric?
+    _(field.type.struct_type.fields[9].type).wont_be :boolean?
+    _(field.type.struct_type.fields[9].type).wont_be :string?
+    _(field.type.struct_type.fields[9].type).wont_be :bytes?
+    _(field.type.struct_type.fields[9].type).wont_be :date?
+    _(field.type.struct_type.fields[9].type).wont_be :datetime?
+    _(field.type.struct_type.fields[9].type).wont_be :geography?
+    _(field.type.struct_type.fields[9].type).must_be :time?
+    _(field.type.struct_type.fields[9].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[9].type).wont_be :array?
+    _(field.type.struct_type.fields[9].type).wont_be :struct?
 
-    field.type.struct_type.fields[10].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[10].name.must_equal "ts_col"
-    field.type.struct_type.fields[10].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[10].type.type_kind.must_equal "TIMESTAMP"
-    field.type.struct_type.fields[10].type.array_element_type.must_be_nil
-    field.type.struct_type.fields[10].type.struct_type.must_be_nil
-    field.type.struct_type.fields[10].type.wont_be :int?
-    field.type.struct_type.fields[10].type.wont_be :float?
-    field.type.struct_type.fields[10].type.wont_be :numeric?
-    field.type.struct_type.fields[10].type.wont_be :boolean?
-    field.type.struct_type.fields[10].type.wont_be :string?
-    field.type.struct_type.fields[10].type.wont_be :bytes?
-    field.type.struct_type.fields[10].type.wont_be :date?
-    field.type.struct_type.fields[10].type.wont_be :datetime?
-    field.type.struct_type.fields[10].type.wont_be :geography?
-    field.type.struct_type.fields[10].type.wont_be :time?
-    field.type.struct_type.fields[10].type.must_be :timestamp?
-    field.type.struct_type.fields[10].type.wont_be :array?
-    field.type.struct_type.fields[10].type.wont_be :struct?
+    _(field.type.struct_type.fields[10]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[10].name).must_equal "ts_col"
+    _(field.type.struct_type.fields[10].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[10].type.type_kind).must_equal "TIMESTAMP"
+    _(field.type.struct_type.fields[10].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[10].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[10].type).wont_be :int?
+    _(field.type.struct_type.fields[10].type).wont_be :float?
+    _(field.type.struct_type.fields[10].type).wont_be :numeric?
+    _(field.type.struct_type.fields[10].type).wont_be :boolean?
+    _(field.type.struct_type.fields[10].type).wont_be :string?
+    _(field.type.struct_type.fields[10].type).wont_be :bytes?
+    _(field.type.struct_type.fields[10].type).wont_be :date?
+    _(field.type.struct_type.fields[10].type).wont_be :datetime?
+    _(field.type.struct_type.fields[10].type).wont_be :geography?
+    _(field.type.struct_type.fields[10].type).wont_be :time?
+    _(field.type.struct_type.fields[10].type).must_be :timestamp?
+    _(field.type.struct_type.fields[10].type).wont_be :array?
+    _(field.type.struct_type.fields[10].type).wont_be :struct?
   end
 
   it "represents all types of array fields" do
@@ -560,282 +560,282 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     struct_data_type = Google::Cloud::Bigquery::StandardSql::DataType.new type_kind: "STRUCT", struct_type: struct_type
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "struct_col", type: struct_data_type
 
-    field.name.must_equal "struct_col"
+    _(field.name).must_equal "struct_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "STRUCT"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.wont_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "STRUCT"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).wont_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.must_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).must_be :struct?
 
-    field.type.struct_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
-    field.type.struct_type.fields.count.must_equal 11
+    _(field.type.struct_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
+    _(field.type.struct_type.fields.count).must_equal 11
 
-    field.type.struct_type.fields[0].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[0].name.must_equal "int_array_col"
-    field.type.struct_type.fields[0].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[0].type.type_kind.must_equal "ARRAY"
-    field.type.struct_type.fields[0].type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[0].type.array_element_type.type_kind.must_equal "INT64"
-    field.type.struct_type.fields[0].type.array_element_type.array_element_type.must_be_nil
-    field.type.struct_type.fields[0].type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.fields[0].type.struct_type.must_be_nil
-    field.type.struct_type.fields[0].type.wont_be :int?
-    field.type.struct_type.fields[0].type.wont_be :float?
-    field.type.struct_type.fields[0].type.wont_be :numeric?
-    field.type.struct_type.fields[0].type.wont_be :boolean?
-    field.type.struct_type.fields[0].type.wont_be :string?
-    field.type.struct_type.fields[0].type.wont_be :bytes?
-    field.type.struct_type.fields[0].type.wont_be :date?
-    field.type.struct_type.fields[0].type.wont_be :datetime?
-    field.type.struct_type.fields[0].type.wont_be :geography?
-    field.type.struct_type.fields[0].type.wont_be :time?
-    field.type.struct_type.fields[0].type.wont_be :timestamp?
-    field.type.struct_type.fields[0].type.must_be :array?
-    field.type.struct_type.fields[0].type.wont_be :struct?
+    _(field.type.struct_type.fields[0]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[0].name).must_equal "int_array_col"
+    _(field.type.struct_type.fields[0].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[0].type.type_kind).must_equal "ARRAY"
+    _(field.type.struct_type.fields[0].type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[0].type.array_element_type.type_kind).must_equal "INT64"
+    _(field.type.struct_type.fields[0].type.array_element_type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[0].type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[0].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[0].type).wont_be :int?
+    _(field.type.struct_type.fields[0].type).wont_be :float?
+    _(field.type.struct_type.fields[0].type).wont_be :numeric?
+    _(field.type.struct_type.fields[0].type).wont_be :boolean?
+    _(field.type.struct_type.fields[0].type).wont_be :string?
+    _(field.type.struct_type.fields[0].type).wont_be :bytes?
+    _(field.type.struct_type.fields[0].type).wont_be :date?
+    _(field.type.struct_type.fields[0].type).wont_be :datetime?
+    _(field.type.struct_type.fields[0].type).wont_be :geography?
+    _(field.type.struct_type.fields[0].type).wont_be :time?
+    _(field.type.struct_type.fields[0].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[0].type).must_be :array?
+    _(field.type.struct_type.fields[0].type).wont_be :struct?
 
-    field.type.struct_type.fields[1].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[1].name.must_equal "float_array_col"
-    field.type.struct_type.fields[1].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[1].type.type_kind.must_equal "ARRAY"
-    field.type.struct_type.fields[1].type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[1].type.array_element_type.type_kind.must_equal "FLOAT64"
-    field.type.struct_type.fields[1].type.array_element_type.array_element_type.must_be_nil
-    field.type.struct_type.fields[1].type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.fields[1].type.struct_type.must_be_nil
-    field.type.struct_type.fields[1].type.wont_be :int?
-    field.type.struct_type.fields[1].type.wont_be :float?
-    field.type.struct_type.fields[1].type.wont_be :numeric?
-    field.type.struct_type.fields[1].type.wont_be :boolean?
-    field.type.struct_type.fields[1].type.wont_be :string?
-    field.type.struct_type.fields[1].type.wont_be :bytes?
-    field.type.struct_type.fields[1].type.wont_be :date?
-    field.type.struct_type.fields[1].type.wont_be :datetime?
-    field.type.struct_type.fields[1].type.wont_be :geography?
-    field.type.struct_type.fields[1].type.wont_be :time?
-    field.type.struct_type.fields[1].type.wont_be :timestamp?
-    field.type.struct_type.fields[1].type.must_be :array?
-    field.type.struct_type.fields[1].type.wont_be :struct?
+    _(field.type.struct_type.fields[1]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[1].name).must_equal "float_array_col"
+    _(field.type.struct_type.fields[1].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[1].type.type_kind).must_equal "ARRAY"
+    _(field.type.struct_type.fields[1].type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[1].type.array_element_type.type_kind).must_equal "FLOAT64"
+    _(field.type.struct_type.fields[1].type.array_element_type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[1].type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[1].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[1].type).wont_be :int?
+    _(field.type.struct_type.fields[1].type).wont_be :float?
+    _(field.type.struct_type.fields[1].type).wont_be :numeric?
+    _(field.type.struct_type.fields[1].type).wont_be :boolean?
+    _(field.type.struct_type.fields[1].type).wont_be :string?
+    _(field.type.struct_type.fields[1].type).wont_be :bytes?
+    _(field.type.struct_type.fields[1].type).wont_be :date?
+    _(field.type.struct_type.fields[1].type).wont_be :datetime?
+    _(field.type.struct_type.fields[1].type).wont_be :geography?
+    _(field.type.struct_type.fields[1].type).wont_be :time?
+    _(field.type.struct_type.fields[1].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[1].type).must_be :array?
+    _(field.type.struct_type.fields[1].type).wont_be :struct?
 
-    field.type.struct_type.fields[2].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[2].name.must_equal "num_array_col"
-    field.type.struct_type.fields[2].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[2].type.type_kind.must_equal "ARRAY"
-    field.type.struct_type.fields[2].type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[2].type.array_element_type.type_kind.must_equal "NUMERIC"
-    field.type.struct_type.fields[2].type.array_element_type.array_element_type.must_be_nil
-    field.type.struct_type.fields[2].type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.fields[2].type.struct_type.must_be_nil
-    field.type.struct_type.fields[2].type.wont_be :int?
-    field.type.struct_type.fields[2].type.wont_be :float?
-    field.type.struct_type.fields[2].type.wont_be :numeric?
-    field.type.struct_type.fields[2].type.wont_be :boolean?
-    field.type.struct_type.fields[2].type.wont_be :string?
-    field.type.struct_type.fields[2].type.wont_be :bytes?
-    field.type.struct_type.fields[2].type.wont_be :date?
-    field.type.struct_type.fields[2].type.wont_be :datetime?
-    field.type.struct_type.fields[2].type.wont_be :geography?
-    field.type.struct_type.fields[2].type.wont_be :time?
-    field.type.struct_type.fields[2].type.wont_be :timestamp?
-    field.type.struct_type.fields[2].type.must_be :array?
-    field.type.struct_type.fields[2].type.wont_be :struct?
+    _(field.type.struct_type.fields[2]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[2].name).must_equal "num_array_col"
+    _(field.type.struct_type.fields[2].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[2].type.type_kind).must_equal "ARRAY"
+    _(field.type.struct_type.fields[2].type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[2].type.array_element_type.type_kind).must_equal "NUMERIC"
+    _(field.type.struct_type.fields[2].type.array_element_type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[2].type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[2].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[2].type).wont_be :int?
+    _(field.type.struct_type.fields[2].type).wont_be :float?
+    _(field.type.struct_type.fields[2].type).wont_be :numeric?
+    _(field.type.struct_type.fields[2].type).wont_be :boolean?
+    _(field.type.struct_type.fields[2].type).wont_be :string?
+    _(field.type.struct_type.fields[2].type).wont_be :bytes?
+    _(field.type.struct_type.fields[2].type).wont_be :date?
+    _(field.type.struct_type.fields[2].type).wont_be :datetime?
+    _(field.type.struct_type.fields[2].type).wont_be :geography?
+    _(field.type.struct_type.fields[2].type).wont_be :time?
+    _(field.type.struct_type.fields[2].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[2].type).must_be :array?
+    _(field.type.struct_type.fields[2].type).wont_be :struct?
 
-    field.type.struct_type.fields[3].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[3].name.must_equal "bool_array_col"
-    field.type.struct_type.fields[3].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[3].type.type_kind.must_equal "ARRAY"
-    field.type.struct_type.fields[3].type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[3].type.array_element_type.type_kind.must_equal "BOOL"
-    field.type.struct_type.fields[3].type.array_element_type.array_element_type.must_be_nil
-    field.type.struct_type.fields[3].type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.fields[3].type.struct_type.must_be_nil
-    field.type.struct_type.fields[3].type.wont_be :int?
-    field.type.struct_type.fields[3].type.wont_be :float?
-    field.type.struct_type.fields[3].type.wont_be :numeric?
-    field.type.struct_type.fields[3].type.wont_be :boolean?
-    field.type.struct_type.fields[3].type.wont_be :string?
-    field.type.struct_type.fields[3].type.wont_be :bytes?
-    field.type.struct_type.fields[3].type.wont_be :date?
-    field.type.struct_type.fields[3].type.wont_be :datetime?
-    field.type.struct_type.fields[3].type.wont_be :geography?
-    field.type.struct_type.fields[3].type.wont_be :time?
-    field.type.struct_type.fields[3].type.wont_be :timestamp?
-    field.type.struct_type.fields[3].type.must_be :array?
-    field.type.struct_type.fields[3].type.wont_be :struct?
+    _(field.type.struct_type.fields[3]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[3].name).must_equal "bool_array_col"
+    _(field.type.struct_type.fields[3].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[3].type.type_kind).must_equal "ARRAY"
+    _(field.type.struct_type.fields[3].type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[3].type.array_element_type.type_kind).must_equal "BOOL"
+    _(field.type.struct_type.fields[3].type.array_element_type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[3].type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[3].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[3].type).wont_be :int?
+    _(field.type.struct_type.fields[3].type).wont_be :float?
+    _(field.type.struct_type.fields[3].type).wont_be :numeric?
+    _(field.type.struct_type.fields[3].type).wont_be :boolean?
+    _(field.type.struct_type.fields[3].type).wont_be :string?
+    _(field.type.struct_type.fields[3].type).wont_be :bytes?
+    _(field.type.struct_type.fields[3].type).wont_be :date?
+    _(field.type.struct_type.fields[3].type).wont_be :datetime?
+    _(field.type.struct_type.fields[3].type).wont_be :geography?
+    _(field.type.struct_type.fields[3].type).wont_be :time?
+    _(field.type.struct_type.fields[3].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[3].type).must_be :array?
+    _(field.type.struct_type.fields[3].type).wont_be :struct?
 
-    field.type.struct_type.fields[4].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[4].name.must_equal "str_array_col"
-    field.type.struct_type.fields[4].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[4].type.type_kind.must_equal "ARRAY"
-    field.type.struct_type.fields[4].type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[4].type.array_element_type.type_kind.must_equal "STRING"
-    field.type.struct_type.fields[4].type.array_element_type.array_element_type.must_be_nil
-    field.type.struct_type.fields[4].type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.fields[4].type.struct_type.must_be_nil
-    field.type.struct_type.fields[4].type.wont_be :int?
-    field.type.struct_type.fields[4].type.wont_be :float?
-    field.type.struct_type.fields[4].type.wont_be :numeric?
-    field.type.struct_type.fields[4].type.wont_be :boolean?
-    field.type.struct_type.fields[4].type.wont_be :string?
-    field.type.struct_type.fields[4].type.wont_be :bytes?
-    field.type.struct_type.fields[4].type.wont_be :date?
-    field.type.struct_type.fields[4].type.wont_be :datetime?
-    field.type.struct_type.fields[4].type.wont_be :geography?
-    field.type.struct_type.fields[4].type.wont_be :time?
-    field.type.struct_type.fields[4].type.wont_be :timestamp?
-    field.type.struct_type.fields[4].type.must_be :array?
-    field.type.struct_type.fields[4].type.wont_be :struct?
+    _(field.type.struct_type.fields[4]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[4].name).must_equal "str_array_col"
+    _(field.type.struct_type.fields[4].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[4].type.type_kind).must_equal "ARRAY"
+    _(field.type.struct_type.fields[4].type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[4].type.array_element_type.type_kind).must_equal "STRING"
+    _(field.type.struct_type.fields[4].type.array_element_type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[4].type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[4].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[4].type).wont_be :int?
+    _(field.type.struct_type.fields[4].type).wont_be :float?
+    _(field.type.struct_type.fields[4].type).wont_be :numeric?
+    _(field.type.struct_type.fields[4].type).wont_be :boolean?
+    _(field.type.struct_type.fields[4].type).wont_be :string?
+    _(field.type.struct_type.fields[4].type).wont_be :bytes?
+    _(field.type.struct_type.fields[4].type).wont_be :date?
+    _(field.type.struct_type.fields[4].type).wont_be :datetime?
+    _(field.type.struct_type.fields[4].type).wont_be :geography?
+    _(field.type.struct_type.fields[4].type).wont_be :time?
+    _(field.type.struct_type.fields[4].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[4].type).must_be :array?
+    _(field.type.struct_type.fields[4].type).wont_be :struct?
 
-    field.type.struct_type.fields[5].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[5].name.must_equal "bytes_array_col"
-    field.type.struct_type.fields[5].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[5].type.type_kind.must_equal "ARRAY"
-    field.type.struct_type.fields[5].type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[5].type.array_element_type.type_kind.must_equal "BYTES"
-    field.type.struct_type.fields[5].type.array_element_type.array_element_type.must_be_nil
-    field.type.struct_type.fields[5].type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.fields[5].type.struct_type.must_be_nil
-    field.type.struct_type.fields[5].type.wont_be :int?
-    field.type.struct_type.fields[5].type.wont_be :float?
-    field.type.struct_type.fields[5].type.wont_be :numeric?
-    field.type.struct_type.fields[5].type.wont_be :boolean?
-    field.type.struct_type.fields[5].type.wont_be :string?
-    field.type.struct_type.fields[5].type.wont_be :bytes?
-    field.type.struct_type.fields[5].type.wont_be :date?
-    field.type.struct_type.fields[5].type.wont_be :datetime?
-    field.type.struct_type.fields[5].type.wont_be :geography?
-    field.type.struct_type.fields[5].type.wont_be :time?
-    field.type.struct_type.fields[5].type.wont_be :timestamp?
-    field.type.struct_type.fields[5].type.must_be :array?
-    field.type.struct_type.fields[5].type.wont_be :struct?
+    _(field.type.struct_type.fields[5]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[5].name).must_equal "bytes_array_col"
+    _(field.type.struct_type.fields[5].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[5].type.type_kind).must_equal "ARRAY"
+    _(field.type.struct_type.fields[5].type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[5].type.array_element_type.type_kind).must_equal "BYTES"
+    _(field.type.struct_type.fields[5].type.array_element_type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[5].type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[5].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[5].type).wont_be :int?
+    _(field.type.struct_type.fields[5].type).wont_be :float?
+    _(field.type.struct_type.fields[5].type).wont_be :numeric?
+    _(field.type.struct_type.fields[5].type).wont_be :boolean?
+    _(field.type.struct_type.fields[5].type).wont_be :string?
+    _(field.type.struct_type.fields[5].type).wont_be :bytes?
+    _(field.type.struct_type.fields[5].type).wont_be :date?
+    _(field.type.struct_type.fields[5].type).wont_be :datetime?
+    _(field.type.struct_type.fields[5].type).wont_be :geography?
+    _(field.type.struct_type.fields[5].type).wont_be :time?
+    _(field.type.struct_type.fields[5].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[5].type).must_be :array?
+    _(field.type.struct_type.fields[5].type).wont_be :struct?
 
-    field.type.struct_type.fields[6].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[6].name.must_equal "date_array_col"
-    field.type.struct_type.fields[6].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[6].type.type_kind.must_equal "ARRAY"
-    field.type.struct_type.fields[6].type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[6].type.array_element_type.type_kind.must_equal "DATE"
-    field.type.struct_type.fields[6].type.array_element_type.array_element_type.must_be_nil
-    field.type.struct_type.fields[6].type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.fields[6].type.struct_type.must_be_nil
-    field.type.struct_type.fields[6].type.wont_be :int?
-    field.type.struct_type.fields[6].type.wont_be :float?
-    field.type.struct_type.fields[6].type.wont_be :numeric?
-    field.type.struct_type.fields[6].type.wont_be :boolean?
-    field.type.struct_type.fields[6].type.wont_be :string?
-    field.type.struct_type.fields[6].type.wont_be :bytes?
-    field.type.struct_type.fields[6].type.wont_be :date?
-    field.type.struct_type.fields[6].type.wont_be :datetime?
-    field.type.struct_type.fields[6].type.wont_be :geography?
-    field.type.struct_type.fields[6].type.wont_be :time?
-    field.type.struct_type.fields[6].type.wont_be :timestamp?
-    field.type.struct_type.fields[6].type.must_be :array?
-    field.type.struct_type.fields[6].type.wont_be :struct?
+    _(field.type.struct_type.fields[6]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[6].name).must_equal "date_array_col"
+    _(field.type.struct_type.fields[6].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[6].type.type_kind).must_equal "ARRAY"
+    _(field.type.struct_type.fields[6].type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[6].type.array_element_type.type_kind).must_equal "DATE"
+    _(field.type.struct_type.fields[6].type.array_element_type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[6].type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[6].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[6].type).wont_be :int?
+    _(field.type.struct_type.fields[6].type).wont_be :float?
+    _(field.type.struct_type.fields[6].type).wont_be :numeric?
+    _(field.type.struct_type.fields[6].type).wont_be :boolean?
+    _(field.type.struct_type.fields[6].type).wont_be :string?
+    _(field.type.struct_type.fields[6].type).wont_be :bytes?
+    _(field.type.struct_type.fields[6].type).wont_be :date?
+    _(field.type.struct_type.fields[6].type).wont_be :datetime?
+    _(field.type.struct_type.fields[6].type).wont_be :geography?
+    _(field.type.struct_type.fields[6].type).wont_be :time?
+    _(field.type.struct_type.fields[6].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[6].type).must_be :array?
+    _(field.type.struct_type.fields[6].type).wont_be :struct?
 
-    field.type.struct_type.fields[7].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[7].name.must_equal "datetime_array_col"
-    field.type.struct_type.fields[7].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[7].type.type_kind.must_equal "ARRAY"
-    field.type.struct_type.fields[7].type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[7].type.array_element_type.type_kind.must_equal "DATETIME"
-    field.type.struct_type.fields[7].type.array_element_type.array_element_type.must_be_nil
-    field.type.struct_type.fields[7].type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.fields[7].type.struct_type.must_be_nil
-    field.type.struct_type.fields[7].type.wont_be :int?
-    field.type.struct_type.fields[7].type.wont_be :float?
-    field.type.struct_type.fields[7].type.wont_be :numeric?
-    field.type.struct_type.fields[7].type.wont_be :boolean?
-    field.type.struct_type.fields[7].type.wont_be :string?
-    field.type.struct_type.fields[7].type.wont_be :bytes?
-    field.type.struct_type.fields[7].type.wont_be :date?
-    field.type.struct_type.fields[7].type.wont_be :datetime?
-    field.type.struct_type.fields[7].type.wont_be :geography?
-    field.type.struct_type.fields[7].type.wont_be :time?
-    field.type.struct_type.fields[7].type.wont_be :timestamp?
-    field.type.struct_type.fields[7].type.must_be :array?
-    field.type.struct_type.fields[7].type.wont_be :struct?
+    _(field.type.struct_type.fields[7]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[7].name).must_equal "datetime_array_col"
+    _(field.type.struct_type.fields[7].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[7].type.type_kind).must_equal "ARRAY"
+    _(field.type.struct_type.fields[7].type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[7].type.array_element_type.type_kind).must_equal "DATETIME"
+    _(field.type.struct_type.fields[7].type.array_element_type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[7].type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[7].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[7].type).wont_be :int?
+    _(field.type.struct_type.fields[7].type).wont_be :float?
+    _(field.type.struct_type.fields[7].type).wont_be :numeric?
+    _(field.type.struct_type.fields[7].type).wont_be :boolean?
+    _(field.type.struct_type.fields[7].type).wont_be :string?
+    _(field.type.struct_type.fields[7].type).wont_be :bytes?
+    _(field.type.struct_type.fields[7].type).wont_be :date?
+    _(field.type.struct_type.fields[7].type).wont_be :datetime?
+    _(field.type.struct_type.fields[7].type).wont_be :geography?
+    _(field.type.struct_type.fields[7].type).wont_be :time?
+    _(field.type.struct_type.fields[7].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[7].type).must_be :array?
+    _(field.type.struct_type.fields[7].type).wont_be :struct?
 
-    field.type.struct_type.fields[8].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[8].name.must_equal "geo_array_col"
-    field.type.struct_type.fields[8].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[8].type.type_kind.must_equal "ARRAY"
-    field.type.struct_type.fields[8].type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[8].type.array_element_type.type_kind.must_equal "GEOGRAPHY"
-    field.type.struct_type.fields[8].type.array_element_type.array_element_type.must_be_nil
-    field.type.struct_type.fields[8].type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.fields[8].type.struct_type.must_be_nil
-    field.type.struct_type.fields[8].type.wont_be :int?
-    field.type.struct_type.fields[8].type.wont_be :float?
-    field.type.struct_type.fields[8].type.wont_be :numeric?
-    field.type.struct_type.fields[8].type.wont_be :boolean?
-    field.type.struct_type.fields[8].type.wont_be :string?
-    field.type.struct_type.fields[8].type.wont_be :bytes?
-    field.type.struct_type.fields[8].type.wont_be :date?
-    field.type.struct_type.fields[8].type.wont_be :datetime?
-    field.type.struct_type.fields[8].type.wont_be :geography?
-    field.type.struct_type.fields[8].type.wont_be :time?
-    field.type.struct_type.fields[8].type.wont_be :timestamp?
-    field.type.struct_type.fields[8].type.must_be :array?
-    field.type.struct_type.fields[8].type.wont_be :struct?
+    _(field.type.struct_type.fields[8]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[8].name).must_equal "geo_array_col"
+    _(field.type.struct_type.fields[8].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[8].type.type_kind).must_equal "ARRAY"
+    _(field.type.struct_type.fields[8].type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[8].type.array_element_type.type_kind).must_equal "GEOGRAPHY"
+    _(field.type.struct_type.fields[8].type.array_element_type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[8].type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[8].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[8].type).wont_be :int?
+    _(field.type.struct_type.fields[8].type).wont_be :float?
+    _(field.type.struct_type.fields[8].type).wont_be :numeric?
+    _(field.type.struct_type.fields[8].type).wont_be :boolean?
+    _(field.type.struct_type.fields[8].type).wont_be :string?
+    _(field.type.struct_type.fields[8].type).wont_be :bytes?
+    _(field.type.struct_type.fields[8].type).wont_be :date?
+    _(field.type.struct_type.fields[8].type).wont_be :datetime?
+    _(field.type.struct_type.fields[8].type).wont_be :geography?
+    _(field.type.struct_type.fields[8].type).wont_be :time?
+    _(field.type.struct_type.fields[8].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[8].type).must_be :array?
+    _(field.type.struct_type.fields[8].type).wont_be :struct?
 
-    field.type.struct_type.fields[9].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[9].name.must_equal "time_array_col"
-    field.type.struct_type.fields[9].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[9].type.type_kind.must_equal "ARRAY"
-    field.type.struct_type.fields[9].type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[9].type.array_element_type.type_kind.must_equal "TIME"
-    field.type.struct_type.fields[9].type.array_element_type.array_element_type.must_be_nil
-    field.type.struct_type.fields[9].type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.fields[9].type.struct_type.must_be_nil
-    field.type.struct_type.fields[9].type.wont_be :int?
-    field.type.struct_type.fields[9].type.wont_be :float?
-    field.type.struct_type.fields[9].type.wont_be :numeric?
-    field.type.struct_type.fields[9].type.wont_be :boolean?
-    field.type.struct_type.fields[9].type.wont_be :string?
-    field.type.struct_type.fields[9].type.wont_be :bytes?
-    field.type.struct_type.fields[9].type.wont_be :date?
-    field.type.struct_type.fields[9].type.wont_be :datetime?
-    field.type.struct_type.fields[9].type.wont_be :geography?
-    field.type.struct_type.fields[9].type.wont_be :time?
-    field.type.struct_type.fields[9].type.wont_be :timestamp?
-    field.type.struct_type.fields[9].type.must_be :array?
-    field.type.struct_type.fields[9].type.wont_be :struct?
+    _(field.type.struct_type.fields[9]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[9].name).must_equal "time_array_col"
+    _(field.type.struct_type.fields[9].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[9].type.type_kind).must_equal "ARRAY"
+    _(field.type.struct_type.fields[9].type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[9].type.array_element_type.type_kind).must_equal "TIME"
+    _(field.type.struct_type.fields[9].type.array_element_type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[9].type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[9].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[9].type).wont_be :int?
+    _(field.type.struct_type.fields[9].type).wont_be :float?
+    _(field.type.struct_type.fields[9].type).wont_be :numeric?
+    _(field.type.struct_type.fields[9].type).wont_be :boolean?
+    _(field.type.struct_type.fields[9].type).wont_be :string?
+    _(field.type.struct_type.fields[9].type).wont_be :bytes?
+    _(field.type.struct_type.fields[9].type).wont_be :date?
+    _(field.type.struct_type.fields[9].type).wont_be :datetime?
+    _(field.type.struct_type.fields[9].type).wont_be :geography?
+    _(field.type.struct_type.fields[9].type).wont_be :time?
+    _(field.type.struct_type.fields[9].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[9].type).must_be :array?
+    _(field.type.struct_type.fields[9].type).wont_be :struct?
 
-    field.type.struct_type.fields[10].must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
-    field.type.struct_type.fields[10].name.must_equal "ts_array_col"
-    field.type.struct_type.fields[10].type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[10].type.type_kind.must_equal "ARRAY"
-    field.type.struct_type.fields[10].type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.struct_type.fields[10].type.array_element_type.type_kind.must_equal "TIMESTAMP"
-    field.type.struct_type.fields[10].type.array_element_type.array_element_type.must_be_nil
-    field.type.struct_type.fields[10].type.array_element_type.struct_type.must_be_nil
-    field.type.struct_type.fields[10].type.struct_type.must_be_nil
-    field.type.struct_type.fields[10].type.wont_be :int?
-    field.type.struct_type.fields[10].type.wont_be :float?
-    field.type.struct_type.fields[10].type.wont_be :numeric?
-    field.type.struct_type.fields[10].type.wont_be :boolean?
-    field.type.struct_type.fields[10].type.wont_be :string?
-    field.type.struct_type.fields[10].type.wont_be :bytes?
-    field.type.struct_type.fields[10].type.wont_be :date?
-    field.type.struct_type.fields[10].type.wont_be :datetime?
-    field.type.struct_type.fields[10].type.wont_be :geography?
-    field.type.struct_type.fields[10].type.wont_be :time?
-    field.type.struct_type.fields[10].type.wont_be :timestamp?
-    field.type.struct_type.fields[10].type.must_be :array?
-    field.type.struct_type.fields[10].type.wont_be :struct?
+    _(field.type.struct_type.fields[10]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[10].name).must_equal "ts_array_col"
+    _(field.type.struct_type.fields[10].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[10].type.type_kind).must_equal "ARRAY"
+    _(field.type.struct_type.fields[10].type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[10].type.array_element_type.type_kind).must_equal "TIMESTAMP"
+    _(field.type.struct_type.fields[10].type.array_element_type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[10].type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[10].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[10].type).wont_be :int?
+    _(field.type.struct_type.fields[10].type).wont_be :float?
+    _(field.type.struct_type.fields[10].type).wont_be :numeric?
+    _(field.type.struct_type.fields[10].type).wont_be :boolean?
+    _(field.type.struct_type.fields[10].type).wont_be :string?
+    _(field.type.struct_type.fields[10].type).wont_be :bytes?
+    _(field.type.struct_type.fields[10].type).wont_be :date?
+    _(field.type.struct_type.fields[10].type).wont_be :datetime?
+    _(field.type.struct_type.fields[10].type).wont_be :geography?
+    _(field.type.struct_type.fields[10].type).wont_be :time?
+    _(field.type.struct_type.fields[10].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[10].type).must_be :array?
+    _(field.type.struct_type.fields[10].type).wont_be :struct?
   end
 
   def value_field name, type_kind

--- a/google-cloud-bigquery/test/google/cloud/bigquery/standard_sql/value_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/standard_sql/value_test.rb
@@ -21,294 +21,294 @@ describe Google::Cloud::Bigquery::StandardSql, :value do
       parent = Google::Cloud::Bigquery::StandardSql::DataType.new type_kind: "STRING"
       data_type = Google::Cloud::Bigquery::StandardSql::DataType.new type_kind: "ARRAY", array_element_type: parent
 
-      data_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-      data_type.type_kind.must_equal "ARRAY"
-      data_type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-      data_type.array_element_type.type_kind.must_equal "STRING"
+      _(data_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+      _(data_type.type_kind).must_equal "ARRAY"
+      _(data_type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+      _(data_type.array_element_type.type_kind).must_equal "STRING"
     end
 
     it "takes Hash as an argument" do
       data_type = Google::Cloud::Bigquery::StandardSql::DataType.new type_kind: "ARRAY", array_element_type: "STRING"
 
-      data_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-      data_type.type_kind.must_equal "ARRAY"
-      data_type.array_element_type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-      data_type.array_element_type.type_kind.must_equal "STRING"
+      _(data_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+      _(data_type.type_kind).must_equal "ARRAY"
+      _(data_type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+      _(data_type.array_element_type.type_kind).must_equal "STRING"
     end
   end
 
   it "represents a INT64 field" do
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "int_col", type: "INT64"
 
-    field.name.must_equal "int_col"
+    _(field.name).must_equal "int_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "INT64"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "INT64"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.must_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.wont_be :struct?
+    _(field.type).must_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a FLOAT64 field" do
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "float_col", type: "FLOAT64"
 
-    field.name.must_equal "float_col"
+    _(field.name).must_equal "float_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "FLOAT64"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "FLOAT64"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.must_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).must_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a NUMERIC field" do
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "num_col", type: "NUMERIC"
 
-    field.name.must_equal "num_col"
+    _(field.name).must_equal "num_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "NUMERIC"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "NUMERIC"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.must_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).must_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a BOOL field" do
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "bool_col", type: "BOOL"
 
-    field.name.must_equal "bool_col"
+    _(field.name).must_equal "bool_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "BOOL"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "BOOL"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.must_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).must_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a STRING field" do
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "str_col", type: "STRING"
 
-    field.name.must_equal "str_col"
+    _(field.name).must_equal "str_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "STRING"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "STRING"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.must_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).must_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a BYTES field" do
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "bytes_col", type: "BYTES"
 
-    field.name.must_equal "bytes_col"
+    _(field.name).must_equal "bytes_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "BYTES"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "BYTES"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.must_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).must_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a DATE field" do
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "date_col", type: "DATE"
 
-    field.name.must_equal "date_col"
+    _(field.name).must_equal "date_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "DATE"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "DATE"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.must_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).must_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a DATETIME field" do
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "datetime_col", type: "DATETIME"
 
-    field.name.must_equal "datetime_col"
+    _(field.name).must_equal "datetime_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "DATETIME"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "DATETIME"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.must_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).must_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a GEOGRAPHY field" do
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "geo_col", type: "GEOGRAPHY"
 
-    field.name.must_equal "geo_col"
+    _(field.name).must_equal "geo_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "GEOGRAPHY"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "GEOGRAPHY"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.must_be :geography?
-    field.type.wont_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).must_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a TIME field" do
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "time_col", type: "TIME"
 
-    field.name.must_equal "time_col"
+    _(field.name).must_equal "time_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "TIME"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "TIME"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.must_be :time?
-    field.type.wont_be :timestamp?
-    field.type.wont_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).must_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).wont_be :struct?
   end
 
   it "represents a TIMESTAMP field" do
     field = Google::Cloud::Bigquery::StandardSql::Field.new name: "ts_col", type: "TIMESTAMP"
 
-    field.name.must_equal "ts_col"
+    _(field.name).must_equal "ts_col"
 
-    field.type.must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
-    field.type.type_kind.must_equal "TIMESTAMP"
-    field.type.array_element_type.must_be_nil
-    field.type.struct_type.must_be_nil
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "TIMESTAMP"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
 
-    field.type.wont_be :int?
-    field.type.wont_be :float?
-    field.type.wont_be :numeric?
-    field.type.wont_be :boolean?
-    field.type.wont_be :string?
-    field.type.wont_be :bytes?
-    field.type.wont_be :date?
-    field.type.wont_be :datetime?
-    field.type.wont_be :geography?
-    field.type.wont_be :time?
-    field.type.must_be :timestamp?
-    field.type.wont_be :array?
-    field.type.wont_be :struct?
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).must_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).wont_be :struct?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
@@ -57,19 +57,19 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
     SecureRandom.stub :uuid, insert_id do
       inserter.insert rows.first
 
-      inserter.batch.rows.must_equal [rows.first]
+      _(inserter.batch.rows).must_equal [rows.first]
 
-      inserter.must_be :started?
-      inserter.wont_be :stopped?
+      _(inserter).must_be :started?
+      _(inserter).wont_be :stopped?
 
       # force the queued rows to be inserted
       inserter.flush
       inserter.stop.wait!
 
-      inserter.wont_be :started?
-      inserter.must_be :stopped?
+      _(inserter).wont_be :started?
+      _(inserter).must_be :stopped?
 
-      inserter.batch.must_be :nil?
+      _(inserter.batch).must_be :nil?
     end
 
     mock.verify
@@ -89,19 +89,19 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
     SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
-      inserter.batch.rows.must_equal rows
+      _(inserter.batch.rows).must_equal rows
 
-      inserter.must_be :started?
-      inserter.wont_be :stopped?
+      _(inserter).must_be :started?
+      _(inserter).wont_be :stopped?
 
       # force the queued rows to be inserted
       inserter.flush
       inserter.stop.wait!
 
-      inserter.wont_be :started?
-      inserter.must_be :stopped?
+      _(inserter).wont_be :started?
+      _(inserter).must_be :stopped?
 
-      inserter.batch.must_be :nil?
+      _(inserter.batch).must_be :nil?
     end
 
     mock.verify
@@ -123,19 +123,19 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
         inserter.insert row
       end
 
-      inserter.batch.rows.must_equal rows
+      _(inserter.batch.rows).must_equal rows
 
-      inserter.must_be :started?
-      inserter.wont_be :stopped?
+      _(inserter).must_be :started?
+      _(inserter).wont_be :stopped?
 
       # force the queued rows to be inserted
       inserter.flush
       inserter.stop.wait!
 
-      inserter.wont_be :started?
-      inserter.must_be :stopped?
+      _(inserter).wont_be :started?
+      _(inserter).must_be :stopped?
 
-      inserter.batch.must_be :nil?
+      _(inserter.batch).must_be :nil?
     end
 
     mock.verify
@@ -161,34 +161,34 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
     SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
-      inserter.batch.rows.must_equal rows
+      _(inserter.batch.rows).must_equal rows
 
-      inserter.must_be :started?
-      inserter.wont_be :stopped?
+      _(inserter).must_be :started?
+      _(inserter).wont_be :stopped?
 
       # force the queued rows to be inserted
       inserter.flush
       wait_until { callback_called == true }
       inserter.stop.wait!
 
-      inserter.wont_be :started?
-      inserter.must_be :stopped?
+      _(inserter).wont_be :started?
+      _(inserter).must_be :stopped?
 
-      inserter.batch.must_be :nil?
+      _(inserter.batch).must_be :nil?
     end
 
-    insert_result.wont_be_nil
-    insert_result.must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
-    insert_result.wont_be :error?
-    insert_result.error.must_be_nil
-    insert_result.must_be :success?
-    insert_result.insert_response.wont_be_nil
-    insert_result.insert_count.must_equal 3
-    insert_result.error_count.must_equal 0
-    insert_result.insert_errors.must_be_kind_of Array
-    insert_result.insert_errors.must_be :empty?
-    insert_result.error_rows.must_be_kind_of Array
-    insert_result.error_rows.must_be :empty?
+    _(insert_result).wont_be_nil
+    _(insert_result).must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
+    _(insert_result).wont_be :error?
+    _(insert_result.error).must_be_nil
+    _(insert_result).must_be :success?
+    _(insert_result.insert_response).wont_be_nil
+    _(insert_result.insert_count).must_equal 3
+    _(insert_result.error_count).must_equal 0
+    _(insert_result.insert_errors).must_be_kind_of Array
+    _(insert_result.insert_errors).must_be :empty?
+    _(insert_result.error_rows).must_be_kind_of Array
+    _(insert_result.error_rows).must_be :empty?
 
     mock.verify
   end
@@ -210,31 +210,31 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
 
     inserter.insert rows
 
-    inserter.batch.rows.must_equal rows
+    _(inserter.batch.rows).must_equal rows
 
-    inserter.must_be :started?
-    inserter.wont_be :stopped?
+    _(inserter).must_be :started?
+    _(inserter).wont_be :stopped?
 
     # force the queued rows to be inserted
     inserter.flush
     wait_until { callback_called == true }
     inserter.stop.wait!
 
-    inserter.wont_be :started?
-    inserter.must_be :stopped?
+    _(inserter).wont_be :started?
+    _(inserter).must_be :stopped?
 
-    inserter.batch.must_be :nil?
+    _(inserter.batch).must_be :nil?
 
-    insert_result.wont_be_nil
-    insert_result.must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
-    insert_result.must_be :error?
-    insert_result.error.must_be_kind_of Google::Cloud::UnavailableError
-    insert_result.wont_be :success?
-    insert_result.insert_response.must_be_nil
-    insert_result.insert_count.must_be_nil
-    insert_result.error_count.must_be_nil
-    insert_result.insert_errors.must_be_nil
-    insert_result.error_rows.must_be_nil
+    _(insert_result).wont_be_nil
+    _(insert_result).must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
+    _(insert_result).must_be :error?
+    _(insert_result.error).must_be_kind_of Google::Cloud::UnavailableError
+    _(insert_result).wont_be :success?
+    _(insert_result.insert_response).must_be_nil
+    _(insert_result.insert_count).must_be_nil
+    _(insert_result.error_count).must_be_nil
+    _(insert_result.insert_errors).must_be_nil
+    _(insert_result.error_rows).must_be_nil
 
     mock.verify
   end
@@ -258,20 +258,20 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
     SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
-      inserter.batch.rows.must_equal [rows.last]
+      _(inserter.batch.rows).must_equal [rows.last]
 
-      inserter.must_be :started?
-      inserter.wont_be :stopped?
+      _(inserter).must_be :started?
+      _(inserter).wont_be :stopped?
 
       # force the queued rows to be inserted
       inserter.flush
       wait_until { callbacks == 2 }
       inserter.stop.wait!
 
-      inserter.wont_be :started?
-      inserter.must_be :stopped?
+      _(inserter).wont_be :started?
+      _(inserter).must_be :stopped?
 
-      inserter.batch.must_be :nil?
+      _(inserter.batch).must_be :nil?
     end
 
     mock.verify
@@ -296,20 +296,20 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
     SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
-      inserter.batch.rows.must_equal [rows.last]
+      _(inserter.batch.rows).must_equal [rows.last]
 
-      inserter.must_be :started?
-      inserter.wont_be :stopped?
+      _(inserter).must_be :started?
+      _(inserter).wont_be :stopped?
 
       # force the queued rows to be inserted
       inserter.flush
       wait_until { callbacks == 2 }
       inserter.stop.wait!
 
-      inserter.wont_be :started?
-      inserter.must_be :stopped?
+      _(inserter).wont_be :started?
+      _(inserter).must_be :stopped?
 
-      inserter.batch.must_be :nil?
+      _(inserter.batch).must_be :nil?
     end
 
     mock.verify
@@ -328,19 +328,19 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
 
     inserter.insert rows, insert_ids: insert_ids
 
-    inserter.batch.rows.must_equal rows
+    _(inserter.batch.rows).must_equal rows
 
-    inserter.must_be :started?
-    inserter.wont_be :stopped?
+    _(inserter).must_be :started?
+    _(inserter).wont_be :stopped?
 
     # force the queued rows to be inserted
     inserter.flush
     inserter.stop.wait!
 
-    inserter.wont_be :started?
-    inserter.must_be :stopped?
+    _(inserter).wont_be :started?
+    _(inserter).must_be :stopped?
 
-    inserter.batch.must_be :nil?
+    _(inserter.batch).must_be :nil?
 
     mock.verify
   end
@@ -360,19 +360,19 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
       inserter.insert row, insert_ids: insert_id
     end
 
-    inserter.batch.rows.must_equal rows
+    _(inserter.batch.rows).must_equal rows
 
-    inserter.must_be :started?
-    inserter.wont_be :stopped?
+    _(inserter).must_be :started?
+    _(inserter).wont_be :stopped?
 
     # force the queued rows to be inserted
     inserter.flush
     inserter.stop.wait!
 
-    inserter.wont_be :started?
-    inserter.must_be :stopped?
+    _(inserter).wont_be :started?
+    _(inserter).must_be :stopped?
 
-    inserter.batch.must_be :nil?
+    _(inserter.batch).must_be :nil?
 
     mock.verify
   end
@@ -384,17 +384,17 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
 
     expect { inserter.insert rows, insert_ids: insert_ids }.must_raise ArgumentError
 
-    inserter.batch.must_be :nil?
+    _(inserter.batch).must_be :nil?
 
-    inserter.must_be :started?
-    inserter.wont_be :stopped?
+    _(inserter).must_be :started?
+    _(inserter).wont_be :stopped?
 
     # force the queued rows to be inserted
     inserter.flush
     inserter.stop.wait!
 
-    inserter.wont_be :started?
-    inserter.must_be :stopped?
+    _(inserter).wont_be :started?
+    _(inserter).must_be :stopped?
   end
 
   def wait_until delay: 0.01, max: 100, output: nil, msg: "criteria not met", &block

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
       [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
-    table.created_at.must_be_close_to ::Time.now, 1
+    _(table.created_at).must_be_close_to ::Time.now, 1
 
     mock.verify
 
@@ -47,7 +47,7 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
       [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
-    table.expires_at.must_be_close_to ::Time.now, 1
+    _(table.expires_at).must_be_close_to ::Time.now, 1
 
     mock.verify
 
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
       [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
-    table.expires_at.must_be :nil?
+    _(table.expires_at).must_be :nil?
 
     mock.verify
 
@@ -77,7 +77,7 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
       [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
-    table.modified_at.must_be_close_to ::Time.now, 1
+    _(table.modified_at).must_be_close_to ::Time.now, 1
 
     mock.verify
 
@@ -91,12 +91,12 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
       [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
-    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    table.schema.must_be :frozen?
-    table.schema.fields.wont_be :empty?
-    table.fields.wont_be :empty?
-    table.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    table.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(table.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(table.schema).must_be :frozen?
+    _(table.schema.fields).wont_be :empty?
+    _(table.fields).wont_be :empty?
+    _(table.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
     mock.verify
 
@@ -111,7 +111,7 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
         [table.project_id, table.dataset_id, table.table_id]
       table.service.mocked_service = mock
 
-      table.send(attr).must_equal val
+      _(table.send(attr)).must_equal val
 
       mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_test.rb
@@ -53,7 +53,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy to a table identified by a string" do
@@ -66,7 +66,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job "target-project:target_dataset.target_table_id"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy to a table name string only" do
@@ -86,7 +86,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job "new_target_table_id"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy itself as a dryrun (deprecated)" do
@@ -100,7 +100,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, dryrun: true
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy itself with create disposition" do
@@ -114,7 +114,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, create: "CREATE_NEVER"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy itself with create disposition symbol" do
@@ -128,7 +128,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, create: :never
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
 
@@ -143,7 +143,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, write: "WRITE_TRUNCATE"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy itself with write disposition symbol" do
@@ -157,7 +157,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, write: :truncate
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy itself with job_id option" do
@@ -171,8 +171,8 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, job_id: job_id
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job.job_id).must_equal job_id
   end
 
   it "can copy itself with prefix option" do
@@ -189,8 +189,8 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, prefix: prefix
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job.job_id).must_equal job_id
   end
 
   it "can copy itself with job_id option if both job_id and prefix options are provided" do
@@ -204,8 +204,8 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, job_id: job_id, prefix: "IGNORED"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job.job_id).must_equal job_id
   end
 
   it "can copy itself with the job labels option" do
@@ -218,7 +218,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, labels: labels
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    job.labels.must_equal labels
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job.labels).must_equal labels
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_updater_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_updater_test.rb
@@ -58,13 +58,13 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :updater, :mock_bigquery do
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
     job = source_table.copy_job target_table, prefix: prefix do |j|
-      j.job_id.must_equal job_id
+      _(j.job_id).must_equal job_id
     end
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job.job_id).must_equal job_id
   end
 
   it "can copy itself with create disposition" do
@@ -80,7 +80,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :updater, :mock_bigquery do
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy itself with create disposition symbol" do
@@ -96,7 +96,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :updater, :mock_bigquery do
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
 
@@ -113,7 +113,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :updater, :mock_bigquery do
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy itself with write disposition symbol" do
@@ -129,7 +129,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :updater, :mock_bigquery do
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy itself with the job labels option" do
@@ -144,8 +144,8 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :updater, :mock_bigquery do
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    job.labels.must_equal labels
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job.labels).must_equal labels
   end
 
   it "can copy itself with the encryption option" do
@@ -163,9 +163,9 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :updater, :mock_bigquery do
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    job.encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
-    job.encryption.kms_key.must_equal kms_key
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job.encryption).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(job.encryption.kms_key).must_equal kms_key
   end
 
   it "can copy itself with the location option" do
@@ -177,13 +177,13 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :updater, :mock_bigquery do
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
     job = source_table.copy_job target_table do |j|
-      j.location.must_equal "US" # default
+      _(j.location).must_equal "US" # default
       j.location = region
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    job.location.must_equal region
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job.location).must_equal region
   end
 
   it "can copy itself with unsetting the location option" do
@@ -195,12 +195,12 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :updater, :mock_bigquery do
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
     job = source_table.copy_job target_table do |j|
-      j.location.must_equal "US" # default
+      _(j.location).must_equal "US" # default
       j.location = nil
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
-    job.location.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job.location).must_be :nil?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_test.rb
@@ -54,7 +54,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
     result = source_table.copy target_table
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can copy to a table identified by a string" do
@@ -69,7 +69,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
     result = source_table.copy "target-project:target_dataset.target_table_id"
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can copy to a table name string only" do
@@ -91,7 +91,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
     result = source_table.copy "new_target_table_id"
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can copy itself with create disposition" do
@@ -107,7 +107,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
     result = source_table.copy target_table, create: "CREATE_NEVER"
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can copy itself with create disposition symbol" do
@@ -123,7 +123,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
     result = source_table.copy target_table, create: :never
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
 
@@ -140,7 +140,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
     result = source_table.copy target_table, write: "WRITE_TRUNCATE"
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can copy itself with write disposition symbol" do
@@ -156,7 +156,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
     result = source_table.copy target_table, write: :truncate
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   def copy_job_gapi source, target, job_id: "job_9876543210", location: "US"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_exists_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_exists_test.rb
@@ -24,19 +24,19 @@ describe Google::Cloud::Bigquery::Table, :exists, :mock_bigquery do
   it "knows if full resource exists when created with an HTTP method" do
     # The absence of a mock means this test will fail
     # if the method exists? makes an HTTP call.
-    table.wont_be :reference?
-    table.must_be :resource?
-    table.wont_be :resource_partial?
-    table.must_be :resource_full?
+    _(table).wont_be :reference?
+    _(table).must_be :resource?
+    _(table).wont_be :resource_partial?
+    _(table).must_be :resource_full?
 
-    table.must_be :exists?
-    table.wont_be :reference?
-    table.must_be :resource?
-    table.wont_be :resource_partial?
-    table.must_be :resource_full?
+    _(table).must_be :exists?
+    _(table).wont_be :reference?
+    _(table).must_be :resource?
+    _(table).wont_be :resource_partial?
+    _(table).must_be :resource_full?
 
     # Additional exists? calls do not make HTTP calls either
-    table.must_be :exists?
+    _(table).must_be :exists?
   end
 
   describe "partial dataset resource from list of a dataset that exists" do
@@ -46,19 +46,19 @@ describe Google::Cloud::Bigquery::Table, :exists, :mock_bigquery do
     it "knows if partial resource exists when created with an HTTP method" do
       # The absence of a mock means this test will fail
       # if the method exists? makes an HTTP call.
-      table.wont_be :reference?
-      table.must_be :resource?
-      table.must_be :resource_partial?
-      table.wont_be :resource_full?
+      _(table).wont_be :reference?
+      _(table).must_be :resource?
+      _(table).must_be :resource_partial?
+      _(table).wont_be :resource_full?
 
-      table.must_be :exists?
-      table.wont_be :reference?
-      table.must_be :resource?
-      table.must_be :resource_partial?
-      table.wont_be :resource_full?
+      _(table).must_be :exists?
+      _(table).wont_be :reference?
+      _(table).must_be :resource?
+      _(table).must_be :resource_partial?
+      _(table).wont_be :resource_full?
 
       # Additional exists? calls do not make HTTP calls
-      table.must_be :exists?
+      _(table).must_be :exists?
     end
   end
 
@@ -70,19 +70,19 @@ describe Google::Cloud::Bigquery::Table, :exists, :mock_bigquery do
       mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
       table.service.mocked_service = mock
 
-      table.must_be :reference?
-      table.wont_be :resource?
-      table.wont_be :resource_partial?
-      table.wont_be :resource_full?
+      _(table).must_be :reference?
+      _(table).wont_be :resource?
+      _(table).wont_be :resource_partial?
+      _(table).wont_be :resource_full?
 
-      table.must_be :exists?
-      table.wont_be :reference?
-      table.must_be :resource?
-      table.wont_be :resource_partial?
-      table.must_be :resource_full?
+      _(table).must_be :exists?
+      _(table).wont_be :reference?
+      _(table).must_be :resource?
+      _(table).wont_be :resource_partial?
+      _(table).must_be :resource_full?
 
       # Additional exists? calls do not make HTTP calls
-      table.must_be :exists?
+      _(table).must_be :exists?
 
       mock.verify
     end
@@ -98,19 +98,19 @@ describe Google::Cloud::Bigquery::Table, :exists, :mock_bigquery do
       end
       table.service.mocked_service = stub
 
-      table.must_be :reference?
-      table.wont_be :resource?
-      table.wont_be :resource_partial?
-      table.wont_be :resource_full?
+      _(table).must_be :reference?
+      _(table).wont_be :resource?
+      _(table).wont_be :resource_partial?
+      _(table).wont_be :resource_full?
 
-      table.wont_be :exists?
-      table.must_be :reference?
-      table.wont_be :resource?
-      table.wont_be :resource_partial?
-      table.wont_be :resource_full?
+      _(table).wont_be :exists?
+      _(table).must_be :reference?
+      _(table).wont_be :resource?
+      _(table).wont_be :resource_partial?
+      _(table).wont_be :resource_full?
 
       # Additional exists? calls do not make HTTP calls
-      table.wont_be :exists?
+      _(table).wont_be :exists?
     end
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_external_test.rb
@@ -39,13 +39,13 @@ describe Google::Cloud::Bigquery::Table, :external, :mock_bigquery do
   let(:etag) { "etag123456789" }
 
   it "can have a permanent external data source" do
-    table.external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
-    table.external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
-    table.external.format.must_equal "CSV"
-    table.external.autodetect.must_equal true
-    table.external.skip_leading_rows.must_equal 1
-    table.external.schema.must_be :empty?
-    table.external.must_be :frozen?
+    _(table.external).must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    _(table.external.urls).must_equal ["gs://my-bucket/path/to/file.csv"]
+    _(table.external.format).must_equal "CSV"
+    _(table.external.autodetect).must_equal true
+    _(table.external.skip_leading_rows).must_equal 1
+    _(table.external.schema).must_be :empty?
+    _(table.external).must_be :frozen?
   end
 
   it "can update the permanent external data source" do
@@ -82,13 +82,13 @@ describe Google::Cloud::Bigquery::Table, :external, :mock_bigquery do
 
     mock.verify
 
-    table.external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-    table.external.urls.must_equal ["gs://my-bucket/path/to/file.json"]
-    table.external.format.must_equal "NEWLINE_DELIMITED_JSON"
-    table.external.autodetect.must_be :nil?
-    table.external.schema.wont_be :empty?
-    table.external.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    table.external.schema.must_be :frozen?
-    table.external.must_be :frozen?
+    _(table.external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+    _(table.external.urls).must_equal ["gs://my-bucket/path/to/file.json"]
+    _(table.external.format).must_equal "NEWLINE_DELIMITED_JSON"
+    _(table.external.autodetect).must_be :nil?
+    _(table.external.schema).wont_be :empty?
+    _(table.external.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(table.external.schema).must_be :frozen?
+    _(table.external).must_be :frozen?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_test.rb
@@ -47,7 +47,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_file
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself to a storage url" do
@@ -60,7 +60,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself as a dryrun (deprecated)" do
@@ -74,7 +74,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, dryrun: true
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself and determine the csv format" do
@@ -89,7 +89,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job "#{extract_url}.csv"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself and specify the csv format" do
@@ -103,7 +103,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, format: :csv
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself and specify the csv format and options" do
@@ -120,7 +120,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, format: :csv, compression: "GZIP", delimiter: "\t", header: false
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself and determine the json format" do
@@ -135,7 +135,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job "#{extract_url}.json"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself and specify the json format" do
@@ -149,7 +149,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, format: :json
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself and determine the avro format" do
@@ -164,7 +164,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job "#{extract_url}.avro"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself and determine the avro format with options" do
@@ -182,7 +182,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself and specify the avro format" do
@@ -196,7 +196,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, format: :avro
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself and specify the avro format with options" do
@@ -214,7 +214,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself with job_id option" do
@@ -228,8 +228,8 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, job_id: job_id
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job.job_id).must_equal job_id
   end
 
   it "can extract itself with prefix option" do
@@ -246,8 +246,8 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, prefix: prefix
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job.job_id).must_equal job_id
   end
 
   it "can extract itself with job_id option if both job_id and prefix options are provided" do
@@ -261,8 +261,8 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, job_id: job_id, prefix: "IGNORED"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job.job_id).must_equal job_id
   end
 
   it "can extract itself with the job labels option" do
@@ -276,8 +276,8 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_file, labels: labels
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-    job.labels.must_equal labels
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job.labels).must_equal labels
   end
 
   # Borrowed from MockStorage, extract to a common module?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_updater_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_updater_test.rb
@@ -50,12 +50,12 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :updater, :mock_bigquery 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
     job = table.extract_job extract_url, prefix: prefix do |j|
-      j.job_id.must_equal job_id
+      _(j.job_id).must_equal job_id
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-    job.job_id.must_equal job_id
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job.job_id).must_equal job_id
   end
 
   it "can extract itself and specify the csv format and options" do
@@ -77,7 +77,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself and specify the json format" do
@@ -93,7 +93,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself and specify the avro format" do
@@ -109,7 +109,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself with the job labels option" do
@@ -125,8 +125,8 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :updater, :mock_bigquery 
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-    job.labels.must_equal labels
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job.labels).must_equal labels
   end
 
   it "can extract itself with the location option" do
@@ -140,13 +140,13 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :updater, :mock_bigquery 
     mock.expect :insert_job, return_job_gapi, [project, insert_job_gapi]
 
     job = table.extract_job extract_file do |j|
-      j.location.must_equal "US"
+      _(j.location).must_equal "US"
       j.location = region
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-    job.location.must_equal region
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job.location).must_equal region
   end
 
   it "can extract itself and unset the location" do
@@ -160,13 +160,13 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :updater, :mock_bigquery 
     mock.expect :insert_job, return_job_gapi, [project, insert_job_gapi]
 
     job = table.extract_job extract_file do |j|
-      j.location.must_equal "US"
+      _(j.location).must_equal "US"
       j.location = nil
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
-    job.location.must_equal "US"
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job.location).must_equal "US"
   end
 
   # Borrowed from MockStorage, extract to a common module?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_test.rb
@@ -48,7 +48,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
     result = table.extract extract_file
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract itself to a storage url" do
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
     result = table.extract extract_url
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract itself and determine the csv format" do
@@ -80,7 +80,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
     result = table.extract "#{extract_url}.csv"
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract itself and specify the csv format" do
@@ -96,7 +96,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
     result = table.extract extract_url, format: :csv
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract itself and specify the csv format and options" do
@@ -115,7 +115,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
     result = table.extract extract_url, format: :csv, compression: "GZIP", delimiter: "\t", header: false
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract itself and determine the json format" do
@@ -132,7 +132,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
     result = table.extract "#{extract_url}.json"
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract itself and specify the json format" do
@@ -148,7 +148,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
     result = table.extract extract_url, format: :json
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract itself and determine the avro format" do
@@ -165,7 +165,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
     result = table.extract "#{extract_url}.avro"
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract itself and determine the avro format with options" do
@@ -185,7 +185,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
     end
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract itself and specify the avro format" do
@@ -201,7 +201,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
     result = table.extract extract_url, format: :avro
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract itself and specify the avro format with options" do
@@ -221,7 +221,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
     end
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   def extract_job_gapi table, extract_file, job_id: "job_9876543210", location: "US"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
@@ -58,9 +58,9 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 1
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 1
+    _(result.error_count).must_equal 0
   end
 
   it "can insert multiple rows" do
@@ -79,9 +79,9 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 3
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 3
+    _(result.error_count).must_equal 0
   end
 
   it "will indicate there was a problem with the data" do
@@ -100,46 +100,46 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.wont_be :success?
-    result.insert_count.must_equal 2
-    result.error_count.must_equal 1
-    result.insert_errors.count.must_equal 1
-    result.insert_errors.first.index.must_equal 0
-    result.insert_errors.first.row.must_equal rows.first
-    result.insert_errors.first.errors.count.must_equal 1
-    result.insert_errors.first.errors.first["reason"].must_equal "r34s0n"
-    result.insert_errors.first.errors.first["location"].must_equal "l0c4t10n"
-    result.insert_errors.first.errors.first["debugInfo"].must_equal "d3bugInf0"
-    result.insert_errors.first.errors.first["message"].must_equal "m3ss4g3"
+    _(result).wont_be :success?
+    _(result.insert_count).must_equal 2
+    _(result.error_count).must_equal 1
+    _(result.insert_errors.count).must_equal 1
+    _(result.insert_errors.first.index).must_equal 0
+    _(result.insert_errors.first.row).must_equal rows.first
+    _(result.insert_errors.first.errors.count).must_equal 1
+    _(result.insert_errors.first.errors.first["reason"]).must_equal "r34s0n"
+    _(result.insert_errors.first.errors.first["location"]).must_equal "l0c4t10n"
+    _(result.insert_errors.first.errors.first["debugInfo"]).must_equal "d3bugInf0"
+    _(result.insert_errors.first.errors.first["message"]).must_equal "m3ss4g3"
 
-    result.error_rows.first.must_equal rows.first
+    _(result.error_rows.first).must_equal rows.first
 
     first_row_insert_error = result.insert_error_for(rows.first)
-    first_row_insert_error.index.must_equal 0
-    first_row_insert_error.row.must_equal rows.first
-    first_row_insert_error.errors.first["reason"].must_equal "r34s0n"
-    first_row_insert_error.errors.first["location"].must_equal "l0c4t10n"
-    first_row_insert_error.errors.first["debugInfo"].must_equal "d3bugInf0"
-    first_row_insert_error.errors.first["message"].must_equal "m3ss4g3"
+    _(first_row_insert_error.index).must_equal 0
+    _(first_row_insert_error.row).must_equal rows.first
+    _(first_row_insert_error.errors.first["reason"]).must_equal "r34s0n"
+    _(first_row_insert_error.errors.first["location"]).must_equal "l0c4t10n"
+    _(first_row_insert_error.errors.first["debugInfo"]).must_equal "d3bugInf0"
+    _(first_row_insert_error.errors.first["message"]).must_equal "m3ss4g3"
 
     first_row_index = result.index_for(rows.first)
-    first_row_index.must_equal 0
+    _(first_row_index).must_equal 0
 
     first_row_errors = result.errors_for(rows.first)
-    first_row_errors.count.must_equal 1
-    first_row_errors.first["reason"].must_equal "r34s0n"
-    first_row_errors.first["location"].must_equal "l0c4t10n"
-    first_row_errors.first["debugInfo"].must_equal "d3bugInf0"
-    first_row_errors.first["message"].must_equal "m3ss4g3"
+    _(first_row_errors.count).must_equal 1
+    _(first_row_errors.first["reason"]).must_equal "r34s0n"
+    _(first_row_errors.first["location"]).must_equal "l0c4t10n"
+    _(first_row_errors.first["debugInfo"]).must_equal "d3bugInf0"
+    _(first_row_errors.first["message"]).must_equal "m3ss4g3"
 
     last_row_insert_error = result.insert_error_for(rows.last)
-    last_row_insert_error.must_be_nil
+    _(last_row_insert_error).must_be_nil
 
     last_row_index = result.index_for(rows.last)
-    last_row_index.must_be_nil
+    _(last_row_index).must_be_nil
 
     last_row_errors = result.errors_for(rows.last)
-    last_row_errors.count.must_equal 0
+    _(last_row_errors.count).must_equal 0
   end
 
   it "can specify skipping invalid rows" do
@@ -158,9 +158,9 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 3
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 3
+    _(result.error_count).must_equal 0
   end
 
   it "can specify ignoring unknown values" do
@@ -179,9 +179,9 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 3
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 3
+    _(result.error_count).must_equal 0
   end
 
   it "properly formats values when inserting" do
@@ -227,9 +227,9 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 1
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 1
+    _(result.error_count).must_equal 0
   end
 
   it "can specify insert_ids" do
@@ -245,9 +245,9 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 3
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 3
+    _(result.error_count).must_equal 0
   end
 
   it "raises if the insert_ids option is provided but size does not match rows" do
@@ -269,9 +269,9 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 3
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 3
+    _(result.error_count).must_equal 0
   end
 
   def success_table_insert_gapi

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_local_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
         [project, load_job_gapi(table_gapi.table_reference, "CSV"), upload_source: file, content_type: "text/csv"]
 
       job = table.load_job file, format: :csv
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
     end
 
     mock.verify
@@ -50,7 +50,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
       job = table.load_job file, format: :csv, jagged_rows: true, quoted_newlines: true, autodetect: true,
         encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",
         quote: "'", skip_leading: 1
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
     end
 
     mock.verify
@@ -69,7 +69,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
         [project, load_job_gapi(table_gapi.table_reference), upload_source: file, content_type: "application/json"]
 
       job = table.load_job file, format: "JSON"
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
     end
 
     mock.verify
@@ -83,7 +83,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
 
     local_json = "acceptance/data/kitten-test-data.json"
     job = table.load_job local_json
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -99,8 +99,8 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
         [project, job_gapi, upload_source: file, content_type: "application/json"]
 
       job = table.load_job file, format: "JSON", job_id: job_id
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-      job.job_id.must_equal job_id
+      _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      _(job.job_id).must_equal job_id
     end
 
     mock.verify
@@ -120,8 +120,8 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
         [project, job_gapi, upload_source: file, content_type: "application/json"]
 
       job = table.load_job file, format: "JSON", prefix: prefix
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-      job.job_id.must_equal job_id
+      _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      _(job.job_id).must_equal job_id
     end
 
     mock.verify
@@ -138,8 +138,8 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
         [project, job_gapi, upload_source: file, content_type: "application/json"]
 
       job = table.load_job file, format: "JSON", job_id: job_id, prefix: "IGNORED"
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-      job.job_id.must_equal job_id
+      _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      _(job.job_id).must_equal job_id
     end
 
     mock.verify
@@ -156,8 +156,8 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
         [project, job_gapi, upload_source: file, content_type: "application/json"]
 
       job = table.load_job file, format: "JSON", labels: labels
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-      job.labels.must_equal labels
+      _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      _(job.labels).must_equal labels
     end
 
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_storage_test.rb
@@ -44,7 +44,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -61,7 +61,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job special_file, format: :csv
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -78,7 +78,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     job = table.load_job special_file, jagged_rows: true, quoted_newlines: true, autodetect: true,
       encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",
       quote: "'", skip_leading: 1
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -114,7 +114,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -131,7 +131,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -148,7 +148,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -165,7 +165,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -184,7 +184,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job special_file, projection_fields: projection_fields
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -197,7 +197,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_url
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -210,7 +210,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job URI load_url
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -224,7 +224,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job [URI(load_url), load_url2]
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -238,7 +238,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_url, dryrun: true
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -252,7 +252,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_url, create: "CREATE_NEVER"
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -266,7 +266,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_url, create: :never
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -280,7 +280,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_url, write: "WRITE_TRUNCATE"
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -294,7 +294,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_url, write: :truncate
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -308,8 +308,8 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_file, labels: labels
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    job.labels.must_equal labels
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job.labels).must_equal labels
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_updater_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_updater_storage_test.rb
@@ -53,9 +53,9 @@ describe Google::Cloud::Bigquery::Table, :load_job, :updater, :storage, :mock_bi
     table.service.mocked_service = mock
 
     job = table.load_job special_file, job_id: job_id do |j|
-      j.job_id.must_equal job_id
+      _(j.job_id).must_equal job_id
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -74,7 +74,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :updater, :storage, :mock_bi
     job = table.load_job special_file do |j|
       j.format = :csv
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -102,7 +102,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :updater, :storage, :mock_bi
       j.quote = "'"
       j.skip_leading = 1
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -123,7 +123,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :updater, :storage, :mock_bi
     job = table.load_job special_file do |j|
       j.projection_fields = projection_fields
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -139,7 +139,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :updater, :storage, :mock_bi
     job = table.load_job load_url do |j|
       j.create = "CREATE_NEVER"
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -155,7 +155,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :updater, :storage, :mock_bi
     job = table.load_job load_url do |j|
       j.create = :never
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -171,7 +171,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :updater, :storage, :mock_bi
     job = table.load_job load_url do |j|
       j.write = "WRITE_TRUNCATE"
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -187,7 +187,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :updater, :storage, :mock_bi
     job = table.load_job load_url do |j|
       j.write = :truncate
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -203,8 +203,8 @@ describe Google::Cloud::Bigquery::Table, :load_job, :updater, :storage, :mock_bi
     job = table.load_job load_file do |j|
       j.labels = labels
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    job.labels.must_equal labels
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job.labels).must_equal labels
 
     mock.verify
   end
@@ -224,9 +224,9 @@ describe Google::Cloud::Bigquery::Table, :load_job, :updater, :storage, :mock_bi
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    job.encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
-    job.encryption.kms_key.must_equal kms_key
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job.encryption).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(job.encryption.kms_key).must_equal kms_key
   end
 
   it "can load a storage file with the location option" do
@@ -240,13 +240,13 @@ describe Google::Cloud::Bigquery::Table, :load_job, :updater, :storage, :mock_bi
     table.service.mocked_service = mock
 
     job = table.load_job load_file do |j|
-      j.location.must_equal "US"
+      _(j.location).must_equal "US"
       j.location = region
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    job.location.must_equal region
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job.location).must_equal region
   end
 
   it "can load a storage file and unset location" do
@@ -260,13 +260,13 @@ describe Google::Cloud::Bigquery::Table, :load_job, :updater, :storage, :mock_bi
     table.service.mocked_service = mock
 
     job = table.load_job load_file do |j|
-      j.location.must_equal "US"
+      _(j.location).must_equal "US"
       j.location = nil
     end
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
-    job.location.must_equal "US"
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job.location).must_equal "US"
   end
 
   def load_job_resp_gapi table, load_url, job_id: "job_9876543210", labels: nil

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_local_test.rb
@@ -32,7 +32,7 @@ describe Google::Cloud::Bigquery::Table, :load, :local, :mock_bigquery do
         [project, load_job_gapi(table_gapi.table_reference, "CSV"), upload_source: file, content_type: "text/csv"]
 
       result = table.load file, format: :csv
-      result.must_equal true
+      _(result).must_equal true
     end
 
     mock.verify
@@ -49,7 +49,7 @@ describe Google::Cloud::Bigquery::Table, :load, :local, :mock_bigquery do
       result = table.load file, format: :csv, jagged_rows: true, quoted_newlines: true, autodetect: true,
         encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",
         quote: "'", skip_leading: 1
-      result.must_equal true
+      _(result).must_equal true
     end
 
     mock.verify
@@ -68,7 +68,7 @@ describe Google::Cloud::Bigquery::Table, :load, :local, :mock_bigquery do
         [project, load_job_gapi(table_gapi.table_reference), upload_source: file, content_type: "application/json"]
 
       result = table.load file, format: "JSON"
-      result.must_equal true
+      _(result).must_equal true
     end
 
     mock.verify
@@ -82,7 +82,7 @@ describe Google::Cloud::Bigquery::Table, :load, :local, :mock_bigquery do
 
     local_json = "acceptance/data/kitten-test-data.json"
     result = table.load local_json
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_storage_test.rb
@@ -44,7 +44,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load load_file
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -61,7 +61,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load special_file, format: :csv
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -78,7 +78,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load special_file
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     result = table.load special_file, jagged_rows: true, quoted_newlines: true, autodetect: true,
       encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",
       quote: "'", skip_leading: 1
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -114,7 +114,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load special_file
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -131,7 +131,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load special_file
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -148,7 +148,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load special_file
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -165,7 +165,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load special_file
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -184,7 +184,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load special_file, projection_fields: projection_fields
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -197,7 +197,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load load_url
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -210,7 +210,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load URI load_url
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -224,7 +224,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load [URI(load_url), load_url2]
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -238,7 +238,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load load_url, create: "CREATE_NEVER"
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -252,7 +252,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load load_url, create: :never
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -266,7 +266,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load load_url, write: "WRITE_TRUNCATE"
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end
@@ -280,7 +280,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load load_url, write: :truncate
-    result.must_equal true
+    _(result).must_equal true
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
@@ -56,58 +56,58 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
                       end }
 
   it "knows its attributes" do
-    table.table_id.must_equal table_id
-    table.dataset_id.must_equal dataset_id
-    table.project_id.must_equal project
-    table.table_ref.must_be_kind_of Google::Apis::BigqueryV2::TableReference
-    table.table_ref.table_id.must_equal table_id
-    table.table_ref.dataset_id.must_equal dataset_id
-    table.table_ref.project_id.must_equal project
+    _(table.table_id).must_equal table_id
+    _(table.dataset_id).must_equal dataset_id
+    _(table.project_id).must_equal project
+    _(table.table_ref).must_be_kind_of Google::Apis::BigqueryV2::TableReference
+    _(table.table_ref.table_id).must_equal table_id
+    _(table.table_ref.dataset_id).must_equal dataset_id
+    _(table.table_ref.project_id).must_equal project
 
-    table.range_partitioning?.must_be_nil
-    table.range_partitioning_field.must_be_nil
-    table.range_partitioning_start.must_be_nil
-    table.range_partitioning_interval.must_be_nil
-    table.range_partitioning_end.must_be_nil
-    table.time_partitioning?.must_be_nil
-    table.time_partitioning_type.must_be_nil
-    table.time_partitioning_field.must_be_nil
-    table.time_partitioning_expiration.must_be_nil
-    table.clustering_fields.must_be_nil
-    table.id.must_be_nil
-    table.name.must_be_nil
-    table.etag.must_be_nil
-    table.api_url.must_be_nil
-    table.description.must_be_nil
-    table.bytes_count.must_be_nil
-    table.rows_count.must_be_nil
-    table.created_at.must_be_nil
-    table.expires_at.must_be_nil
-    table.modified_at.must_be_nil
-    table.table?.must_be_nil
-    table.view?.must_be_nil
-    table.external?.must_be_nil
-    table.location.must_be_nil
-    table.labels.must_be_nil
-    table.schema.must_be_nil
-    table.fields.must_be_nil
-    table.headers.must_be_nil
-    table.param_types.must_be_nil
-    table.external.must_be_nil
-    table.buffer_bytes.must_be_nil
-    table.buffer_rows.must_be_nil
-    table.buffer_oldest_at.must_be_nil
+    _(table.range_partitioning?).must_be_nil
+    _(table.range_partitioning_field).must_be_nil
+    _(table.range_partitioning_start).must_be_nil
+    _(table.range_partitioning_interval).must_be_nil
+    _(table.range_partitioning_end).must_be_nil
+    _(table.time_partitioning?).must_be_nil
+    _(table.time_partitioning_type).must_be_nil
+    _(table.time_partitioning_field).must_be_nil
+    _(table.time_partitioning_expiration).must_be_nil
+    _(table.clustering_fields).must_be_nil
+    _(table.id).must_be_nil
+    _(table.name).must_be_nil
+    _(table.etag).must_be_nil
+    _(table.api_url).must_be_nil
+    _(table.description).must_be_nil
+    _(table.bytes_count).must_be_nil
+    _(table.rows_count).must_be_nil
+    _(table.created_at).must_be_nil
+    _(table.expires_at).must_be_nil
+    _(table.modified_at).must_be_nil
+    _(table.table?).must_be_nil
+    _(table.view?).must_be_nil
+    _(table.external?).must_be_nil
+    _(table.location).must_be_nil
+    _(table.labels).must_be_nil
+    _(table.schema).must_be_nil
+    _(table.fields).must_be_nil
+    _(table.headers).must_be_nil
+    _(table.param_types).must_be_nil
+    _(table.external).must_be_nil
+    _(table.buffer_bytes).must_be_nil
+    _(table.buffer_rows).must_be_nil
+    _(table.buffer_oldest_at).must_be_nil
   end
 
   it "knows its fully-qualified query ID" do
     standard_id = "`#{project}.#{dataset_id}.#{table_id}`"
     legacy_id = "[#{project}:#{dataset_id}.#{table_id}]"
 
-    table.query_id.must_equal standard_id
-    table.query_id(standard_sql: true).must_equal standard_id
-    table.query_id(standard_sql: false).must_equal legacy_id
-    table.query_id(legacy_sql: true).must_equal legacy_id
-    table.query_id(legacy_sql: false).must_equal standard_id
+    _(table.query_id).must_equal standard_id
+    _(table.query_id(standard_sql: true)).must_equal standard_id
+    _(table.query_id(standard_sql: false)).must_equal legacy_id
+    _(table.query_id(legacy_sql: true)).must_equal legacy_id
+    _(table.query_id(legacy_sql: false)).must_equal standard_id
   end
 
   it "adds to its existing schema" do
@@ -132,7 +132,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
 
     mock.verify
 
-    table.headers.must_include :end_date
+    _(table.headers).must_include :end_date
   end
 
   it "replaces existing schema with replace option" do
@@ -154,7 +154,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
 
     mock.verify
 
-    table.schema.fields.must_include field_timestamp
+    _(table.schema.fields).must_include field_timestamp
   end
 
   it "can update the permanent external data source" do
@@ -192,14 +192,14 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
 
     mock.verify
 
-    table.external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
-    table.external.urls.must_equal ["gs://my-bucket/path/to/file.json"]
-    table.external.format.must_equal "NEWLINE_DELIMITED_JSON"
-    table.external.autodetect.must_be :nil?
-    table.external.schema.wont_be :empty?
-    table.external.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    table.external.schema.must_be :frozen?
-    table.external.must_be :frozen?
+    _(table.external).must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+    _(table.external.urls).must_equal ["gs://my-bucket/path/to/file.json"]
+    _(table.external.format).must_equal "NEWLINE_DELIMITED_JSON"
+    _(table.external.autodetect).must_be :nil?
+    _(table.external.schema).wont_be :empty?
+    _(table.external.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(table.external.schema).must_be :frozen?
+    _(table.external).must_be :frozen?
   end
 
   it "returns data as a list of hashes" do
@@ -213,9 +213,9 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     data = table.data
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.count.must_equal 3
-    data[0].must_be_kind_of Hash
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.count).must_equal 3
+    _(data[0]).must_be_kind_of Hash
   end
 
   it "can copy itself with copy_job" do
@@ -227,7 +227,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     job = table.copy_job target_table
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::CopyJob
   end
 
   it "can copy itself with copy" do
@@ -241,7 +241,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     result = table.copy target_table
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can extract itself with extract_job" do
@@ -254,7 +254,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     job = table.extract_job storage_file
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::ExtractJob
   end
 
   it "can extract itself with extract" do
@@ -269,7 +269,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     result = table.extract storage_file
     mock.verify
 
-    result.must_equal true
+    _(result).must_equal true
   end
 
   it "can load data from a storage file with load_job" do
@@ -280,7 +280,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify
   end
@@ -296,7 +296,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
         [project, load_job_gapi(table_gapi.table_reference, "CSV", location: nil), upload_source: file, content_type: "text/csv"]
 
       result = table.load file, format: :csv
-      result.must_equal true
+      _(result).must_equal true
     end
 
     mock.verify
@@ -318,9 +318,9 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
 
     mock.verify
 
-    result.must_be :success?
-    result.insert_count.must_equal 3
-    result.error_count.must_equal 0
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 3
+    _(result.error_count).must_equal 0
   end
 
   it "inserts three rows one at a time with insert_async" do
@@ -339,19 +339,19 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
         inserter.insert row
       end
 
-      inserter.batch.rows.must_equal rows
+      _(inserter.batch.rows).must_equal rows
 
-      inserter.must_be :started?
-      inserter.wont_be :stopped?
+      _(inserter).must_be :started?
+      _(inserter).wont_be :stopped?
 
       # force the queued rows to be inserted
       inserter.flush
       inserter.stop.wait!
 
-      inserter.wont_be :started?
-      inserter.must_be :stopped?
+      _(inserter).wont_be :started?
+      _(inserter).must_be :stopped?
 
-      inserter.batch.must_be :nil?
+      _(inserter.batch).must_be :nil?
     end
 
     mock.verify
@@ -362,7 +362,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     mock.expect :get_table, table_gapi, [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
-    table.exists?.must_equal true
+    _(table.exists?).must_equal true
 
     mock.verify
   end
@@ -372,7 +372,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     mock.expect :get_table, table_gapi, [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
-    table.exists?(force: true).must_equal true
+    _(table.exists?(force: true)).must_equal true
 
     mock.verify
   end
@@ -383,9 +383,9 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
       [project, dataset_id, table_id]
     table.service.mocked_service = mock
 
-    table.delete.must_equal true
+    _(table.delete).must_equal true
 
-    table.exists?.must_equal false
+    _(table.exists?).must_equal false
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_update_test.rb
@@ -42,7 +42,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
 
     table.name = new_table_name
 
-    table.name.must_equal new_table_name
+    _(table.name).must_equal new_table_name
     mock.verify
   end
 
@@ -60,7 +60,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
 
     table.description = new_description
 
-    table.description.must_equal new_description
+    _(table.description).must_equal new_description
     mock.verify
   end
 
@@ -82,7 +82,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
 
     table.time_partitioning_type = type
 
-    table.time_partitioning_type.must_equal type
+    _(table.time_partitioning_type).must_equal type
     mock.verify
   end
 
@@ -104,7 +104,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
 
     table.time_partitioning_field = field
 
-    table.time_partitioning_field.must_equal field
+    _(table.time_partitioning_field).must_equal field
     mock.verify
   end
 
@@ -127,7 +127,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
 
     table.time_partitioning_expiration = expiration
 
-    table.time_partitioning_expiration.must_equal expiration
+    _(table.time_partitioning_expiration).must_equal expiration
     mock.verify
   end
 
@@ -147,7 +147,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
 
     table.labels = new_labels
 
-    table.labels.must_equal new_labels
+    _(table.labels).must_equal new_labels
     mock.verify
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reload_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reload_test.rb
@@ -27,16 +27,16 @@ describe Google::Cloud::Bigquery::Table, :reload, :mock_bigquery do
     mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
     table.service.mocked_service = mock
 
-    table.wont_be :reference?
-    table.must_be :resource?
-    table.wont_be :resource_partial?
-    table.must_be :resource_full?
+    _(table).wont_be :reference?
+    _(table).must_be :resource?
+    _(table).wont_be :resource_partial?
+    _(table).must_be :resource_full?
 
     table.reload!
-    table.wont_be :reference?
-    table.must_be :resource?
-    table.wont_be :resource_partial?
-    table.must_be :resource_full?
+    _(table).wont_be :reference?
+    _(table).must_be :resource?
+    _(table).wont_be :resource_partial?
+    _(table).must_be :resource_full?
 
     mock.verify
   end
@@ -50,16 +50,16 @@ describe Google::Cloud::Bigquery::Table, :reload, :mock_bigquery do
       mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
       table.service.mocked_service = mock
 
-      table.wont_be :reference?
-      table.must_be :resource?
-      table.must_be :resource_partial?
-      table.wont_be :resource_full?
+      _(table).wont_be :reference?
+      _(table).must_be :resource?
+      _(table).must_be :resource_partial?
+      _(table).wont_be :resource_full?
 
       table.reload!
-      table.wont_be :reference?
-      table.must_be :resource?
-      table.wont_be :resource_partial?
-      table.must_be :resource_full?
+      _(table).wont_be :reference?
+      _(table).must_be :resource?
+      _(table).wont_be :resource_partial?
+      _(table).must_be :resource_full?
 
       mock.verify
     end
@@ -73,16 +73,16 @@ describe Google::Cloud::Bigquery::Table, :reload, :mock_bigquery do
       mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
       table.service.mocked_service = mock
 
-      table.must_be :reference?
-      table.wont_be :resource?
-      table.wont_be :resource_partial?
-      table.wont_be :resource_full?
+      _(table).must_be :reference?
+      _(table).wont_be :resource?
+      _(table).wont_be :resource_partial?
+      _(table).wont_be :resource_full?
 
       table.reload!
-      table.wont_be :reference?
-      table.must_be :resource?
-      table.wont_be :resource_partial?
-      table.must_be :resource_full?
+      _(table).wont_be :reference?
+      _(table).must_be :resource?
+      _(table).wont_be :resource_partial?
+      _(table).must_be :resource_full?
 
       mock.verify
     end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -70,64 +70,64 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   end
 
   it "gets the schema, fields, and headers" do
-    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    table.schema.must_be :frozen?
-    table.schema.fields.count.must_equal 10
+    _(table.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(table.schema).must_be :frozen?
+    _(table.schema.fields.count).must_equal 10
 
-    table.schema.fields[0].name.must_equal "name"
-    table.schema.fields[0].type.must_equal "STRING"
-    table.schema.fields[0].description.must_be :nil?
-    table.schema.fields[0].mode.must_equal "REQUIRED"
+    _(table.schema.fields[0].name).must_equal "name"
+    _(table.schema.fields[0].type).must_equal "STRING"
+    _(table.schema.fields[0].description).must_be :nil?
+    _(table.schema.fields[0].mode).must_equal "REQUIRED"
 
-    table.schema.fields[1].name.must_equal "age"
-    table.schema.fields[1].type.must_equal "INTEGER"
-    table.schema.fields[1].description.must_be :nil?
-    table.schema.fields[1].mode.must_equal "NULLABLE"
+    _(table.schema.fields[1].name).must_equal "age"
+    _(table.schema.fields[1].type).must_equal "INTEGER"
+    _(table.schema.fields[1].description).must_be :nil?
+    _(table.schema.fields[1].mode).must_equal "NULLABLE"
 
-    table.schema.fields[2].name.must_equal "score"
-    table.schema.fields[2].type.must_equal "FLOAT"
-    table.schema.fields[2].description.must_be :nil?
-    table.schema.fields[2].mode.must_equal "NULLABLE"
+    _(table.schema.fields[2].name).must_equal "score"
+    _(table.schema.fields[2].type).must_equal "FLOAT"
+    _(table.schema.fields[2].description).must_be :nil?
+    _(table.schema.fields[2].mode).must_equal "NULLABLE"
 
-    table.schema.fields[3].name.must_equal "pi"
-    table.schema.fields[3].type.must_equal "NUMERIC"
-    table.schema.fields[3].description.must_be :nil?
-    table.schema.fields[3].mode.must_equal "NULLABLE"
+    _(table.schema.fields[3].name).must_equal "pi"
+    _(table.schema.fields[3].type).must_equal "NUMERIC"
+    _(table.schema.fields[3].description).must_be :nil?
+    _(table.schema.fields[3].mode).must_equal "NULLABLE"
 
-    table.schema.fields[4].name.must_equal "active"
-    table.schema.fields[4].type.must_equal "BOOLEAN"
-    table.schema.fields[4].description.must_be :nil?
-    table.schema.fields[4].mode.must_equal "NULLABLE"
+    _(table.schema.fields[4].name).must_equal "active"
+    _(table.schema.fields[4].type).must_equal "BOOLEAN"
+    _(table.schema.fields[4].description).must_be :nil?
+    _(table.schema.fields[4].mode).must_equal "NULLABLE"
 
-    table.schema.fields[5].name.must_equal "avatar"
-    table.schema.fields[5].type.must_equal "BYTES"
-    table.schema.fields[5].description.must_be :nil?
-    table.schema.fields[5].mode.must_equal "NULLABLE"
+    _(table.schema.fields[5].name).must_equal "avatar"
+    _(table.schema.fields[5].type).must_equal "BYTES"
+    _(table.schema.fields[5].description).must_be :nil?
+    _(table.schema.fields[5].mode).must_equal "NULLABLE"
 
-    table.schema.fields[6].name.must_equal "started_at"
-    table.schema.fields[6].type.must_equal "TIMESTAMP"
-    table.schema.fields[6].description.must_be :nil?
-    table.schema.fields[6].mode.must_equal "NULLABLE"
+    _(table.schema.fields[6].name).must_equal "started_at"
+    _(table.schema.fields[6].type).must_equal "TIMESTAMP"
+    _(table.schema.fields[6].description).must_be :nil?
+    _(table.schema.fields[6].mode).must_equal "NULLABLE"
 
-    table.schema.fields[7].name.must_equal "duration"
-    table.schema.fields[7].type.must_equal "TIME"
-    table.schema.fields[7].description.must_be :nil?
-    table.schema.fields[7].mode.must_equal "NULLABLE"
+    _(table.schema.fields[7].name).must_equal "duration"
+    _(table.schema.fields[7].type).must_equal "TIME"
+    _(table.schema.fields[7].description).must_be :nil?
+    _(table.schema.fields[7].mode).must_equal "NULLABLE"
 
-    table.schema.fields[8].name.must_equal "target_end"
-    table.schema.fields[8].type.must_equal "DATETIME"
-    table.schema.fields[8].description.must_be :nil?
-    table.schema.fields[8].mode.must_equal "NULLABLE"
+    _(table.schema.fields[8].name).must_equal "target_end"
+    _(table.schema.fields[8].type).must_equal "DATETIME"
+    _(table.schema.fields[8].description).must_be :nil?
+    _(table.schema.fields[8].mode).must_equal "NULLABLE"
 
-    table.schema.fields[9].name.must_equal "birthday"
-    table.schema.fields[9].type.must_equal "DATE"
-    table.schema.fields[9].description.must_be :nil?
-    table.schema.fields[9].mode.must_equal "NULLABLE"
+    _(table.schema.fields[9].name).must_equal "birthday"
+    _(table.schema.fields[9].type).must_equal "DATE"
+    _(table.schema.fields[9].description).must_be :nil?
+    _(table.schema.fields[9].mode).must_equal "NULLABLE"
 
-    table.fields.count.must_equal 10
-    table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
-    table.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    table.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(table.fields.count).must_equal 10
+    _(table.fields.map(&:name)).must_equal table.schema.fields.map(&:name)
+    _(table.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
   end
 
   it "sets a flat schema via a block with replace option true" do
@@ -189,7 +189,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
 
     mock.verify
 
-    table.headers.must_include :end_date
+    _(table.headers).must_include :end_date
   end
 
   it "replaces existing schema with replace option" do
@@ -210,7 +210,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
 
     mock.verify
 
-    table.schema.fields.must_include field_timestamp
+    _(table.schema.fields).must_include field_timestamp
   end
 
   it "replaces the schema when loaded from a file" do
@@ -257,9 +257,9 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
 
     mock.verify
 
-    table.schema.fields.must_include field_string_required
-    table.schema.fields.must_include field_record_repeated
-    table.schema.fields.must_equal [field_string_required, field_record_repeated]
+    _(table.schema.fields).must_include field_string_required
+    _(table.schema.fields).must_include field_record_repeated
+    _(table.schema.fields).must_equal [field_string_required, field_record_repeated]
   end
 
   it "modifies a nested schema via field" do
@@ -297,7 +297,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.service.mocked_service = mock
 
     table.schema do |schema|
-      schema.field("first_name").mode.must_equal "REQUIRED"
+      _(schema.field("first_name").mode).must_equal "REQUIRED"
       schema.field "cities_lived" do |nested|
         # Add a new field to the existing record
         nested.string "first_name", mode: :required
@@ -306,11 +306,11 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
 
     mock.verify
 
-    table.schema.headers.must_include :first_name
-    table.schema.headers.must_include :cities_lived
-    table.schema.field(:cities_lived).headers.must_include :started_at
-    table.schema.field(:cities_lived).headers.must_include :rank
-    table.schema.field("cities_lived").headers.must_include :first_name
+    _(table.schema.headers).must_include :first_name
+    _(table.schema.headers).must_include :cities_lived
+    _(table.schema.field(:cities_lived).headers).must_include :started_at
+    _(table.schema.field(:cities_lived).headers).must_include :rank
+    _(table.schema.field("cities_lived").headers).must_include :first_name
   end
 
   it "allows nested records several levels deep" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
@@ -33,44 +33,44 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
 
   it "knows its attributes" do
-    table.table_id.must_equal table_id
-    table.dataset_id.must_equal dataset
-    table.project_id.must_equal project
-    table.table_ref.must_be_kind_of Google::Apis::BigqueryV2::TableReference
-    table.table_ref.table_id.must_equal table_id
-    table.table_ref.dataset_id.must_equal dataset
-    table.table_ref.project_id.must_equal project
+    _(table.table_id).must_equal table_id
+    _(table.dataset_id).must_equal dataset
+    _(table.project_id).must_equal project
+    _(table.table_ref).must_be_kind_of Google::Apis::BigqueryV2::TableReference
+    _(table.table_ref.table_id).must_equal table_id
+    _(table.table_ref.dataset_id).must_equal dataset
+    _(table.table_ref.project_id).must_equal project
 
-    table.name.must_equal table_name
-    table.description.must_equal description
-    table.etag.must_equal etag
-    table.api_url.must_equal api_url
-    table.bytes_count.must_equal 1000
-    table.rows_count.must_equal 100
-    table.table?.must_equal true
-    table.view?.must_equal false
-    table.location.must_equal location_code
-    table.labels.must_equal labels
-    table.labels.must_be :frozen?
-    table.require_partition_filter.must_equal true
-    table.encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
-    table.encryption.kms_key.must_equal kms_key
-    table.encryption.must_be :frozen?
+    _(table.name).must_equal table_name
+    _(table.description).must_equal description
+    _(table.etag).must_equal etag
+    _(table.api_url).must_equal api_url
+    _(table.bytes_count).must_equal 1000
+    _(table.rows_count).must_equal 100
+    _(table.table?).must_equal true
+    _(table.view?).must_equal false
+    _(table.location).must_equal location_code
+    _(table.labels).must_equal labels
+    _(table.labels).must_be :frozen?
+    _(table.require_partition_filter).must_equal true
+    _(table.encryption).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(table.encryption.kms_key).must_equal kms_key
+    _(table.encryption).must_be :frozen?
   end
 
   it "knows its fully-qualified ID" do
-    table.id.must_equal "#{project}:#{dataset}.#{table_id}"
+    _(table.id).must_equal "#{project}:#{dataset}.#{table_id}"
   end
 
   it "knows its fully-qualified query ID" do
     standard_id = "`#{project}.#{dataset}.#{table_id}`"
     legacy_id = "[#{project}:#{dataset}.#{table_id}]"
 
-    table.query_id.must_equal standard_id
-    table.query_id(standard_sql: true).must_equal standard_id
-    table.query_id(standard_sql: false).must_equal legacy_id
-    table.query_id(legacy_sql: true).must_equal legacy_id
-    table.query_id(legacy_sql: false).must_equal standard_id
+    _(table.query_id).must_equal standard_id
+    _(table.query_id(standard_sql: true)).must_equal standard_id
+    _(table.query_id(standard_sql: false)).must_equal legacy_id
+    _(table.query_id(legacy_sql: true)).must_equal legacy_id
+    _(table.query_id(legacy_sql: false)).must_equal standard_id
   end
 
   it "knows its creation and modification and expiration times" do
@@ -80,33 +80,33 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table_hash["expirationTime"] = time_millis
 
 
-    table.created_at.must_be_close_to now, 1
-    table.modified_at.must_be_close_to now, 1
-    table.expires_at.must_be_close_to now, 1
+    _(table.created_at).must_be_close_to now, 1
+    _(table.modified_at).must_be_close_to now, 1
+    _(table.expires_at).must_be_close_to now, 1
   end
 
   it "can have an empty expiration times" do
     table_hash["expirationTime"] = nil
 
-    table.expires_at.must_be :nil?
+    _(table.expires_at).must_be :nil?
   end
 
   it "knows schema, fields, and headers" do
-    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    table.schema.must_be :frozen?
-    table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
-    table.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    table.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(table.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(table.schema).must_be :frozen?
+    _(table.fields.map(&:name)).must_equal table.schema.fields.map(&:name)
+    _(table.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
   end
 
   it "knows its streaming buffer attributes" do
-    table.buffer_bytes.must_equal 2000
-    table.buffer_rows.must_equal 200
-    table.buffer_oldest_at.must_be_close_to ::Time.now, 1
+    _(table.buffer_bytes).must_equal 2000
+    _(table.buffer_rows).must_equal 200
+    _(table.buffer_oldest_at).must_be_close_to ::Time.now, 1
   end
 
   it "can test its existence" do
-    table.exists?.must_equal true
+    _(table.exists?).must_equal true
   end
 
   it "can test its existence with force to load resource" do
@@ -114,7 +114,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     mock.expect :get_table, table_gapi, [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
-    table.exists?(force: true).must_equal true
+    _(table.exists?(force: true)).must_equal true
 
     mock.verify
   end
@@ -125,9 +125,9 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       [project, dataset, table_id]
     table.service.mocked_service = mock
 
-    table.delete.must_equal true
+    _(table.delete).must_equal true
 
-    table.exists?.must_equal false
+    _(table.exists?).must_equal false
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
@@ -39,25 +39,25 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
 
     table.service.mocked_service = mock
 
-    table.name.must_equal table_name
-    table.description.must_equal description
-    table.schema.fields.count.must_equal schema.fields.count
-    table.time_partitioning_type.must_be_nil
-    table.time_partitioning_field.must_be_nil
-    table.time_partitioning_expiration.must_be_nil
-    table.require_partition_filter.must_equal true
-    table.clustering_fields.must_be_nil
+    _(table.name).must_equal table_name
+    _(table.description).must_equal description
+    _(table.schema.fields.count).must_equal schema.fields.count
+    _(table.time_partitioning_type).must_be_nil
+    _(table.time_partitioning_field).must_be_nil
+    _(table.time_partitioning_expiration).must_be_nil
+    _(table.require_partition_filter).must_equal true
+    _(table.clustering_fields).must_be_nil
 
     table.name = new_table_name
 
-    table.name.must_equal new_table_name
-    table.description.must_equal description
-    table.schema.fields.count.must_equal schema.fields.count
-    table.time_partitioning_type.must_be_nil
-    table.time_partitioning_field.must_be_nil
-    table.time_partitioning_expiration.must_be_nil
-    table.require_partition_filter.must_equal true
-    table.clustering_fields.must_be_nil
+    _(table.name).must_equal new_table_name
+    _(table.description).must_equal description
+    _(table.schema.fields.count).must_equal schema.fields.count
+    _(table.time_partitioning_type).must_be_nil
+    _(table.time_partitioning_field).must_be_nil
+    _(table.time_partitioning_expiration).must_be_nil
+    _(table.require_partition_filter).must_equal true
+    _(table.clustering_fields).must_be_nil
 
     mock.verify
   end
@@ -73,23 +73,23 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
     table.service.mocked_service = mock
 
-    table.name.must_equal table_name
-    table.description.must_equal description
-    table.schema.fields.count.must_equal schema.fields.count
-    table.time_partitioning_type.must_be_nil
-    table.time_partitioning_field.must_be_nil
-    table.time_partitioning_expiration.must_be_nil
-    table.require_partition_filter.must_equal true
+    _(table.name).must_equal table_name
+    _(table.description).must_equal description
+    _(table.schema.fields.count).must_equal schema.fields.count
+    _(table.time_partitioning_type).must_be_nil
+    _(table.time_partitioning_field).must_be_nil
+    _(table.time_partitioning_expiration).must_be_nil
+    _(table.require_partition_filter).must_equal true
 
     table.description = new_description
 
-    table.name.must_equal table_name
-    table.description.must_equal new_description
-    table.schema.fields.count.must_equal schema.fields.count
-    table.time_partitioning_type.must_be_nil
-    table.time_partitioning_field.must_be_nil
-    table.time_partitioning_expiration.must_be_nil
-    table.require_partition_filter.must_equal true
+    _(table.name).must_equal table_name
+    _(table.description).must_equal new_description
+    _(table.schema.fields.count).must_equal schema.fields.count
+    _(table.time_partitioning_type).must_be_nil
+    _(table.time_partitioning_field).must_be_nil
+    _(table.time_partitioning_expiration).must_be_nil
+    _(table.require_partition_filter).must_equal true
 
     mock.verify
   end
@@ -109,22 +109,22 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
     table.service.mocked_service = mock
 
-    table.name.must_equal table_name
-    table.description.must_equal description
-    table.schema.fields.count.must_equal schema.fields.count
-    table.time_partitioning_type.must_be_nil
-    table.time_partitioning_field.must_be_nil
-    table.time_partitioning_expiration.must_be_nil
-    table.require_partition_filter.must_equal true
+    _(table.name).must_equal table_name
+    _(table.description).must_equal description
+    _(table.schema.fields.count).must_equal schema.fields.count
+    _(table.time_partitioning_type).must_be_nil
+    _(table.time_partitioning_field).must_be_nil
+    _(table.time_partitioning_expiration).must_be_nil
+    _(table.require_partition_filter).must_equal true
 
     table.time_partitioning_type = type
 
-    table.name.must_equal table_name
-    table.description.must_equal description
-    table.schema.fields.count.must_equal schema.fields.count
-    table.time_partitioning_type.must_equal type
-    table.time_partitioning_expiration.must_be_nil
-    table.require_partition_filter.must_equal true
+    _(table.name).must_equal table_name
+    _(table.description).must_equal description
+    _(table.schema.fields.count).must_equal schema.fields.count
+    _(table.time_partitioning_type).must_equal type
+    _(table.time_partitioning_expiration).must_be_nil
+    _(table.require_partition_filter).must_equal true
 
     mock.verify
   end
@@ -144,23 +144,23 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
     table.service.mocked_service = mock
 
-    table.name.must_equal table_name
-    table.description.must_equal description
-    table.schema.fields.count.must_equal schema.fields.count
-    table.time_partitioning_type.must_be_nil
-    table.time_partitioning_field.must_be_nil
-    table.time_partitioning_expiration.must_be_nil
-    table.require_partition_filter.must_equal true
+    _(table.name).must_equal table_name
+    _(table.description).must_equal description
+    _(table.schema.fields.count).must_equal schema.fields.count
+    _(table.time_partitioning_type).must_be_nil
+    _(table.time_partitioning_field).must_be_nil
+    _(table.time_partitioning_expiration).must_be_nil
+    _(table.require_partition_filter).must_equal true
 
     table.time_partitioning_field = field
 
-    table.name.must_equal table_name
-    table.description.must_equal description
-    table.schema.fields.count.must_equal schema.fields.count
-    table.time_partitioning_type.must_be_nil
-    table.time_partitioning_field.must_equal field
-    table.time_partitioning_expiration.must_be_nil
-    table.require_partition_filter.must_equal true
+    _(table.name).must_equal table_name
+    _(table.description).must_equal description
+    _(table.schema.fields.count).must_equal schema.fields.count
+    _(table.time_partitioning_type).must_be_nil
+    _(table.time_partitioning_field).must_equal field
+    _(table.time_partitioning_expiration).must_be_nil
+    _(table.require_partition_filter).must_equal true
 
     mock.verify
   end
@@ -181,23 +181,23 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
     table.service.mocked_service = mock
 
-    table.name.must_equal table_name
-    table.description.must_equal description
-    table.schema.fields.count.must_equal schema.fields.count
-    table.time_partitioning_type.must_be_nil
-    table.time_partitioning_field.must_be_nil
-    table.time_partitioning_expiration.must_be_nil
-    table.require_partition_filter.must_equal true
+    _(table.name).must_equal table_name
+    _(table.description).must_equal description
+    _(table.schema.fields.count).must_equal schema.fields.count
+    _(table.time_partitioning_type).must_be_nil
+    _(table.time_partitioning_field).must_be_nil
+    _(table.time_partitioning_expiration).must_be_nil
+    _(table.require_partition_filter).must_equal true
 
     table.time_partitioning_expiration = expiration
 
-    table.name.must_equal table_name
-    table.description.must_equal description
-    table.schema.fields.count.must_equal schema.fields.count
-    table.time_partitioning_type.must_be_nil
-    table.time_partitioning_field.must_be_nil
-    table.time_partitioning_expiration.must_equal expiration
-    table.require_partition_filter.must_equal true
+    _(table.name).must_equal table_name
+    _(table.description).must_equal description
+    _(table.schema.fields.count).must_equal schema.fields.count
+    _(table.time_partitioning_type).must_be_nil
+    _(table.time_partitioning_field).must_be_nil
+    _(table.time_partitioning_expiration).must_equal expiration
+    _(table.require_partition_filter).must_equal true
 
     mock.verify
   end
@@ -212,23 +212,23 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
     table.service.mocked_service = mock
 
-    table.name.must_equal table_name
-    table.description.must_equal description
-    table.schema.fields.count.must_equal schema.fields.count
-    table.time_partitioning_type.must_be_nil
-    table.time_partitioning_field.must_be_nil
-    table.time_partitioning_expiration.must_be_nil
-    table.require_partition_filter.must_equal true
+    _(table.name).must_equal table_name
+    _(table.description).must_equal description
+    _(table.schema.fields.count).must_equal schema.fields.count
+    _(table.time_partitioning_type).must_be_nil
+    _(table.time_partitioning_field).must_be_nil
+    _(table.time_partitioning_expiration).must_be_nil
+    _(table.require_partition_filter).must_equal true
 
     table.require_partition_filter = false
 
-    table.name.must_equal table_name
-    table.description.must_equal description
-    table.schema.fields.count.must_equal schema.fields.count
-    table.time_partitioning_type.must_be_nil
-    table.time_partitioning_field.must_be_nil
-    table.time_partitioning_expiration.must_be_nil
-    table.require_partition_filter.must_equal false
+    _(table.name).must_equal table_name
+    _(table.description).must_equal description
+    _(table.schema.fields.count).must_equal schema.fields.count
+    _(table.time_partitioning_type).must_be_nil
+    _(table.time_partitioning_field).must_be_nil
+    _(table.time_partitioning_expiration).must_be_nil
+    _(table.require_partition_filter).must_equal false
 
     mock.verify
   end
@@ -246,11 +246,11 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
     table.service.mocked_service = mock
 
-    table.labels.must_equal labels
+    _(table.labels).must_equal labels
 
     table.labels = new_labels
 
-    table.labels.must_equal new_labels
+    _(table.labels).must_equal new_labels
     mock.verify
   end
 
@@ -267,15 +267,15 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
     table.service.mocked_service = mock
 
-    table.encryption.must_be :nil?
+    _(table.encryption).must_be :nil?
 
     encrypt_config = bigquery.encryption kms_key: kms_key
 
     table.encryption = encrypt_config
 
-    table.encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
-    table.encryption.kms_key.must_equal kms_key
-    table.encryption.must_be :frozen?
+    _(table.encryption).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    _(table.encryption.kms_key).must_equal kms_key
+    _(table.encryption).must_be :frozen?
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Bigquery::Table, :view, :attributes, :mock_bigquery do
       [view.project_id, view.dataset_id, view.table_id]
     view.service.mocked_service = mock
 
-    view.created_at.must_be_close_to ::Time.now, 1
+    _(view.created_at).must_be_close_to ::Time.now, 1
 
     mock.verify
 
@@ -47,7 +47,7 @@ describe Google::Cloud::Bigquery::Table, :view, :attributes, :mock_bigquery do
       [view.project_id, view.dataset_id, view.table_id]
     view.service.mocked_service = mock
 
-    view.expires_at.must_be_close_to ::Time.now, 1
+    _(view.expires_at).must_be_close_to ::Time.now, 1
 
     mock.verify
 
@@ -61,7 +61,7 @@ describe Google::Cloud::Bigquery::Table, :view, :attributes, :mock_bigquery do
       [view.project_id, view.dataset_id, view.table_id]
     view.service.mocked_service = mock
 
-    view.modified_at.must_be_close_to ::Time.now, 1
+    _(view.modified_at).must_be_close_to ::Time.now, 1
 
     mock.verify
 
@@ -75,12 +75,12 @@ describe Google::Cloud::Bigquery::Table, :view, :attributes, :mock_bigquery do
       [view.project_id, view.dataset_id, view.table_id]
     view.service.mocked_service = mock
 
-    view.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    view.schema.must_be :frozen?
-    view.schema.fields.wont_be :empty?
-    view.fields.wont_be :empty?
-    view.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    view.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(view.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(view.schema).must_be :frozen?
+    _(view.schema.fields).wont_be :empty?
+    _(view.fields).wont_be :empty?
+    _(view.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(view.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
     mock.verify
 
@@ -95,7 +95,7 @@ describe Google::Cloud::Bigquery::Table, :view, :attributes, :mock_bigquery do
         [view.project_id, view.dataset_id, view.table_id]
       view.service.mocked_service = mock
 
-      view.send(attr).must_equal val
+      _(view.send(attr)).must_equal val
 
       mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
@@ -31,17 +31,17 @@ describe Google::Cloud::Bigquery::Table, :view, :mock_bigquery do
                                                 bigquery.service }
 
   it "knows its attributes" do
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.etag.must_equal etag
-    view.api_url.must_equal api_url
-    view.query.must_equal "SELECT name, age, score, active FROM `external.publicdata.users`"
-    view.wont_be :query_standard_sql?
-    view.must_be :query_legacy_sql?
-    view.query_udfs.must_be :empty?
-    view.view?.must_equal true
-    view.table?.must_equal false
-    view.location.must_equal location_code
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.etag).must_equal etag
+    _(view.api_url).must_equal api_url
+    _(view.query).must_equal "SELECT name, age, score, active FROM `external.publicdata.users`"
+    _(view).wont_be :query_standard_sql?
+    _(view).must_be :query_legacy_sql?
+    _(view.query_udfs).must_be :empty?
+    _(view.view?).must_equal true
+    _(view.table?).must_equal false
+    _(view.location).must_equal location_code
   end
 
   it "knows its creation and modification and expiration times" do
@@ -51,21 +51,21 @@ describe Google::Cloud::Bigquery::Table, :view, :mock_bigquery do
     view_hash["expirationTime"] = time_millis
 
 
-    view.created_at.must_be_close_to now, 1
-    view.modified_at.must_be_close_to now, 1
-    view.expires_at.must_be_close_to now, 1
+    _(view.created_at).must_be_close_to now, 1
+    _(view.modified_at).must_be_close_to now, 1
+    _(view.expires_at).must_be_close_to now, 1
   end
 
   it "knows schema, fields, and headers" do
-    view.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
-    view.schema.must_be :frozen?
-    view.fields.map(&:name).must_equal view.schema.fields.map(&:name)
-    view.headers.must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    view.param_types.must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(view.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(view.schema).must_be :frozen?
+    _(view.fields.map(&:name)).must_equal view.schema.fields.map(&:name)
+    _(view.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(view.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
   end
 
   it "can test its existence" do
-    view.exists?.must_equal true
+    _(view.exists?).must_equal true
   end
 
   it "can test its existence with force to load resource" do
@@ -73,7 +73,7 @@ describe Google::Cloud::Bigquery::Table, :view, :mock_bigquery do
     mock.expect :get_table, view_gapi, [view.project_id, view.dataset_id, view.table_id]
     view.service.mocked_service = mock
 
-    view.exists?(force: true).must_equal true
+    _(view.exists?(force: true)).must_equal true
 
     mock.verify
   end
@@ -84,9 +84,9 @@ describe Google::Cloud::Bigquery::Table, :view, :mock_bigquery do
       [project, dataset, table_id]
     view.service.mocked_service = mock
 
-    view.delete.must_equal true
+    _(view.delete).must_equal true
 
-    view.exists?.must_equal false
+    _(view.exists?).must_equal false
 
     mock.verify
   end
@@ -100,11 +100,11 @@ describe Google::Cloud::Bigquery::Table, :view, :mock_bigquery do
       [project, dataset, table_id]
     view.service.mocked_service = mock
 
-    view.description.must_equal description
+    _(view.description).must_equal description
     view.reload!
 
     mock.verify
 
-    view.description.must_equal new_description
+    _(view.description).must_equal new_description
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
@@ -39,15 +39,15 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     mock.expect :get_table, return_view(view_hash), [project, dataset_id, table_id]
     view.service.mocked_service = mock
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
 
     view.name = new_table_name
 
-    view.name.must_equal new_table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
+    _(view.name).must_equal new_table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
 
     mock.verify
   end
@@ -63,15 +63,15 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     mock.expect :get_table, return_view(view_hash), [project, dataset_id, table_id]
     view.service.mocked_service = mock
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
 
     view.description = new_description
 
-    view.description.must_equal new_description
-    view.name.must_equal table_name
-    view.schema.fields.count.must_equal schema.fields.count
+    _(view.description).must_equal new_description
+    _(view.name).must_equal table_name
+    _(view.schema.fields.count).must_equal schema.fields.count
 
     mock.verify
   end
@@ -95,19 +95,19 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     mock.expect :get_table, return_view(view_hash, request_view_gapi.view), [project, dataset_id, table_id]
     view.service.mocked_service = mock
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
 
     view.query = new_query
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
-    view.query.must_equal new_query
-    view.must_be :query_standard_sql?
-    view.wont_be :query_legacy_sql?
-    view.query_udfs.must_be :empty?
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
+    _(view.query).must_equal new_query
+    _(view).must_be :query_standard_sql?
+    _(view).wont_be :query_legacy_sql?
+    _(view.query_udfs).must_be :empty?
 
     mock.verify
   end
@@ -131,19 +131,19 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     mock.expect :get_table, return_view(view_hash, request_view_gapi.view), [project, dataset_id, table_id]
     view.service.mocked_service = mock
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
 
     view.set_query new_query
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
-    view.query.must_equal new_query
-    view.must_be :query_standard_sql?
-    view.wont_be :query_legacy_sql?
-    view.query_udfs.must_be :empty?
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
+    _(view.query).must_equal new_query
+    _(view).must_be :query_standard_sql?
+    _(view).wont_be :query_legacy_sql?
+    _(view.query_udfs).must_be :empty?
 
     mock.verify
   end
@@ -167,19 +167,19 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     mock.expect :get_table, return_view(view_hash, request_view_gapi.view), [project, dataset_id, table_id]
     view.service.mocked_service = mock
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
 
     view.set_query new_query, standard_sql: true
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
-    view.query.must_equal new_query
-    view.must_be :query_standard_sql?
-    view.wont_be :query_legacy_sql?
-    view.query_udfs.must_be :empty?
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
+    _(view.query).must_equal new_query
+    _(view).must_be :query_standard_sql?
+    _(view).wont_be :query_legacy_sql?
+    _(view.query_udfs).must_be :empty?
 
     mock.verify
   end
@@ -203,19 +203,19 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     mock.expect :get_table, return_view(view_hash, request_view_gapi.view), [project, dataset_id, table_id]
     view.service.mocked_service = mock
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
 
     view.set_query new_query, legacy_sql: true
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
-    view.query.must_equal new_query
-    view.wont_be :query_standard_sql?
-    view.must_be :query_legacy_sql?
-    view.query_udfs.must_be :empty?
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
+    _(view.query).must_equal new_query
+    _(view).wont_be :query_standard_sql?
+    _(view).must_be :query_legacy_sql?
+    _(view.query_udfs).must_be :empty?
 
     mock.verify
   end
@@ -242,19 +242,19 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     mock.expect :get_table, return_view(view_hash, request_view_gapi.view), [project, dataset_id, table_id]
     view.service.mocked_service = mock
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
 
     view.set_query new_query, udfs: ["return x+1;", "gs://my-bucket/my-lib.js"]
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
-    view.query.must_equal new_query
-    view.must_be :query_standard_sql?
-    view.wont_be :query_legacy_sql?
-    view.query_udfs.must_equal ["return x+1;", "gs://my-bucket/my-lib.js"]
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
+    _(view.query).must_equal new_query
+    _(view).must_be :query_standard_sql?
+    _(view).wont_be :query_legacy_sql?
+    _(view.query_udfs).must_equal ["return x+1;", "gs://my-bucket/my-lib.js"]
 
     mock.verify
   end
@@ -280,19 +280,19 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     mock.expect :get_table, return_view(view_hash, request_view_gapi.view), [project, dataset_id, table_id]
     view.service.mocked_service = mock
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
 
     view.set_query new_query, udfs: "return x+1;"
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
-    view.query.must_equal new_query
-    view.must_be :query_standard_sql?
-    view.wont_be :query_legacy_sql?
-    view.query_udfs.must_equal ["return x+1;"]
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
+    _(view.query).must_equal new_query
+    _(view).must_be :query_standard_sql?
+    _(view).wont_be :query_legacy_sql?
+    _(view.query_udfs).must_equal ["return x+1;"]
 
     mock.verify
   end
@@ -318,19 +318,19 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     mock.expect :get_table, return_view(view_hash, request_view_gapi.view), [project, dataset_id, table_id]
     view.service.mocked_service = mock
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
 
     view.set_query new_query, udfs: "gs://my-bucket/my-lib.js"
 
-    view.name.must_equal table_name
-    view.description.must_equal description
-    view.schema.fields.count.must_equal schema.fields.count
-    view.query.must_equal new_query
-    view.must_be :query_standard_sql?
-    view.wont_be :query_legacy_sql?
-    view.query_udfs.must_equal ["gs://my-bucket/my-lib.js"]
+    _(view.name).must_equal table_name
+    _(view.description).must_equal description
+    _(view.schema.fields.count).must_equal schema.fields.count
+    _(view.query).must_equal new_query
+    _(view).must_be :query_standard_sql?
+    _(view).wont_be :query_legacy_sql?
+    _(view.query_udfs).must_equal ["gs://my-bucket/my-lib.js"]
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
@@ -20,51 +20,51 @@ describe Google::Cloud do
     it "calls out to Google::Cloud.bigquery" do
       gcloud = Google::Cloud.new
       stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, host: nil) {
-        project.must_be :nil?
-        keyfile.must_be :nil?
-        scope.must_be :nil?
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_be :nil?
+        _(keyfile).must_be :nil?
+        _(scope).must_be :nil?
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         "bigquery-project-object-empty"
       }
       Google::Cloud.stub :bigquery, stubbed_bigquery do
         project = gcloud.bigquery
-        project.must_equal "bigquery-project-object-empty"
+        _(project).must_equal "bigquery-project-object-empty"
       end
     end
 
     it "passes project and keyfile to Google::Cloud.bigquery" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_be :nil?
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_be :nil?
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         "bigquery-project-object"
       }
       Google::Cloud.stub :bigquery, stubbed_bigquery do
         project = gcloud.bigquery
-        project.must_equal "bigquery-project-object"
+        _(project).must_equal "bigquery-project-object"
       end
     end
 
     it "passes project and keyfile and options to Google::Cloud.bigquery" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_equal "http://example.com/scope"
-        retries.must_equal 5
-        timeout.must_equal 60
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_equal "http://example.com/scope"
+        _(retries).must_equal 5
+        _(timeout).must_equal 60
+        _(host).must_be :nil?
         "bigquery-project-object-scoped"
       }
       Google::Cloud.stub :bigquery, stubbed_bigquery do
         project = gcloud.bigquery scope: "http://example.com/scope", retries: 5, timeout: 60
-        project.must_equal "bigquery-project-object-scoped"
+        _(project).must_equal "bigquery-project-object-scoped"
       end
     end
   end
@@ -86,9 +86,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Bigquery::Credentials.stub :default, default_credentials do
             bigquery = Google::Cloud.bigquery
-            bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
-            bigquery.project.must_equal "project-id"
-            bigquery.service.credentials.must_equal default_credentials
+            _(bigquery).must_be_kind_of Google::Cloud::Bigquery::Project
+            _(bigquery.project).must_equal "project-id"
+            _(bigquery.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -96,16 +96,16 @@ describe Google::Cloud do
 
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigquery-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "bigquery-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "bigquery-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -116,9 +116,9 @@ describe Google::Cloud do
             Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
                 bigquery = Google::Cloud.bigquery "project-id", "path/to/keyfile.json"
-                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
-                bigquery.project.must_equal "project-id"
-                bigquery.service.must_be_kind_of OpenStruct
+                _(bigquery).must_be_kind_of Google::Cloud::Bigquery::Project
+                _(bigquery.project).must_equal "project-id"
+                _(bigquery.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -144,9 +144,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Bigquery::Credentials.stub :default, default_credentials do
             bigquery = Google::Cloud::Bigquery.new
-            bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
-            bigquery.project.must_equal "project-id"
-            bigquery.service.credentials.must_equal default_credentials
+            _(bigquery).must_be_kind_of Google::Cloud::Bigquery::Project
+            _(bigquery.project).must_equal "project-id"
+            _(bigquery.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -154,11 +154,11 @@ describe Google::Cloud do
 
     it "uses provided endpoint" do
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal default_credentials
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_equal "bigquery-endpoint2.example.com"
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_equal "bigquery-endpoint2.example.com"
         OpenStruct.new project: project
       }
 
@@ -167,9 +167,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
             bigquery = Google::Cloud::Bigquery.new credentials: default_credentials, endpoint: "bigquery-endpoint2.example.com"
-            bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
-            bigquery.project.must_equal "project-id"
-            bigquery.service.must_be_kind_of OpenStruct
+            _(bigquery).must_be_kind_of Google::Cloud::Bigquery::Project
+            _(bigquery.project).must_equal "project-id"
+            _(bigquery.service).must_be_kind_of OpenStruct
           end
         end
       end
@@ -177,16 +177,16 @@ describe Google::Cloud do
 
     it "uses provided project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigquery-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "bigquery-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "bigquery-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -197,9 +197,9 @@ describe Google::Cloud do
             Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
                 bigquery = Google::Cloud::Bigquery.new project_id: "project-id", credentials: "path/to/keyfile.json"
-                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
-                bigquery.project.must_equal "project-id"
-                bigquery.service.must_be_kind_of OpenStruct
+                _(bigquery).must_be_kind_of Google::Cloud::Bigquery::Project
+                _(bigquery.project).must_equal "project-id"
+                _(bigquery.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -209,16 +209,16 @@ describe Google::Cloud do
 
     it "uses provided project and keyfile aliases" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigquery-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "bigquery-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "bigquery-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -229,9 +229,9 @@ describe Google::Cloud do
             Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
                 bigquery = Google::Cloud::Bigquery.new project: "project-id", keyfile: "path/to/keyfile.json"
-                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
-                bigquery.project.must_equal "project-id"
-                bigquery.service.must_be_kind_of OpenStruct
+                _(bigquery).must_be_kind_of Google::Cloud::Bigquery::Project
+                _(bigquery.project).must_equal "project-id"
+                _(bigquery.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -241,17 +241,17 @@ describe Google::Cloud do
 
     it "gets project_id from credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         OpenStruct.new project_id: "project-id"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_be_kind_of OpenStruct
-        credentials.project_id.must_equal "project-id"
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_be_kind_of OpenStruct
+        _(credentials.project_id).must_equal "project-id"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
       empty_env = OpenStruct.new
@@ -264,9 +264,9 @@ describe Google::Cloud do
               Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
                 Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
                   bigquery = Google::Cloud::Bigquery.new credentials: "path/to/keyfile.json"
-                  bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
-                  bigquery.project.must_equal "project-id"
-                  bigquery.service.must_be_kind_of OpenStruct
+                  _(bigquery).must_be_kind_of Google::Cloud::Bigquery::Project
+                  _(bigquery.project).must_equal "project-id"
+                  _(bigquery.service).must_be_kind_of OpenStruct
                 end
               end
             end
@@ -285,16 +285,16 @@ describe Google::Cloud do
 
     it "uses shared config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigquery-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "bigquery-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "bigquery-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -311,9 +311,9 @@ describe Google::Cloud do
             Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
                 bigquery = Google::Cloud::Bigquery.new
-                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
-                bigquery.project.must_equal "project-id"
-                bigquery.service.must_be_kind_of OpenStruct
+                _(bigquery).must_be_kind_of Google::Cloud::Bigquery::Project
+                _(bigquery.project).must_equal "project-id"
+                _(bigquery.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -323,16 +323,16 @@ describe Google::Cloud do
 
     it "uses shared config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigquery-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "bigquery-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "bigquery-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -349,9 +349,9 @@ describe Google::Cloud do
             Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
                 bigquery = Google::Cloud::Bigquery.new
-                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
-                bigquery.project.must_equal "project-id"
-                bigquery.service.must_be_kind_of OpenStruct
+                _(bigquery).must_be_kind_of Google::Cloud::Bigquery::Project
+                _(bigquery.project).must_equal "project-id"
+                _(bigquery.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -361,16 +361,16 @@ describe Google::Cloud do
 
     it "uses bigquery config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigquery-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "bigquery-credentials"
-        retries.must_equal 3
-        timeout.must_equal 42
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "bigquery-credentials"
+        _(retries).must_equal 3
+        _(timeout).must_equal 42
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -389,9 +389,9 @@ describe Google::Cloud do
             Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
                 bigquery = Google::Cloud::Bigquery.new
-                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
-                bigquery.project.must_equal "project-id"
-                bigquery.service.must_be_kind_of OpenStruct
+                _(bigquery).must_be_kind_of Google::Cloud::Bigquery::Project
+                _(bigquery.project).must_equal "project-id"
+                _(bigquery.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -401,16 +401,16 @@ describe Google::Cloud do
 
     it "uses bigquery config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigquery-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "bigquery-credentials"
-        retries.must_equal 3
-        timeout.must_equal 42
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "bigquery-credentials"
+        _(retries).must_equal 3
+        _(timeout).must_equal 42
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -429,9 +429,9 @@ describe Google::Cloud do
             Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
                 bigquery = Google::Cloud::Bigquery.new
-                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
-                bigquery.project.must_equal "project-id"
-                bigquery.service.must_be_kind_of OpenStruct
+                _(bigquery).must_be_kind_of Google::Cloud::Bigquery::Project
+                _(bigquery.project).must_equal "project-id"
+                _(bigquery.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -441,16 +441,16 @@ describe Google::Cloud do
 
     it "uses bigquery config for endpoint" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigquery-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "bigquery-credentials"
-        retries.must_equal 3
-        timeout.must_equal 42
-        host.must_equal "bigquery-endpoint2.example.com"
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "bigquery-credentials"
+        _(retries).must_equal 3
+        _(timeout).must_equal 42
+        _(host).must_equal "bigquery-endpoint2.example.com"
         OpenStruct.new project: project
       }
 
@@ -470,9 +470,9 @@ describe Google::Cloud do
             Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
                 bigquery = Google::Cloud::Bigquery.new
-                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
-                bigquery.project.must_equal "project-id"
-                bigquery.service.must_be_kind_of OpenStruct
+                _(bigquery).must_be_kind_of Google::Cloud::Bigquery::Project
+                _(bigquery.project).must_equal "project-id"
+                _(bigquery.service).must_be_kind_of OpenStruct
               end
             end
           end


### PR DESCRIPTION
Use `rubocop-minitest` gem and `bundle exec rubocop --only Minitest/GlobalExpectations -a` to autocorrect minitest warnings for Ruby 2.7.

refs: #4110
refs: #4116