### PR TITLE
fix: Remove unneeded synth hacks from automl versioned libraries

### DIFF
--- a/google-cloud-automl-v1/synth.py
+++ b/google-cloud-automl-v1/synth.py
@@ -39,10 +39,3 @@ library = gapic.ruby_library(
 )
 
 s.copy(library, merge=ruby.global_merge)
-
-# Workaround for https://github.com/googleapis/gapic-generator-ruby/issues/382
-s.replace(
-    "lib/google/cloud/automl/v1/service_services_pb.rb",
-    "module AutoMl\n",
-    "module AutoML\n"
-)

--- a/google-cloud-automl-v1beta1/synth.py
+++ b/google-cloud-automl-v1beta1/synth.py
@@ -38,10 +38,3 @@ library = gapic.ruby_library(
 )
 
 s.copy(library, merge=ruby.global_merge)
-
-# Workaround for https://github.com/googleapis/gapic-generator-ruby/issues/382
-s.replace(
-    "lib/google/cloud/automl/v1beta1/service_services_pb.rb",
-    "module AutoMl\n",
-    "module AutoML\n"
-)


### PR DESCRIPTION
These synth hacks were in place because we were doing more overriding in the microgenerator than we really should. The microgenerator has been fixed, so we need to remove them. (Note: #5592 and #5593 show the error that happens when these synth hacks are still applied to a client generated by the fixed microgenerator.)