### PR TITLE
chore(spanner): Update minitest to 5.14

### DIFF
--- a/google-cloud-spanner/.rubocop.yml
+++ b/google-cloud-spanner/.rubocop.yml
@@ -1,13 +1,13 @@
-require: rubocop-minitest
-
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
+    - "acceptance/**/*"
     - "support/**/*"
     - "google-cloud-spanner.gemspec"
     - "Rakefile"
+    - "test/**/*"
     - "benchmark/**/*"
     - "lib/google/spanner/**/*"
     - "lib/google/cloud/spanner/v1/**/*"

--- a/google-cloud-spanner/.rubocop.yml
+++ b/google-cloud-spanner/.rubocop.yml
@@ -1,13 +1,13 @@
+require: rubocop-minitest
+
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
     - "support/**/*"
     - "google-cloud-spanner.gemspec"
     - "Rakefile"
-    - "test/**/*"
     - "benchmark/**/*"
     - "lib/google/spanner/**/*"
     - "lib/google/cloud/spanner/v1/**/*"

--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -7,3 +7,5 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "rake"
+
+gem "rubocop-minitest"

--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -7,5 +7,3 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "rake"
-
-gem "rubocop-minitest"

--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -7,7 +7,3 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "rake"
-
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"

--- a/google-cloud-spanner/acceptance/spanner/backup_operations_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/backup_operations_test.rb
@@ -23,63 +23,63 @@ describe "Spanner Database Backup Operations", :spanner do
 
   it "list backup operations" do
     instance = spanner.instance instance_id
-    instance.wont_be :nil?
+    _(instance).wont_be :nil?
 
     database = instance.database database_id
-    database.wont_be :nil?
+    _(database).wont_be :nil?
 
     job = database.create_backup backup_id, expire_time
     job.wait_until_done!
 
     # All
     jobs = instance.backup_operations.all.to_a
-    jobs.wont_be :empty?
+    _(jobs).wont_be :empty?
 
     jobs.each do |job|
-      job.must_be_kind_of Google::Cloud::Spanner::Backup::Job
+      _(job).must_be_kind_of Google::Cloud::Spanner::Backup::Job
 
       unless job.error?
-        job.backup.must_be_kind_of Google::Cloud::Spanner::Backup
+        _(job.backup).must_be_kind_of Google::Cloud::Spanner::Backup
       end
 
-      job.progress_percent.must_be :>=, 0
-      job.start_time.must_be_kind_of Time
+      _(job.progress_percent).must_be :>=, 0
+      _(job.start_time).must_be_kind_of Time
     end
 
     job = jobs.first
-    job.reload!.must_be_kind_of Google::Cloud::Spanner::Backup::Job
+    _(job.reload!).must_be_kind_of Google::Cloud::Spanner::Backup::Job
 
     # Filter completed jobs
     filter = "done:true"
     jobs = instance.backup_operations(filter: filter).all.to_a
-    jobs.wont_be :empty?
+    _(jobs).wont_be :empty?
     jobs.each do |job|
-      job.must_be :done?
+      _(job).must_be :done?
     end
 
     # Filter by database name
     filter = "metadata.database:#{database_id}"
     jobs = instance.backup_operations(filter: filter).all.to_a
-    jobs.wont_be :empty?
+    _(jobs).wont_be :empty?
     jobs.each do |job|
-      job.backup.database_id.must_equal database_id unless job.error?
+      _(job.backup.database_id).must_equal database_id unless job.error?
     end
 
     # Filter by metdata type
     filter = "metadata.@type:CreateBackupMetadata"
     jobs = instance.backup_operations(filter: filter).all.to_a
-    jobs.wont_be :empty?
+    _(jobs).wont_be :empty?
     jobs.each do |job|
-      job.grpc.metadata.must_be_kind_of Google::Spanner::Admin::Database::V1::CreateBackupMetadata
+      _(job.grpc.metadata).must_be_kind_of Google::Spanner::Admin::Database::V1::CreateBackupMetadata
     end
 
     # Filter by job start time
     time = (Time.now - 360000)
     filter = "metadata.progress.start_time > \"#{time.iso8601}\""
     jobs = instance.backup_operations(filter: filter).all.to_a
-    jobs.wont_be :empty?
+    _(jobs).wont_be :empty?
     jobs.each do |job|
-      job.start_time.must_be :>, time
+      _(job.start_time).must_be :>, time
     end
 
     # Filer - AND
@@ -90,10 +90,10 @@ describe "Spanner Database Backup Operations", :spanner do
     ].map{|f| "(#{f})"}.join(" AND ")
 
     jobs = instance.backup_operations(filter: filter).all.to_a
-    jobs.wont_be :empty?
+    _(jobs).wont_be :empty?
     jobs.each do |job|
-      job.backup.database_id.must_equal database_id unless job.error?
-      job.start_time.must_be :>, time
+      _(job.backup.database_id).must_equal database_id unless job.error?
+      _(job.start_time).must_be :>, time
     end
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/backup_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/backup_test.rb
@@ -23,88 +23,88 @@ describe "Spanner Database Backup", :spanner do
   it "creates, get, updates, restore and delete a database backup" do
     backup_id = "#{$spanner_database_id}-crud"
     database = spanner.database instance_id, database_id
-    database.wont_be :nil?
+    _(database).wont_be :nil?
 
     # Create
     job = database.create_backup backup_id, expire_time
 
-    job.must_be_kind_of Google::Cloud::Spanner::Backup::Job
-    job.wont_be :done?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Backup::Job
+    _(job).wont_be :done?
     job.wait_until_done!
 
-    job.must_be :done?
-    job.error.must_be :nil?
+    _(job).must_be :done?
+    _(job.error).must_be :nil?
 
     backup = job.backup
-    backup.wont_be :nil?
-    backup.must_be_kind_of Google::Cloud::Spanner::Backup
-    backup.backup_id.must_equal backup_id
-    backup.database_id.must_equal database_id
-    backup.instance_id.must_equal instance_id
-    backup.project_id.must_equal spanner.project
-    backup.expire_time.to_i.must_equal expire_time.to_i
-    backup.create_time.must_be_kind_of Time
-    backup.size_in_bytes.must_be :>, 0
+    _(backup).wont_be :nil?
+    _(backup).must_be_kind_of Google::Cloud::Spanner::Backup
+    _(backup.backup_id).must_equal backup_id
+    _(backup.database_id).must_equal database_id
+    _(backup.instance_id).must_equal instance_id
+    _(backup.project_id).must_equal spanner.project
+    _(backup.expire_time.to_i).must_equal expire_time.to_i
+    _(backup.create_time).must_be_kind_of Time
+    _(backup.size_in_bytes).must_be :>, 0
 
     # Get
     instance = spanner.instance instance_id
     backup = instance.backup backup_id
 
-    backup.wont_be :nil?
-    backup.must_be_kind_of Google::Cloud::Spanner::Backup
-    backup.backup_id.must_equal backup_id
-    backup.database_id.must_equal database_id
-    backup.instance_id.must_equal instance_id
-    backup.project_id.must_equal spanner.project
-    backup.expire_time.to_i.must_equal expire_time.to_i
-    backup.create_time.must_be_kind_of Time
-    backup.size_in_bytes.must_be :>, 0
+    _(backup).wont_be :nil?
+    _(backup).must_be_kind_of Google::Cloud::Spanner::Backup
+    _(backup.backup_id).must_equal backup_id
+    _(backup.database_id).must_equal database_id
+    _(backup.instance_id).must_equal instance_id
+    _(backup.project_id).must_equal spanner.project
+    _(backup.expire_time.to_i).must_equal expire_time.to_i
+    _(backup.create_time).must_be_kind_of Time
+    _(backup.size_in_bytes).must_be :>, 0
 
     # Update
     backup.expire_time = expire_time + 3600
     backup = instance.backup backup_id
-    backup.expire_time.to_i.must_equal((expire_time + 3600).to_i)
+    _(backup.expire_time.to_i).must_equal((expire_time + 3600).to_i)
 
-    proc {
+    _ { proc {
       backup.expire_time = Time.now - 36000
-    }.must_raise Google::Cloud::Error
-    backup.expire_time.to_i.must_equal((expire_time + 3600 ).to_i)
+    } }.must_raise Google::Cloud::Error
+    _(backup.expire_time.to_i).must_equal((expire_time + 3600 ).to_i)
 
     # Restore
     restore_database_id = "restore-#{database_id}"
     backup = instance.backup backup_id
     job = backup.restore restore_database_id
-    job.wont_be :done?
+    _(job).wont_be :done?
 
     job.wait_until_done!
 
-    job.must_be :done?
-    job.wont_be :error?
+    _(job).must_be :done?
+    _(job).wont_be :error?
 
     database = job.database
-    database.must_be_kind_of Google::Cloud::Spanner::Database
-    database.database_id.must_equal restore_database_id
-    database.instance_id.must_equal instance_id
-    database.project_id.must_equal spanner.project
+    _(database).must_be_kind_of Google::Cloud::Spanner::Database
+    _(database.database_id).must_equal restore_database_id
+    _(database.instance_id).must_equal instance_id
+    _(database.project_id).must_equal spanner.project
 
     restore_info = database.restore_info
-    restore_info.must_be_kind_of Google::Cloud::Spanner::Database::RestoreInfo
-    restore_info.source_type.must_equal :BACKUP
-    restore_info.must_be :source_backup?
+    _(restore_info).must_be_kind_of Google::Cloud::Spanner::Database::RestoreInfo
+    _(restore_info.source_type).must_equal :BACKUP
+    _(restore_info).must_be :source_backup?
 
     backup_info = restore_info.backup_info
-    backup_info.must_be_kind_of Google::Cloud::Spanner::Database::BackupInfo
-    backup_info.project_id.must_equal spanner.project
-    backup_info.instance_id.must_equal instance_id
-    backup_info.backup_id.must_equal backup_id
-    backup_info.source_database_project_id.must_equal spanner.project
-    backup_info.source_database_instance_id.must_equal instance_id
-    backup_info.source_database_id.must_equal database_id
-    backup_info.create_time.must_be_kind_of Time
+    _(backup_info).must_be_kind_of Google::Cloud::Spanner::Database::BackupInfo
+    _(backup_info.project_id).must_equal spanner.project
+    _(backup_info.instance_id).must_equal instance_id
+    _(backup_info.backup_id).must_equal backup_id
+    _(backup_info.source_database_project_id).must_equal spanner.project
+    _(backup_info.source_database_instance_id).must_equal instance_id
+    _(backup_info.source_database_id).must_equal database_id
+    _(backup_info.create_time).must_be_kind_of Time
 
     # Delete
     backup.delete
-    instance.backup(backup_id).must_be :nil?
+    _(instance.backup(backup_id)).must_be :nil?
   end
 
   it "cancel create backup operation" do
@@ -112,21 +112,21 @@ describe "Spanner Database Backup", :spanner do
     database = spanner.database instance_id, database_id
 
     job = database.create_backup backup_id, expire_time
-    job.wont_be :done?
+    _(job).wont_be :done?
 
     job.cancel
 
     job.reload!
-    job.must_be :done?
-    job.error.wont_be :nil?
-    job.error.code.must_equal 1
-    job.error.description.must_equal "CANCELLED"
+    _(job).must_be :done?
+    _(job.error).wont_be :nil?
+    _(job.error.code).must_equal 1
+    _(job.error.description).must_equal "CANCELLED"
   end
 
   it "lists and gets database backups" do
     backup_id = "#{$spanner_database_id}-list"
     database = spanner.database instance_id, database_id
-    database.wont_be :nil?
+    _(database).wont_be :nil?
 
     job = database.create_backup backup_id, expire_time
     job.wait_until_done!
@@ -136,20 +136,20 @@ describe "Spanner Database Backup", :spanner do
 
     # List all
     all_backups = instance.backups.all.to_a
-    all_backups.wont_be :empty?
+    _(all_backups).wont_be :empty?
     all_backups.each do |backup|
-      backup.must_be_kind_of Google::Cloud::Spanner::Backup
+      _(backup).must_be_kind_of Google::Cloud::Spanner::Backup
     end
 
     # Filter by backup name
     backups = instance.backups(filter: "name:#{backup_id}").to_a
-    backups.length.must_equal 1
-    backups.first.backup_id.must_equal backup_id
+    _(backups.length).must_equal 1
+    _(backups.first.backup_id).must_equal backup_id
 
     # Filter by database name
     backups = instance.backups(filter: "database:#{database_id}").to_a
-    backups.wont_be :empty?
-    backups.first.database_id.must_equal database_id
+    _(backups).wont_be :empty?
+    _(backups.first.database_id).must_equal database_id
 
     backup.delete
   end

--- a/google-cloud-spanner/acceptance/spanner/batch_client/execute_partition_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/batch_client/execute_partition_test.rb
@@ -45,28 +45,28 @@ describe "Spanner Batch Client", :execute_partition, :spanner do
   end
 
   it "reads all by default" do
-    batch_snapshot.timestamp.must_be_kind_of Time
+    _(batch_snapshot.timestamp).must_be_kind_of Time
     serialized_snapshot = batch_snapshot.dump
 
     columns = [:id]
     partitions = batch_snapshot.partition_read table_name, columns
     partitions.each do |partition|
-      partition.read.partition_token.wont_be_nil
-      partition.read.columns.must_equal columns.map(&:to_s)
-      partition.read.table.must_equal "stuffs"
+      _(partition.read.partition_token).wont_be_nil
+      _(partition.read.columns).must_equal columns.map(&:to_s)
+      _(partition.read.table).must_equal "stuffs"
 
       partition = batch_client.load_partition partition.dump
 
-      partition.read.partition_token.wont_be_nil
-      partition.read.columns.must_equal columns.map(&:to_s)
-      partition.read.table.must_equal "stuffs"
+      _(partition.read.partition_token).wont_be_nil
+      _(partition.read.columns).must_equal columns.map(&:to_s)
+      _(partition.read.table).must_equal "stuffs"
 
       new_batch_snapshot = batch_client.load_batch_snapshot serialized_snapshot
-      new_batch_snapshot.timestamp.must_be_kind_of Time
+      _(new_batch_snapshot.timestamp).must_be_kind_of Time
       results = new_batch_snapshot.execute_partition partition
-      results.must_be_kind_of Google::Cloud::Spanner::Results
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
       unless results.fields.to_a.empty? # With so little data, just one partition should get the entire result set
-        results.rows.map(&:to_h).must_equal [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }, { id: 11 }, { id: 12 }]
+        _(results.rows.map(&:to_h)).must_equal [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }, { id: 11 }, { id: 12 }]
       end
     end
     batch_snapshot.close
@@ -79,19 +79,19 @@ describe "Spanner Batch Client", :execute_partition, :spanner do
     sql = "SELECT s.id, s.bool FROM stuffs AS s WHERE s.id = 2 AND s.bool = false"
     partitions = batch_snapshot.partition_query sql
     partitions.each do |partition|
-      partition.execute.partition_token.wont_be_nil
-      partition.execute.sql.must_equal sql
+      _(partition.execute.partition_token).wont_be_nil
+      _(partition.execute.sql).must_equal sql
 
       partition = batch_client.load_partition partition.dump
 
-      partition.execute.partition_token.wont_be_nil
-      partition.execute.sql.must_equal sql
+      _(partition.execute.partition_token).wont_be_nil
+      _(partition.execute.sql).must_equal sql
 
       new_batch_snapshot = batch_client.load_batch_snapshot serialized_snapshot
       results = new_batch_snapshot.execute_partition partition
-      results.must_be_kind_of Google::Cloud::Spanner::Results
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
       unless results.fields.to_a.empty? # With so little data, just one partition should get the entire result set
-        results.rows.map(&:to_h).must_equal [{:id=>2, :bool=>false}]
+        _(results.rows.map(&:to_h)).must_equal [{:id=>2, :bool=>false}]
       end
     end
     batch_snapshot.close
@@ -105,19 +105,19 @@ describe "Spanner Batch Client", :execute_partition, :spanner do
     query_options = { optimizer_version: "1" }
     partitions = batch_snapshot.partition_query sql, query_options: query_options
     partitions.each do |partition|
-      partition.execute.partition_token.wont_be_nil
-      partition.execute.sql.must_equal sql
+      _(partition.execute.partition_token).wont_be_nil
+      _(partition.execute.sql).must_equal sql
 
       partition = batch_client.load_partition partition.dump
 
-      partition.execute.partition_token.wont_be_nil
-      partition.execute.sql.must_equal sql
+      _(partition.execute.partition_token).wont_be_nil
+      _(partition.execute.sql).must_equal sql
 
       new_batch_snapshot = batch_client.load_batch_snapshot serialized_snapshot
       results = new_batch_snapshot.execute_partition partition
-      results.must_be_kind_of Google::Cloud::Spanner::Results
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
       unless results.fields.to_a.empty? # With so little data, just one partition should get the entire result set
-        results.rows.map(&:to_h).must_equal [{:id=>2, :bool=>false}]
+        _(results.rows.map(&:to_h)).must_equal [{:id=>2, :bool=>false}]
       end
     end
     batch_snapshot.close

--- a/google-cloud-spanner/acceptance/spanner/client/batch_update_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/batch_update_test.rb
@@ -38,10 +38,10 @@ describe "Spanner Client", :batch_update, :spanner do
 
   it "executes multiple DML statements in a batch" do
     prior_results = db.execute_sql "SELECT * FROM accounts"
-    prior_results.rows.count.must_equal 3
+    _(prior_results.rows.count).must_equal 3
 
     timestamp = db.transaction do |tx|
-      tx.transaction_id.wont_be :nil?
+      _(tx.transaction_id).wont_be :nil?
 
       row_counts = tx.batch_update do |b|
         b.batch_update insert_dml, params: insert_params
@@ -49,41 +49,41 @@ describe "Spanner Client", :batch_update, :spanner do
         b.batch_update delete_dml, params: delete_params
       end
 
-      row_counts.must_be_kind_of Array
-      row_counts.count.must_equal 3
-      row_counts[0].must_equal 1
-      row_counts[1].must_equal 1
-      row_counts[2].must_equal 1
+      _(row_counts).must_be_kind_of Array
+      _(row_counts.count).must_equal 3
+      _(row_counts[0]).must_equal 1
+      _(row_counts[1]).must_equal 1
+      _(row_counts[2]).must_equal 1
 
       update_results = tx.execute_sql \
         "SELECT username FROM accounts WHERE account_id = @account_id",
         params: { account_id: 4 }
-      update_results.rows.count.must_equal 0
+      _(update_results.rows.count).must_equal 0
     end
-    timestamp.must_be_kind_of Time
+    _(timestamp).must_be_kind_of Time
   end
 
   it "raises InvalidArgumentError when no DML statements are executed in a batch" do
       prior_results = db.execute_sql "SELECT * FROM accounts"
-      prior_results.rows.count.must_equal 3
+      _(prior_results.rows.count).must_equal 3
 
       timestamp = db.transaction do |tx|
-        tx.transaction_id.wont_be :nil?
+        _(tx.transaction_id).wont_be :nil?
 
         err = expect do
           tx.batch_update do |b| end
         end.must_raise Google::Cloud::InvalidArgumentError
-        err.message.must_equal "3:No statements in batch DML request."
+        _(err.message).must_equal "3:No statements in batch DML request."
       end
-    timestamp.must_be_kind_of Time
+    _(timestamp).must_be_kind_of Time
   end
 
   it "executes multiple DML statements in a batch with syntax error" do
     prior_results = db.execute_sql "SELECT * FROM accounts"
-    prior_results.rows.count.must_equal 3
+    _(prior_results.rows.count).must_equal 3
 
     timestamp = db.transaction do |tx|
-      tx.transaction_id.wont_be :nil?
+      _(tx.transaction_id).wont_be :nil?
       begin
         tx.batch_update do |b|
           b.batch_update insert_dml, params: insert_params
@@ -91,48 +91,48 @@ describe "Spanner Client", :batch_update, :spanner do
           b.batch_update delete_dml, params: delete_params
         end
       rescue Google::Cloud::Spanner::BatchUpdateError => batch_update_error
-        batch_update_error.cause.must_be_kind_of Google::Cloud::InvalidArgumentError
-        batch_update_error.cause.message.must_equal "Statement 1: 'UPDDDD accounts' is not valid DML."
+        _(batch_update_error.cause).must_be_kind_of Google::Cloud::InvalidArgumentError
+        _(batch_update_error.cause.message).must_equal "Statement 1: 'UPDDDD accounts' is not valid DML."
 
         row_counts = batch_update_error.row_counts
-        row_counts.must_be_kind_of Array
-        row_counts.count.must_equal 1
-        row_counts[0].must_equal 1
+        _(row_counts).must_be_kind_of Array
+        _(row_counts.count).must_equal 1
+        _(row_counts[0]).must_equal 1
       end
       update_results = tx.execute_sql \
         "SELECT username FROM accounts WHERE account_id = @account_id",
         params: { account_id: 4 }
-      update_results.rows.count.must_equal 1 # DELETE statement did not execute.
+      _(update_results.rows.count).must_equal 1 # DELETE statement did not execute.
     end
-    timestamp.must_be_kind_of Time
+    _(timestamp).must_be_kind_of Time
   end
 
   it "runs execute_update and batch_update in the same transaction" do
     prior_results = db.execute_sql "SELECT * FROM accounts"
-    prior_results.rows.count.must_equal 3
+    _(prior_results.rows.count).must_equal 3
 
     timestamp = db.transaction do |tx|
-      tx.transaction_id.wont_be :nil?
+      _(tx.transaction_id).wont_be :nil?
 
       row_counts = tx.batch_update do |b|
         b.batch_update insert_dml, params: insert_params
         b.batch_update update_dml, params: update_params
       end
 
-      row_counts.must_be_kind_of Array
-      row_counts.count.must_equal 2
-      row_counts[0].must_equal 1
-      row_counts[1].must_equal 1
+      _(row_counts).must_be_kind_of Array
+      _(row_counts.count).must_equal 2
+      _(row_counts[0]).must_equal 1
+      _(row_counts[1]).must_equal 1
 
       delete_row_count = tx.execute_update delete_dml, params: delete_params
 
-      delete_row_count.must_equal 1
+      _(delete_row_count).must_equal 1
 
       update_results = tx.execute_sql \
         "SELECT username FROM accounts WHERE account_id = @account_id",
         params: { account_id: 4 }
-      update_results.rows.count.must_equal 0
+      _(update_results.rows.count).must_equal 0
     end
-    timestamp.must_be_kind_of Time
+    _(timestamp).must_be_kind_of Time
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/commit_timestamp_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/commit_timestamp_test.rb
@@ -23,8 +23,8 @@ describe "Spanner Client", :commit_timestamp, :spanner do
     commit_timestamp = db.upsert table_name, { committs: db.commit_timestamp }
     results = db.read table_name, table_types, keys: commit_timestamp
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ committs: :TIMESTAMP })
-    results.rows.first.to_h.must_equal({ committs: commit_timestamp })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ committs: :TIMESTAMP })
+    _(results.rows.first.to_h).must_equal({ committs: commit_timestamp })
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
@@ -23,42 +23,42 @@ describe "Spanner Client", :crud, :spanner do
 
   it "inserts, updates, upserts, reads, and deletes records" do
     results = db.read "accounts", ["account_id"], single_use: { timestamp: @setup_timestamp }
-    results.rows.count.must_equal 0
-    results.timestamp.wont_be :nil?
+    _(results.rows.count).must_equal 0
+    _(results.timestamp).wont_be :nil?
 
     db.insert "accounts", default_account_rows[0]
     db.upsert "accounts", default_account_rows[1]
     timestamp = db.insert "accounts", default_account_rows[2]
 
     results = db.read "accounts", ["account_id"], single_use: { timestamp: timestamp }
-    results.rows.count.must_equal 3
-    results.timestamp.wont_be :nil?
+    _(results.rows.count).must_equal 3
+    _(results.timestamp).wont_be :nil?
 
     active_count_sql = "SELECT COUNT(*) AS count FROM accounts WHERE active = true"
 
     results = db.execute_query active_count_sql, single_use: { timestamp: timestamp }
-    results.rows.first[:count].must_equal 2
-    results.timestamp.wont_be :nil?
+    _(results.rows.first[:count]).must_equal 2
+    _(results.timestamp).wont_be :nil?
 
     activate_inactive_account = { account_id: 3, active: true }
 
     timestamp = db.upsert "accounts", activate_inactive_account
 
     results = db.execute_query active_count_sql, single_use: { timestamp: timestamp }
-    results.rows.first[:count].must_equal 3
-    results.timestamp.wont_be :nil?
+    _(results.rows.first[:count]).must_equal 3
+    _(results.timestamp).wont_be :nil?
 
     timestamp = db.delete "accounts", [1, 2, 3]
 
     results = db.read "accounts", ["account_id"], single_use: { timestamp: timestamp }
-    results.rows.count.must_equal 0
-    results.timestamp.wont_be :nil?
+    _(results.rows.count).must_equal 0
+    _(results.timestamp).wont_be :nil?
   end
 
   it "inserts, updates, upserts, reads, and deletes records using commit" do
     results = db.read "accounts", ["account_id"], single_use: { timestamp: @setup_timestamp }
-    results.rows.count.must_equal 0
-    results.timestamp.wont_be :nil?
+    _(results.rows.count).must_equal 0
+    _(results.timestamp).wont_be :nil?
 
     timestamp = db.commit do |c|
       c.insert "accounts", default_account_rows[0]
@@ -67,14 +67,14 @@ describe "Spanner Client", :crud, :spanner do
     end
 
     results = db.read "accounts", ["account_id"], single_use: { timestamp: timestamp }
-    results.rows.count.must_equal 3
-    results.timestamp.wont_be :nil?
+    _(results.rows.count).must_equal 3
+    _(results.timestamp).wont_be :nil?
 
     active_count_sql = "SELECT COUNT(*) AS count FROM accounts WHERE active = true"
 
     results = db.execute_query active_count_sql, single_use: { timestamp: timestamp }
-    results.rows.first[:count].must_equal 2
-    results.timestamp.wont_be :nil?
+    _(results.rows.first[:count]).must_equal 2
+    _(results.timestamp).wont_be :nil?
 
     activate_inactive_account = { account_id: 3, active: true }
 
@@ -83,16 +83,16 @@ describe "Spanner Client", :crud, :spanner do
     end
 
     results = db.execute_query active_count_sql, single_use: { timestamp: timestamp }
-    results.rows.first[:count].must_equal 3
-    results.timestamp.wont_be :nil?
+    _(results.rows.first[:count]).must_equal 3
+    _(results.timestamp).wont_be :nil?
 
     timestamp = db.commit do |c|
       c.delete "accounts", [1, 2, 3]
     end
 
     results = db.read "accounts", ["account_id"], single_use: { timestamp: timestamp }
-    results.rows.count.must_equal 0
-    results.timestamp.wont_be :nil?
+    _(results.rows.count).must_equal 0
+    _(results.timestamp).wont_be :nil?
   end
 
   it "inserts, updates, upserts, reads, and deletes records in a transaction" do
@@ -100,7 +100,7 @@ describe "Spanner Client", :crud, :spanner do
     active_count_sql = "SELECT COUNT(*) AS count FROM accounts WHERE active = true"
 
     db.transaction do |tx|
-      tx.read("accounts", ["account_id"]).rows.count.must_equal 0
+      _(tx.read("accounts", ["account_id"]).rows.count).must_equal 0
 
       tx.insert "accounts", default_account_rows[0]
       tx.upsert "accounts", default_account_rows[1]
@@ -108,9 +108,9 @@ describe "Spanner Client", :crud, :spanner do
     end
 
     timestamp = db.transaction do |tx|
-      db.read("accounts", ["account_id"]).rows.count.must_equal 3
+      _(db.read("accounts", ["account_id"]).rows.count).must_equal 3
 
-      tx.execute_query(active_count_sql).rows.first[:count].must_equal 2
+      _(tx.execute_query(active_count_sql).rows.first[:count]).must_equal 2
 
       activate_inactive_account = { account_id: 3, active: true }
 
@@ -118,13 +118,13 @@ describe "Spanner Client", :crud, :spanner do
     end
 
     timestamp = db.transaction do |tx|
-      tx.execute_query(active_count_sql).rows.first[:count].must_equal 3
+      _(tx.execute_query(active_count_sql).rows.first[:count]).must_equal 3
 
       tx.delete "accounts", [1, 2, 3]
     end
 
     results = db.read "accounts", ["account_id"], single_use: { timestamp: timestamp }
-    results.rows.count.must_equal 0
-    results.timestamp.wont_be :nil?
+    _(results.rows.count).must_equal 0
+    _(results.timestamp).wont_be :nil?
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/dml_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/dml_test.rb
@@ -31,93 +31,93 @@ describe "Spanner Client", :dml, :spanner do
 
   it "executes multiple DML statements in a transaction" do
     prior_results = db.execute_sql "SELECT * FROM accounts"
-    prior_results.rows.count.must_equal 3
+    _(prior_results.rows.count).must_equal 3
 
     timestamp = db.transaction do |tx|
-      tx.transaction_id.wont_be :nil?
+      _(tx.transaction_id).wont_be :nil?
 
       # Execute a DML using execute_update and make sure data is updated and correct count is returned.
       insert_row_count = tx.execute_update \
         "INSERT INTO accounts (account_id, username, active, reputation) VALUES (@account_id, @username, @active, @reputation)",
         params: { account_id: 4, username: "inserted", active: true, reputation: 88.8 }
-      insert_row_count.must_equal 1
+      _(insert_row_count).must_equal 1
 
       insert_results = tx.execute_sql \
         "SELECT username FROM accounts WHERE account_id = @account_id",
         params: { account_id: 4 }
       insert_rows = insert_results.rows.to_a
-      insert_rows.count.must_equal 1
-      insert_rows.first[:username].must_equal "inserted"
+      _(insert_rows.count).must_equal 1
+      _(insert_rows.first[:username]).must_equal "inserted"
 
       # Execute a DML using execute_sql and make sure data is updated and correct count is returned.
       update_results = tx.execute_sql \
         "UPDATE accounts SET username = @username, active = @active WHERE account_id = @account_id",
         params: { account_id: 4, username: "updated", active: false }
       update_results.rows.to_a # fetch all the results
-      update_results.must_be :row_count_exact?
-      update_results.row_count.must_equal 1
+      _(update_results).must_be :row_count_exact?
+      _(update_results.row_count).must_equal 1
 
       update_results = tx.execute_sql \
         "SELECT username FROM accounts WHERE account_id = @account_id",
         params: { account_id: 4 }
       update_rows = update_results.rows.to_a
-      update_rows.count.must_equal 1
-      update_rows.first[:username].must_equal "updated"
+      _(update_rows.count).must_equal 1
+      _(update_rows.first[:username]).must_equal "updated"
     end
-    timestamp.must_be_kind_of Time
+    _(timestamp).must_be_kind_of Time
 
     post_results = db.execute_sql "SELECT * FROM accounts", single_use: { timestamp: timestamp }
-    post_results.rows.count.must_equal 4
+    _(post_results.rows.count).must_equal 4
   end
 
   it "executes a DML statement, then rollback the transaction" do
     prior_results = db.execute_sql "SELECT * FROM accounts"
-    prior_results.rows.count.must_equal 3
+    _(prior_results.rows.count).must_equal 3
 
     timestamp = db.transaction do |tx|
-      tx.transaction_id.wont_be :nil?
+      _(tx.transaction_id).wont_be :nil?
 
       # Execute a DML using execute_update and make sure data is updated and correct count is returned.
       insert_row_count = tx.execute_update \
         "INSERT INTO accounts (account_id, username, active, reputation) VALUES (@account_id, @username, @active, @reputation)",
         params: { account_id: 4, username: "inserted", active: true, reputation: 88.8 }
-      insert_row_count.must_equal 1
+      _(insert_row_count).must_equal 1
 
       insert_results = tx.execute_sql \
         "SELECT username FROM accounts WHERE account_id = @account_id",
         params: { account_id: 4 }
       insert_rows = insert_results.rows.to_a
-      insert_rows.count.must_equal 1
-      insert_rows.first[:username].must_equal "inserted"
+      _(insert_rows.count).must_equal 1
+      _(insert_rows.first[:username]).must_equal "inserted"
 
       # Execute a DML statement, then rollback the transaction and assert that data is not updated.
       raise Google::Cloud::Spanner::Rollback
     end
-    timestamp.must_be :nil? # because the transaction was rolled back
+    _(timestamp).must_be :nil? # because the transaction was rolled back
 
     post_results = db.execute_sql "SELECT * FROM accounts"
-    post_results.rows.count.must_equal 3
+    _(post_results.rows.count).must_equal 3
   end
 
   it "executes a DML statement, then a mutation" do
     prior_results = db.execute_sql "SELECT * FROM accounts"
-    prior_results.rows.count.must_equal 3
+    _(prior_results.rows.count).must_equal 3
 
     timestamp = db.transaction do |tx|
-      tx.transaction_id.wont_be :nil?
+      _(tx.transaction_id).wont_be :nil?
 
       # Execute a DML statement, followed by calling existing insert method, commit the transaction and assert that both the updates are present.
       insert_row_count = tx.execute_update \
         "INSERT INTO accounts (account_id, username, active, reputation) VALUES (@account_id, @username, @active, @reputation)",
         params: { account_id: 4, username: "inserted by DML", active: true, reputation: 88.8 }
-      insert_row_count.must_equal 1
+      _(insert_row_count).must_equal 1
 
       insert_mut_rows = tx.insert "accounts", { account_id: 5, username: "inserted by mutation", active: true, reputation: 99.9 }
-      insert_mut_rows.count.must_equal 1
+      _(insert_mut_rows.count).must_equal 1
     end
-    timestamp.must_be_kind_of Time
+    _(timestamp).must_be_kind_of Time
 
     post_results = db.execute_sql "SELECT * FROM accounts", single_use: { timestamp: timestamp }
-    post_results.rows.count.must_equal 5
+    _(post_results.rows.count).must_equal 5
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/execute_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/execute_test.rb
@@ -19,152 +19,152 @@ describe "Spanner Client", :execute_sql, :spanner do
 
   it "runs SELECT 1" do
     results = db.execute_sql "SELECT 1"
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[0].must_equal :INT64
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[0]).must_equal :INT64
 
     rows = results.rows.to_a # grab all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [0]
-    row[0].must_equal 1
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [0]
+    _(row[0]).must_equal 1
   end
 
   it "runs a simple query" do
     results = db.execute_sql "SELECT 42 AS num"
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:num].must_equal :INT64
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:num]).must_equal :INT64
 
     rows = results.rows.to_a # grab all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:num]
-    row[:num].must_equal 42
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:num]
+    _(row[:num]).must_equal 42
   end
 
   it "runs a simple query using a single-use strong option" do
     results = db.execute_sql "SELECT 42 AS num", single_use: { strong: true }
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:num].must_equal :INT64
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:num]).must_equal :INT64
 
     rows = results.rows.to_a # grab all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:num]
-    row[:num].must_equal 42
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:num]
+    _(row[:num]).must_equal 42
   end
 
   it "runs a simple query using a single-use timestamp option" do
     results = db.execute_sql "SELECT 42 AS num", single_use: { timestamp: (Time.now - 60) }
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:num].must_equal :INT64
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:num]).must_equal :INT64
 
     rows = results.rows.to_a # grab all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:num]
-    row[:num].must_equal 42
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:num]
+    _(row[:num]).must_equal 42
   end
 
   it "runs a simple query using a single-use staleness option" do
     results = db.execute_sql "SELECT 42 AS num", single_use: { staleness: 60 }
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:num].must_equal :INT64
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:num]).must_equal :INT64
 
     rows = results.rows.to_a # grab all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:num]
-    row[:num].must_equal 42
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:num]
+    _(row[:num]).must_equal 42
   end
 
   it "runs a simple query using a single-use bounded_timestamp option" do
     results = db.execute_sql "SELECT 42 AS num", single_use: { bounded_timestamp: (Time.now - 60) }
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:num].must_equal :INT64
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:num]).must_equal :INT64
 
     rows = results.rows.to_a # grab all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:num]
-    row[:num].must_equal 42
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:num]
+    _(row[:num]).must_equal 42
   end
 
   it "runs a simple query using a single-use bounded_staleness option" do
     results = db.execute_sql "SELECT 42 AS num", single_use: { bounded_staleness: 60 }
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:num].must_equal :INT64
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:num]).must_equal :INT64
 
     rows = results.rows.to_a # grab all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:num]
-    row[:num].must_equal 42
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:num]
+    _(row[:num]).must_equal 42
   end
 
   it "runs a simple query with query options" do
     query_options = { optimizer_version: "1" }
     results = db.execute_sql "SELECT 42 AS num", query_options: query_options
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:num].must_equal :INT64
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:num]).must_equal :INT64
 
     rows = results.rows.to_a # grab all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:num]
-    row[:num].must_equal 42
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:num]
+    _(row[:num]).must_equal 42
   end
 
   it "runs a simple query when the client-level config of query options is set" do
     query_options = { optimizer_version: "1" }
     new_spanner = Google::Cloud::Spanner.new
     new_db = new_spanner.client db.instance_id, db.database_id, query_options: query_options
-    new_db.query_options.must_equal({ optimizer_version: "1" })
+    _(new_db.query_options).must_equal({ optimizer_version: "1" })
 
     results = new_db.execute_sql "SELECT 42 AS num"
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:num].must_equal :INT64
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:num]).must_equal :INT64
 
     rows = results.rows.to_a # grab all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:num]
-    row[:num].must_equal 42
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:num]
+    _(row[:num]).must_equal 42
   end
 
   describe "when the environment variable of query options is set" do
@@ -182,21 +182,21 @@ describe "Spanner Client", :execute_sql, :spanner do
     it "runs a simple query " do
       new_spanner = Google::Cloud::Spanner.new
       new_db = new_spanner.client db.instance_id, db.database_id
-      new_db.project.query_options.must_equal({ optimizer_version: "1" })
+      _(new_db.project.query_options).must_equal({ optimizer_version: "1" })
 
       results = new_db.execute_sql "SELECT 42 AS num"
-      results.must_be_kind_of Google::Cloud::Spanner::Results
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-      results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-      results.fields.keys.count.must_equal 1
-      results.fields[:num].must_equal :INT64
+      _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+      _(results.fields.keys.count).must_equal 1
+      _(results.fields[:num]).must_equal :INT64
 
       rows = results.rows.to_a # grab all from the enumerator
-      rows.count.must_equal 1
+      _(rows.count).must_equal 1
       row = rows.first
-      row.must_be_kind_of Google::Cloud::Spanner::Data
-      row.keys.must_equal [:num]
-      row[:num].must_equal 42
+      _(row).must_be_kind_of Google::Cloud::Spanner::Data
+      _(row.keys).must_equal [:num]
+      _(row[:num]).must_equal 42
     end
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/large_data_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/large_data_test.rb
@@ -61,24 +61,24 @@ describe "Spanner Client", :large_data, :spanner do
     db.upsert table_name, my_row
     results = db.read table_name, [:id, :string, :byte, :strings, :bytes], keys: my_row[:id]
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, string: :STRING, byte: :BYTES, strings: [:STRING], bytes: [:BYTES] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, string: :STRING, byte: :BYTES, strings: [:STRING], bytes: [:BYTES] })
     returned_row = results.rows.first
 
-    returned_row[:string].must_equal my_row[:string]
+    _(returned_row[:string]).must_equal my_row[:string]
 
-    returned_row[:strings].must_equal my_row[:strings]
+    _(returned_row[:strings]).must_equal my_row[:strings]
 
-    returned_row[:byte].must_be_kind_of StringIO
+    _(returned_row[:byte]).must_be_kind_of StringIO
     my_row[:byte].rewind
-    returned_row[:byte].read.must_equal my_row[:byte].read
+    _(returned_row[:byte].read).must_equal my_row[:byte].read
 
     returned_row[:bytes].each do |byte|
-      byte.must_be_kind_of StringIO
+      _(byte).must_be_kind_of StringIO
     end
     my_row[:bytes].each(&:rewind)
     returned_row[:bytes].each_with_index do |byte, index|
-      byte.read.must_equal my_row[:bytes][index].read
+      _(byte.read).must_equal my_row[:bytes][index].read
     end
   end
 
@@ -87,24 +87,24 @@ describe "Spanner Client", :large_data, :spanner do
     db.upsert table_name, my_row
     results = db.execute_sql "SELECT id, string, byte, strings, bytes FROM #{table_name} WHERE id = @id", params: { id: my_row[:id] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, string: :STRING, byte: :BYTES, strings: [:STRING], bytes: [:BYTES] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, string: :STRING, byte: :BYTES, strings: [:STRING], bytes: [:BYTES] })
     returned_row = results.rows.first
 
-    returned_row[:string].must_equal my_row[:string]
+    _(returned_row[:string]).must_equal my_row[:string]
 
-    returned_row[:strings].must_equal my_row[:strings]
+    _(returned_row[:strings]).must_equal my_row[:strings]
 
-    returned_row[:byte].must_be_kind_of StringIO
+    _(returned_row[:byte]).must_be_kind_of StringIO
     my_row[:byte].rewind
-    returned_row[:byte].read.must_equal my_row[:byte].read
+    _(returned_row[:byte].read).must_equal my_row[:byte].read
 
     returned_row[:bytes].each do |byte|
-      byte.must_be_kind_of StringIO
+      _(byte).must_be_kind_of StringIO
     end
     my_row[:bytes].each(&:rewind)
     returned_row[:bytes].each_with_index do |byte, index|
-      byte.read.must_equal my_row[:bytes][index].read
+      _(byte.read).must_equal my_row[:bytes][index].read
     end
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/params/bool_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/bool_test.rb
@@ -20,48 +20,48 @@ describe "Spanner Client", :params, :bool, :spanner do
   it "queries and returns a bool parameter" do
     results = db.execute_query "SELECT @value AS value", params: { value: true }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :BOOL
-    results.rows.first[:value].must_equal true
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :BOOL
+    _(results.rows.first[:value]).must_equal true
   end
 
   it "queries and returns a NULL bool parameter" do
     results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: :BOOL }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :BOOL
-    results.rows.first[:value].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :BOOL
+    _(results.rows.first[:value]).must_be :nil?
   end
 
   it "queries and returns an array of bool parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: [false, true, false] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:BOOL]
-    results.rows.first[:value].must_equal [false, true, false]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:BOOL]
+    _(results.rows.first[:value]).must_equal [false, true, false]
   end
 
   it "queries and returns an array of bool parameters with a nil value" do
     results = db.execute_query "SELECT @value AS value", params: { value: [nil, false, true, false] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:BOOL]
-    results.rows.first[:value].must_equal [nil, false, true, false]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:BOOL]
+    _(results.rows.first[:value]).must_equal [nil, false, true, false]
   end
 
   it "queries and returns an empty array of bool parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: [] }, types: { value: [:BOOL] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:BOOL]
-    results.rows.first[:value].must_equal []
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:BOOL]
+    _(results.rows.first[:value]).must_equal []
   end
 
   it "queries and returns a NULL array of bool parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: [:BOOL] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:BOOL]
-    results.rows.first[:value].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:BOOL]
+    _(results.rows.first[:value]).must_be :nil?
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/params/bytes_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/bytes_test.rb
@@ -20,59 +20,59 @@ describe "Spanner Client", :params, :bytes, :spanner do
   it "queries and returns a bytes parameter" do
     results = db.execute_query "SELECT @value AS value", params: { value: StringIO.new("hello world!") }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :BYTES
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :BYTES
     returned_value = results.rows.first[:value]
-    returned_value.must_be_kind_of StringIO
-    returned_value.read.must_equal "hello world!"
+    _(returned_value).must_be_kind_of StringIO
+    _(returned_value.read).must_equal "hello world!"
   end
 
   it "queries and returns a NULL bytes parameter" do
     results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: :BYTES }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :BYTES
-    results.rows.first[:value].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :BYTES
+    _(results.rows.first[:value]).must_be :nil?
   end
 
   it "queries and returns an array of bytes parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: [StringIO.new("foo"), StringIO.new("bar"), StringIO.new("baz")] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:BYTES]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:BYTES]
     bytes_array = results.rows.first[:value]
-    bytes_array.size.must_equal 3
-    bytes_array[0].read.must_equal "foo"
-    bytes_array[1].read.must_equal "bar"
-    bytes_array[2].read.must_equal "baz"
+    _(bytes_array.size).must_equal 3
+    _(bytes_array[0].read).must_equal "foo"
+    _(bytes_array[1].read).must_equal "bar"
+    _(bytes_array[2].read).must_equal "baz"
   end
 
   it "queries and returns an array of bytes parameters with a nil value" do
     results = db.execute_query "SELECT @value AS value", params: { value: [nil, StringIO.new("foo"), StringIO.new("bar"), StringIO.new("baz")] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:BYTES]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:BYTES]
     bytes_array = results.rows.first[:value]
-    bytes_array.size.must_equal 4
-    bytes_array[0].must_be :nil?
-    bytes_array[1].read.must_equal "foo"
-    bytes_array[2].read.must_equal "bar"
-    bytes_array[3].read.must_equal "baz"
+    _(bytes_array.size).must_equal 4
+    _(bytes_array[0]).must_be :nil?
+    _(bytes_array[1].read).must_equal "foo"
+    _(bytes_array[2].read).must_equal "bar"
+    _(bytes_array[3].read).must_equal "baz"
   end
 
   it "queries and returns an empty array of bytes parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: [] }, types: { value: [:BYTES] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:BYTES]
-    results.rows.first[:value].must_equal []
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:BYTES]
+    _(results.rows.first[:value]).must_equal []
   end
 
   it "queries and returns a NULL array of bytes parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: [:BYTES] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:BYTES]
-    results.rows.first[:value].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:BYTES]
+    _(results.rows.first[:value]).must_be :nil?
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/params/date_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/date_test.rb
@@ -21,48 +21,48 @@ describe "Spanner Client", :params, :date, :spanner do
   it "queries and returns a date parameter" do
     results = db.execute_query "SELECT @value AS value", params: { value: date_value }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :DATE
-    results.rows.first[:value].must_equal date_value
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :DATE
+    _(results.rows.first[:value]).must_equal date_value
   end
 
   it "queries and returns a NULL date parameter" do
     results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: :DATE }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :DATE
-    results.rows.first[:value].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :DATE
+    _(results.rows.first[:value]).must_be :nil?
   end
 
   it "queries and returns an array of date parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: [(date_value - 1), date_value, (date_value + 1)] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:DATE]
-    results.rows.first[:value].must_equal [(date_value - 1), date_value, (date_value + 1)]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:DATE]
+    _(results.rows.first[:value]).must_equal [(date_value - 1), date_value, (date_value + 1)]
   end
 
   it "queries and returns an array of date parameters with a nil value" do
     results = db.execute_query "SELECT @value AS value", params: { value: [nil, (date_value - 1), date_value, (date_value + 1)] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:DATE]
-    results.rows.first[:value].must_equal [nil, (date_value - 1), date_value, (date_value + 1)]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:DATE]
+    _(results.rows.first[:value]).must_equal [nil, (date_value - 1), date_value, (date_value + 1)]
   end
 
   it "queries and returns an empty array of date parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: [] }, types: { value: [:DATE] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:DATE]
-    results.rows.first[:value].must_equal []
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:DATE]
+    _(results.rows.first[:value]).must_equal []
   end
 
   it "queries and returns a NULL array of date parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: [:DATE] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:DATE]
-    results.rows.first[:value].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:DATE]
+    _(results.rows.first[:value]).must_be :nil?
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/params/float64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/float64_test.rb
@@ -20,86 +20,86 @@ describe "Spanner Client", :params, :float64, :spanner do
   it "queries and returns a float64 parameter" do
     results = db.execute_query "SELECT @value AS value", params: { value: 12.0 }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :FLOAT64
-    results.rows.first[:value].must_equal 12.0
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :FLOAT64
+    _(results.rows.first[:value]).must_equal 12.0
   end
 
   it "queries and returns a float64 parameter (Infinity)" do
     results = db.execute_query "SELECT @value AS value", params: { value: Float::INFINITY }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :FLOAT64
-    results.rows.first[:value].must_equal Float::INFINITY
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :FLOAT64
+    _(results.rows.first[:value]).must_equal Float::INFINITY
   end
 
   it "queries and returns a float64 parameter (-Infinity)" do
     results = db.execute_query "SELECT @value AS value", params: { value: -Float::INFINITY }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :FLOAT64
-    results.rows.first[:value].must_equal -Float::INFINITY
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :FLOAT64
+    _(results.rows.first[:value]).must_equal -Float::INFINITY
   end
 
   it "queries and returns a float64 parameter (-NaN)" do
     results = db.execute_query "SELECT @value AS value", params: { value: Float::NAN }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :FLOAT64
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :FLOAT64
     returned_value = results.rows.first[:value]
-    returned_value.must_be_kind_of Float
-    returned_value.must_be :nan?
+    _(returned_value).must_be_kind_of Float
+    _(returned_value).must_be :nan?
   end
 
   it "queries and returns a NULL float64 parameter" do
     results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: :FLOAT64 }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :FLOAT64
-    results.rows.first[:value].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :FLOAT64
+    _(results.rows.first[:value]).must_be :nil?
   end
 
   it "queries and returns an array of float64 parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: [1.0, 2.2, 3.5] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:FLOAT64]
-    results.rows.first[:value].must_equal [1.0, 2.2, 3.5]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:FLOAT64]
+    _(results.rows.first[:value]).must_equal [1.0, 2.2, 3.5]
   end
 
   it "queries and returns an array of special float64 parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: [Float::INFINITY, -Float::INFINITY, -Float::NAN] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:FLOAT64]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:FLOAT64]
     float_array = results.rows.first[:value]
-    float_array.size.must_equal 3
-    float_array[0].must_equal Float::INFINITY
-    float_array[1].must_equal -Float::INFINITY
-    float_array[2].must_be :nan?
+    _(float_array.size).must_equal 3
+    _(float_array[0]).must_equal Float::INFINITY
+    _(float_array[1]).must_equal -Float::INFINITY
+    _(float_array[2]).must_be :nan?
   end
 
   it "queries and returns an array of float64 parameters with a nil value" do
     results = db.execute_query "SELECT @value AS value", params: { value: [nil, 1.0, 2.2, 3.5] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:FLOAT64]
-    results.rows.first[:value].must_equal [nil, 1.0, 2.2, 3.5]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:FLOAT64]
+    _(results.rows.first[:value]).must_equal [nil, 1.0, 2.2, 3.5]
   end
 
   it "queries and returns an empty array of float64 parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: [] }, types: { value: [:FLOAT64] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:FLOAT64]
-    results.rows.first[:value].must_equal []
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:FLOAT64]
+    _(results.rows.first[:value]).must_equal []
   end
 
   it "queries and returns a NULL array of float64 parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: [:FLOAT64] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:FLOAT64]
-    results.rows.first[:value].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:FLOAT64]
+    _(results.rows.first[:value]).must_be :nil?
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/params/int64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/int64_test.rb
@@ -20,48 +20,48 @@ describe "Spanner Client", :params, :int64, :spanner do
   it "queries and returns a int64 parameter" do
     results = db.execute_query "SELECT @value AS value", params: { value: 99 }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :INT64
-    results.rows.first[:value].must_equal 99
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :INT64
+    _(results.rows.first[:value]).must_equal 99
   end
 
   it "queries and returns a NULL int64 parameter" do
     results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: :INT64 }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :INT64
-    results.rows.first[:value].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :INT64
+    _(results.rows.first[:value]).must_be :nil?
   end
 
   it "queries and returns an array of int64 parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: [1, 2, 3] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:INT64]
-    results.rows.first[:value].must_equal [1, 2, 3]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:INT64]
+    _(results.rows.first[:value]).must_equal [1, 2, 3]
   end
 
   it "queries and returns an array of int64 parameters with a nil value" do
     results = db.execute_query "SELECT @value AS value", params: { value: [nil, 1, 2, 3] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:INT64]
-    results.rows.first[:value].must_equal [nil, 1, 2, 3]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:INT64]
+    _(results.rows.first[:value]).must_equal [nil, 1, 2, 3]
   end
 
   it "queries and returns an empty array of int64 parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: [] }, types: { value: [:INT64] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:INT64]
-    results.rows.first[:value].must_equal []
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:INT64]
+    _(results.rows.first[:value]).must_equal []
   end
 
   it "queries and returns a NULL array of int64 parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: [:INT64] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:INT64]
-    results.rows.first[:value].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:INT64]
+    _(results.rows.first[:value]).must_be :nil?
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/params/string_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/string_test.rb
@@ -20,48 +20,48 @@ describe "Spanner Client", :params, :string, :spanner do
   it "queries and returns a string parameter" do
     results = db.execute_query "SELECT @value AS value", params: { value: "hello" }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :STRING
-    results.rows.first[:value].must_equal "hello"
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :STRING
+    _(results.rows.first[:value]).must_equal "hello"
   end
 
   it "queries and returns a NULL string parameter" do
     results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: :STRING }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :STRING
-    results.rows.first[:value].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :STRING
+    _(results.rows.first[:value]).must_be :nil?
   end
 
   it "queries and returns an array of string parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: ["foo", "bar", "baz"] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:STRING]
-    results.rows.first[:value].must_equal ["foo", "bar", "baz"]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:STRING]
+    _(results.rows.first[:value]).must_equal ["foo", "bar", "baz"]
   end
 
   it "queries and returns an array of string parameters with a nil value" do
     results = db.execute_query "SELECT @value AS value", params: { value: [nil, "foo", "bar", "baz"] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:STRING]
-    results.rows.first[:value].must_equal [nil, "foo", "bar", "baz"]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:STRING]
+    _(results.rows.first[:value]).must_equal [nil, "foo", "bar", "baz"]
   end
 
   it "queries and returns an empty array of string parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: [] }, types: { value: [:STRING] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:STRING]
-    results.rows.first[:value].must_equal []
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:STRING]
+    _(results.rows.first[:value]).must_equal []
   end
 
   it "queries and returns a NULL array of string parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: [:STRING] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:STRING]
-    results.rows.first[:value].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:STRING]
+    _(results.rows.first[:value]).must_be :nil?
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/params/struct_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/struct_test.rb
@@ -25,9 +25,9 @@ describe "Spanner Client", :params, :struct, :spanner do
       results = db.execute "SELECT @struct_param.userf, @p4",
                            params: { struct_param: { threadf: 1, userf: "bob" }, p4: 10 }
 
-      results.must_be_kind_of Google::Cloud::Spanner::Results
-      results.fields.to_h.must_equal({ userf: :STRING, 1 => :INT64 })
-      results.rows.first.to_h.must_equal({ userf: "bob", 1 => 10 })
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(results.fields.to_h).must_equal({ userf: :STRING, 1 => :INT64 })
+      _(results.rows.first.to_h).must_equal({ userf: "bob", 1 => 10 })
     end
 
     # # Simple field access on NULL struct value.
@@ -39,9 +39,9 @@ describe "Spanner Client", :params, :struct, :spanner do
                            params: { struct_param: nil },
                            types:  { struct_param: struct_type }
 
-      results.must_be_kind_of Google::Cloud::Spanner::Results
-      results.fields.to_h.must_equal({ userf: :STRING })
-      results.rows.first.to_h.must_equal({ userf: nil })
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(results.fields.to_h).must_equal({ userf: :STRING })
+      _(results.rows.first.to_h).must_equal({ userf: nil })
     end
 
     # # Nested struct field access.
@@ -51,9 +51,9 @@ describe "Spanner Client", :params, :struct, :spanner do
       results = db.execute "SELECT @struct_param.structf.nestedf",
                            params: { struct_param: { structf: { nestedf: "bob" } } }
 
-      results.must_be_kind_of Google::Cloud::Spanner::Results
-      results.fields.to_h.must_equal({ nestedf: :STRING })
-      results.rows.first.to_h.must_equal({ nestedf: "bob" })
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(results.fields.to_h).must_equal({ nestedf: :STRING })
+      _(results.rows.first.to_h).must_equal({ nestedf: "bob" })
     end
 
     # # Nested struct field access on NULL struct value.
@@ -65,9 +65,9 @@ describe "Spanner Client", :params, :struct, :spanner do
                            params: { struct_param: nil },
                            types:  { struct_param: struct_type }
 
-      results.must_be_kind_of Google::Cloud::Spanner::Results
-      results.fields.to_h.must_equal({ nestedf: :STRING })
-      results.rows.first.to_h.must_equal({ nestedf: nil })
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(results.fields.to_h).must_equal({ nestedf: :STRING })
+      _(results.rows.first.to_h).must_equal({ nestedf: nil })
     end
 
     # # Non-NULL struct with no fields (empty struct).
@@ -77,9 +77,9 @@ describe "Spanner Client", :params, :struct, :spanner do
       results = db.execute "SELECT @struct_param IS NULL",
                            params: { struct_param: {} }
 
-      results.must_be_kind_of Google::Cloud::Spanner::Results
-      results.fields.to_h.must_equal({ 0 => :BOOL })
-      results.rows.first.to_h.must_equal({ 0 => false })
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(results.fields.to_h).must_equal({ 0 => :BOOL })
+      _(results.rows.first.to_h).must_equal({ 0 => false })
     end
 
     # # NULL struct with no fields.
@@ -91,9 +91,9 @@ describe "Spanner Client", :params, :struct, :spanner do
                            params: { struct_param: nil },
                            types:  { struct_param: struct_type }
 
-      results.must_be_kind_of Google::Cloud::Spanner::Results
-      results.fields.to_h.must_equal({ 0 => :BOOL })
-      results.rows.first.to_h.must_equal({ 0 => true })
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(results.fields.to_h).must_equal({ 0 => :BOOL })
+      _(results.rows.first.to_h).must_equal({ 0 => true })
     end
 
     # # Struct with single NULL field.
@@ -105,9 +105,9 @@ describe "Spanner Client", :params, :struct, :spanner do
                            params: { struct_param: { f1: nil } },
                            types:  { struct_param: struct_type }
 
-      results.must_be_kind_of Google::Cloud::Spanner::Results
-      results.fields.to_h.must_equal({ f1: :INT64 })
-      results.rows.first.to_h.must_equal({ f1: nil })
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(results.fields.to_h).must_equal({ f1: :INT64 })
+      _(results.rows.first.to_h).must_equal({ f1: nil })
     end
 
     # # Equality check.
@@ -118,9 +118,9 @@ describe "Spanner Client", :params, :struct, :spanner do
       results = db.execute_query "SELECT @struct_param=STRUCT<threadf INT64, userf STRING>(1,\"bob\")",
                                  params: { struct_param: struct_value }
 
-      results.must_be_kind_of Google::Cloud::Spanner::Results
-      results.fields.to_h.must_equal({ 0 => :BOOL })
-      results.rows.first.to_h.must_equal({ 0 => true })
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(results.fields.to_h).must_equal({ 0 => :BOOL })
+      _(results.rows.first.to_h).must_equal({ 0 => true })
     end
 
     # # Nullness check.
@@ -131,9 +131,9 @@ describe "Spanner Client", :params, :struct, :spanner do
       results = db.execute_query "SELECT @struct_arr_param IS NULL",
                                  params: { struct_arr_param: [struct_value] }
 
-      results.must_be_kind_of Google::Cloud::Spanner::Results
-      results.fields.to_h.must_equal({ 0 => :BOOL })
-      results.rows.first.to_h.must_equal({ 0 => false })
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(results.fields.to_h).must_equal({ 0 => :BOOL })
+      _(results.rows.first.to_h).must_equal({ 0 => false })
     end
 
     # # Null array of struct field.
@@ -144,9 +144,9 @@ describe "Spanner Client", :params, :struct, :spanner do
       results = db.execute_query "SELECT a.threadid FROM UNNEST(@struct_param.arraysf) a",
                                  params: { struct_param: struct_value }
 
-      results.must_be_kind_of Google::Cloud::Spanner::Results
-      results.fields.to_h.must_equal({ threadid: :INT64 })
-      results.rows.count.must_equal 0
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(results.fields.to_h).must_equal({ threadid: :INT64 })
+      _(results.rows.count).must_equal 0
     end
 
     # # Null array of struct.
@@ -158,44 +158,44 @@ describe "Spanner Client", :params, :struct, :spanner do
                                  params: { struct_arr_param: nil },
                                  types:  { struct_arr_param: [struct_type] }
 
-      results.must_be_kind_of Google::Cloud::Spanner::Results
-      results.fields.to_h.must_equal({ threadid: :INT64 })
-      results.rows.count.must_equal 0
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(results.fields.to_h).must_equal({ threadid: :INT64 })
+      _(results.rows.count).must_equal 0
     end
   end
 
   it "queries and returns a struct parameter" do
     results = db.execute "SELECT ARRAY(SELECT AS STRUCT message, repeat FROM (SELECT @value.message AS message, @value.repeat AS repeat)) AS value", params: { value: { message: "hello", repeat: 1 } }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ value: [db.fields(message: :STRING, repeat: :INT64)] })
-    results.rows.first.to_h.must_equal({ value: [{ message: "hello", repeat: 1 }] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ value: [db.fields(message: :STRING, repeat: :INT64)] })
+    _(results.rows.first.to_h).must_equal({ value: [{ message: "hello", repeat: 1 }] })
   end
 
   it "queries a struct parameter and returns string and integer" do
     results = db.execute_query "SELECT @value.message AS message, @value.repeat AS repeat", params: { value: { message: "hello", repeat: 1 } }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ message: :STRING, repeat: :INT64 })
-    results.rows.first.to_h.must_equal({ message: "hello", repeat: 1 })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ message: :STRING, repeat: :INT64 })
+    _(results.rows.first.to_h).must_equal({ message: "hello", repeat: 1 })
   end
 
   it "queries and returns a struct array" do
     struct_sql = "SELECT ARRAY(SELECT AS STRUCT message, repeat FROM (SELECT 'hello' AS message, 1 AS repeat UNION ALL SELECT 'hola' AS message, 2 AS repeat))"
     results = db.execute_query struct_sql
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ 0 => [db.fields(message: :STRING, repeat: :INT64)] })
-    results.rows.first.to_h.must_equal({ 0 => [{ message: "hello", repeat: 1 }, { message: "hola", repeat: 2 }] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ 0 => [db.fields(message: :STRING, repeat: :INT64)] })
+    _(results.rows.first.to_h).must_equal({ 0 => [{ message: "hello", repeat: 1 }, { message: "hola", repeat: 2 }] })
   end
 
   it "queries and returns an empty struct array" do
     struct_sql = "SELECT ARRAY(SELECT AS STRUCT * FROM (SELECT 'empty', 0) WHERE 0 = 1)"
     results = db.execute_query struct_sql
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ 0 => [db.fields(0 => :STRING, 1 => :INT64)] })
-    results.rows.first.to_h.must_equal({ 0 => [] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ 0 => [db.fields(0 => :STRING, 1 => :INT64)] })
+    _(results.rows.first.to_h).must_equal({ 0 => [] })
   end
 
 end

--- a/google-cloud-spanner/acceptance/spanner/client/params/timestamp_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/timestamp_test.rb
@@ -21,49 +21,49 @@ describe "Spanner Client", :params, :timestamp, :spanner do
   it "queries and returns a timestamp parameter" do
     results = db.execute_query "SELECT @value AS value", params: { value: timestamp_value }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :TIMESTAMP
-    results.rows.first[:value].must_equal timestamp_value
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :TIMESTAMP
+    _(results.rows.first[:value]).must_equal timestamp_value
   end
 
   it "queries and returns a NULL timestamp parameter" do
     results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: :TIMESTAMP }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal :TIMESTAMP
-    results.rows.first[:value].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal :TIMESTAMP
+    _(results.rows.first[:value]).must_be :nil?
   end
 
   it "queries and returns an array of timestamp parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: [(timestamp_value - 180.0), timestamp_value, (timestamp_value - 240.0)] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:TIMESTAMP]
-    results.rows.first[:value].must_equal [(timestamp_value - 180.0), timestamp_value, (timestamp_value - 240.0)]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:TIMESTAMP]
+    _(results.rows.first[:value]).must_equal [(timestamp_value - 180.0), timestamp_value, (timestamp_value - 240.0)]
   end
 
   it "queries and returns an array of timestamp parameters with a nil value" do
     results = db.execute_query "SELECT @value AS value", params: { value: [nil, (timestamp_value - 180.0), timestamp_value, (timestamp_value - 240.0)] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:TIMESTAMP]
-    results.rows.first[:value].must_equal [nil, (timestamp_value - 180.0), timestamp_value, (timestamp_value - 240.0)]
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:TIMESTAMP]
+    _(results.rows.first[:value]).must_equal [nil, (timestamp_value - 180.0), timestamp_value, (timestamp_value - 240.0)]
   end
 
   it "queries and returns an empty array of timestamp parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: [] }, types: { value: [:TIMESTAMP] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:TIMESTAMP]
-    results.rows.first[:value].must_equal []
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:TIMESTAMP]
+    _(results.rows.first[:value]).must_equal []
   end
 
   it "queries and returns an NULL array of timestamp parameters" do
     results = db.execute_query "SELECT @value AS value", params: { value: nil }, types: { value: [:TIMESTAMP] }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields[:value].must_equal [:TIMESTAMP]
-    results.rows.first[:value].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields[:value]).must_equal [:TIMESTAMP]
+    _(results.rows.first[:value]).must_be :nil?
   end
 
   describe "using DateTime" do
@@ -72,25 +72,25 @@ describe "Spanner Client", :params, :timestamp, :spanner do
     it "queries and returns a timestamp parameter" do
       results = db.execute_query "SELECT @value AS value", params: { value: datetime_value }
 
-      results.must_be_kind_of Google::Cloud::Spanner::Results
-      results.fields[:value].must_equal :TIMESTAMP
-      results.rows.first[:value].must_equal timestamp_value
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(results.fields[:value]).must_equal :TIMESTAMP
+      _(results.rows.first[:value]).must_equal timestamp_value
     end
 
     it "queries and returns an array of timestamp parameters" do
       results = db.execute_query "SELECT @value AS value", params: { value: [(datetime_value - 1), datetime_value, (datetime_value + 1)] }
 
-      results.must_be_kind_of Google::Cloud::Spanner::Results
-      results.fields[:value].must_equal [:TIMESTAMP]
-      results.rows.first[:value].must_equal [(timestamp_value - 86400), timestamp_value, (timestamp_value + 86400)]
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(results.fields[:value]).must_equal [:TIMESTAMP]
+      _(results.rows.first[:value]).must_equal [(timestamp_value - 86400), timestamp_value, (timestamp_value + 86400)]
     end
 
     it "queries and returns an array of timestamp parameters with a nil value" do
       results = db.execute_query "SELECT @value AS value", params: { value: [nil, (datetime_value - 1), datetime_value, (datetime_value + 1)] }
 
-      results.must_be_kind_of Google::Cloud::Spanner::Results
-      results.fields[:value].must_equal [:TIMESTAMP]
-      results.rows.first[:value].must_equal [nil, (timestamp_value - 86400), timestamp_value, (timestamp_value + 86400)]
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(results.fields[:value]).must_equal [:TIMESTAMP]
+      _(results.rows.first[:value]).must_equal [nil, (timestamp_value - 86400), timestamp_value, (timestamp_value + 86400)]
     end
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/pdml_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/pdml_test.rb
@@ -31,24 +31,24 @@ describe "Spanner Client", :pdml, :spanner do
 
   it "executes a simple Partitioned DML statement" do
     prior_results = db.execute_sql "SELECT * FROM accounts WHERE active = TRUE"
-    prior_results.rows.count.must_equal 2
+    _(prior_results.rows.count).must_equal 2
 
     pdml_row_count = db.execute_partition_update "UPDATE accounts a SET a.active = TRUE WHERE a.active = FALSE"
-    pdml_row_count.must_equal 1
+    _(pdml_row_count).must_equal 1
 
     post_results = db.execute_sql "SELECT * FROM accounts WHERE active = TRUE", single_use: { strong: true }
-    post_results.rows.count.must_equal 3
+    _(post_results.rows.count).must_equal 3
   end
 
   it "executes a simple Partitioned DML statement with query options" do
     prior_results = db.execute_sql "SELECT * FROM accounts WHERE active = TRUE"
-    prior_results.rows.count.must_equal 2
+    _(prior_results.rows.count).must_equal 2
 
     query_options = { optimizer_version: "1" }
     pdml_row_count = db.execute_partition_update "UPDATE accounts a SET a.active = TRUE WHERE a.active = FALSE", query_options: query_options
-    pdml_row_count.must_equal 1
+    _(pdml_row_count).must_equal 1
 
     post_results = db.execute_sql "SELECT * FROM accounts WHERE active = TRUE", single_use: { strong: true }
-    post_results.rows.count.must_equal 3
+    _(post_results.rows.count).must_equal 3
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/read_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/read_test.rb
@@ -42,83 +42,83 @@ describe "Spanner Client", :read, :spanner do
   end
 
   it "reads all by default" do
-    db.read(table_name, [:id]).rows.map(&:to_h).must_equal [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }, { id: 11 }, { id: 12 }]
-    db.read(table_name, [:id], limit: 5).rows.map(&:to_h).must_equal [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]
+    _(db.read(table_name, [:id]).rows.map(&:to_h)).must_equal [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }, { id: 11 }, { id: 12 }]
+    _(db.read(table_name, [:id], limit: 5).rows.map(&:to_h)).must_equal [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]
 
-    db.read(table_name, [:id, :bool], index: table_index).rows.map(&:to_h).must_equal [{ id: 1, bool: false }, { id: 2, bool: false }, { id: 4, bool: false }, { id: 6, bool: false }, { id: 8, bool: false }, { id: 9, bool: false }, { id: 10, bool: false }, { id: 12, bool: false }, { id: 3, bool: true }, { id: 5, bool: true }, { id: 7, bool: true }, { id: 11, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, limit: 5).rows.map(&:to_h).must_equal [{ id: 1, bool: false }, { id: 2, bool: false }, { id: 4, bool: false }, { id: 6, bool: false }, { id: 8, bool: false }]
+    _(db.read(table_name, [:id, :bool], index: table_index).rows.map(&:to_h)).must_equal [{ id: 1, bool: false }, { id: 2, bool: false }, { id: 4, bool: false }, { id: 6, bool: false }, { id: 8, bool: false }, { id: 9, bool: false }, { id: 10, bool: false }, { id: 12, bool: false }, { id: 3, bool: true }, { id: 5, bool: true }, { id: 7, bool: true }, { id: 11, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, limit: 5).rows.map(&:to_h)).must_equal [{ id: 1, bool: false }, { id: 2, bool: false }, { id: 4, bool: false }, { id: 6, bool: false }, { id: 8, bool: false }]
   end
 
   it "empty read works" do
     random_id = SecureRandom.int64
     db.delete table_name, random_id
-    db.read(table_name, [:id], keys: random_id).rows.map(&:to_h).must_equal []
+    _(db.read(table_name, [:id], keys: random_id).rows.map(&:to_h)).must_equal []
 
     db.delete table_name, 9997..9999
-    db.read(table_name, [:id], keys: 9997..9999).rows.map(&:to_h).must_equal []
+    _(db.read(table_name, [:id], keys: 9997..9999).rows.map(&:to_h)).must_equal []
 
-    db.read(table_name, [:id, :bool], index: table_index, keys: [[false, 3]]).rows.map(&:to_h).must_equal []
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [[false, 3]]).rows.map(&:to_h)).must_equal []
   end
 
   it "reads with a list of keys" do
-    db.read(table_name, [:id], keys: 1).rows.map(&:to_h).must_equal [{ id: 1 }]
-    db.read(table_name, [:id], keys: [1]).rows.map(&:to_h).must_equal [{ id: 1 }]
-    db.read(table_name, [:id], keys: [3, 4, 5]).rows.map(&:to_h).must_equal [{ id: 3 }, { id: 4 }, { id: 5 }]
-    db.read(table_name, [:id], keys: [3, 5, 7, 11]).rows.map(&:to_h).must_equal [{ id: 3 }, { id: 5 }, { id: 7 }, { id: 11 }]
+    _(db.read(table_name, [:id], keys: 1).rows.map(&:to_h)).must_equal [{ id: 1 }]
+    _(db.read(table_name, [:id], keys: [1]).rows.map(&:to_h)).must_equal [{ id: 1 }]
+    _(db.read(table_name, [:id], keys: [3, 4, 5]).rows.map(&:to_h)).must_equal [{ id: 3 }, { id: 4 }, { id: 5 }]
+    _(db.read(table_name, [:id], keys: [3, 5, 7, 11]).rows.map(&:to_h)).must_equal [{ id: 3 }, { id: 5 }, { id: 7 }, { id: 11 }]
 
-    db.read(table_name, [:id], keys: [3, 5, 7, 11], limit: 2).rows.map(&:to_h).must_equal [{ id: 3 }, { id: 5 }]
+    _(db.read(table_name, [:id], keys: [3, 5, 7, 11], limit: 2).rows.map(&:to_h)).must_equal [{ id: 3 }, { id: 5 }]
   end
 
   it "reads with range key sets" do
-    db.read(table_name, [:id], keys: 3..5).rows.map(&:to_h).must_equal [{ id: 3 }, { id: 4 }, { id: 5 }]
-    db.read(table_name, [:id], keys: 3...5).rows.map(&:to_h).must_equal [{ id: 3 }, { id: 4 }]
-    db.read(table_name, [:id], keys: db.range(3, 5, exclude_begin: true)).rows.map(&:to_h).must_equal [{ id: 4 }, { id: 5 }]
-    db.read(table_name, [:id], keys: db.range(3, 5, exclude_begin: true, exclude_end: true)).rows.map(&:to_h).must_equal [{ id: 4 }]
-    db.read(table_name, [:id], keys: [7]..[]).rows.map(&:to_h).must_equal [{ id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }, { id: 11 }, { id: 12 }]
-    db.read(table_name, [:id], keys: db.range([7], [], exclude_begin: true)).rows.map(&:to_h).must_equal [{ id: 8 }, { id: 9 }, { id: 10 }, { id: 11 }, { id: 12 }]
-    db.read(table_name, [:id], keys: []..[5]).rows.map(&:to_h).must_equal [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]
-    db.read(table_name, [:id], keys: []...[5]).rows.map(&:to_h).must_equal [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]
+    _(db.read(table_name, [:id], keys: 3..5).rows.map(&:to_h)).must_equal [{ id: 3 }, { id: 4 }, { id: 5 }]
+    _(db.read(table_name, [:id], keys: 3...5).rows.map(&:to_h)).must_equal [{ id: 3 }, { id: 4 }]
+    _(db.read(table_name, [:id], keys: db.range(3, 5, exclude_begin: true)).rows.map(&:to_h)).must_equal [{ id: 4 }, { id: 5 }]
+    _(db.read(table_name, [:id], keys: db.range(3, 5, exclude_begin: true, exclude_end: true)).rows.map(&:to_h)).must_equal [{ id: 4 }]
+    _(db.read(table_name, [:id], keys: [7]..[]).rows.map(&:to_h)).must_equal [{ id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }, { id: 11 }, { id: 12 }]
+    _(db.read(table_name, [:id], keys: db.range([7], [], exclude_begin: true)).rows.map(&:to_h)).must_equal [{ id: 8 }, { id: 9 }, { id: 10 }, { id: 11 }, { id: 12 }]
+    _(db.read(table_name, [:id], keys: []..[5]).rows.map(&:to_h)).must_equal [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]
+    _(db.read(table_name, [:id], keys: []...[5]).rows.map(&:to_h)).must_equal [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]
   end
 
   it "reads with range key sets and limit" do
-    db.read(table_name, [:id], keys: 3..9, limit: 2).rows.map(&:to_h).must_equal [{ id: 3 }, { id: 4 }]
-    db.read(table_name, [:id], keys: 3...9, limit: 2).rows.map(&:to_h).must_equal [{ id: 3 }, { id: 4 }]
-    db.read(table_name, [:id], keys: db.range(3, 9, exclude_begin: true), limit: 2).rows.map(&:to_h).must_equal [{ id: 4 }, { id: 5 }]
-    db.read(table_name, [:id], keys: db.range(3, 9, exclude_begin: true, exclude_end: true), limit: 2).rows.map(&:to_h).must_equal [{ id: 4 }, { id: 5 }]
-    db.read(table_name, [:id], keys: [3]..[], limit: 2).rows.map(&:to_h).must_equal [{ id: 3}, { id: 4}]
-    db.read(table_name, [:id], keys: db.range([3], [], exclude_begin: true), limit: 2).rows.map(&:to_h).must_equal [{ id: 4 }, { id: 5 }]
-    db.read(table_name, [:id], keys: []..[9], limit: 2).rows.map(&:to_h).must_equal [{ id: 1 }, { id: 2 }]
-    db.read(table_name, [:id], keys: []...[9], limit: 2).rows.map(&:to_h).must_equal [{ id: 1 }, { id: 2 }]
+    _(db.read(table_name, [:id], keys: 3..9, limit: 2).rows.map(&:to_h)).must_equal [{ id: 3 }, { id: 4 }]
+    _(db.read(table_name, [:id], keys: 3...9, limit: 2).rows.map(&:to_h)).must_equal [{ id: 3 }, { id: 4 }]
+    _(db.read(table_name, [:id], keys: db.range(3, 9, exclude_begin: true), limit: 2).rows.map(&:to_h)).must_equal [{ id: 4 }, { id: 5 }]
+    _(db.read(table_name, [:id], keys: db.range(3, 9, exclude_begin: true, exclude_end: true), limit: 2).rows.map(&:to_h)).must_equal [{ id: 4 }, { id: 5 }]
+    _(db.read(table_name, [:id], keys: [3]..[], limit: 2).rows.map(&:to_h)).must_equal [{ id: 3}, { id: 4}]
+    _(db.read(table_name, [:id], keys: db.range([3], [], exclude_begin: true), limit: 2).rows.map(&:to_h)).must_equal [{ id: 4 }, { id: 5 }]
+    _(db.read(table_name, [:id], keys: []..[9], limit: 2).rows.map(&:to_h)).must_equal [{ id: 1 }, { id: 2 }]
+    _(db.read(table_name, [:id], keys: []...[9], limit: 2).rows.map(&:to_h)).must_equal [{ id: 1 }, { id: 2 }]
   end
 
   it "reads from index with a list of composite keys" do
-    db.read(table_name, [:id, :bool], index: table_index, keys: [[false, 1]]).rows.map(&:to_h).must_equal [{ id: 1, bool: false }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [[false, 1]]).rows.map(&:to_h)).must_equal [{ id: 1, bool: false }]
     # Provide 3 keys, but only get 2 results...
-    db.read(table_name, [:id, :bool], index: table_index, keys: [[true, 3], [true, 4], [true, 5]]).rows.map(&:to_h).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: [[true, 3], [true, 5], [true, 7], [true, 11]]).rows.map(&:to_h).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }, { id: 7, bool: true }, { id: 11, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [[true, 3], [true, 4], [true, 5]]).rows.map(&:to_h)).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [[true, 3], [true, 5], [true, 7], [true, 11]]).rows.map(&:to_h)).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }, { id: 7, bool: true }, { id: 11, bool: true }]
 
-    db.read(table_name, [:id, :bool], index: table_index, keys: [[false, 1], [false, 2], [false, 3], [false, 4], [false, 5], [false, 6]], limit: 3).rows.map(&:to_h).must_equal [{ id: 1, bool: false }, { id: 2, bool: false }, { id: 4, bool: false }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [[false, 1], [false, 2], [false, 3], [false, 4], [false, 5], [false, 6]], limit: 3).rows.map(&:to_h)).must_equal [{ id: 1, bool: false }, { id: 2, bool: false }, { id: 4, bool: false }]
   end
 
   it "reads from index with range key sets" do
-    db.read(table_name, [:id, :bool], index: table_index, keys: [true, 3]..[true, 7]).rows.map(&:to_h).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }, { id: 7, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: [true, 3]...[true, 7]).rows.map(&:to_h).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: db.range([true, 3], [true, 7], exclude_begin: true)).rows.map(&:to_h).must_equal [{ id: 5, bool: true }, { id: 7, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: db.range([true, 3], [true, 7], exclude_begin: true, exclude_end: true)).rows.map(&:to_h).must_equal [{ id: 5, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: [true, 7]..[]).rows.map(&:to_h).must_equal [{ id: 7, bool: true }, { id: 11, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: db.range([true, 7], [], exclude_begin: true)).rows.map(&:to_h).must_equal [{ id: 11, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: [true]..[true, 7]).rows.map(&:to_h).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }, { id: 7, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: [true]...[true, 7]).rows.map(&:to_h).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [true, 3]..[true, 7]).rows.map(&:to_h)).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }, { id: 7, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [true, 3]...[true, 7]).rows.map(&:to_h)).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: db.range([true, 3], [true, 7], exclude_begin: true)).rows.map(&:to_h)).must_equal [{ id: 5, bool: true }, { id: 7, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: db.range([true, 3], [true, 7], exclude_begin: true, exclude_end: true)).rows.map(&:to_h)).must_equal [{ id: 5, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [true, 7]..[]).rows.map(&:to_h)).must_equal [{ id: 7, bool: true }, { id: 11, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: db.range([true, 7], [], exclude_begin: true)).rows.map(&:to_h)).must_equal [{ id: 11, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [true]..[true, 7]).rows.map(&:to_h)).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }, { id: 7, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [true]...[true, 7]).rows.map(&:to_h)).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
   end
 
   it "reads from index with range key sets and limit" do
-    db.read(table_name, [:id, :bool], index: table_index, keys: [true, 3]..[true, 11], limit: 2).rows.map(&:to_h).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: [true, 3]...[true, 11], limit: 2).rows.map(&:to_h).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: db.range([true, 3], [true, 7], exclude_begin: true), limit: 2).rows.map(&:to_h).must_equal [{ id: 5, bool: true }, { id: 7, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: db.range([true, 3], [true, 7], exclude_begin: true, exclude_end: true), limit: 2).rows.map(&:to_h).must_equal [{ id: 5, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: [true, 5]..[], limit: 2).rows.map(&:to_h).must_equal [{ id: 5, bool: true }, { id: 7, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: db.range([true, 5], [], exclude_begin: true), limit: 2).rows.map(&:to_h).must_equal [{ id: 7, bool: true }, { id: 11, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: [true]..[true, 11], limit: 2).rows.map(&:to_h).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
-    db.read(table_name, [:id, :bool], index: table_index, keys: [true]...[true, 11], limit: 2).rows.map(&:to_h).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [true, 3]..[true, 11], limit: 2).rows.map(&:to_h)).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [true, 3]...[true, 11], limit: 2).rows.map(&:to_h)).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: db.range([true, 3], [true, 7], exclude_begin: true), limit: 2).rows.map(&:to_h)).must_equal [{ id: 5, bool: true }, { id: 7, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: db.range([true, 3], [true, 7], exclude_begin: true, exclude_end: true), limit: 2).rows.map(&:to_h)).must_equal [{ id: 5, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [true, 5]..[], limit: 2).rows.map(&:to_h)).must_equal [{ id: 5, bool: true }, { id: 7, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: db.range([true, 5], [], exclude_begin: true), limit: 2).rows.map(&:to_h)).must_equal [{ id: 7, bool: true }, { id: 11, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [true]..[true, 11], limit: 2).rows.map(&:to_h)).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
+    _(db.read(table_name, [:id, :bool], index: table_index, keys: [true]...[true, 11], limit: 2).rows.map(&:to_h)).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/reset_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/reset_test.rb
@@ -18,7 +18,7 @@ describe "Spanner Client", :reset, :spanner do
   let(:db) { spanner_client }
 
   it "closes all sessions and creates new sessions" do
-    db.reset.must_equal true
-    db.execute_query("SELECT 1").rows.first.values.must_equal [1]
+    _(db.reset).must_equal true
+    _(db.execute_query("SELECT 1").rows.first.values).must_equal [1]
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/single_use_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/single_use_test.rb
@@ -33,166 +33,166 @@ describe "Spanner Client", :single_use, :spanner do
   it "runs a query with strong option" do
     results = db.execute_sql "SELECT * FROM accounts", single_use: { strong: true }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
 
-    results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
+    _(results.timestamp).wont_be :nil?
+    _(results.timestamp).must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   it "runs a read with strong option" do
     results = db.read "accounts", columns, single_use: { strong: true }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
 
-    results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
+    _(results.timestamp).wont_be :nil?
+    _(results.timestamp).must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   it "runs a query with timestamp option" do
     results = db.execute_sql "SELECT * FROM accounts", single_use: { timestamp: @setup_timestamp }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
 
-    results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to @setup_timestamp, 1
+    _(results.timestamp).wont_be :nil?
+    _(results.timestamp).must_be_close_to @setup_timestamp, 1
   end
 
   it "runs a read with timestamp option" do
     results = db.read "accounts", columns, single_use: { timestamp: @setup_timestamp }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
 
-    results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to @setup_timestamp, 1
+    _(results.timestamp).wont_be :nil?
+    _(results.timestamp).must_be_close_to @setup_timestamp, 1
   end
 
   it "runs a query with staleness option" do
     results = db.execute_sql "SELECT * FROM accounts", single_use: { staleness: 0.0001 }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
 
-    results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
+    _(results.timestamp).wont_be :nil?
+    _(results.timestamp).must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   it "runs a read with staleness option" do
     results = db.read "accounts", columns, single_use: { staleness: 0.0001 }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
 
-    results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
+    _(results.timestamp).wont_be :nil?
+    _(results.timestamp).must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   it "runs a query with bounded_timestamp option" do
     results = db.execute_sql "SELECT * FROM accounts", single_use: { bounded_timestamp: @setup_timestamp }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
 
-    results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
+    _(results.timestamp).wont_be :nil?
+    _(results.timestamp).must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   it "runs a read with bounded_timestamp option" do
     results = db.read "accounts", columns, single_use: { bounded_timestamp: @setup_timestamp }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
 
-    results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
+    _(results.timestamp).wont_be :nil?
+    _(results.timestamp).must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   it "runs a query with bounded_staleness option" do
     results = db.execute_sql "SELECT * FROM accounts", single_use: { bounded_staleness: 0.0001 }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
 
-    results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
+    _(results.timestamp).wont_be :nil?
+    _(results.timestamp).must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   it "runs a read with bounded_staleness option" do
     results = db.read "accounts", columns, single_use: { bounded_staleness: 0.0001 }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
 
-    results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
+    _(results.timestamp).wont_be :nil?
+    _(results.timestamp).must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   def assert_accounts_equal expected, actual
     if actual[:account_id].nil?
-      expected[:account_id].must_be :nil?
+      _(expected[:account_id]).must_be :nil?
     else
-      expected[:account_id].must_equal actual[:account_id]
+      _(expected[:account_id]).must_equal actual[:account_id]
     end
 
     if actual[:username].nil?
-      expected[:username].must_be :nil?
+      _(expected[:username]).must_be :nil?
     else
-      expected[:username].must_equal actual[:username]
+      _(expected[:username]).must_equal actual[:username]
     end
 
     if actual[:reputation].nil?
-      expected[:reputation].must_be :nil?
+      _(expected[:reputation]).must_be :nil?
     else
-      expected[:reputation].must_equal actual[:reputation]
+      _(expected[:reputation]).must_equal actual[:reputation]
     end
 
     if actual[:active].nil?
-      expected[:active].must_be :nil?
+      _(expected[:active]).must_be :nil?
     else
-      expected[:active].must_equal actual[:active]
+      _(expected[:active]).must_equal actual[:active]
     end
 
     if expected[:avatar] && actual[:avatar]
-      expected[:avatar].read.must_equal actual[:avatar].read
+      _(expected[:avatar].read).must_equal actual[:avatar].read
     end
 
     if actual[:friends].nil?
-      expected[:friends].must_be :nil?
+      _(expected[:friends]).must_be :nil?
     else
-      expected[:friends].must_equal actual[:friends]
+      _(expected[:friends]).must_equal actual[:friends]
     end
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
@@ -33,14 +33,14 @@ describe "Spanner Client", :snapshot, :spanner do
   it "runs a query" do
     results = nil
     db.snapshot do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.execute_sql "SELECT * FROM accounts"
     end
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
@@ -50,14 +50,14 @@ describe "Spanner Client", :snapshot, :spanner do
     query_options = { optimizer_version: "latest" }
     results = nil
     db.snapshot do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.execute_sql "SELECT * FROM accounts", query_options: query_options
     end
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
@@ -66,14 +66,14 @@ describe "Spanner Client", :snapshot, :spanner do
   it "runs a read" do
     results = nil
     db.snapshot do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.read "accounts", columns
     end
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
@@ -82,14 +82,14 @@ describe "Spanner Client", :snapshot, :spanner do
   it "runs a query with strong option" do
     results = nil
     db.snapshot strong: true do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.execute_sql "SELECT * FROM accounts"
     end
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
@@ -98,14 +98,14 @@ describe "Spanner Client", :snapshot, :spanner do
   it "runs a read with strong option" do
     results = nil
     db.snapshot strong: true do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.read "accounts", columns
     end
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
@@ -114,14 +114,14 @@ describe "Spanner Client", :snapshot, :spanner do
   it "runs a query with timestamp option" do
     results = nil
     db.snapshot timestamp: @setup_timestamp do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.execute_sql "SELECT * FROM accounts"
     end
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
@@ -130,14 +130,14 @@ describe "Spanner Client", :snapshot, :spanner do
   it "runs a read with timestamp option" do
     results = nil
     db.snapshot timestamp: @setup_timestamp do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.read "accounts", columns
     end
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
@@ -146,14 +146,14 @@ describe "Spanner Client", :snapshot, :spanner do
   it "runs a query with staleness option" do
     results = nil
     db.snapshot staleness: 0.0001 do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.execute_sql "SELECT * FROM accounts"
     end
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
@@ -162,14 +162,14 @@ describe "Spanner Client", :snapshot, :spanner do
   it "runs a read with staleness option" do
     results = nil
     db.snapshot staleness: 0.0001 do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.read "accounts", columns
     end
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
@@ -181,19 +181,19 @@ describe "Spanner Client", :snapshot, :spanner do
     modified_row = { account_id: first_row[:account_id], username: first_row[:username].reverse }
 
     db.snapshot strong: true do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.read "accounts", [:account_id, :username], keys: sample_row[:account_id]
       # verify we got the row we were expecting
-      results.rows.first.to_h.must_equal sample_row
+      _(results.rows.first.to_h).must_equal sample_row
 
       # outside of the snapshot, update the row!
       db.update "accounts", modified_row
 
       results2 = snp.read "accounts", [:account_id, :username], keys: modified_row[:account_id]
       # verify we got the previous row, not the modified row
-      results2.rows.first.to_h.must_equal sample_row
+      _(results2.rows.first.to_h).must_equal sample_row
     end
   end
 
@@ -203,19 +203,19 @@ describe "Spanner Client", :snapshot, :spanner do
     modified_row = { account_id: first_row[:account_id], username: first_row[:username].reverse }
 
     db.snapshot strong: true do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.execute_sql "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: sample_row[:account_id] }
       # verify we got the row we were expecting
-      results.rows.first.to_h.must_equal sample_row
+      _(results.rows.first.to_h).must_equal sample_row
 
       # outside of the snapshot, update the row!
       db.update "accounts", modified_row
 
       results2 = snp.execute_sql "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: modified_row[:account_id] }
       # verify we got the previous row, not the modified row
-      results2.rows.first.to_h.must_equal sample_row
+      _(results2.rows.first.to_h).must_equal sample_row
     end
   end
 
@@ -225,19 +225,19 @@ describe "Spanner Client", :snapshot, :spanner do
     modified_row = { account_id: first_row[:account_id], username: first_row[:username].reverse }
 
     db.snapshot timestamp: @setup_timestamp do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.read "accounts", [:account_id, :username], keys: sample_row[:account_id]
       # verify we got the row we were expecting
-      results.rows.first.to_h.must_equal sample_row
+      _(results.rows.first.to_h).must_equal sample_row
 
       # outside of the snapshot, update the row!
       db.update "accounts", modified_row
 
       results2 = snp.read "accounts", [:account_id, :username], keys: modified_row[:account_id]
       # verify we got the previous row, not the modified row
-      results2.rows.first.to_h.must_equal sample_row
+      _(results2.rows.first.to_h).must_equal sample_row
     end
   end
 
@@ -247,19 +247,19 @@ describe "Spanner Client", :snapshot, :spanner do
     modified_row = { account_id: first_row[:account_id], username: first_row[:username].reverse }
 
     db.snapshot timestamp: @setup_timestamp do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.execute_sql "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: sample_row[:account_id] }
       # verify we got the row we were expecting
-      results.rows.first.to_h.must_equal sample_row
+      _(results.rows.first.to_h).must_equal sample_row
 
       # outside of the snapshot, update the row!
       db.update "accounts", modified_row
 
       results2 = snp.execute_sql "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: modified_row[:account_id] }
       # verify we got the previous row, not the modified row
-      results2.rows.first.to_h.must_equal sample_row
+      _(results2.rows.first.to_h).must_equal sample_row
     end
   end
 
@@ -269,19 +269,19 @@ describe "Spanner Client", :snapshot, :spanner do
     modified_row = { account_id: first_row[:account_id], username: first_row[:username].reverse }
 
     db.snapshot staleness: 0.01 do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.read "accounts", [:account_id, :username], keys: sample_row[:account_id]
       # verify we got the row we were expecting
-      results.rows.first.to_h.must_equal sample_row
+      _(results.rows.first.to_h).must_equal sample_row
 
       # outside of the snapshot, update the row!
       db.update "accounts", modified_row
 
       results2 = snp.read "accounts", [:account_id, :username], keys: modified_row[:account_id]
       # verify we got the previous row, not the modified row
-      results2.rows.first.to_h.must_equal sample_row
+      _(results2.rows.first.to_h).must_equal sample_row
     end
   end
 
@@ -291,19 +291,19 @@ describe "Spanner Client", :snapshot, :spanner do
     modified_row = { account_id: first_row[:account_id], username: first_row[:username].reverse }
 
     db.snapshot staleness: 0.01 do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.execute_sql "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: sample_row[:account_id] }
       # verify we got the row we were expecting
-      results.rows.first.to_h.must_equal sample_row
+      _(results.rows.first.to_h).must_equal sample_row
 
       # outside of the snapshot, update the row!
       db.update "accounts", modified_row
 
       results2 = snp.execute_sql "SELECT account_id, username FROM accounts WHERE account_id = @id", params: { id: modified_row[:account_id] }
       # verify we got the previous row, not the modified row
-      results2.rows.first.to_h.must_equal sample_row
+      _(results2.rows.first.to_h).must_equal sample_row
     end
   end
 
@@ -311,17 +311,17 @@ describe "Spanner Client", :snapshot, :spanner do
     keys = default_account_rows.map{|row| row[:account_id] }
 
     db.snapshot do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.read "accounts", [:account_id, :username], keys: keys
-      results.must_be_kind_of Google::Cloud::Spanner::Results
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
       rows = results.rows.to_a
-      rows.count.must_equal default_account_rows.count
+      _(rows.count).must_equal default_account_rows.count
       rows.zip(default_account_rows).each do |expected, actual|
-        expected[:account_id].must_equal actual[:account_id]
-        expected[:username].must_equal actual[:username]
+        _(expected[:account_id]).must_equal actual[:account_id]
+        _(expected[:username]).must_equal actual[:username]
       end
 
       # outside of the snapshot, delete rows
@@ -329,36 +329,36 @@ describe "Spanner Client", :snapshot, :spanner do
 
       # read rows and from snaphot and verify rows got from the snapshot
       results2 = snp.read "accounts", [:account_id, :username], keys: keys
-      results2.must_be_kind_of Google::Cloud::Spanner::Results
+      _(results2).must_be_kind_of Google::Cloud::Spanner::Results
       rows2 = results2.rows.to_a
 
-      rows2.count.must_equal default_account_rows.count
+      _(rows2.count).must_equal default_account_rows.count
       rows2.zip(default_account_rows).each do |expected, actual|
-        expected[:account_id].must_equal actual[:account_id]
-        expected[:username].must_equal actual[:username]
+        _(expected[:account_id]).must_equal actual[:account_id]
+        _(expected[:username]).must_equal actual[:username]
       end
     end
 
     # outside of snapshot check all rows are deleted
     rows3 = db.execute_sql("SELECT * FROM accounts").rows.to_a
-    rows3.count.must_equal 0
+    _(rows3.count).must_equal 0
   end
 
   it "multiuse snapshot reads with read timestamp are consistent even when delete happen" do
     keys = default_account_rows.map{|row| row[:account_id] }
 
     db.snapshot read_timestamp: @setup_timestamp do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.read "accounts", [:account_id, :username], keys: keys
-      results.must_be_kind_of Google::Cloud::Spanner::Results
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
       rows = results.rows.to_a
-      rows.count.must_equal default_account_rows.count
+      _(rows.count).must_equal default_account_rows.count
       rows.zip(default_account_rows).each do |expected, actual|
-        expected[:account_id].must_equal actual[:account_id]
-        expected[:username].must_equal actual[:username]
+        _(expected[:account_id]).must_equal actual[:account_id]
+        _(expected[:username]).must_equal actual[:username]
       end
 
       # outside of the snapshot, delete rows
@@ -366,18 +366,18 @@ describe "Spanner Client", :snapshot, :spanner do
 
       # read rows and from snaphot and verify rows got from the snapshot
       results2 = snp.read "accounts", [:account_id, :username], keys: keys
-      results2.must_be_kind_of Google::Cloud::Spanner::Results
+      _(results2).must_be_kind_of Google::Cloud::Spanner::Results
       rows2 = results2.rows.to_a
-      rows2.count.must_equal default_account_rows.count
+      _(rows2.count).must_equal default_account_rows.count
       rows2.zip(default_account_rows).each do |expected, actual|
-        expected[:account_id].must_equal actual[:account_id]
-        expected[:username].must_equal actual[:username]
+        _(expected[:account_id]).must_equal actual[:account_id]
+        _(expected[:username]).must_equal actual[:username]
       end
     end
 
     # outside of snapshot check all rows are deleted
     rows3 = db.execute_sql("SELECT * FROM accounts").rows.to_a
-    rows3.count.must_equal 0
+    _(rows3.count).must_equal 0
   end
 
   it "multiuse snapshot reads with exact staleness are consistent even when delete happen" do
@@ -387,17 +387,17 @@ describe "Spanner Client", :snapshot, :spanner do
     delta = 0.001
 
     db.snapshot exact_staleness: delta do |snp|
-      snp.transaction_id.wont_be :nil?
-      snp.timestamp.wont_be :nil?
+      _(snp.transaction_id).wont_be :nil?
+      _(snp.timestamp).wont_be :nil?
 
       results = snp.read "accounts", [:account_id, :username], keys: keys
-      results.must_be_kind_of Google::Cloud::Spanner::Results
+      _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
       rows = results.rows.to_a
-      rows.count.must_equal default_account_rows.count
+      _(rows.count).must_equal default_account_rows.count
       rows.zip(default_account_rows).each do |expected, actual|
-        expected[:account_id].must_equal actual[:account_id]
-        expected[:username].must_equal actual[:username]
+        _(expected[:account_id]).must_equal actual[:account_id]
+        _(expected[:username]).must_equal actual[:username]
       end
 
       # outside of the snapshot, delete rows
@@ -405,53 +405,53 @@ describe "Spanner Client", :snapshot, :spanner do
 
       # read rows and from snaphot and verify rows got from the snapshot
       results2 = snp.read "accounts", [:account_id, :username], keys: keys
-      results2.must_be_kind_of Google::Cloud::Spanner::Results
+      _(results2).must_be_kind_of Google::Cloud::Spanner::Results
       rows2 = results2.rows.to_a
-      rows2.count.must_equal default_account_rows.count
+      _(rows2.count).must_equal default_account_rows.count
       rows2.zip(default_account_rows).each do |expected, actual|
-        expected[:account_id].must_equal actual[:account_id]
-        expected[:username].must_equal actual[:username]
+        _(expected[:account_id]).must_equal actual[:account_id]
+        _(expected[:username]).must_equal actual[:username]
       end
     end
 
     # outside of snapshot check all rows are deleted
     rows3 = db.execute_sql("SELECT * FROM accounts").rows.to_a
-    rows3.count.must_equal 0
+    _(rows3.count).must_equal 0
   end
 
   def assert_accounts_equal expected, actual
     if actual[:account_id].nil?
-      expected[:account_id].must_be :nil?
+      _(expected[:account_id]).must_be :nil?
     else
-      expected[:account_id].must_equal actual[:account_id]
+      _(expected[:account_id]).must_equal actual[:account_id]
     end
 
     if actual[:username].nil?
-      expected[:username].must_be :nil?
+      _(expected[:username]).must_be :nil?
     else
-      expected[:username].must_equal actual[:username]
+      _(expected[:username]).must_equal actual[:username]
     end
 
     if actual[:reputation].nil?
-      expected[:reputation].must_be :nil?
+      _(expected[:reputation]).must_be :nil?
     else
-      expected[:reputation].must_equal actual[:reputation]
+      _(expected[:reputation]).must_equal actual[:reputation]
     end
 
     if actual[:active].nil?
-      expected[:active].must_be :nil?
+      _(expected[:active]).must_be :nil?
     else
-      expected[:active].must_equal actual[:active]
+      _(expected[:active]).must_equal actual[:active]
     end
 
     if expected[:avatar] && actual[:avatar]
-      expected[:avatar].read.must_equal actual[:avatar].read
+      _(expected[:avatar].read).must_equal actual[:avatar].read
     end
 
     if actual[:friends].nil?
-      expected[:friends].must_be :nil?
+      _(expected[:friends]).must_be :nil?
     else
-      expected[:friends].must_equal actual[:friends]
+      _(expected[:friends]).must_equal actual[:friends]
     end
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/transaction_test.rb
@@ -35,11 +35,11 @@ describe "Spanner Client", :transaction, :spanner do
 
   it "modifies accounts and verifies data with reads" do
     timestamp = db.transaction do |tx|
-      tx.transaction_id.wont_be :nil?
+      _(tx.transaction_id).wont_be :nil?
 
       tx_results = tx.read "accounts", columns
-      tx_results.must_be_kind_of Google::Cloud::Spanner::Results
-      tx_results.fields.to_h.must_equal fields_hash
+      _(tx_results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(tx_results.fields.to_h).must_equal fields_hash
       tx_results.rows.zip(default_account_rows).each do |expected, actual|
         assert_accounts_equal expected, actual
       end
@@ -50,12 +50,12 @@ describe "Spanner Client", :transaction, :spanner do
       tx.update "accounts", reversed_update_rows
       tx.insert "accounts", additional_account
     end
-    timestamp.must_be_kind_of Time
+    _(timestamp).must_be_kind_of Time
 
     # outside of transaction, verify the new account was added
     results = db.read "accounts", columns
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     # new data fixtures to match updated rows
     reversed_account_rows = default_account_rows.map do |row|
       row[:username] = row[:username].reverse
@@ -68,11 +68,11 @@ describe "Spanner Client", :transaction, :spanner do
 
   it "can rollback a transaction without passing on using Rollback" do
     timestamp = db.transaction do |tx|
-      tx.transaction_id.wont_be :nil?
+      _(tx.transaction_id).wont_be :nil?
 
       tx_results = tx.read "accounts", columns
-      tx_results.must_be_kind_of Google::Cloud::Spanner::Results
-      tx_results.fields.to_h.must_equal fields_hash
+      _(tx_results).must_be_kind_of Google::Cloud::Spanner::Results
+      _(tx_results.fields.to_h).must_equal fields_hash
       tx_results.rows.zip(default_account_rows).each do |expected, actual|
         assert_accounts_equal expected, actual
       end
@@ -85,12 +85,12 @@ describe "Spanner Client", :transaction, :spanner do
 
       raise Google::Cloud::Spanner::Rollback
     end
-    timestamp.must_be :nil?
+    _(timestamp).must_be :nil?
 
     # outside of transaction, the new account was NOT added
     results = db.read "accounts", columns
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
@@ -99,11 +99,11 @@ describe "Spanner Client", :transaction, :spanner do
   it "can rollback a transaction and pass on the error" do
     assert_raises ZeroDivisionError do
       db.transaction do |tx|
-        tx.transaction_id.wont_be :nil?
+        _(tx.transaction_id).wont_be :nil?
 
         tx_results = tx.read "accounts", columns
-        tx_results.must_be_kind_of Google::Cloud::Spanner::Results
-        tx_results.fields.to_h.must_equal fields_hash
+        _(tx_results).must_be_kind_of Google::Cloud::Spanner::Results
+        _(tx_results.fields.to_h).must_equal fields_hash
         tx_results.rows.zip(default_account_rows).each do |expected, actual|
           assert_accounts_equal expected, actual
         end
@@ -120,8 +120,8 @@ describe "Spanner Client", :transaction, :spanner do
 
     # outside of transaction, the new account was NOT added
     results = db.read "accounts", columns
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal fields_hash
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
     end
@@ -165,7 +165,7 @@ describe "Spanner Client", :transaction, :spanner do
     end
 
     results = db.read "accounts", [:reputation], keys: 1, limit: 1
-    results.rows.first[:reputation].must_equal original_val + 2
+    _(results.rows.first[:reputation]).must_equal original_val + 2
   end
 
   it "supports tx isolation with query and update" do
@@ -184,14 +184,14 @@ describe "Spanner Client", :transaction, :spanner do
     end
 
     results = db.execute_sql query_reputation
-    results.rows.first[:reputation].must_equal original_val + 2
+    _(results.rows.first[:reputation]).must_equal original_val + 2
   end
 
   it "can execute sql with query options" do
     query_options = { optimizer_version: "latest" }
     db.transaction do |tx|
       tx_results = tx.execute_sql query_reputation, query_options: query_options
-      tx_results.rows.first[:reputation].must_equal 63.5
+      _(tx_results.rows.first[:reputation]).must_equal 63.5
     end
   end
 
@@ -217,37 +217,37 @@ describe "Spanner Client", :transaction, :spanner do
 
   def assert_accounts_equal expected, actual
     if actual[:account_id].nil?
-      expected[:account_id].must_be :nil?
+      _(expected[:account_id]).must_be :nil?
     else
-      expected[:account_id].must_equal actual[:account_id]
+      _(expected[:account_id]).must_equal actual[:account_id]
     end
 
     if actual[:username].nil?
-      expected[:username].must_be :nil?
+      _(expected[:username]).must_be :nil?
     else
-      expected[:username].must_equal actual[:username]
+      _(expected[:username]).must_equal actual[:username]
     end
 
     if actual[:reputation].nil?
-      expected[:reputation].must_be :nil?
+      _(expected[:reputation]).must_be :nil?
     else
-      expected[:reputation].must_equal actual[:reputation]
+      _(expected[:reputation]).must_equal actual[:reputation]
     end
 
     if actual[:active].nil?
-      expected[:active].must_be :nil?
+      _(expected[:active]).must_be :nil?
     else
-      expected[:active].must_equal actual[:active]
+      _(expected[:active]).must_equal actual[:active]
     end
 
     if expected[:avatar] && actual[:avatar]
-      expected[:avatar].read.must_equal actual[:avatar].read
+      _(expected[:avatar].read).must_equal actual[:avatar].read
     end
 
     if actual[:friends].nil?
-      expected[:friends].must_be :nil?
+      _(expected[:friends]).must_be :nil?
     else
-      expected[:friends].must_equal actual[:friends]
+      _(expected[:friends]).must_equal actual[:friends]
     end
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/types/bool_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/bool_test.rb
@@ -23,9 +23,9 @@ describe "Spanner Client", :types, :bool, :spanner do
     db.upsert table_name, { id: id, bool: true }
     results = db.read table_name, [:id, :bool], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bool: :BOOL })
-    results.rows.first.to_h.must_equal({ id: id, bool: true })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bool: :BOOL })
+    _(results.rows.first.to_h).must_equal({ id: id, bool: true })
   end
 
   it "writes and queries bool" do
@@ -33,9 +33,9 @@ describe "Spanner Client", :types, :bool, :spanner do
     db.upsert table_name, { id: id, bool: true }
     results = db.execute_query "SELECT id, bool FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bool: :BOOL })
-    results.rows.first.to_h.must_equal({ id: id, bool: true })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bool: :BOOL })
+    _(results.rows.first.to_h).must_equal({ id: id, bool: true })
   end
 
   it "writes and reads NULL bool" do
@@ -43,9 +43,9 @@ describe "Spanner Client", :types, :bool, :spanner do
     db.upsert table_name, { id: id, bool: nil }
     results = db.read table_name, [:id, :bool], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bool: :BOOL })
-    results.rows.first.to_h.must_equal({ id: id, bool: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bool: :BOOL })
+    _(results.rows.first.to_h).must_equal({ id: id, bool: nil })
   end
 
   it "writes and queries NULL bool" do
@@ -53,9 +53,9 @@ describe "Spanner Client", :types, :bool, :spanner do
     db.upsert table_name, { id: id, bool: nil }
     results = db.execute_query "SELECT id, bool FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bool: :BOOL })
-    results.rows.first.to_h.must_equal({ id: id, bool: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bool: :BOOL })
+    _(results.rows.first.to_h).must_equal({ id: id, bool: nil })
   end
 
   it "writes and reads array of bool" do
@@ -63,9 +63,9 @@ describe "Spanner Client", :types, :bool, :spanner do
     db.upsert table_name, { id: id, bools: [true, false, true] }
     results = db.read table_name, [:id, :bools], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bools: [:BOOL] })
-    results.rows.first.to_h.must_equal({ id: id, bools: [true, false, true] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bools: [:BOOL] })
+    _(results.rows.first.to_h).must_equal({ id: id, bools: [true, false, true] })
   end
 
   it "writes and queries array of bool" do
@@ -73,9 +73,9 @@ describe "Spanner Client", :types, :bool, :spanner do
     db.upsert table_name, { id: id, bools: [true, false, true] }
     results = db.execute_query "SELECT id, bools FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bools: [:BOOL] })
-    results.rows.first.to_h.must_equal({ id: id, bools: [true, false, true] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bools: [:BOOL] })
+    _(results.rows.first.to_h).must_equal({ id: id, bools: [true, false, true] })
   end
 
   it "writes and reads array of bool with NULL" do
@@ -83,9 +83,9 @@ describe "Spanner Client", :types, :bool, :spanner do
     db.upsert table_name, { id: id, bools: [nil, true, false, true] }
     results = db.read table_name, [:id, :bools], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bools: [:BOOL] })
-    results.rows.first.to_h.must_equal({ id: id, bools: [nil, true, false, true] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bools: [:BOOL] })
+    _(results.rows.first.to_h).must_equal({ id: id, bools: [nil, true, false, true] })
   end
 
   it "writes and queries array of bool with NULL" do
@@ -93,9 +93,9 @@ describe "Spanner Client", :types, :bool, :spanner do
     db.upsert table_name, { id: id, bools: [nil, true, false, true] }
     results = db.execute_query "SELECT id, bools FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bools: [:BOOL] })
-    results.rows.first.to_h.must_equal({ id: id, bools: [nil, true, false, true] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bools: [:BOOL] })
+    _(results.rows.first.to_h).must_equal({ id: id, bools: [nil, true, false, true] })
   end
 
   it "writes and reads empty array of bool" do
@@ -103,9 +103,9 @@ describe "Spanner Client", :types, :bool, :spanner do
     db.upsert table_name, { id: id, bools: [] }
     results = db.read table_name, [:id, :bools], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bools: [:BOOL] })
-    results.rows.first.to_h.must_equal({ id: id, bools: [] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bools: [:BOOL] })
+    _(results.rows.first.to_h).must_equal({ id: id, bools: [] })
   end
 
   it "writes and queries empty array of bool" do
@@ -113,9 +113,9 @@ describe "Spanner Client", :types, :bool, :spanner do
     db.upsert table_name, { id: id, bools: [] }
     results = db.execute_query "SELECT id, bools FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bools: [:BOOL] })
-    results.rows.first.to_h.must_equal({ id: id, bools: [] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bools: [:BOOL] })
+    _(results.rows.first.to_h).must_equal({ id: id, bools: [] })
   end
 
   it "writes and reads NULL array of bool" do
@@ -123,9 +123,9 @@ describe "Spanner Client", :types, :bool, :spanner do
     db.upsert table_name, { id: id, bools: nil }
     results = db.read table_name, [:id, :bools], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bools: [:BOOL] })
-    results.rows.first.to_h.must_equal({ id: id, bools: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bools: [:BOOL] })
+    _(results.rows.first.to_h).must_equal({ id: id, bools: nil })
   end
 
   it "writes and queries NULL array of bool" do
@@ -133,8 +133,8 @@ describe "Spanner Client", :types, :bool, :spanner do
     db.upsert table_name, { id: id, bools: nil }
     results = db.execute_query "SELECT id, bools FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bools: [:BOOL] })
-    results.rows.first.to_h.must_equal({ id: id, bools: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bools: [:BOOL] })
+    _(results.rows.first.to_h).must_equal({ id: id, bools: nil })
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/types/bytes_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/bytes_test.rb
@@ -23,11 +23,11 @@ describe "Spanner Client", :types, :bytes, :spanner do
     db.upsert table_name, { id: id, byte: StringIO.new("hello") }
     results = db.read table_name, [:id, :byte], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, byte: :BYTES })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, byte: :BYTES })
     returned_value = results.rows.first[:byte]
-    returned_value.must_be_kind_of StringIO
-    returned_value.read.must_equal "hello"
+    _(returned_value).must_be_kind_of StringIO
+    _(returned_value.read).must_equal "hello"
   end
 
   it "writes and queries bytes" do
@@ -35,11 +35,11 @@ describe "Spanner Client", :types, :bytes, :spanner do
     db.upsert table_name, { id: id, byte: StringIO.new("hello") }
     results = db.execute_query "SELECT id, byte FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, byte: :BYTES })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, byte: :BYTES })
     returned_value = results.rows.first[:byte]
-    returned_value.must_be_kind_of StringIO
-    returned_value.read.must_equal "hello"
+    _(returned_value).must_be_kind_of StringIO
+    _(returned_value.read).must_equal "hello"
   end
 
   it "writes and reads random bytes" do
@@ -48,12 +48,12 @@ describe "Spanner Client", :types, :bytes, :spanner do
     db.upsert table_name, { id: id, byte: random_bytes }
     results = db.read table_name, [:id, :byte], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, byte: :BYTES })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, byte: :BYTES })
     returned_value = results.rows.first[:byte]
-    returned_value.must_be_kind_of StringIO
+    _(returned_value).must_be_kind_of StringIO
     random_bytes.rewind
-    returned_value.read.must_equal random_bytes.read
+    _(returned_value.read).must_equal random_bytes.read
   end
 
   it "writes and queries random bytes" do
@@ -62,12 +62,12 @@ describe "Spanner Client", :types, :bytes, :spanner do
     db.upsert table_name, { id: id, byte: random_bytes }
     results = db.execute_query "SELECT id, byte FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, byte: :BYTES })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, byte: :BYTES })
     returned_value = results.rows.first[:byte]
-    returned_value.must_be_kind_of StringIO
+    _(returned_value).must_be_kind_of StringIO
     random_bytes.rewind
-    returned_value.read.must_equal random_bytes.read
+    _(returned_value.read).must_equal random_bytes.read
   end
 
   it "writes and reads NULL bytes" do
@@ -75,10 +75,10 @@ describe "Spanner Client", :types, :bytes, :spanner do
     db.upsert table_name, { id: id, byte: nil }
     results = db.read table_name, [:id, :byte], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, byte: :BYTES })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, byte: :BYTES })
     returned_value = results.rows.first[:byte]
-    returned_value.must_be :nil?
+    _(returned_value).must_be :nil?
   end
 
   it "writes and queries NULL bytes" do
@@ -86,10 +86,10 @@ describe "Spanner Client", :types, :bytes, :spanner do
     db.upsert table_name, { id: id, byte: nil }
     results = db.execute_query "SELECT id, byte FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, byte: :BYTES })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, byte: :BYTES })
     returned_value = results.rows.first[:byte]
-    returned_value.must_be :nil?
+    _(returned_value).must_be :nil?
   end
 
   it "writes and reads array of bytes" do
@@ -97,15 +97,15 @@ describe "Spanner Client", :types, :bytes, :spanner do
     db.upsert table_name, { id: id, bytes: [StringIO.new("howdy"), StringIO.new("hola"), StringIO.new("hello")] }
     results = db.read table_name, [:id, :bytes], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bytes: [:BYTES] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bytes: [:BYTES] })
     returned_values = results.rows.first[:bytes]
-    returned_values[0].must_be_kind_of StringIO
-    returned_values[0].read.must_equal "howdy"
-    returned_values[1].must_be_kind_of StringIO
-    returned_values[1].read.must_equal "hola"
-    returned_values[2].must_be_kind_of StringIO
-    returned_values[2].read.must_equal "hello"
+    _(returned_values[0]).must_be_kind_of StringIO
+    _(returned_values[0].read).must_equal "howdy"
+    _(returned_values[1]).must_be_kind_of StringIO
+    _(returned_values[1].read).must_equal "hola"
+    _(returned_values[2]).must_be_kind_of StringIO
+    _(returned_values[2].read).must_equal "hello"
   end
 
   it "writes and queries array of bytes" do
@@ -113,15 +113,15 @@ describe "Spanner Client", :types, :bytes, :spanner do
     db.upsert table_name, { id: id, bytes: [StringIO.new("howdy"), StringIO.new("hola"), StringIO.new("hello")] }
     results = db.execute_query "SELECT id, bytes FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bytes: [:BYTES] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bytes: [:BYTES] })
     returned_values = results.rows.first[:bytes]
-    returned_values[0].must_be_kind_of StringIO
-    returned_values[0].read.must_equal "howdy"
-    returned_values[1].must_be_kind_of StringIO
-    returned_values[1].read.must_equal "hola"
-    returned_values[2].must_be_kind_of StringIO
-    returned_values[2].read.must_equal "hello"
+    _(returned_values[0]).must_be_kind_of StringIO
+    _(returned_values[0].read).must_equal "howdy"
+    _(returned_values[1]).must_be_kind_of StringIO
+    _(returned_values[1].read).must_equal "hola"
+    _(returned_values[2]).must_be_kind_of StringIO
+    _(returned_values[2].read).must_equal "hello"
   end
 
   it "writes and reads array of byte with NULL" do
@@ -129,16 +129,16 @@ describe "Spanner Client", :types, :bytes, :spanner do
     db.upsert table_name, { id: id, bytes: [nil, StringIO.new("howdy"), StringIO.new("hola"), StringIO.new("hello")] }
     results = db.read table_name, [:id, :bytes], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bytes: [:BYTES] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bytes: [:BYTES] })
     returned_values = results.rows.first[:bytes]
-    returned_values[0].must_be :nil?
-    returned_values[1].must_be_kind_of StringIO
-    returned_values[1].read.must_equal "howdy"
-    returned_values[2].must_be_kind_of StringIO
-    returned_values[2].read.must_equal "hola"
-    returned_values[3].must_be_kind_of StringIO
-    returned_values[3].read.must_equal "hello"
+    _(returned_values[0]).must_be :nil?
+    _(returned_values[1]).must_be_kind_of StringIO
+    _(returned_values[1].read).must_equal "howdy"
+    _(returned_values[2]).must_be_kind_of StringIO
+    _(returned_values[2].read).must_equal "hola"
+    _(returned_values[3]).must_be_kind_of StringIO
+    _(returned_values[3].read).must_equal "hello"
   end
 
   it "writes and queries array of byte with NULL" do
@@ -146,16 +146,16 @@ describe "Spanner Client", :types, :bytes, :spanner do
     db.upsert table_name, { id: id, bytes: [nil, StringIO.new("howdy"), StringIO.new("hola"), StringIO.new("hello")] }
     results = db.execute_query "SELECT id, bytes FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bytes: [:BYTES] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bytes: [:BYTES] })
     returned_values = results.rows.first[:bytes]
-    returned_values[0].must_be :nil?
-    returned_values[1].must_be_kind_of StringIO
-    returned_values[1].read.must_equal "howdy"
-    returned_values[2].must_be_kind_of StringIO
-    returned_values[2].read.must_equal "hola"
-    returned_values[3].must_be_kind_of StringIO
-    returned_values[3].read.must_equal "hello"
+    _(returned_values[0]).must_be :nil?
+    _(returned_values[1]).must_be_kind_of StringIO
+    _(returned_values[1].read).must_equal "howdy"
+    _(returned_values[2]).must_be_kind_of StringIO
+    _(returned_values[2].read).must_equal "hola"
+    _(returned_values[3]).must_be_kind_of StringIO
+    _(returned_values[3].read).must_equal "hello"
   end
 
   it "writes and reads empty array of byte" do
@@ -163,9 +163,9 @@ describe "Spanner Client", :types, :bytes, :spanner do
     db.upsert table_name, { id: id, bytes: [] }
     results = db.read table_name, [:id, :bytes], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bytes: [:BYTES] })
-    results.rows.first[:bytes].must_equal []
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bytes: [:BYTES] })
+    _(results.rows.first[:bytes]).must_equal []
   end
 
   it "writes and queries empty array of byte" do
@@ -173,9 +173,9 @@ describe "Spanner Client", :types, :bytes, :spanner do
     db.upsert table_name, { id: id, bytes: [] }
     results = db.execute_query "SELECT id, bytes FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bytes: [:BYTES] })
-    results.rows.first[:bytes].must_equal []
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bytes: [:BYTES] })
+    _(results.rows.first[:bytes]).must_equal []
   end
 
   it "writes and reads NULL array of byte" do
@@ -183,9 +183,9 @@ describe "Spanner Client", :types, :bytes, :spanner do
     db.upsert table_name, { id: id, bytes: nil }
     results = db.read table_name, [:id, :bytes], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bytes: [:BYTES] })
-    results.rows.first[:bytes].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bytes: [:BYTES] })
+    _(results.rows.first[:bytes]).must_be :nil?
   end
 
   it "writes and queries NULL array of byte" do
@@ -193,8 +193,8 @@ describe "Spanner Client", :types, :bytes, :spanner do
     db.upsert table_name, { id: id, bytes: nil }
     results = db.execute_query "SELECT id, bytes FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, bytes: [:BYTES] })
-    results.rows.first[:bytes].must_be :nil?
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, bytes: [:BYTES] })
+    _(results.rows.first[:bytes]).must_be :nil?
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/types/date_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/date_test.rb
@@ -23,9 +23,9 @@ describe "Spanner Client", :types, :date, :spanner do
     db.upsert table_name, { id: id, date: Date.parse("2017-01-01") }
     results = db.read table_name, [:id, :date], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, date: :DATE })
-    results.rows.first.to_h.must_equal({ id: id, date: Date.parse("2017-01-01") })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, date: :DATE })
+    _(results.rows.first.to_h).must_equal({ id: id, date: Date.parse("2017-01-01") })
   end
 
   it "writes and queries date" do
@@ -33,9 +33,9 @@ describe "Spanner Client", :types, :date, :spanner do
     db.upsert table_name, { id: id, date: Date.parse("2017-01-01") }
     results = db.execute_query "SELECT id, date FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, date: :DATE })
-    results.rows.first.to_h.must_equal({ id: id, date: Date.parse("2017-01-01") })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, date: :DATE })
+    _(results.rows.first.to_h).must_equal({ id: id, date: Date.parse("2017-01-01") })
   end
 
   it "writes and reads NULL date" do
@@ -43,9 +43,9 @@ describe "Spanner Client", :types, :date, :spanner do
     db.upsert table_name, { id: id, date: nil }
     results = db.read table_name, [:id, :date], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, date: :DATE })
-    results.rows.first.to_h.must_equal({ id: id, date: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, date: :DATE })
+    _(results.rows.first.to_h).must_equal({ id: id, date: nil })
   end
 
   it "writes and queries NULL date" do
@@ -53,9 +53,9 @@ describe "Spanner Client", :types, :date, :spanner do
     db.upsert table_name, { id: id, date: nil }
     results = db.execute_query "SELECT id, date FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, date: :DATE })
-    results.rows.first.to_h.must_equal({ id: id, date: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, date: :DATE })
+    _(results.rows.first.to_h).must_equal({ id: id, date: nil })
   end
 
   it "writes and reads array of date" do
@@ -63,9 +63,9 @@ describe "Spanner Client", :types, :date, :spanner do
     db.upsert table_name, { id: id, dates: [Date.parse("2016-12-30"), Date.parse("2016-12-31"), Date.parse("2017-01-01")] }
     results = db.read table_name, [:id, :dates], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, dates: [:DATE] })
-    results.rows.first.to_h.must_equal({ id: id, dates: [Date.parse("2016-12-30"), Date.parse("2016-12-31"), Date.parse("2017-01-01")] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, dates: [:DATE] })
+    _(results.rows.first.to_h).must_equal({ id: id, dates: [Date.parse("2016-12-30"), Date.parse("2016-12-31"), Date.parse("2017-01-01")] })
   end
 
   it "writes and queries array of date" do
@@ -73,9 +73,9 @@ describe "Spanner Client", :types, :date, :spanner do
     db.upsert table_name, { id: id, dates: [Date.parse("2016-12-30"), Date.parse("2016-12-31"), Date.parse("2017-01-01")] }
     results = db.execute_query "SELECT id, dates FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, dates: [:DATE] })
-    results.rows.first.to_h.must_equal({ id: id, dates: [Date.parse("2016-12-30"), Date.parse("2016-12-31"), Date.parse("2017-01-01")] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, dates: [:DATE] })
+    _(results.rows.first.to_h).must_equal({ id: id, dates: [Date.parse("2016-12-30"), Date.parse("2016-12-31"), Date.parse("2017-01-01")] })
   end
 
   it "writes and reads array of date with NULL" do
@@ -83,9 +83,9 @@ describe "Spanner Client", :types, :date, :spanner do
     db.upsert table_name, { id: id, dates: [nil, Date.parse("2016-12-30"), Date.parse("2016-12-31"), Date.parse("2017-01-01")] }
     results = db.read table_name, [:id, :dates], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, dates: [:DATE] })
-    results.rows.first.to_h.must_equal({ id: id, dates: [nil, Date.parse("2016-12-30"), Date.parse("2016-12-31"), Date.parse("2017-01-01")] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, dates: [:DATE] })
+    _(results.rows.first.to_h).must_equal({ id: id, dates: [nil, Date.parse("2016-12-30"), Date.parse("2016-12-31"), Date.parse("2017-01-01")] })
   end
 
   it "writes and queries array of date with NULL" do
@@ -93,9 +93,9 @@ describe "Spanner Client", :types, :date, :spanner do
     db.upsert table_name, { id: id, dates: [nil, Date.parse("2016-12-30"), Date.parse("2016-12-31"), Date.parse("2017-01-01")] }
     results = db.execute_query "SELECT id, dates FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, dates: [:DATE] })
-    results.rows.first.to_h.must_equal({ id: id, dates: [nil, Date.parse("2016-12-30"), Date.parse("2016-12-31"), Date.parse("2017-01-01")] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, dates: [:DATE] })
+    _(results.rows.first.to_h).must_equal({ id: id, dates: [nil, Date.parse("2016-12-30"), Date.parse("2016-12-31"), Date.parse("2017-01-01")] })
   end
 
   it "writes and reads empty array of date" do
@@ -103,9 +103,9 @@ describe "Spanner Client", :types, :date, :spanner do
     db.upsert table_name, { id: id, dates: [] }
     results = db.read table_name, [:id, :dates], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, dates: [:DATE] })
-    results.rows.first.to_h.must_equal({ id: id, dates: [] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, dates: [:DATE] })
+    _(results.rows.first.to_h).must_equal({ id: id, dates: [] })
   end
 
   it "writes and queries empty array of date" do
@@ -113,9 +113,9 @@ describe "Spanner Client", :types, :date, :spanner do
     db.upsert table_name, { id: id, dates: [] }
     results = db.execute_query "SELECT id, dates FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, dates: [:DATE] })
-    results.rows.first.to_h.must_equal({ id: id, dates: [] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, dates: [:DATE] })
+    _(results.rows.first.to_h).must_equal({ id: id, dates: [] })
   end
 
   it "writes and reads NULL array of date" do
@@ -123,9 +123,9 @@ describe "Spanner Client", :types, :date, :spanner do
     db.upsert table_name, { id: id, dates: nil }
     results = db.read table_name, [:id, :dates], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, dates: [:DATE] })
-    results.rows.first.to_h.must_equal({ id: id, dates: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, dates: [:DATE] })
+    _(results.rows.first.to_h).must_equal({ id: id, dates: nil })
   end
 
   it "writes and queries NULL array of date" do
@@ -133,8 +133,8 @@ describe "Spanner Client", :types, :date, :spanner do
     db.upsert table_name, { id: id, dates: nil }
     results = db.execute_query "SELECT id, dates FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, dates: [:DATE] })
-    results.rows.first.to_h.must_equal({ id: id, dates: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, dates: [:DATE] })
+    _(results.rows.first.to_h).must_equal({ id: id, dates: nil })
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/types/float64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/float64_test.rb
@@ -23,9 +23,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, float: 99.99 }
     results = db.read table_name, [:id, :float], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
-    results.rows.first.to_h.must_equal({ id: id, float: 99.99 })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, float: :FLOAT64 })
+    _(results.rows.first.to_h).must_equal({ id: id, float: 99.99 })
   end
 
   it "writes and queries float64" do
@@ -33,9 +33,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, float: 99.99 }
     results = db.execute_sql "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
-    results.rows.first.to_h.must_equal({ id: id, float: 99.99 })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, float: :FLOAT64 })
+    _(results.rows.first.to_h).must_equal({ id: id, float: 99.99 })
   end
 
   it "writes and reads Infinity float64" do
@@ -43,9 +43,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, float: Float::INFINITY }
     results = db.read table_name, [:id, :float], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
-    results.rows.first.to_h.must_equal({ id: id, float: Float::INFINITY })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, float: :FLOAT64 })
+    _(results.rows.first.to_h).must_equal({ id: id, float: Float::INFINITY })
   end
 
   it "writes and queries Infinity float64" do
@@ -53,9 +53,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, float: Float::INFINITY }
     results = db.execute_sql "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
-    results.rows.first.to_h.must_equal({ id: id, float: Float::INFINITY })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, float: :FLOAT64 })
+    _(results.rows.first.to_h).must_equal({ id: id, float: Float::INFINITY })
   end
 
   it "writes and reads -Infinity float64" do
@@ -63,9 +63,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, float: -Float::INFINITY }
     results = db.read table_name, [:id, :float], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
-    results.rows.first.to_h.must_equal({ id: id, float: -Float::INFINITY })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, float: :FLOAT64 })
+    _(results.rows.first.to_h).must_equal({ id: id, float: -Float::INFINITY })
   end
 
   it "writes and queries -Infinity float64" do
@@ -73,9 +73,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, float: -Float::INFINITY }
     results = db.execute_sql "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
-    results.rows.first.to_h.must_equal({ id: id, float: -Float::INFINITY })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, float: :FLOAT64 })
+    _(results.rows.first.to_h).must_equal({ id: id, float: -Float::INFINITY })
   end
 
   it "writes and reads NaN float64" do
@@ -83,12 +83,12 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, float: Float::NAN }
     results = db.read table_name, [:id, :float], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, float: :FLOAT64 })
     returned_hash = results.rows.first.to_h
     returned_value = returned_hash[:float]
-    returned_value.must_be_kind_of Float
-    returned_value.must_be :nan?
+    _(returned_value).must_be_kind_of Float
+    _(returned_value).must_be :nan?
   end
 
   it "writes and queries NaN float64" do
@@ -96,12 +96,12 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, float: Float::NAN }
     results = db.execute_sql "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, float: :FLOAT64 })
     returned_hash = results.rows.first.to_h
     returned_value = returned_hash[:float]
-    returned_value.must_be_kind_of Float
-    returned_value.must_be :nan?
+    _(returned_value).must_be_kind_of Float
+    _(returned_value).must_be :nan?
   end
 
   it "writes and reads NULL float64" do
@@ -109,9 +109,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, float: nil }
     results = db.read table_name, [:id, :float], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
-    results.rows.first.to_h.must_equal({ id: id, float: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, float: :FLOAT64 })
+    _(results.rows.first.to_h).must_equal({ id: id, float: nil })
   end
 
   it "writes and queries NULL float64" do
@@ -119,9 +119,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, float: nil }
     results = db.execute_sql "SELECT id, float FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, float: :FLOAT64 })
-    results.rows.first.to_h.must_equal({ id: id, float: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, float: :FLOAT64 })
+    _(results.rows.first.to_h).must_equal({ id: id, float: nil })
   end
 
   it "writes and reads array of float64" do
@@ -129,9 +129,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, floats: [77.77, 88.88, 99.99] }
     results = db.read table_name, [:id, :floats], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, floats: [:FLOAT64] })
-    results.rows.first.to_h.must_equal({ id: id, floats: [77.77, 88.88, 99.99] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, floats: [:FLOAT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, floats: [77.77, 88.88, 99.99] })
   end
 
   it "writes and queries array of float64" do
@@ -139,9 +139,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, floats: [77.77, 88.88, 99.99] }
     results = db.execute_sql "SELECT id, floats FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, floats: [:FLOAT64] })
-    results.rows.first.to_h.must_equal({ id: id, floats: [77.77, 88.88, 99.99] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, floats: [:FLOAT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, floats: [77.77, 88.88, 99.99] })
   end
 
   it "writes and reads array of float64 with NULL" do
@@ -149,9 +149,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, floats: [nil, 77.77, 88.88, 99.99] }
     results = db.read table_name, [:id, :floats], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, floats: [:FLOAT64] })
-    results.rows.first.to_h.must_equal({ id: id, floats: [nil, 77.77, 88.88, 99.99] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, floats: [:FLOAT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, floats: [nil, 77.77, 88.88, 99.99] })
   end
 
   it "writes and queries array of float64 with NULL" do
@@ -159,9 +159,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, floats: [nil, 77.77, 88.88, 99.99] }
     results = db.execute_sql "SELECT id, floats FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, floats: [:FLOAT64] })
-    results.rows.first.to_h.must_equal({ id: id, floats: [nil, 77.77, 88.88, 99.99] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, floats: [:FLOAT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, floats: [nil, 77.77, 88.88, 99.99] })
   end
 
   it "writes and reads empty array of float64" do
@@ -169,9 +169,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, floats: [] }
     results = db.read table_name, [:id, :floats], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, floats: [:FLOAT64] })
-    results.rows.first.to_h.must_equal({ id: id, floats: [] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, floats: [:FLOAT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, floats: [] })
   end
 
   it "writes and queries empty array of float64" do
@@ -179,9 +179,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, floats: [] }
     results = db.execute_sql "SELECT id, floats FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, floats: [:FLOAT64] })
-    results.rows.first.to_h.must_equal({ id: id, floats: [] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, floats: [:FLOAT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, floats: [] })
   end
 
   it "writes and reads NULL array of float64" do
@@ -189,9 +189,9 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, floats: nil }
     results = db.read table_name, [:id, :floats], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, floats: [:FLOAT64] })
-    results.rows.first.to_h.must_equal({ id: id, floats: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, floats: [:FLOAT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, floats: nil })
   end
 
   it "writes and queries NULL array of float64" do
@@ -199,8 +199,8 @@ describe "Spanner Client", :types, :float64, :spanner do
     db.upsert table_name, { id: id, floats: nil }
     results = db.execute_sql "SELECT id, floats FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, floats: [:FLOAT64] })
-    results.rows.first.to_h.must_equal({ id: id, floats: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, floats: [:FLOAT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, floats: nil })
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/types/int64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/int64_test.rb
@@ -23,9 +23,9 @@ describe "Spanner Client", :types, :int64, :spanner do
     db.upsert table_name, { id: id, int: 9999 }
     results = db.read table_name, [:id, :int], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, int: :INT64 })
-    results.rows.first.to_h.must_equal({ id: id, int: 9999 })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, int: :INT64 })
+    _(results.rows.first.to_h).must_equal({ id: id, int: 9999 })
   end
 
   it "writes and queries int64" do
@@ -33,9 +33,9 @@ describe "Spanner Client", :types, :int64, :spanner do
     db.upsert table_name, { id: id, int: 9999 }
     results = db.execute_query "SELECT id, int FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, int: :INT64 })
-    results.rows.first.to_h.must_equal({ id: id, int: 9999 })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, int: :INT64 })
+    _(results.rows.first.to_h).must_equal({ id: id, int: 9999 })
   end
 
   it "writes and reads NULL int64" do
@@ -43,9 +43,9 @@ describe "Spanner Client", :types, :int64, :spanner do
     db.upsert table_name, { id: id, int: nil }
     results = db.read table_name, [:id, :int], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, int: :INT64 })
-    results.rows.first.to_h.must_equal({ id: id, int: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, int: :INT64 })
+    _(results.rows.first.to_h).must_equal({ id: id, int: nil })
   end
 
   it "writes and queries NULL int64" do
@@ -53,9 +53,9 @@ describe "Spanner Client", :types, :int64, :spanner do
     db.upsert table_name, { id: id, int: nil }
     results = db.execute_query "SELECT id, int FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, int: :INT64 })
-    results.rows.first.to_h.must_equal({ id: id, int: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, int: :INT64 })
+    _(results.rows.first.to_h).must_equal({ id: id, int: nil })
   end
 
   it "writes and reads array of int64" do
@@ -63,9 +63,9 @@ describe "Spanner Client", :types, :int64, :spanner do
     db.upsert table_name, { id: id, ints: [9997, 9998, 9999] }
     results = db.read table_name, [:id, :ints], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, ints: [:INT64] })
-    results.rows.first.to_h.must_equal({ id: id, ints: [9997, 9998, 9999] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, ints: [:INT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, ints: [9997, 9998, 9999] })
   end
 
   it "writes and queries array of int64" do
@@ -73,9 +73,9 @@ describe "Spanner Client", :types, :int64, :spanner do
     db.upsert table_name, { id: id, ints: [9997, 9998, 9999] }
     results = db.execute_query "SELECT id, ints FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, ints: [:INT64] })
-    results.rows.first.to_h.must_equal({ id: id, ints: [9997, 9998, 9999] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, ints: [:INT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, ints: [9997, 9998, 9999] })
   end
 
   it "writes and reads array of int64 with NULL" do
@@ -83,9 +83,9 @@ describe "Spanner Client", :types, :int64, :spanner do
     db.upsert table_name, { id: id, ints: [nil, 9997, 9998, 9999] }
     results = db.read table_name, [:id, :ints], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, ints: [:INT64] })
-    results.rows.first.to_h.must_equal({ id: id, ints: [nil, 9997, 9998, 9999] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, ints: [:INT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, ints: [nil, 9997, 9998, 9999] })
   end
 
   it "writes and queries array of int64 with NULL" do
@@ -93,9 +93,9 @@ describe "Spanner Client", :types, :int64, :spanner do
     db.upsert table_name, { id: id, ints: [nil, 9997, 9998, 9999] }
     results = db.execute_query "SELECT id, ints FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, ints: [:INT64] })
-    results.rows.first.to_h.must_equal({ id: id, ints: [nil, 9997, 9998, 9999] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, ints: [:INT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, ints: [nil, 9997, 9998, 9999] })
   end
 
   it "writes and reads empty array of int64" do
@@ -103,9 +103,9 @@ describe "Spanner Client", :types, :int64, :spanner do
     db.upsert table_name, { id: id, ints: [] }
     results = db.read table_name, [:id, :ints], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, ints: [:INT64] })
-    results.rows.first.to_h.must_equal({ id: id, ints: [] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, ints: [:INT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, ints: [] })
   end
 
   it "writes and queries empty array of int64" do
@@ -113,9 +113,9 @@ describe "Spanner Client", :types, :int64, :spanner do
     db.upsert table_name, { id: id, ints: [] }
     results = db.execute_query "SELECT id, ints FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, ints: [:INT64] })
-    results.rows.first.to_h.must_equal({ id: id, ints: [] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, ints: [:INT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, ints: [] })
   end
 
   it "writes and reads NULL array of int64" do
@@ -123,9 +123,9 @@ describe "Spanner Client", :types, :int64, :spanner do
     db.upsert table_name, { id: id, ints: nil }
     results = db.read table_name, [:id, :ints], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, ints: [:INT64] })
-    results.rows.first.to_h.must_equal({ id: id, ints: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, ints: [:INT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, ints: nil })
   end
 
   it "writes and queries NULL array of int64" do
@@ -133,8 +133,8 @@ describe "Spanner Client", :types, :int64, :spanner do
     db.upsert table_name, { id: id, ints: nil }
     results = db.execute_query "SELECT id, ints FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, ints: [:INT64] })
-    results.rows.first.to_h.must_equal({ id: id, ints: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, ints: [:INT64] })
+    _(results.rows.first.to_h).must_equal({ id: id, ints: nil })
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/types/string_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/string_test.rb
@@ -24,9 +24,9 @@ describe "Spanner Client", :types, :string, :spanner do
     db.upsert table_name, { id: id, string: "hello" }
     results = db.read table_name, [:id, :string], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, string: :STRING })
-    results.rows.first.to_h.must_equal({ id: id, string: "hello" })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, string: :STRING })
+    _(results.rows.first.to_h).must_equal({ id: id, string: "hello" })
   end
 
   it "writes and queries string" do
@@ -34,9 +34,9 @@ describe "Spanner Client", :types, :string, :spanner do
     db.upsert table_name, { id: id, string: "hello" }
     results = db.execute_query "SELECT id, string FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, string: :STRING })
-    results.rows.first.to_h.must_equal({ id: id, string: "hello" })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, string: :STRING })
+    _(results.rows.first.to_h).must_equal({ id: id, string: "hello" })
   end
 
   it "writes and reads NULL string" do
@@ -44,9 +44,9 @@ describe "Spanner Client", :types, :string, :spanner do
     db.upsert table_name, { id: id, string: nil }
     results = db.read table_name, [:id, :string], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, string: :STRING })
-    results.rows.first.to_h.must_equal({ id: id, string: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, string: :STRING })
+    _(results.rows.first.to_h).must_equal({ id: id, string: nil })
   end
 
   it "writes and queries NULL string" do
@@ -54,9 +54,9 @@ describe "Spanner Client", :types, :string, :spanner do
     db.upsert table_name, { id: id, string: nil }
     results = db.execute_query "SELECT id, string FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, string: :STRING })
-    results.rows.first.to_h.must_equal({ id: id, string: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, string: :STRING })
+    _(results.rows.first.to_h).must_equal({ id: id, string: nil })
   end
 
   it "writes and reads array of string" do
@@ -64,9 +64,9 @@ describe "Spanner Client", :types, :string, :spanner do
     db.upsert table_name, { id: id, strings: ["howdy", "hola", "hello"] }
     results = db.read table_name, [:id, :strings], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, strings: [:STRING] })
-    results.rows.first.to_h.must_equal({ id: id, strings: ["howdy", "hola", "hello"] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, strings: [:STRING] })
+    _(results.rows.first.to_h).must_equal({ id: id, strings: ["howdy", "hola", "hello"] })
   end
 
   it "writes and queries array of string" do
@@ -74,9 +74,9 @@ describe "Spanner Client", :types, :string, :spanner do
     db.upsert table_name, { id: id, strings: ["howdy", "hola", "hello"] }
     results = db.execute_query "SELECT id, strings FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, strings: [:STRING] })
-    results.rows.first.to_h.must_equal({ id: id, strings: ["howdy", "hola", "hello"] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, strings: [:STRING] })
+    _(results.rows.first.to_h).must_equal({ id: id, strings: ["howdy", "hola", "hello"] })
   end
 
   it "writes and reads array of string with NULL" do
@@ -84,9 +84,9 @@ describe "Spanner Client", :types, :string, :spanner do
     db.upsert table_name, { id: id, strings: [nil, "howdy", "hola", "hello"] }
     results = db.read table_name, [:id, :strings], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, strings: [:STRING] })
-    results.rows.first.to_h.must_equal({ id: id, strings: [nil, "howdy", "hola", "hello"] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, strings: [:STRING] })
+    _(results.rows.first.to_h).must_equal({ id: id, strings: [nil, "howdy", "hola", "hello"] })
   end
 
   it "writes and queries array of string with NULL" do
@@ -94,9 +94,9 @@ describe "Spanner Client", :types, :string, :spanner do
     db.upsert table_name, { id: id, strings: [nil, "howdy", "hola", "hello"] }
     results = db.execute_query "SELECT id, strings FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, strings: [:STRING] })
-    results.rows.first.to_h.must_equal({ id: id, strings: [nil, "howdy", "hola", "hello"] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, strings: [:STRING] })
+    _(results.rows.first.to_h).must_equal({ id: id, strings: [nil, "howdy", "hola", "hello"] })
   end
 
   it "writes and reads empty array of string" do
@@ -104,9 +104,9 @@ describe "Spanner Client", :types, :string, :spanner do
     db.upsert table_name, { id: id, strings: [] }
     results = db.read table_name, [:id, :strings], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, strings: [:STRING] })
-    results.rows.first.to_h.must_equal({ id: id, strings: [] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, strings: [:STRING] })
+    _(results.rows.first.to_h).must_equal({ id: id, strings: [] })
   end
 
   it "writes and queries empty array of string" do
@@ -114,9 +114,9 @@ describe "Spanner Client", :types, :string, :spanner do
     db.upsert table_name, { id: id, strings: [] }
     results = db.execute_query "SELECT id, strings FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, strings: [:STRING] })
-    results.rows.first.to_h.must_equal({ id: id, strings: [] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, strings: [:STRING] })
+    _(results.rows.first.to_h).must_equal({ id: id, strings: [] })
   end
 
   it "writes and reads NULL array of string" do
@@ -124,9 +124,9 @@ describe "Spanner Client", :types, :string, :spanner do
     db.upsert table_name, { id: id, strings: nil }
     results = db.read table_name, [:id, :strings], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, strings: [:STRING] })
-    results.rows.first.to_h.must_equal({ id: id, strings: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, strings: [:STRING] })
+    _(results.rows.first.to_h).must_equal({ id: id, strings: nil })
   end
 
   it "writes and queries NULL array of string" do
@@ -134,8 +134,8 @@ describe "Spanner Client", :types, :string, :spanner do
     db.upsert table_name, { id: id, strings: nil }
     results = db.execute_query "SELECT id, strings FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, strings: [:STRING] })
-    results.rows.first.to_h.must_equal({ id: id, strings: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, strings: [:STRING] })
+    _(results.rows.first.to_h).must_equal({ id: id, strings: nil })
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/types/struct_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/struct_test.rb
@@ -23,17 +23,17 @@ describe "Spanner Client", :types, :struct, :spanner do
       "ORDER BY C1 ASC)"
     results = db.execute_query nested_sql
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ 0 => [db.fields(C1: :STRING, C2: :INT64)] })
-    results.rows.first.to_h.must_equal({ 0 => [{ C1: "a", C2: 1 }, { C1: "b", C2: 2 }] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ 0 => [db.fields(C1: :STRING, C2: :INT64)] })
+    _(results.rows.first.to_h).must_equal({ 0 => [{ C1: "a", C2: 1 }, { C1: "b", C2: 2 }] })
   end
 
   it "queries an empty struct" do
     empty_sql = "SELECT ARRAY(SELECT AS STRUCT * FROM (SELECT 'a', 1) WHERE 0 = 1)"
     results = db.execute_query empty_sql
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ 0 => [db.fields(0 => :STRING, 1 => :INT64)] })
-    results.rows.first.to_h.must_equal({ 0 => [] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ 0 => [db.fields(0 => :STRING, 1 => :INT64)] })
+    _(results.rows.first.to_h).must_equal({ 0 => [] })
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/types/timestamp_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/timestamp_test.rb
@@ -24,9 +24,9 @@ describe "Spanner Client", :types, :timestamp, :spanner do
     db.upsert table_name, { id: id, timestamp: Time.parse("2017-01-01 00:00:00Z") }
     results = db.read table_name, [:id, :timestamp], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, timestamp: :TIMESTAMP })
-    results.rows.first.to_h.must_equal({ id: id, timestamp: Time.parse("2017-01-01 00:00:00Z") })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, timestamp: :TIMESTAMP })
+    _(results.rows.first.to_h).must_equal({ id: id, timestamp: Time.parse("2017-01-01 00:00:00Z") })
   end
 
   it "writes and reads commit_timestamp timestamp" do
@@ -34,9 +34,9 @@ describe "Spanner Client", :types, :timestamp, :spanner do
     commit_timestamp = db.upsert table_name, { id: id, timestamp: db.commit_timestamp }
     results = db.read table_name, [:id, :timestamp], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, timestamp: :TIMESTAMP })
-    results.rows.first.to_h.must_equal({ id: id, timestamp: commit_timestamp })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, timestamp: :TIMESTAMP })
+    _(results.rows.first.to_h).must_equal({ id: id, timestamp: commit_timestamp })
   end
 
   it "writes and queries timestamp" do
@@ -44,9 +44,9 @@ describe "Spanner Client", :types, :timestamp, :spanner do
     db.upsert table_name, { id: id, timestamp: Time.parse("2017-01-01 00:00:00Z") }
     results = db.execute_query "SELECT id, timestamp FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, timestamp: :TIMESTAMP })
-    results.rows.first.to_h.must_equal({ id: id, timestamp: Time.parse("2017-01-01 00:00:00Z") })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, timestamp: :TIMESTAMP })
+    _(results.rows.first.to_h).must_equal({ id: id, timestamp: Time.parse("2017-01-01 00:00:00Z") })
   end
 
   it "writes and queries commit_timestamp timestamp" do
@@ -54,9 +54,9 @@ describe "Spanner Client", :types, :timestamp, :spanner do
     commit_timestamp = db.upsert table_name, { id: id, timestamp: db.commit_timestamp }
     results = db.execute_query "SELECT id, timestamp FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, timestamp: :TIMESTAMP })
-    results.rows.first.to_h.must_equal({ id: id, timestamp: commit_timestamp })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, timestamp: :TIMESTAMP })
+    _(results.rows.first.to_h).must_equal({ id: id, timestamp: commit_timestamp })
   end
 
   it "writes and reads NULL timestamp" do
@@ -64,9 +64,9 @@ describe "Spanner Client", :types, :timestamp, :spanner do
     db.upsert table_name, { id: id, timestamp: nil }
     results = db.read table_name, [:id, :timestamp], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, timestamp: :TIMESTAMP })
-    results.rows.first.to_h.must_equal({ id: id, timestamp: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, timestamp: :TIMESTAMP })
+    _(results.rows.first.to_h).must_equal({ id: id, timestamp: nil })
   end
 
   it "writes and queries NULL timestamp" do
@@ -74,9 +74,9 @@ describe "Spanner Client", :types, :timestamp, :spanner do
     db.upsert table_name, { id: id, timestamp: nil }
     results = db.execute_query "SELECT id, timestamp FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, timestamp: :TIMESTAMP })
-    results.rows.first.to_h.must_equal({ id: id, timestamp: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, timestamp: :TIMESTAMP })
+    _(results.rows.first.to_h).must_equal({ id: id, timestamp: nil })
   end
 
   it "writes and reads array of timestamp" do
@@ -84,9 +84,9 @@ describe "Spanner Client", :types, :timestamp, :spanner do
     db.upsert table_name, { id: id, timestamps: [Time.parse("2016-12-30 00:00:00Z"), Time.parse("2016-12-31 00:00:00Z"), Time.parse("2017-01-01 00:00:00Z")] }
     results = db.read table_name, [:id, :timestamps], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
-    results.rows.first.to_h.must_equal({ id: id, timestamps: [Time.parse("2016-12-30 00:00:00Z"), Time.parse("2016-12-31 00:00:00Z"), Time.parse("2017-01-01 00:00:00Z")] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
+    _(results.rows.first.to_h).must_equal({ id: id, timestamps: [Time.parse("2016-12-30 00:00:00Z"), Time.parse("2016-12-31 00:00:00Z"), Time.parse("2017-01-01 00:00:00Z")] })
   end
 
   it "writes and queries array of timestamp" do
@@ -94,9 +94,9 @@ describe "Spanner Client", :types, :timestamp, :spanner do
     db.upsert table_name, { id: id, timestamps: [Time.parse("2016-12-30 00:00:00Z"), Time.parse("2016-12-31 00:00:00Z"), Time.parse("2017-01-01 00:00:00Z")] }
     results = db.execute_query "SELECT id, timestamps FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
-    results.rows.first.to_h.must_equal({ id: id, timestamps: [Time.parse("2016-12-30 00:00:00Z"), Time.parse("2016-12-31 00:00:00Z"), Time.parse("2017-01-01 00:00:00Z")] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
+    _(results.rows.first.to_h).must_equal({ id: id, timestamps: [Time.parse("2016-12-30 00:00:00Z"), Time.parse("2016-12-31 00:00:00Z"), Time.parse("2017-01-01 00:00:00Z")] })
   end
 
   it "writes and reads array of timestamp with NULL" do
@@ -104,9 +104,9 @@ describe "Spanner Client", :types, :timestamp, :spanner do
     db.upsert table_name, { id: id, timestamps: [nil, Time.parse("2016-12-30 00:00:00Z"), Time.parse("2016-12-31 00:00:00Z"), Time.parse("2017-01-01 00:00:00Z")] }
     results = db.read table_name, [:id, :timestamps], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
-    results.rows.first.to_h.must_equal({ id: id, timestamps: [nil, Time.parse("2016-12-30 00:00:00Z"), Time.parse("2016-12-31 00:00:00Z"), Time.parse("2017-01-01 00:00:00Z")] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
+    _(results.rows.first.to_h).must_equal({ id: id, timestamps: [nil, Time.parse("2016-12-30 00:00:00Z"), Time.parse("2016-12-31 00:00:00Z"), Time.parse("2017-01-01 00:00:00Z")] })
   end
 
   it "writes and queries array of timestamp with NULL" do
@@ -114,9 +114,9 @@ describe "Spanner Client", :types, :timestamp, :spanner do
     db.upsert table_name, { id: id, timestamps: [nil, Time.parse("2016-12-30 00:00:00Z"), Time.parse("2016-12-31 00:00:00Z"), Time.parse("2017-01-01 00:00:00Z")] }
     results = db.execute_query "SELECT id, timestamps FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
-    results.rows.first.to_h.must_equal({ id: id, timestamps: [nil, Time.parse("2016-12-30 00:00:00Z"), Time.parse("2016-12-31 00:00:00Z"), Time.parse("2017-01-01 00:00:00Z")] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
+    _(results.rows.first.to_h).must_equal({ id: id, timestamps: [nil, Time.parse("2016-12-30 00:00:00Z"), Time.parse("2016-12-31 00:00:00Z"), Time.parse("2017-01-01 00:00:00Z")] })
   end
 
   it "writes and reads empty array of timestamp" do
@@ -124,9 +124,9 @@ describe "Spanner Client", :types, :timestamp, :spanner do
     db.upsert table_name, { id: id, timestamps: [] }
     results = db.read table_name, [:id, :timestamps], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
-    results.rows.first.to_h.must_equal({ id: id, timestamps: [] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
+    _(results.rows.first.to_h).must_equal({ id: id, timestamps: [] })
   end
 
   it "writes and queries empty array of timestamp" do
@@ -134,9 +134,9 @@ describe "Spanner Client", :types, :timestamp, :spanner do
     db.upsert table_name, { id: id, timestamps: [] }
     results = db.execute_query "SELECT id, timestamps FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
-    results.rows.first.to_h.must_equal({ id: id, timestamps: [] })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
+    _(results.rows.first.to_h).must_equal({ id: id, timestamps: [] })
   end
 
   it "writes and reads NULL array of timestamp" do
@@ -144,9 +144,9 @@ describe "Spanner Client", :types, :timestamp, :spanner do
     db.upsert table_name, { id: id, timestamps: nil }
     results = db.read table_name, [:id, :timestamps], keys: id
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
-    results.rows.first.to_h.must_equal({ id: id, timestamps: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
+    _(results.rows.first.to_h).must_equal({ id: id, timestamps: nil })
   end
 
   it "writes and queries NULL array of timestamp" do
@@ -154,8 +154,8 @@ describe "Spanner Client", :types, :timestamp, :spanner do
     db.upsert table_name, { id: id, timestamps: nil }
     results = db.execute_query "SELECT id, timestamps FROM #{table_name} WHERE id = @id", params: { id: id }
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
-    results.rows.first.to_h.must_equal({ id: id, timestamps: nil })
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
+    _(results.fields.to_h).must_equal({ id: :INT64, timestamps: [:TIMESTAMP] })
+    _(results.rows.first.to_h).must_equal({ id: id, timestamps: nil })
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/database_operations_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/database_operations_test.rb
@@ -21,34 +21,34 @@ describe "Spanner Database Operations", :spanner do
 
   it "list database operations" do
     instance = spanner.instance instance_id
-    instance.wont_be :nil?
+    _(instance).wont_be :nil?
 
     # All
     jobs = instance.database_operations.all.to_a
-    jobs.wont_be :empty?
+    _(jobs).wont_be :empty?
 
     jobs.each do |job|
-      job.must_be_kind_of Google::Cloud::Spanner::Database::Job
+      _(job).must_be_kind_of Google::Cloud::Spanner::Database::Job
 
       if job.database
-        job.database.must_be_kind_of Google::Cloud::Spanner::Database
+        _(job.database).must_be_kind_of Google::Cloud::Spanner::Database
       end
     end
 
     # Filter completed jobs
     filter = "done:true"
     jobs = instance.database_operations(filter: filter).all.to_a
-    jobs.wont_be :empty?
+    _(jobs).wont_be :empty?
     jobs.each do |job|
-      job.must_be :done?
+      _(job).must_be :done?
     end
 
     # Filter by metdata type
     filter = "metadata.@type:CreateDatabaseMetadata"
     jobs = instance.database_operations(filter: filter).all.to_a
-    jobs.wont_be :empty?
+    _(jobs).wont_be :empty?
     jobs.each do |job|
-      job.grpc.metadata.must_be_kind_of Google::Spanner::Admin::Database::V1::CreateDatabaseMetadata
+      _(job.grpc.metadata).must_be_kind_of Google::Spanner::Admin::Database::V1::CreateDatabaseMetadata
     end
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/database_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/database_test.rb
@@ -19,45 +19,45 @@ describe "Spanner Databases", :spanner do
   let(:database_id) { "#{$spanner_database_id}-crud" }
 
   it "creates, updates, and drops a database" do
-    spanner.database(instance_id, database_id).must_be :nil?
+    _(spanner.database(instance_id, database_id)).must_be :nil?
 
     job = spanner.create_database instance_id, database_id
-    job.must_be_kind_of Google::Cloud::Spanner::Database::Job
-    job.wont_be :done?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Database::Job
+    _(job).wont_be :done?
     job.wait_until_done!
 
-    job.must_be :done?
+    _(job).must_be :done?
     raise Google::Cloud::Error.from_error(job.error) if job.error?
     database = job.database
-    database.wont_be :nil?
-    database.must_be_kind_of Google::Cloud::Spanner::Database
-    database.database_id.must_equal database_id
-    database.instance_id.must_equal instance_id
-    database.project_id.must_equal spanner.project
+    _(database).wont_be :nil?
+    _(database).must_be_kind_of Google::Cloud::Spanner::Database
+    _(database.database_id).must_equal database_id
+    _(database.instance_id).must_equal instance_id
+    _(database.project_id).must_equal spanner.project
 
-    spanner.database(instance_id, database_id).wont_be :nil?
+    _(spanner.database(instance_id, database_id)).wont_be :nil?
 
     job2 = database.update statements: "CREATE TABLE users (id INT64 NOT NULL) PRIMARY KEY(id)"
 
-    job2.must_be_kind_of Google::Cloud::Spanner::Database::Job
-    job2.wont_be :done?
+    _(job2).must_be_kind_of Google::Cloud::Spanner::Database::Job
+    _(job2).wont_be :done?
     job2.wait_until_done!
 
-    job2.must_be :done?
-    job2.database.must_be :nil?
+    _(job2).must_be :done?
+    _(job2.database).must_be :nil?
 
     database.drop
-    spanner.database(instance_id, database_id).must_be :nil?
+    _(spanner.database(instance_id, database_id)).must_be :nil?
   end
 
   it "lists and gets databases" do
     all_databases = spanner.databases(instance_id).all.to_a
-    all_databases.wont_be :empty?
+    _(all_databases).wont_be :empty?
     all_databases.each do |database|
-      database.must_be_kind_of Google::Cloud::Spanner::Database
+      _(database).must_be_kind_of Google::Cloud::Spanner::Database
     end
 
     first_database = spanner.database all_databases.first.instance_id, all_databases.first.database_id
-    first_database.must_be_kind_of Google::Cloud::Spanner::Database
+    _(first_database).must_be_kind_of Google::Cloud::Spanner::Database
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/instance_config_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/instance_config_test.rb
@@ -17,12 +17,12 @@ require "spanner_helper"
 describe "Spanner Instance Configs", :spanner do
   it "lists and gets instance configs" do
     all_configs = spanner.instance_configs.all.to_a
-    all_configs.wont_be :empty?
+    _(all_configs).wont_be :empty?
     all_configs.each do |config|
-      config.must_be_kind_of Google::Cloud::Spanner::Instance::Config
+      _(config).must_be_kind_of Google::Cloud::Spanner::Instance::Config
     end
 
     first_configs = spanner.instance_config all_configs.first.instance_config_id
-    first_configs.must_be_kind_of Google::Cloud::Spanner::Instance::Config
+    _(first_configs).must_be_kind_of Google::Cloud::Spanner::Instance::Config
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/instance_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/instance_test.rb
@@ -17,13 +17,13 @@ require "spanner_helper"
 describe "Spanner Instances", :spanner do
   it "lists and gets instances" do
     all_instances = spanner.instances.all.to_a
-    all_instances.wont_be :empty?
+    _(all_instances).wont_be :empty?
     all_instances.each do |instance|
-      instance.must_be_kind_of Google::Cloud::Spanner::Instance
+      _(instance).must_be_kind_of Google::Cloud::Spanner::Instance
     end
 
     first_instance = spanner.instance all_instances.first.instance_id
-    first_instance.must_be_kind_of Google::Cloud::Spanner::Instance
+    _(first_instance).must_be_kind_of Google::Cloud::Spanner::Instance
   end
 
   describe "IAM Policies and Permissions" do
@@ -37,10 +37,10 @@ describe "Spanner Instances", :spanner do
       permissions = instance.test_permissions roles
       skip "Don't have permissions to get/set topic's policy" unless permissions == roles
 
-      instance.policy.must_be_kind_of Google::Cloud::Spanner::Policy
+      _(instance.policy).must_be_kind_of Google::Cloud::Spanner::Policy
 
       # We need a valid service account in order to update the policy
-      service_account.wont_be :nil?
+      _(service_account).wont_be :nil?
       role = "roles/viewer"
       member = "serviceAccount:#{service_account}"
       instance.policy do |p|
@@ -49,7 +49,7 @@ describe "Spanner Instances", :spanner do
       end
 
       role_member = instance.policy.role(role).select { |x| x == member }
-      role_member.size.must_equal 1
+      _(role_member.size).must_equal 1
     end
   end
 end

--- a/google-cloud-spanner/acceptance/spanner_helper.rb
+++ b/google-cloud-spanner/acceptance/spanner_helper.rb
@@ -31,9 +31,6 @@ def SecureRandom.int64
   random_bytes(8).unpack("q")[0]
 end
 
-# Disable exit handlers because it messes with minitest/autorun
-Concurrent.disable_at_exit_handlers!
-
 # Create shared spanner object so we don't create new for each test
 $spanner = Google::Cloud::Spanner.new
 

--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "concurrent-ruby", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
-  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"

--- a/google-cloud-spanner/test/google/cloud/spanner/backup/delete_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/backup/delete_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::Spanner::Backup, :delete, :mock_spanner do
     mock.expect :delete_backup, nil, [backup_grpc.name]
     spanner.service.mocked_databases = mock
 
-    backup.delete.must_equal true
+    _(backup.delete).must_equal true
     mock.verify
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/backup/expire_time_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/backup/expire_time_test.rb
@@ -34,7 +34,7 @@ describe Google::Cloud::Spanner::Backup, :expire_time=, :mock_spanner do
 
     expire_time = Time.now + 36000
     backup.expire_time = expire_time
-    backup.expire_time.must_equal expire_time
+    _(backup.expire_time).must_equal expire_time
 
     mock.verify
   end
@@ -48,10 +48,10 @@ describe Google::Cloud::Spanner::Backup, :expire_time=, :mock_spanner do
     backup.service.mocked_databases = stub
     expire_time_was = backup.expire_time
 
-    proc {
+    _ { proc {
       backup.expire_time = (Time.now - 36000)
-    }.must_raise Google::Cloud::Error
+    } }.must_raise Google::Cloud::Error
 
-    backup.expire_time.must_equal expire_time_was
+    _(backup.expire_time).must_equal expire_time_was
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/backup/expire_time_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/backup/expire_time_test.rb
@@ -48,9 +48,9 @@ describe Google::Cloud::Spanner::Backup, :expire_time=, :mock_spanner do
     backup.service.mocked_databases = stub
     expire_time_was = backup.expire_time
 
-    _ { proc {
+    assert_raises Google::Cloud::Error do
       backup.expire_time = (Time.now - 36000)
-    } }.must_raise Google::Cloud::Error
+    end
 
     _(backup.expire_time).must_equal expire_time_was
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/backup/referencing_databases_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/backup/referencing_databases_test.rb
@@ -40,11 +40,11 @@ describe Google::Cloud::Spanner::Backup, :referencing_databases, :mock_spanner d
     referencing_databases = backup.referencing_databases
     mock.verify
 
-    referencing_databases.must_be_kind_of Array
-    referencing_databases.length.must_equal 1
+    _(referencing_databases).must_be_kind_of Array
+    _(referencing_databases.length).must_equal 1
 
     referencing_database = referencing_databases[0]
-    referencing_database.instance_id.must_equal instance_id
-    referencing_database.database_id.must_equal referencing_database_id
+    _(referencing_database.instance_id).must_equal instance_id
+    _(referencing_database.database_id).must_equal referencing_database_id
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/backup/restore_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/backup/restore_test.rb
@@ -67,15 +67,15 @@ describe Google::Cloud::Spanner::Backup, :restore_database, :mock_spanner do
 
     job = backup.restore "restored-database"
 
-    job.must_be_kind_of Google::Cloud::Spanner::Backup::Restore::Job
-    job.wont_be :done?
-    job.wont_be :error?
-    job.error.must_be :nil?
-    job.database.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Backup::Restore::Job
+    _(job).wont_be :done?
+    _(job).wont_be :error?
+    _(job.error).must_be :nil?
+    _(job.database).must_be :nil?
     job.reload!
     database = job.database
-    database.wont_be :nil?
-    database.must_be_kind_of Google::Cloud::Spanner::Database
+    _(database).wont_be :nil?
+    _(database).must_be_kind_of Google::Cloud::Spanner::Database
 
     mock.verify
   end
@@ -98,15 +98,15 @@ describe Google::Cloud::Spanner::Backup, :restore_database, :mock_spanner do
 
     job = backup.restore "restored-database", instance_id: "other-instance"
 
-    job.must_be_kind_of Google::Cloud::Spanner::Backup::Restore::Job
-    job.wont_be :done?
-    job.wont_be :error?
-    job.error.must_be :nil?
-    job.database.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Backup::Restore::Job
+    _(job).wont_be :done?
+    _(job).wont_be :error?
+    _(job.error).must_be :nil?
+    _(job.database).must_be :nil?
     job.reload!
     database = job.database
-    database.wont_be :nil?
-    database.must_be_kind_of Google::Cloud::Spanner::Database
+    _(database).wont_be :nil?
+    _(database).must_be_kind_of Google::Cloud::Spanner::Database
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/backup_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/backup_test.rb
@@ -34,18 +34,18 @@ describe Google::Cloud::Spanner::Backup, :mock_spanner do
   let(:backup) { Google::Cloud::Spanner::Backup.from_grpc backup_grpc, spanner.service }
 
   it "knows the identifiers" do
-    backup.must_be_kind_of Google::Cloud::Spanner::Backup
-    backup.project_id.must_equal project
-    backup.instance_id.must_equal instance_id
-    backup.database_id.must_equal database_id
-    backup.backup_id.must_equal backup_id
+    _(backup).must_be_kind_of Google::Cloud::Spanner::Backup
+    _(backup.project_id).must_equal project
+    _(backup.instance_id).must_equal instance_id
+    _(backup.database_id).must_equal database_id
+    _(backup.backup_id).must_equal backup_id
 
-    backup.state.must_equal :READY
-    backup.must_be :ready?
-    backup.wont_be :creating?
+    _(backup.state).must_equal :READY
+    _(backup).must_be :ready?
+    _(backup).wont_be :creating?
 
-    backup.expire_time.must_be_kind_of Time
-    backup.create_time.must_be_kind_of Time
-    backup.size_in_bytes.must_be :>, 0
+    _(backup.expire_time).must_be_kind_of Time
+    _(backup.create_time).must_be_kind_of Time
+    _(backup.size_in_bytes).must_be :>, 0
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_client_test.rb
@@ -34,15 +34,15 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
   let(:batch_client_labels) { spanner.batch_client instance_id, database_id, labels: labels }
 
   it "knows its project_id" do
-    batch_client.project_id.must_equal project
+    _(batch_client.project_id).must_equal project
   end
 
   it "holds a reference to project" do
-    batch_client.project.must_equal spanner
+    _(batch_client.project).must_equal spanner
   end
 
   it "knows its instance_id" do
-    batch_client.instance_id.must_equal instance_id
+    _(batch_client.instance_id).must_equal instance_id
   end
 
   it "retrieves the instance" do
@@ -55,13 +55,13 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
     mock.verify
 
-    instance.project_id.must_equal project
-    instance.instance_id.must_equal instance_id
-    instance.path.must_equal instance_path(instance_id)
+    _(instance.project_id).must_equal project
+    _(instance.instance_id).must_equal instance_id
+    _(instance.path).must_equal instance_path(instance_id)
   end
 
   it "knows its database_id" do
-    batch_client.database_id.must_equal database_id
+    _(batch_client.database_id).must_equal database_id
   end
 
   it "retrieves the database" do
@@ -74,10 +74,10 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
     mock.verify
 
-    database.project_id.must_equal project
-    database.instance_id.must_equal instance_id
-    database.database_id.must_equal database_id
-    database.path.must_equal database_path(instance_id, database_id)
+    _(database.project_id).must_equal project
+    _(database.instance_id).must_equal instance_id
+    _(database.database_id).must_equal database_id
+    _(database.path).must_equal database_path(instance_id, database_id)
   end
 
   it "creates a batch_snapshot" do
@@ -90,9 +90,9 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
     mock.verify
 
-    batch_snapshot.transaction_id.must_equal transaction_id
-    batch_snapshot.timestamp.must_equal timestamp_time
-    batch_snapshot.session.path.must_equal session.path
+    _(batch_snapshot.transaction_id).must_equal transaction_id
+    _(batch_snapshot.timestamp).must_equal timestamp_time
+    _(batch_snapshot.session.path).must_equal session.path
   end
 
   it "creates a batch_snapshot with session labels" do
@@ -107,9 +107,9 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
     mock.verify
 
-    batch_snapshot.transaction_id.must_equal transaction_id
-    batch_snapshot.timestamp.must_equal timestamp_time
-    batch_snapshot.session.path.must_equal session.path
+    _(batch_snapshot.transaction_id).must_equal transaction_id
+    _(batch_snapshot.timestamp).must_equal timestamp_time
+    _(batch_snapshot.session.path).must_equal session.path
   end
 
   describe :strong do
@@ -125,9 +125,9 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
       mock.verify
 
-      batch_snapshot.transaction_id.must_equal transaction_id
-      batch_snapshot.timestamp.must_equal timestamp_time
-      batch_snapshot.session.path.must_equal session.path
+      _(batch_snapshot.transaction_id).must_equal transaction_id
+      _(batch_snapshot.timestamp).must_equal timestamp_time
+      _(batch_snapshot.session.path).must_equal session.path
     end
   end
 
@@ -147,9 +147,9 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
       mock.verify
 
-      batch_snapshot.transaction_id.must_equal transaction_id
-      batch_snapshot.timestamp.must_equal timestamp_time
-      batch_snapshot.session.path.must_equal session.path
+      _(batch_snapshot.transaction_id).must_equal transaction_id
+      _(batch_snapshot.timestamp).must_equal timestamp_time
+      _(batch_snapshot.session.path).must_equal session.path
     end
 
     it "creates a batch_snapshot with read_timestamp option (Time)" do
@@ -162,9 +162,9 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
       mock.verify
 
-      batch_snapshot.transaction_id.must_equal transaction_id
-      batch_snapshot.timestamp.must_equal timestamp_time
-      batch_snapshot.session.path.must_equal session.path
+      _(batch_snapshot.transaction_id).must_equal transaction_id
+      _(batch_snapshot.timestamp).must_equal timestamp_time
+      _(batch_snapshot.session.path).must_equal session.path
     end
 
     it "creates a batch_snapshot with timestamp option (DateTime)" do
@@ -177,9 +177,9 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
       mock.verify
 
-      batch_snapshot.transaction_id.must_equal transaction_id
-      batch_snapshot.timestamp.must_equal timestamp_time
-      batch_snapshot.session.path.must_equal session.path
+      _(batch_snapshot.transaction_id).must_equal transaction_id
+      _(batch_snapshot.timestamp).must_equal timestamp_time
+      _(batch_snapshot.session.path).must_equal session.path
     end
 
     it "creates a batch_snapshot with read_timestamp option (DateTime)" do
@@ -192,9 +192,9 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
       mock.verify
 
-      batch_snapshot.transaction_id.must_equal transaction_id
-      batch_snapshot.timestamp.must_equal timestamp_time
-      batch_snapshot.session.path.must_equal session.path
+      _(batch_snapshot.transaction_id).must_equal transaction_id
+      _(batch_snapshot.timestamp).must_equal timestamp_time
+      _(batch_snapshot.session.path).must_equal session.path
     end
   end
 
@@ -213,9 +213,9 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
       mock.verify
 
-      batch_snapshot.transaction_id.must_equal transaction_id
-      batch_snapshot.timestamp.must_equal timestamp_time
-      batch_snapshot.session.path.must_equal session.path
+      _(batch_snapshot.transaction_id).must_equal transaction_id
+      _(batch_snapshot.timestamp).must_equal timestamp_time
+      _(batch_snapshot.session.path).must_equal session.path
     end
 
     it "creates a batch_snapshot with the exact_staleness option" do
@@ -228,65 +228,65 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
       mock.verify
 
-      batch_snapshot.transaction_id.must_equal transaction_id
-      batch_snapshot.timestamp.must_equal timestamp_time
-      batch_snapshot.session.path.must_equal session.path
+      _(batch_snapshot.transaction_id).must_equal transaction_id
+      _(batch_snapshot.timestamp).must_equal timestamp_time
+      _(batch_snapshot.session.path).must_equal session.path
     end
   end
 
   it "loads a batch_snapshot (hash)" do
     batch_snapshot = batch_client.load_batch_snapshot batch_tx_hash
 
-    batch_snapshot.transaction_id.must_equal transaction_id
-    batch_snapshot.timestamp.must_equal timestamp_time
-    batch_snapshot.session.path.must_equal session.path
+    _(batch_snapshot.transaction_id).must_equal transaction_id
+    _(batch_snapshot.timestamp).must_equal timestamp_time
+    _(batch_snapshot.session.path).must_equal session.path
   end
 
   it "loads a batch_snapshot (json)" do
     batch_snapshot = batch_client.load_batch_snapshot batch_tx_hash
 
-    batch_snapshot.transaction_id.must_equal transaction_id
-    batch_snapshot.timestamp.must_equal timestamp_time
-    batch_snapshot.session.path.must_equal session.path
+    _(batch_snapshot.transaction_id).must_equal transaction_id
+    _(batch_snapshot.timestamp).must_equal timestamp_time
+    _(batch_snapshot.session.path).must_equal session.path
   end
 
   it "creates an inclusive range" do
     range = batch_client.range 1, 100
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.wont_be :exclude_begin?
-    range.wont_be :exclude_end?
+    _(range).wont_be :exclude_begin?
+    _(range).wont_be :exclude_end?
   end
 
   it "creates an exclusive range" do
     range = batch_client.range 1, 100, exclude_begin: true, exclude_end: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.must_be :exclude_begin?
-    range.must_be :exclude_end?
+    _(range).must_be :exclude_begin?
+    _(range).must_be :exclude_end?
   end
 
   it "creates a range that excludes beginning" do
     range = batch_client.range 1, 100, exclude_begin: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.must_be :exclude_begin?
-    range.wont_be :exclude_end?
+    _(range).must_be :exclude_begin?
+    _(range).wont_be :exclude_end?
   end
 
   it "creates a range that excludes ending" do
     range = batch_client.range 1, 100, exclude_end: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.wont_be :exclude_begin?
-    range.must_be :exclude_end?
+    _(range).wont_be :exclude_begin?
+    _(range).must_be :exclude_end?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
@@ -361,35 +361,35 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
 
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_query_test.rb
@@ -298,35 +298,35 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/metadata_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/metadata_test.rb
@@ -27,14 +27,14 @@ describe Google::Cloud::Spanner::BatchSnapshot, :metadata, :mock_spanner do
   let(:batch_snapshot) { Google::Cloud::Spanner::BatchSnapshot.from_grpc transaction_grpc, session }
 
   it "knows it has a transaction_id" do
-    batch_snapshot.must_be_kind_of Google::Cloud::Spanner::BatchSnapshot
+    _(batch_snapshot).must_be_kind_of Google::Cloud::Spanner::BatchSnapshot
 
-    batch_snapshot.transaction_id.must_equal transaction_id
+    _(batch_snapshot.transaction_id).must_equal transaction_id
   end
 
   it "knows it has a timestamp" do
-    batch_snapshot.must_be_kind_of Google::Cloud::Spanner::BatchSnapshot
+    _(batch_snapshot).must_be_kind_of Google::Cloud::Spanner::BatchSnapshot
 
-    batch_snapshot.timestamp.must_equal time_obj
+    _(batch_snapshot.timestamp).must_equal time_obj
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_query_test.rb
@@ -402,31 +402,31 @@ describe Google::Cloud::Spanner::BatchSnapshot, :partition_query, :mock_spanner 
     mock.verify
 
     partitions.each do |p|
-      p.execute.query_options.to_h.must_equal expect_query_options
+      _(p.execute.query_options.to_h).must_equal expect_query_options
     end
   end
 
   def assert_partitions partitions, sql = "SELECT * FROM users", params: nil, types: nil
-    partitions.must_be_kind_of Array
-    partitions.wont_be :empty?
+    _(partitions).must_be_kind_of Array
+    _(partitions).wont_be :empty?
 
     params, types = Google::Cloud::Spanner::Convert.to_input_params_and_types params, types
 
     partitions.each do |partition|
-      partition.must_be :execute?
-      partition.must_be :execute_query?
+      _(partition).must_be :execute?
+      _(partition).must_be :execute_query?
 
-      partition.execute.partition_token.must_equal "partition-token"
-      partition.execute.sql.must_equal sql
+      _(partition.execute.partition_token).must_equal "partition-token"
+      _(partition.execute.sql).must_equal sql
       if params.nil?
-        partition.execute.params.must_be_nil
+        _(partition.execute.params).must_be_nil
       else
-        partition.execute.params.must_equal params
+        _(partition.execute.params).must_equal params
       end
       types_hash = Hash[Hash(types).map { |key, value| [key, value.to_h] }]
-      partition.execute.param_types.to_h.must_equal types_hash
+      _(partition.execute.param_types.to_h).must_equal types_hash
 
-      partition.read.must_be_nil
+      _(partition.read).must_be_nil
     end
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_read_test.rb
@@ -153,19 +153,19 @@ describe Google::Cloud::Spanner::BatchSnapshot, :partition_read, :mock_spanner d
   end
 
   def assert_partitions partitions, keys: nil, index: nil
-    partitions.must_be_kind_of Array
-    partitions.wont_be :empty?
+    _(partitions).must_be_kind_of Array
+    _(partitions).wont_be :empty?
 
     partitions.each do |partition|
-      partition.must_be :read?
+      _(partition).must_be :read?
 
-      partition.read.partition_token.must_equal "partition-token"
-      partition.read.table.must_equal "my-table"
-      partition.read.key_set.must_equal Google::Cloud::Spanner::Convert.to_key_set(keys)
-      partition.read.columns.must_equal columns.map(&:to_s)
-      partition.read.index.must_equal index.to_s
+      _(partition.read.partition_token).must_equal "partition-token"
+      _(partition.read.table).must_equal "my-table"
+      _(partition.read.key_set).must_equal Google::Cloud::Spanner::Convert.to_key_set(keys)
+      _(partition.read.columns).must_equal columns.map(&:to_s)
+      _(partition.read.index).must_equal index.to_s
 
-      partition.execute.must_be_nil
+      _(partition.execute).must_be_nil
     end
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/read_test.rb
@@ -160,35 +160,35 @@ describe Google::Cloud::Spanner::BatchSnapshot, :read, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/admin_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/admin_test.rb
@@ -28,15 +28,15 @@ describe Google::Cloud::Spanner::Client, :admin, :mock_spanner do
   end
 
   it "knows its project_id" do
-    client.project_id.must_equal project
+    _(client.project_id).must_equal project
   end
 
   it "holds a reference to project" do
-    client.project.must_equal spanner
+    _(client.project).must_equal spanner
   end
 
   it "knows its instance_id" do
-    client.instance_id.must_equal instance_id
+    _(client.instance_id).must_equal instance_id
   end
 
   it "retrieves the instance" do
@@ -49,13 +49,13 @@ describe Google::Cloud::Spanner::Client, :admin, :mock_spanner do
 
     mock.verify
 
-    instance.project_id.must_equal project
-    instance.instance_id.must_equal instance_id
-    instance.path.must_equal instance_path(instance_id)
+    _(instance.project_id).must_equal project
+    _(instance.instance_id).must_equal instance_id
+    _(instance.path).must_equal instance_path(instance_id)
   end
 
   it "knows its database_id" do
-    client.database_id.must_equal database_id
+    _(client.database_id).must_equal database_id
   end
 
   it "retrieves the database" do
@@ -68,9 +68,9 @@ describe Google::Cloud::Spanner::Client, :admin, :mock_spanner do
 
     mock.verify
 
-    database.project_id.must_equal project
-    database.instance_id.must_equal instance_id
-    database.database_id.must_equal database_id
-    database.path.must_equal database_path(instance_id, database_id)
+    _(database.project_id).must_equal project
+    _(database.instance_id).must_equal instance_id
+    _(database.database_id).must_equal database_id
+    _(database.path).must_equal database_path(instance_id, database_id)
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_field_values_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_field_values_test.rb
@@ -66,7 +66,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
         c.upsert "users", [{ id: 3, name: "Marley",  updated_at: client.commit_timestamp }]
         c.replace "users", [{ id: 4, name: "Henry",  updated_at: client.commit_timestamp }]
       end
-      timestamp.must_equal commit_time
+      _(timestamp).must_equal commit_time
 
       shutdown_client! client
 
@@ -89,7 +89,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       spanner.service.mocked_service = mock
 
       timestamp = client.update "users", [{ id: 1, name: "Charlie", updated_at: client.commit_timestamp }]
-      timestamp.must_equal commit_time
+      _(timestamp).must_equal commit_time
 
       shutdown_client! client
 
@@ -112,7 +112,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       spanner.service.mocked_service = mock
 
       timestamp = client.insert "users", [{ id: 2, name: "Harvey", updated_at: client.commit_timestamp }]
-      timestamp.must_equal commit_time
+      _(timestamp).must_equal commit_time
 
       shutdown_client! client
 
@@ -135,7 +135,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       spanner.service.mocked_service = mock
 
       timestamp = client.upsert "users", [{ id: 3, name: "Marley", updated_at: client.commit_timestamp }]
-      timestamp.must_equal commit_time
+      _(timestamp).must_equal commit_time
 
       shutdown_client! client
 
@@ -158,7 +158,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       spanner.service.mocked_service = mock
 
       timestamp = client.save "users", [{ id: 3, name: "Marley", updated_at: client.commit_timestamp }]
-      timestamp.must_equal commit_time
+      _(timestamp).must_equal commit_time
 
       shutdown_client! client
 
@@ -181,7 +181,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       spanner.service.mocked_service = mock
 
       timestamp = client.replace "users", [{ id: 4, name: "Henry", updated_at: client.commit_timestamp }]
-      timestamp.must_equal commit_time
+      _(timestamp).must_equal commit_time
 
       shutdown_client! client
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -75,7 +75,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       c.replace "users", [{ id: 4, name: "Henry",  active: true }]
       c.delete "users", [1, 2, 3, 4, 5]
     end
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -98,7 +98,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     spanner.service.mocked_service = mock
 
     timestamp = client.update "users", [{ id: 1, name: "Charlie", active: false }]
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -121,7 +121,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     spanner.service.mocked_service = mock
 
     timestamp = client.insert "users", [{ id: 2, name: "Harvey",  active: true }]
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -144,7 +144,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     spanner.service.mocked_service = mock
 
     timestamp = client.upsert "users", [{ id: 3, name: "Marley",  active: false }]
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -167,7 +167,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     spanner.service.mocked_service = mock
 
     timestamp = client.save "users", [{ id: 3, name: "Marley",  active: false }]
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -190,7 +190,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     spanner.service.mocked_service = mock
 
     timestamp = client.replace "users", [{ id: 4, name: "Henry",  active: true }]
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -216,7 +216,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users", [1, 2, 3, 4, 5]
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -247,7 +247,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users", [time1, time2, time3, time4]
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -271,7 +271,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users", 1..100
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -297,7 +297,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users", 5
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -325,7 +325,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users", time5
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -347,7 +347,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users"
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_timestamp.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_timestamp.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::Spanner::Client, :commit_timestamp, :mock_spanner do
   it "creates a commit_timestamp column value" do
     column_value = client.commit_timestamp
 
-    column_value.must_be_kind_of Google::Cloud::Spanner::ColumnValue
-    column_value.type.must_equal :commit_timestamp
+    _(column_value).must_be_kind_of Google::Cloud::Spanner::ColumnValue
+    _(column_value.type).must_equal :commit_timestamp
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_partition_update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_partition_update_test.rb
@@ -53,7 +53,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a PDML statement with bool param" do
@@ -67,7 +67,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a PDML statement with int param" do
@@ -81,7 +81,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a PDML statement with float param" do
@@ -95,7 +95,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a PDML statement with Time param" do
@@ -111,7 +111,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a PDML statement with Date param" do
@@ -127,7 +127,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a PDML statement with String param" do
@@ -141,7 +141,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a PDML statement with IO-ish param" do
@@ -157,7 +157,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a PDML statement with an Array param" do
@@ -171,7 +171,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a PDML statement with an empty Array param" do
@@ -185,7 +185,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a PDML statement with a simple Hash param" do
@@ -199,7 +199,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a PDML statement with a complex Hash param" do
@@ -213,7 +213,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a PDML statement with an empty Hash param" do
@@ -227,7 +227,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "raises InvalidArgumentError if the response does not contain stats" do
@@ -260,7 +260,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a PDML statement with query options (environment variable or client-level)" do
@@ -276,7 +276,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a PDML statement with query options that query-level configs merge over environment variable or client-level configs" do
@@ -292,6 +292,6 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_resume_test.rb
@@ -120,35 +120,35 @@ describe Google::Cloud::Spanner::Client, :execute_query, :resume, :mock_spanner 
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_single_use_test.rb
@@ -268,35 +268,35 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_test.rb
@@ -364,35 +364,35 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
@@ -60,17 +60,17 @@ describe Google::Cloud::Spanner::Client, :fields_for, :mock_spanner do
   end
 
   def assert_fields fields
-    fields.wont_be :nil?
-    fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    fields.keys.count.must_equal 9
-    fields[:id].must_equal          :INT64
-    fields[:name].must_equal        :STRING
-    fields[:active].must_equal      :BOOL
-    fields[:age].must_equal         :INT64
-    fields[:score].must_equal       :FLOAT64
-    fields[:updated_at].must_equal  :TIMESTAMP
-    fields[:birthday].must_equal    :DATE
-    fields[:avatar].must_equal      :BYTES
-    fields[:project_ids].must_equal [:INT64]
+    _(fields).wont_be :nil?
+    _(fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(fields.keys.count).must_equal 9
+    _(fields[:id]).must_equal          :INT64
+    _(fields[:name]).must_equal        :STRING
+    _(fields[:active]).must_equal      :BOOL
+    _(fields[:age]).must_equal         :INT64
+    _(fields[:score]).must_equal       :FLOAT64
+    _(fields[:updated_at]).must_equal  :TIMESTAMP
+    _(fields[:birthday]).must_equal    :DATE
+    _(fields[:avatar]).must_equal      :BYTES
+    _(fields[:project_ids]).must_equal [:INT64]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/range_test.rb
@@ -31,40 +31,40 @@ describe Google::Cloud::Spanner::Client, :range, :mock_spanner do
   it "creates an inclusive range" do
     range = client.range 1, 100
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.wont_be :exclude_begin?
-    range.wont_be :exclude_end?
+    _(range).wont_be :exclude_begin?
+    _(range).wont_be :exclude_end?
   end
 
   it "creates an exclusive range" do
     range = client.range 1, 100, exclude_begin: true, exclude_end: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.must_be :exclude_begin?
-    range.must_be :exclude_end?
+    _(range).must_be :exclude_begin?
+    _(range).must_be :exclude_end?
   end
 
   it "creates a range that excludes beginning" do
     range = client.range 1, 100, exclude_begin: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.must_be :exclude_begin?
-    range.wont_be :exclude_end?
+    _(range).must_be :exclude_begin?
+    _(range).wont_be :exclude_end?
   end
 
   it "creates a range that excludes ending" do
     range = client.range 1, 100, exclude_end: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.wont_be :exclude_begin?
-    range.must_be :exclude_end?
+    _(range).wont_be :exclude_begin?
+    _(range).must_be :exclude_end?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
@@ -113,7 +113,7 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
 
     assert_results results
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 3
+    _(rows.count).must_equal 3
     rows.each { |row| assert_row row }
 
     shutdown_client! client
@@ -150,7 +150,7 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
 
     assert_results results
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 3
+    _(rows.count).must_equal 3
     rows.each { |row| assert_row row }
 
     shutdown_client! client
@@ -203,34 +203,34 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
   end
 
   def assert_row row
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
@@ -122,35 +122,35 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
@@ -270,35 +270,35 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -218,35 +218,35 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/reset_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/reset_test.rb
@@ -60,8 +60,8 @@ describe Google::Cloud::Spanner::Client, :close, :mock_spanner do
     expect_execute_streaming_sql results_enum, session.path, "SELECT 1", options: default_options
     
     client = spanner.client instance_id, database_id, pool: { min: 1, max: 1 }
-    client.reset.must_equal true
-    client.execute_query("SELECT 1").rows.first.values.must_equal [1]
+    _(client.reset).must_equal true
+    _(client.execute_query("SELECT 1").rows.first.values).must_equal [1]
 
     pool = client.instance_variable_get :@pool
     shutdown_pool! pool

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -78,7 +78,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     results = nil
     client.snapshot do |snp|
-      snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
+      _(snp).must_be_kind_of Google::Cloud::Spanner::Snapshot
       results = snp.execute_query "SELECT * FROM users"
     end
 
@@ -112,7 +112,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
       results = nil
       client.snapshot strong: true do |snp|
-        snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
+        _(snp).must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute_query "SELECT * FROM users"
       end
 
@@ -135,7 +135,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
       results = nil
       client.snapshot timestamp: snapshot_time do |snp|
-        snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
+        _(snp).must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute_query "SELECT * FROM users"
       end
 
@@ -151,7 +151,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
       results = nil
       client.snapshot read_timestamp: snapshot_time do |snp|
-        snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
+        _(snp).must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute_query "SELECT * FROM users"
       end
 
@@ -167,7 +167,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
       results = nil
       client.snapshot timestamp: snapshot_datetime do |snp|
-        snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
+        _(snp).must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute_query "SELECT * FROM users"
       end
 
@@ -183,7 +183,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
       results = nil
       client.snapshot read_timestamp: snapshot_datetime do |snp|
-        snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
+        _(snp).must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute_query "SELECT * FROM users"
       end
 
@@ -205,7 +205,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
       results = nil
       client.snapshot staleness: snapshot_staleness do |snp|
-        snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
+        _(snp).must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute_query "SELECT * FROM users"
       end
 
@@ -221,7 +221,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
       results = nil
       client.snapshot exact_staleness: snapshot_staleness do |snp|
-        snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
+        _(snp).must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute_query "SELECT * FROM users"
       end
 
@@ -241,16 +241,16 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     nested_error = assert_raises RuntimeError do
       client.snapshot do |snp|
-        snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
+        _(snp).must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute_query "SELECT * FROM users"
 
         client.snapshot do |snp2|
-          snp2.must_be_kind_of Google::Cloud::Spanner::Snapshot
+          _(snp2).must_be_kind_of Google::Cloud::Spanner::Snapshot
           results2 = snp2.execute_query "SELECT * FROM other_users"
         end
       end
     end
-    nested_error.message.must_equal "Nested snapshots are not allowed"
+    _(nested_error.message).must_equal "Nested snapshots are not allowed"
 
     shutdown_client! client
 
@@ -261,35 +261,35 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/threads_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/threads_test.rb
@@ -31,8 +31,8 @@ describe Google::Cloud::Spanner::Client, :threads, :mock_spanner do
     threads = pool.instance_variable_get :@threads
     thread_pool = pool.instance_variable_get :@thread_pool
 
-    threads.must_equal 13
-    thread_pool.max_length.must_equal 13
+    _(threads).must_equal 13
+    _(thread_pool.max_length).must_equal 13
 
     client.close
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -105,7 +105,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
 
     results = nil
     client.transaction do |tx|
-      tx.must_be_kind_of Google::Cloud::Spanner::Transaction
+      _(tx).must_be_kind_of Google::Cloud::Spanner::Transaction
       results = tx.execute_query "SELECT * FROM users"
       tx.update "users", [{ id: 1, name: "Charlie", active: false }]
     end
@@ -159,7 +159,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
 
     results = nil
     client.transaction do |tx|
-      tx.must_be_kind_of Google::Cloud::Spanner::Transaction
+      _(tx).must_be_kind_of Google::Cloud::Spanner::Transaction
       results = tx.execute_query "SELECT * FROM users"
       tx.update "users", [{ id: 1, name: "Charlie", active: false }]
     end
@@ -213,7 +213,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
 
     results = nil
     client.transaction do |tx|
-      tx.must_be_kind_of Google::Cloud::Spanner::Transaction
+      _(tx).must_be_kind_of Google::Cloud::Spanner::Transaction
       results = tx.execute_query "SELECT * FROM users"
       tx.update "users", [{ id: 1, name: "Charlie", active: false }]
     end
@@ -277,7 +277,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
 
     results = nil
     client.transaction do |tx|
-      tx.must_be_kind_of Google::Cloud::Spanner::Transaction
+      _(tx).must_be_kind_of Google::Cloud::Spanner::Transaction
       results = tx.execute_query "SELECT * FROM users"
       tx.update "users", [{ id: 1, name: "Charlie", active: false }]
     end
@@ -348,7 +348,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
 
     assert_raises Google::Cloud::AbortedError do
       client.transaction do |tx|
-        tx.must_be_kind_of Google::Cloud::Spanner::Transaction
+        _(tx).must_be_kind_of Google::Cloud::Spanner::Transaction
         results = tx.execute_query "SELECT * FROM users"
         tx.update "users", [{ id: 1, name: "Charlie", active: false }]
       end
@@ -360,35 +360,35 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
@@ -75,14 +75,14 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
 
     results = nil
     timestamp = client.transaction do |tx|
-      tx.must_be_kind_of Google::Cloud::Spanner::Transaction
+      _(tx).must_be_kind_of Google::Cloud::Spanner::Transaction
       results = tx.execute_query "SELECT * FROM users"
       # This mutation will never be committed, so no mocks for it.
       tx.update "users", [{ id: 1, name: "Charlie", active: false }]
       # Cause an error
       raise Google::Cloud::Spanner::Rollback
     end
-    timestamp.must_be :nil?
+    _(timestamp).must_be :nil?
 
     shutdown_client! client
 
@@ -104,7 +104,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
     results = nil
     assert_raises ZeroDivisionError do
       client.transaction do |tx|
-        tx.must_be_kind_of Google::Cloud::Spanner::Transaction
+        _(tx).must_be_kind_of Google::Cloud::Spanner::Transaction
         results = tx.execute_query "SELECT * FROM users"
         # This mutation will never be committed, so no mocks for it.
         tx.update "users", [{ id: 1, name: "Charlie", active: false }]
@@ -143,7 +143,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
         end
       end
     end
-    nested_error.message.must_equal "Nested transactions are not allowed"
+    _(nested_error.message).must_equal "Nested transactions are not allowed"
 
     shutdown_client! client
 
@@ -151,35 +151,35 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -77,10 +77,10 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
 
     results = nil
     timestamp = client.transaction do |tx|
-      tx.must_be_kind_of Google::Cloud::Spanner::Transaction
+      _(tx).must_be_kind_of Google::Cloud::Spanner::Transaction
       results = tx.execute_query "SELECT * FROM users"
     end
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -110,7 +110,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     timestamp = client.transaction do |tx|
       tx.update "users", [{ id: 1, name: "Charlie", active: false }]
     end
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -138,7 +138,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     timestamp = client.transaction do |tx|
       tx.insert "users", [{ id: 2, name: "Harvey",  active: true }]
     end
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -166,7 +166,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     timestamp = client.transaction do |tx|
       tx.upsert "users", [{ id: 3, name: "Marley",  active: false }]
     end
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -194,7 +194,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     timestamp = client.transaction do |tx|
       tx.save "users", [{ id: 3, name: "Marley",  active: false }]
     end
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -222,7 +222,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     timestamp = client.transaction do |tx|
       tx.replace "users", [{ id: 4, name: "Henry",  active: true }]
     end
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -253,7 +253,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     timestamp = client.transaction do |tx|
       tx.delete "users", [1, 2, 3, 4, 5]
     end
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -282,7 +282,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     timestamp = client.transaction do |tx|
       tx.delete "users", 1..100
     end
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -313,7 +313,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     timestamp = client.transaction do |tx|
       tx.delete "users", 5
     end
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -340,7 +340,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     timestamp = client.transaction do |tx|
       tx.delete "users"
     end
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -399,7 +399,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
       tx.replace "users", [{ id: 4, name: "Henry",  active: true }]
       tx.delete "users", [1, 2, 3, 4, 5]
     end
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     shutdown_client! client
 
@@ -407,35 +407,35 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/column_value_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/column_value_test.rb
@@ -18,8 +18,8 @@ describe Google::Cloud::Spanner::ColumnValue do
   it "creates an commit_timestamp" do
     column_value = Google::Cloud::Spanner::ColumnValue.commit_timestamp
 
-    column_value.must_be_kind_of Google::Cloud::Spanner::ColumnValue
-    column_value.type.must_equal :commit_timestamp
-    column_value.to_column_value.must_equal "spanner.commit_timestamp()"
+    _(column_value).must_be_kind_of Google::Cloud::Spanner::ColumnValue
+    _(column_value.type).must_equal :commit_timestamp
+    _(column_value.to_column_value).must_equal "spanner.commit_timestamp()"
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/duration_to_number_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/duration_to_number_test.rb
@@ -23,54 +23,54 @@ describe Google::Cloud::Spanner::Convert, :duration_to_number, :mock_spanner do
   it "converts an integer" do
     duration = Google::Protobuf::Duration.new seconds: 42, nanos: 0
     number = Google::Cloud::Spanner::Convert.duration_to_number duration
-    number.must_equal 42
+    _(number).must_equal 42
   end
 
   it "converts a negative integer" do
     duration = Google::Protobuf::Duration.new seconds: -42, nanos: 0
     number = Google::Cloud::Spanner::Convert.duration_to_number duration
-    number.must_equal -42
+    _(number).must_equal -42
   end
 
   it "converts a small number" do
     duration = Google::Protobuf::Duration.new seconds: 1, nanos: 500000000
     number = Google::Cloud::Spanner::Convert.duration_to_number duration
-    number.must_equal 1.5
+    _(number).must_equal 1.5
   end
 
   it "converts a negative small number" do
     duration = Google::Protobuf::Duration.new seconds: -1, nanos: -500000000
     number = Google::Cloud::Spanner::Convert.duration_to_number duration
-    number.must_equal -1.5
+    _(number).must_equal -1.5
   end
 
   it "converts a big number" do
     duration = Google::Protobuf::Duration.new seconds: 643383279502884, nanos: 197169399
     number = Google::Cloud::Spanner::Convert.duration_to_number duration
-    number.must_equal 643383279502884.197169399
+    _(number).must_equal 643383279502884.197169399
   end
 
   it "converts a negative big number" do
     duration = Google::Protobuf::Duration.new seconds: -643383279502884, nanos: -197169399
     number = Google::Cloud::Spanner::Convert.duration_to_number duration
-    number.must_equal -643383279502884.197169399
+    _(number).must_equal -643383279502884.197169399
   end
 
   it "converts pi" do
     duration = Google::Protobuf::Duration.new seconds: 3, nanos: 141592654
     number = Google::Cloud::Spanner::Convert.duration_to_number duration
-    number.must_equal 3.141592654
+    _(number).must_equal 3.141592654
   end
 
   it "converts a negative pi" do
     duration = Google::Protobuf::Duration.new seconds: -3, nanos: -141592654
     number = Google::Cloud::Spanner::Convert.duration_to_number duration
-    number.must_equal -3.141592654
+    _(number).must_equal -3.141592654
   end
 
   it "returns nil when given nil" do
     duration = nil
     number = Google::Cloud::Spanner::Convert.duration_to_number duration
-    number.must_be :nil?
+    _(number).must_be :nil?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/grpc_value_to_object_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/grpc_value_to_object_test.rb
@@ -24,105 +24,105 @@ describe Google::Cloud::Spanner::Convert, :grpc_value_to_object, :mock_spanner d
     value = Google::Protobuf::Value.new(bool_value: true)
     type = Google::Spanner::V1::Type.new(code: :BOOL)
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_equal true
+    _(raw).must_equal true
   end
 
   it "converts a INT64 value" do
     value = Google::Protobuf::Value.new(string_value: "29")
     type = Google::Spanner::V1::Type.new(code: :INT64)
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_equal 29
+    _(raw).must_equal 29
   end
 
   it "converts a FLOAT64 value" do
     value = Google::Protobuf::Value.new(number_value: 0.9)
     type = Google::Spanner::V1::Type.new(code: :FLOAT64)
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_equal 0.9
+    _(raw).must_equal 0.9
   end
 
   it "converts a FLOAT64 value (Infinity)" do
     value = Google::Protobuf::Value.new(string_value: "Infinity")
     type = Google::Spanner::V1::Type.new(code: :FLOAT64)
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_equal Float::INFINITY
+    _(raw).must_equal Float::INFINITY
   end
 
   it "converts a FLOAT64 value (-Infinity)" do
     value = Google::Protobuf::Value.new(string_value: "-Infinity")
     type = Google::Spanner::V1::Type.new(code: :FLOAT64)
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_equal -Float::INFINITY
+    _(raw).must_equal -Float::INFINITY
   end
 
   it "converts a FLOAT64 value (NaN)" do
     value = Google::Protobuf::Value.new(string_value: "NaN")
     type = Google::Spanner::V1::Type.new(code: :FLOAT64)
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_be :nan? # equality checks on Float::NAN fails
+    _(raw).must_be :nan? # equality checks on Float::NAN fails
   end
 
   it "converts a TIMESTAMP value" do
     value = Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z")
     type = Google::Spanner::V1::Type.new(code: :TIMESTAMP)
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_equal Time.parse("2017-01-02 03:04:05.06 UTC")
+    _(raw).must_equal Time.parse("2017-01-02 03:04:05.06 UTC")
   end
 
   it "converts a DATE value" do
     value = Google::Protobuf::Value.new(string_value: "2017-01-02")
     type = Google::Spanner::V1::Type.new(code: :DATE)
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_equal Date.parse("2017-01-02")
+    _(raw).must_equal Date.parse("2017-01-02")
   end
 
   it "converts a STRING value" do
     value = Google::Protobuf::Value.new(string_value: "Charlie")
     type = Google::Spanner::V1::Type.new(code: :STRING)
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_equal "Charlie"
+    _(raw).must_equal "Charlie"
   end
 
   it "converts a BYTES value" do
     value = Google::Protobuf::Value.new(string_value: Base64.encode64("contents"))
     type = Google::Spanner::V1::Type.new(code: :BYTES)
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_be_kind_of StringIO
-    raw.read.must_equal "contents"
+    _(raw).must_be_kind_of StringIO
+    _(raw.read).must_equal "contents"
   end
 
   it "converts an ARRAY of INT64 values" do
     value = Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")]))
     type = Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64))
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_equal [1, 2, 3]
+    _(raw).must_equal [1, 2, 3]
   end
 
   it "converts an ARRAY of STRING values" do
     value = Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "foo"), Google::Protobuf::Value.new(string_value: "bar"), Google::Protobuf::Value.new(string_value: "baz")]))
     type = Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRING))
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_equal %w(foo bar baz)
+    _(raw).must_equal %w(foo bar baz)
   end
 
   it "converts a simple STRUCT value" do
     value = Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "bar")]))
     type = Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "foo", type: Google::Spanner::V1::Type.new(code: :STRING))]))
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_equal Google::Cloud::Spanner::Fields.new(foo: :STRING).struct(foo: "bar")
+    _(raw).must_equal Google::Cloud::Spanner::Fields.new(foo: :STRING).struct(foo: "bar")
   end
 
   it "converts a complex STRUCT value" do
     value = Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ]))
     type = Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64))) ] ))
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_equal Google::Cloud::Spanner::Fields.new(env: :STRING, score: :FLOAT64, project_ids: [:INT64]).struct({env: "production", score: 0.9, project_ids: [1,2,3]})
+    _(raw).must_equal Google::Cloud::Spanner::Fields.new(env: :STRING, score: :FLOAT64, project_ids: [:INT64]).struct({env: "production", score: 0.9, project_ids: [1,2,3]})
   end
 
   it "converts an emtpy STRUCT value" do
     value = Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: []))
     type = Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: []))
     raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
-    raw.must_equal(Google::Cloud::Spanner::Fields.new([]).struct([]))
+    _(raw).must_equal(Google::Cloud::Spanner::Fields.new([]).struct([]))
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
@@ -24,71 +24,71 @@ describe Google::Cloud::Spanner::Convert, :number_to_duration, :mock_spanner do
   it "converts an Integer" do
     number = 42
     duration = Google::Cloud::Spanner::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
-    duration.seconds.must_equal 42
-    duration.nanos.must_equal 0
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal 42
+    _(duration.nanos).must_equal 0
   end
 
   it "converts a negative Integer" do
     number = -42
     duration = Google::Cloud::Spanner::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
-    duration.seconds.must_equal -42
-    duration.nanos.must_equal 0
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal -42
+    _(duration.nanos).must_equal 0
   end
 
   it "converts a Float" do
     number = 1.5
     duration = Google::Cloud::Spanner::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
-    duration.seconds.must_equal 1
-    duration.nanos.must_equal 500000000
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal 1
+    _(duration.nanos).must_equal 500000000
   end
 
   it "converts a negative Float" do
     number = -1.5
     duration = Google::Cloud::Spanner::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
-    duration.seconds.must_equal -1
-    duration.nanos.must_equal -500000000
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal -1
+    _(duration.nanos).must_equal -500000000
   end
 
   it "converts a BigDecimal" do
     number = BigDecimal "643383279502884.1971693993751058209749445923078164062"
     duration = Google::Cloud::Spanner::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
-    duration.seconds.must_equal 643383279502884
-    duration.nanos.must_equal 197169399
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal 643383279502884
+    _(duration.nanos).must_equal 197169399
   end
 
   it "converts a negative BigDecimal" do
     number = BigDecimal "-643383279502884.1971693993751058209749445923078164062"
     duration = Google::Cloud::Spanner::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
+    _(duration).must_be_kind_of Google::Protobuf::Duration
     # This should really be -643383279502884, but BigDecimal is doing something here...
-    duration.seconds.must_equal -643383279502885
-    duration.nanos.must_equal -197169399
+    _(duration.seconds).must_equal -643383279502885
+    _(duration.nanos).must_equal -197169399
   end
 
   it "converts a Rational" do
     number = Rational "3.14159265358979323846264338327950288419716939937510582097"
     duration = Google::Cloud::Spanner::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
-    duration.seconds.must_equal 3
-    duration.nanos.must_equal 141592654
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal 3
+    _(duration.nanos).must_equal 141592654
   end
 
   it "converts a negative Rational" do
     number = Rational "-3.14159265358979323846264338327950288419716939937510582097"
     duration = Google::Cloud::Spanner::Convert.number_to_duration number
-    duration.must_be_kind_of Google::Protobuf::Duration
-    duration.seconds.must_equal -3
-    duration.nanos.must_equal -141592654
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal -3
+    _(duration.nanos).must_equal -141592654
   end
 
   it "returns nil when given nil" do
     number = nil
     duration = Google::Cloud::Spanner::Convert.number_to_duration number
-    duration.must_be :nil?
+    _(duration).must_be :nil?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/timestamp_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/timestamp_test.rb
@@ -24,35 +24,35 @@ describe Google::Cloud::Spanner::Convert, :timestamp, :mock_spanner do
   it "converts a Time to a Timestamp" do
     time = Time.parse "2014-10-02T15:01:23.045123456Z"
     timestamp = Google::Cloud::Spanner::Convert.time_to_timestamp time
-    timestamp.must_be_kind_of Google::Protobuf::Timestamp
-    timestamp.seconds.must_equal 1412262083
-    timestamp.nanos.must_equal 45123456
+    _(timestamp).must_be_kind_of Google::Protobuf::Timestamp
+    _(timestamp.seconds).must_equal 1412262083
+    _(timestamp.nanos).must_equal 45123456
   end
 
   it "converts a DateTime to a Timestamp" do
     datetime = DateTime.parse "2014-10-02T15:01:23.045123456Z"
     timestamp = Google::Cloud::Spanner::Convert.time_to_timestamp datetime
-    timestamp.must_be_kind_of Google::Protobuf::Timestamp
-    timestamp.seconds.must_equal 1412262083
-    timestamp.nanos.must_equal 45123456
+    _(timestamp).must_be_kind_of Google::Protobuf::Timestamp
+    _(timestamp.seconds).must_equal 1412262083
+    _(timestamp.nanos).must_equal 45123456
   end
 
   it "converts an empty Time to an empty Timestamp" do
     time = nil
     timestamp = Google::Cloud::Spanner::Convert.time_to_timestamp time
-    timestamp.must_be :nil?
+    _(timestamp).must_be :nil?
   end
 
   it "converts a Timestamp to a Time" do
     timestamp = Google::Protobuf::Timestamp.new seconds: 1412262083, nanos: 45123456
     time = Google::Cloud::Spanner::Convert.timestamp_to_time timestamp
-    time.must_be_kind_of Time
-    time.must_equal Time.parse("2014-10-02T15:01:23.045123456Z")
+    _(time).must_be_kind_of Time
+    _(time).must_equal Time.parse("2014-10-02T15:01:23.045123456Z")
   end
 
   it "converts an empty Timestamp to an empty Time" do
     timestamp = nil
     time = Google::Cloud::Spanner::Convert.timestamp_to_time timestamp
-    time.must_be :nil?
+    _(time).must_be :nil?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/to_key_range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/to_key_range_test.rb
@@ -24,65 +24,65 @@ describe Google::Cloud::Spanner::Convert, :to_key_range, :mock_spanner do
     range = Google::Cloud::Spanner::Range.new 1, 100
     key_range = Google::Cloud::Spanner::Convert.to_key_range range
 
-    key_range.must_be_kind_of Google::Spanner::V1::KeyRange
-    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
-    key_range.start_open.must_be :nil?
-    key_range.end_closed.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
-    key_range.end_open.must_be :nil?
+    _(key_range).must_be_kind_of Google::Spanner::V1::KeyRange
+    _(key_range.start_closed).must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
+    _(key_range.start_open).must_be :nil?
+    _(key_range.end_closed).must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
+    _(key_range.end_open).must_be :nil?
   end
 
   it "creates an exclusive Spanner::Range" do
     range = Google::Cloud::Spanner::Range.new 1, 100, exclude_begin: true, exclude_end: true
     key_range = Google::Cloud::Spanner::Convert.to_key_range range
 
-    key_range.must_be_kind_of Google::Spanner::V1::KeyRange
-    key_range.start_closed.must_be :nil?
-    key_range.start_open.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
-    key_range.end_closed.must_be :nil?
-    key_range.end_open.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
+    _(key_range).must_be_kind_of Google::Spanner::V1::KeyRange
+    _(key_range.start_closed).must_be :nil?
+    _(key_range.start_open).must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
+    _(key_range.end_closed).must_be :nil?
+    _(key_range.end_open).must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
   end
 
   it "creates a Spanner::Range that excludes beginning" do
     range = Google::Cloud::Spanner::Range.new 1, 100, exclude_begin: true
     key_range = Google::Cloud::Spanner::Convert.to_key_range range
 
-    key_range.must_be_kind_of Google::Spanner::V1::KeyRange
-    key_range.start_closed.must_be :nil?
-    key_range.start_open.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
-    key_range.end_closed.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
-    key_range.end_open.must_be :nil?
+    _(key_range).must_be_kind_of Google::Spanner::V1::KeyRange
+    _(key_range.start_closed).must_be :nil?
+    _(key_range.start_open).must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
+    _(key_range.end_closed).must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
+    _(key_range.end_open).must_be :nil?
   end
 
   it "creates a Spanner::Range that excludes ending" do
     range = Google::Cloud::Spanner::Range.new 1, 100, exclude_end: true
     key_range = Google::Cloud::Spanner::Convert.to_key_range range
 
-    key_range.must_be_kind_of Google::Spanner::V1::KeyRange
-    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
-    key_range.start_open.must_be :nil?
-    key_range.end_closed.must_be :nil?
-    key_range.end_open.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
+    _(key_range).must_be_kind_of Google::Spanner::V1::KeyRange
+    _(key_range.start_closed).must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
+    _(key_range.start_open).must_be :nil?
+    _(key_range.end_closed).must_be :nil?
+    _(key_range.end_open).must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
   end
 
   it "creates an inclusive Range" do
     range = 1..100
     key_range = Google::Cloud::Spanner::Convert.to_key_range range
 
-    key_range.must_be_kind_of Google::Spanner::V1::KeyRange
-    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
-    key_range.start_open.must_be :nil?
-    key_range.end_closed.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
-    key_range.end_open.must_be :nil?
+    _(key_range).must_be_kind_of Google::Spanner::V1::KeyRange
+    _(key_range.start_closed).must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
+    _(key_range.start_open).must_be :nil?
+    _(key_range.end_closed).must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
+    _(key_range.end_open).must_be :nil?
   end
 
   it "creates a Range that excludes ending" do
     range = 1...100
     key_range = Google::Cloud::Spanner::Convert.to_key_range range
 
-    key_range.must_be_kind_of Google::Spanner::V1::KeyRange
-    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
-    key_range.start_open.must_be :nil?
-    key_range.end_closed.must_be :nil?
-    key_range.end_open.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
+    _(key_range).must_be_kind_of Google::Spanner::V1::KeyRange
+    _(key_range.start_closed).must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
+    _(key_range.start_open).must_be :nil?
+    _(key_range.end_closed).must_be :nil?
+    _(key_range.end_open).must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/to_query_params_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/to_query_params_test.rb
@@ -22,55 +22,55 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
 
   it "converts a bool value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params active: true
-    combined_params.must_equal({ "active" => [Google::Protobuf::Value.new(bool_value: true),
+    _(combined_params).must_equal({ "active" => [Google::Protobuf::Value.new(bool_value: true),
                                               Google::Spanner::V1::Type.new(code: :BOOL)] })
   end
 
   it "converts a nil bool value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({active: nil}, {active: :BOOL})
-    combined_params.must_equal({ "active" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+    _(combined_params).must_equal({ "active" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
                                               Google::Spanner::V1::Type.new(code: :BOOL)] })
   end
 
   it "converts a int value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params age: 29
-    combined_params.must_equal({ "age" => [Google::Protobuf::Value.new(string_value: "29"),
+    _(combined_params).must_equal({ "age" => [Google::Protobuf::Value.new(string_value: "29"),
                                            Google::Spanner::V1::Type.new(code: :INT64)] })
   end
 
   it "converts a nil int value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({age: nil}, {age: :INT64})
-    combined_params.must_equal({ "age" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+    _(combined_params).must_equal({ "age" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
                                            Google::Spanner::V1::Type.new(code: :INT64)] })
   end
 
   it "converts a float value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params score: 0.9
-    combined_params.must_equal({ "score" => [Google::Protobuf::Value.new(number_value: 0.9),
+    _(combined_params).must_equal({ "score" => [Google::Protobuf::Value.new(number_value: 0.9),
                                              Google::Spanner::V1::Type.new(code: :FLOAT64)] })
   end
 
   it "converts a float value (Infinity)" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params score: Float::INFINITY
-    combined_params.must_equal({ "score" => [Google::Protobuf::Value.new(string_value: "Infinity"),
+    _(combined_params).must_equal({ "score" => [Google::Protobuf::Value.new(string_value: "Infinity"),
                                              Google::Spanner::V1::Type.new(code: :FLOAT64)] })
   end
 
   it "converts a float value (-Infinity)" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params score: -Float::INFINITY
-    combined_params.must_equal({ "score" => [Google::Protobuf::Value.new(string_value: "-Infinity"),
+    _(combined_params).must_equal({ "score" => [Google::Protobuf::Value.new(string_value: "-Infinity"),
                                              Google::Spanner::V1::Type.new(code: :FLOAT64)] })
   end
 
   it "converts a float value (NaN)" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params score: Float::NAN
-    combined_params.must_equal({ "score" => [Google::Protobuf::Value.new(string_value: "NaN"),
+    _(combined_params).must_equal({ "score" => [Google::Protobuf::Value.new(string_value: "NaN"),
                                              Google::Spanner::V1::Type.new(code: :FLOAT64)] })
   end
 
   it "converts a nil float value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({score: nil}, {score: :FLOAT64})
-    combined_params.must_equal({ "score" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+    _(combined_params).must_equal({ "score" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
                                              Google::Spanner::V1::Type.new(code: :FLOAT64)] })
   end
 
@@ -78,7 +78,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     combined_params = Google::Cloud::Spanner::Convert.to_query_params updated_at: timestamp
-    combined_params.must_equal({ "updated_at" => [Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z"),
+    _(combined_params).must_equal({ "updated_at" => [Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z"),
                                                   Google::Spanner::V1::Type.new(code: :TIMESTAMP)] })
   end
 
@@ -86,13 +86,13 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
     timestamp = DateTime.parse "2017-01-01 20:04:05.06 -0700"
 
     combined_params = Google::Cloud::Spanner::Convert.to_query_params updated_at: timestamp
-    combined_params.must_equal({ "updated_at" => [Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z"),
+    _(combined_params).must_equal({ "updated_at" => [Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z"),
                                                   Google::Spanner::V1::Type.new(code: :TIMESTAMP)] })
   end
 
   it "converts a nil value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({updated_at: nil}, {updated_at: :TIMESTAMP})
-    combined_params.must_equal({ "updated_at" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+    _(combined_params).must_equal({ "updated_at" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
                                                   Google::Spanner::V1::Type.new(code: :TIMESTAMP)] })
   end
 
@@ -100,31 +100,31 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
     date = Date.parse "2017-01-02"
 
     combined_params = Google::Cloud::Spanner::Convert.to_query_params birthday: date
-    combined_params.must_equal({ "birthday" => [Google::Protobuf::Value.new(string_value: "2017-01-02"),
+    _(combined_params).must_equal({ "birthday" => [Google::Protobuf::Value.new(string_value: "2017-01-02"),
                                                 Google::Spanner::V1::Type.new(code: :DATE)] })
   end
 
   it "converts a nil Date value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({birthday: nil}, {birthday: :DATE})
-    combined_params.must_equal({ "birthday" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+    _(combined_params).must_equal({ "birthday" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
                                                 Google::Spanner::V1::Type.new(code: :DATE)] })
   end
 
   it "converts a String value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params name: "Charlie"
-    combined_params.must_equal({ "name" => [Google::Protobuf::Value.new(string_value: "Charlie"),
+    _(combined_params).must_equal({ "name" => [Google::Protobuf::Value.new(string_value: "Charlie"),
                                             Google::Spanner::V1::Type.new(code: :STRING)] })
   end
 
   it "converts a Symbol value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params name: :foo
-    combined_params.must_equal({ "name" => [Google::Protobuf::Value.new(string_value: "foo"),
+    _(combined_params).must_equal({ "name" => [Google::Protobuf::Value.new(string_value: "foo"),
                                             Google::Spanner::V1::Type.new(code: :STRING)] })
   end
 
   it "converts a nil String value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({name: nil}, {name: :STRING})
-    combined_params.must_equal({ "name" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+    _(combined_params).must_equal({ "name" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
                                             Google::Spanner::V1::Type.new(code: :STRING)] })
   end
 
@@ -132,13 +132,13 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
     file = StringIO.new "contents"
 
     combined_params = Google::Cloud::Spanner::Convert.to_query_params avatar: file
-    combined_params.must_equal({ "avatar" => [Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")),
+    _(combined_params).must_equal({ "avatar" => [Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")),
                                               Google::Spanner::V1::Type.new(code: :BYTES)] })
   end
 
   it "converts a nil IO-ish value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({avatar: nil}, {avatar: :BYTES})
-    combined_params.must_equal({ "avatar" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+    _(combined_params).must_equal({ "avatar" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
                                               Google::Spanner::V1::Type.new(code: :BYTES)] })
   end
 
@@ -146,19 +146,19 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
     array = [1, 2, 3]
 
     combined_params = Google::Cloud::Spanner::Convert.to_query_params list: array
-    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])),
+    _(combined_params).must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])),
                                             Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64))] })
   end
 
   it "converts an empty Array of Integer values" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({list: []}, {list: [:INT64]})
-    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])),
+    _(combined_params).must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])),
                                             Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64))] })
   end
 
   it "converts a nil Array of Integer values" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({list: nil}, {list: [:INT64]})
-    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+    _(combined_params).must_equal({ "list" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
                                             Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64))] })
   end
 
@@ -166,19 +166,19 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
     array = %w(foo bar baz)
 
     combined_params = Google::Cloud::Spanner::Convert.to_query_params list: array
-    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "foo"), Google::Protobuf::Value.new(string_value: "bar"), Google::Protobuf::Value.new(string_value: "baz")])),
+    _(combined_params).must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "foo"), Google::Protobuf::Value.new(string_value: "bar"), Google::Protobuf::Value.new(string_value: "baz")])),
                                             Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRING))] })
   end
 
   it "converts an empty Array of String values" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({list: []}, list: [:STRING])
-    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])),
+    _(combined_params).must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])),
                                             Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRING))] })
   end
 
   it "converts a nil Array of String values" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({list: nil}, {list: [:STRING]})
-    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+    _(combined_params).must_equal({ "list" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
                                             Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRING))] })
   end
 
@@ -188,61 +188,61 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
     foo, bar, baz = %w[ foo bar baz ].map {|raw| Base64.strict_encode64(raw) }
 
     combined_params = Google::Cloud::Spanner::Convert.to_query_params list: array
-    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: foo), Google::Protobuf::Value.new(string_value: bar), Google::Protobuf::Value.new(string_value: baz)])),
+    _(combined_params).must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: foo), Google::Protobuf::Value.new(string_value: bar), Google::Protobuf::Value.new(string_value: baz)])),
                                             Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :BYTES))] })
   end
 
   it "converts an empty Array of IO-ish values" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({list: []}, list: [:BYTES])
-    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])),
+    _(combined_params).must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])),
                                             Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :BYTES))] })
   end
 
   it "converts a nil Array of IO-ish values" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({list: nil}, {list: [:BYTES]})
-    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+    _(combined_params).must_equal({ "list" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
                                             Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :BYTES))] })
   end
 
   it "converts a simple Hash value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params settings: { foo: :bar }
-    combined_params.must_equal({ "settings" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "bar")])),
+    _(combined_params).must_equal({ "settings" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "bar")])),
                                                 Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "foo", type: Google::Spanner::V1::Type.new(code: :STRING))]))] })
   end
 
   it "converts a complex Hash value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params settings: { env: "production", score: 0.9, project_ids: [1,2,3] }
-    combined_params.must_equal({ "settings" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])),
+    _(combined_params).must_equal({ "settings" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])),
                                                 Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64))) ] ))] })
   end
 
   it "converts an emtpy Hash value" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params settings: {}
-    combined_params.must_equal({ "settings" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])),
+    _(combined_params).must_equal({ "settings" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])),
                                                 Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: []))] })
   end
 
   it "converts an empty Array of Data values" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({list: []}, list: [fields(foo: :STRING)])
-    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])),
+    _(combined_params).must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])),
                                             Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "foo", type: Google::Spanner::V1::Type.new(code: :STRING))])))] })
   end
 
   it "converts a nil Array of Data values" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params({list: nil}, list: [fields(foo: :STRING)])
-    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+    _(combined_params).must_equal({ "list" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
                                             Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "foo", type: Google::Spanner::V1::Type.new(code: :STRING))])))] })
   end
 
   it "converts an Array of simple Data values" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params list: [{ foo: :bar }]
-    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "bar")]))])),
+    _(combined_params).must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "bar")]))])),
                                             Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT,struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "foo", type: Google::Spanner::V1::Type.new(code: :STRING))]))) ]})
   end
 
   it "converts an Array complex Data values" do
     combined_params = Google::Cloud::Spanner::Convert.to_query_params list: [{ env: "production", score: 0.9, project_ids: [1,2,3] }]
-    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")]))]))])),
+    _(combined_params).must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")]))]))])),
                                             Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))]))) ]})
   end
 
@@ -255,7 +255,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: { threadf: 1, userf: "bob" }, p4: 10 }
         types = nil
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -293,7 +293,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: { threadf: 1, userf: "bob" }, p4: 10 }
         types = { struct_param: fields, p4: :INT64 }
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -332,7 +332,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: data, p4: 10 }
         types = nil
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -375,7 +375,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: nil }
         types = { struct_param: fields }
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(null_value: :NULL_VALUE),
             Google::Spanner::V1::Type.new(
@@ -406,7 +406,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: { structf: { nestedf: "bob" } } }
         types = nil
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -451,7 +451,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: { structf: { nestedf: "bob" } } }
         types = { struct_param: fields }
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -497,7 +497,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: data }
         types = nil
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -547,7 +547,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: nil }
         types = { struct_param: fields }
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(null_value: :NULL_VALUE),
             Google::Spanner::V1::Type.new(
@@ -584,7 +584,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: {} }
         types = nil
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -606,7 +606,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: {} }
         types = { struct_param: fields }
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -629,7 +629,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: data }
         types = nil
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -656,7 +656,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: nil }
         types = { struct_param: fields }
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(null_value: :NULL_VALUE),
             Google::Spanner::V1::Type.new(
@@ -679,7 +679,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: { f1: nil } }
         types = { struct_param: fields }
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -709,7 +709,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: data }
         types = nil
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -742,7 +742,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: { threadf: 1, userf: "bob" } }
         types = nil
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -776,7 +776,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: { threadf: 1, userf: "bob" } }
         types = { struct_param: fields }
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -811,7 +811,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: data }
         types = nil
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -849,7 +849,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_arr_param: [{ threadf: 1, userf: "bob" }] }
         types = nil
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_arr_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -892,7 +892,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_arr_param: [{ threadf: 1, userf: "bob" }] }
         types = { struct_arr_param: [fields] }
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_arr_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -936,7 +936,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_arr_param: [data] }
         types = nil
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_arr_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -985,7 +985,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: { intf: 10, arraysf: nil } }
         types = { struct_param: fields }
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -1033,7 +1033,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_param: data }
         types = { struct_param: fields }
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_param" => [
             Google::Protobuf::Value.new(
               list_value: Google::Protobuf::ListValue.new(
@@ -1085,7 +1085,7 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
         params = { struct_arr_param: nil }
         types = { struct_arr_param: [fields] }
         combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
-        combined_params.must_equal({
+        _(combined_params).must_equal({
           "struct_arr_param" => [
             Google::Protobuf::Value.new(null_value: :NULL_VALUE),
             Google::Spanner::V1::Type.new(

--- a/google-cloud-spanner/test/google/cloud/spanner/database/backup_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/backup_test.rb
@@ -47,7 +47,7 @@ describe Google::Cloud::Spanner::Database, :backups, :mock_spanner do
 
     mock.verify
 
-    backups.size.must_equal 3
+    _(backups.size).must_equal 3
   end
 
   it "paginates backups with page size" do
@@ -60,7 +60,7 @@ describe Google::Cloud::Spanner::Database, :backups, :mock_spanner do
 
     mock.verify
 
-    backups.size.must_equal 3
+    _(backups.size).must_equal 3
   end
 
   it "paginates backups with next? and next" do
@@ -73,10 +73,10 @@ describe Google::Cloud::Spanner::Database, :backups, :mock_spanner do
 
     mock.verify
 
-    list.size.must_equal 3
-    list.next?.must_equal true
-    list.next.size.must_equal 2
-    list.next?.must_equal false
+    _(list.size).must_equal 3
+    _(list.next?).must_equal true
+    _(list.next.size).must_equal 2
+    _(list.next?).must_equal false
   end
 
   it "paginates backups with next? and next and page size" do
@@ -89,10 +89,10 @@ describe Google::Cloud::Spanner::Database, :backups, :mock_spanner do
 
     mock.verify
 
-    list.size.must_equal 3
-    list.next?.must_equal true
-    list.next.size.must_equal 2
-    list.next?.must_equal false
+    _(list.size).must_equal 3
+    _(list.next?).must_equal true
+    _(list.next.size).must_equal 2
+    _(list.next?).must_equal false
   end
 
   it "paginates backups with all" do
@@ -105,7 +105,7 @@ describe Google::Cloud::Spanner::Database, :backups, :mock_spanner do
 
     mock.verify
 
-    backups.size.must_equal 5
+    _(backups.size).must_equal 5
   end
 
   it "paginates backups with all and page size" do
@@ -118,7 +118,7 @@ describe Google::Cloud::Spanner::Database, :backups, :mock_spanner do
 
     mock.verify
 
-    backups.size.must_equal 5
+    _(backups.size).must_equal 5
   end
 
   it "iterates backups with all using Enumerator" do
@@ -131,6 +131,6 @@ describe Google::Cloud::Spanner::Database, :backups, :mock_spanner do
 
     mock.verify
 
-    backups.size.must_equal 5
+    _(backups.size).must_equal 5
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/database/create_backup_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/create_backup_test.rb
@@ -163,8 +163,8 @@ describe Google::Cloud::Spanner::Backup, :create_backup, :mock_spanner do
 
     spanner.service.mocked_databases = stub
 
-    _ { proc {
+    assert_raises Google::Cloud::Error do
       database.create_backup backup_id, Time.now - 36000
-    } }.must_raise Google::Cloud::Error
+    end 
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/database/create_backup_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/create_backup_test.rb
@@ -96,23 +96,23 @@ describe Google::Cloud::Spanner::Backup, :create_backup, :mock_spanner do
 
     job = database.create_backup backup_id, expire_time
 
-    job.must_be_kind_of Google::Cloud::Spanner::Backup::Job
-    job.wont_be :done?
-    job.wont_be :error?
-    job.error.must_be :nil?
-    job.backup.must_be :nil?
-    job.start_time.must_be_kind_of Time
-    job.end_time.must_be :nil?
-    job.progress_percent.must_equal 0
+    _(job).must_be_kind_of Google::Cloud::Spanner::Backup::Job
+    _(job).wont_be :done?
+    _(job).wont_be :error?
+    _(job.error).must_be :nil?
+    _(job.backup).must_be :nil?
+    _(job.start_time).must_be_kind_of Time
+    _(job.end_time).must_be :nil?
+    _(job.progress_percent).must_equal 0
 
     job.reload!
     backup = job.backup
-    backup.wont_be :nil?
-    backup.must_be_kind_of Google::Cloud::Spanner::Backup
-    job.start_time.must_be_kind_of Time
-    job.end_time.must_be_kind_of Time
-    job.cancel_time.must_be :nil?
-    job.progress_percent.must_equal 100
+    _(backup).wont_be :nil?
+    _(backup).must_be_kind_of Google::Cloud::Spanner::Backup
+    _(job.start_time).must_be_kind_of Time
+    _(job.end_time).must_be_kind_of Time
+    _(job.cancel_time).must_be :nil?
+    _(job.progress_percent).must_equal 100
 
     mock.verify
   end
@@ -140,16 +140,16 @@ describe Google::Cloud::Spanner::Backup, :create_backup, :mock_spanner do
 
     job = database.create_backup backup_id, expire_time
 
-    job.must_be_kind_of Google::Cloud::Spanner::Backup::Job
-    job.wont_be :done?
-    job.cancel.must_be_nil
+    _(job).must_be_kind_of Google::Cloud::Spanner::Backup::Job
+    _(job).wont_be :done?
+    _(job.cancel).must_be_nil
 
     job.reload!
-    job.must_be :done?
-    job.start_time.must_be_kind_of Time
-    job.end_time.must_be_kind_of Time
-    job.cancel_time.must_be_kind_of Time
-    job.progress_percent.must_equal 100
+    _(job).must_be :done?
+    _(job.start_time).must_be_kind_of Time
+    _(job.end_time).must_be_kind_of Time
+    _(job.cancel_time).must_be_kind_of Time
+    _(job.progress_percent).must_equal 100
 
     mock.verify
   end
@@ -163,8 +163,8 @@ describe Google::Cloud::Spanner::Backup, :create_backup, :mock_spanner do
 
     spanner.service.mocked_databases = stub
 
-    proc {
+    _ { proc {
       database.create_backup backup_id, Time.now - 36000
-    }.must_raise Google::Cloud::Error
+    } }.must_raise Google::Cloud::Error
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/database/database_operations_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/database_operations_test.rb
@@ -86,19 +86,19 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
     database.service.mocked_databases = mock
 
     jobs = database.database_operations
-    jobs.size.must_equal 3
+    _(jobs.size).must_equal 3
 
     jobs.each do |job|
-      job.must_be_kind_of Google::Cloud::Spanner::Database::Job
-      job.wont_be :done?
-      job.wont_be :error?
-      job.error.must_be :nil?
-      job.database.must_be :nil?
+      _(job).must_be_kind_of Google::Cloud::Spanner::Database::Job
+      _(job).wont_be :done?
+      _(job).wont_be :error?
+      _(job.error).must_be :nil?
+      _(job.database).must_be :nil?
       job.reload!
 
       database = job.database
-      database.wont_be :nil?
-      database.must_be_kind_of Google::Cloud::Spanner::Database
+      _(database).wont_be :nil?
+      _(database).must_be_kind_of Google::Cloud::Spanner::Database
     end
 
     mock.verify
@@ -116,19 +116,19 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
     database.service.mocked_databases = mock
 
     jobs = database.database_operations page_size: 3
-    jobs.size.must_equal 3
+    _(jobs.size).must_equal 3
 
     jobs.each do |job|
-      job.must_be_kind_of Google::Cloud::Spanner::Database::Job
-      job.wont_be :done?
-      job.wont_be :error?
-      job.error.must_be :nil?
-      job.database.must_be :nil?
+      _(job).must_be_kind_of Google::Cloud::Spanner::Database::Job
+      _(job).wont_be :done?
+      _(job).wont_be :error?
+      _(job.error).must_be :nil?
+      _(job.database).must_be :nil?
       job.reload!
 
       database = job.database
-      database.wont_be :nil?
-      database.must_be_kind_of Google::Cloud::Spanner::Database
+      _(database).wont_be :nil?
+      _(database).must_be_kind_of Google::Cloud::Spanner::Database
     end
 
     mock.verify
@@ -145,10 +145,10 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
 
     jobs = database.database_operations
 
-    jobs.size.must_equal 3
-    jobs.next?.must_equal true
-    jobs.next.size.must_equal 2
-    jobs.next?.must_equal false
+    _(jobs.size).must_equal 3
+    _(jobs.next?).must_equal true
+    _(jobs.next.size).must_equal 2
+    _(jobs.next?).must_equal false
 
     mock.verify
   end
@@ -166,7 +166,7 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
 
     mock.verify
 
-    jobs.size.must_equal 5
+    _(jobs.size).must_equal 5
   end
 
   it "paginates database operations with all and page size" do
@@ -182,7 +182,7 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
 
     mock.verify
 
-    jobs.size.must_equal 5
+    _(jobs.size).must_equal 5
   end
 
   it "iterates database operations with all using Enumerator" do
@@ -198,7 +198,7 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
 
     mock.verify
 
-    jobs.size.must_equal 5
+    _(jobs.size).must_equal 5
   end
 
   it "paginates database operations with filter" do
@@ -216,7 +216,7 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
 
     mock.verify
 
-    jobs.size.must_equal 3
+    _(jobs.size).must_equal 3
   end
 
   it "paginates database operations with filter and page size" do
@@ -234,6 +234,6 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
 
     mock.verify
 
-    jobs.size.must_equal 3
+    _(jobs.size).must_equal 3
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/database/ddl_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/ddl_test.rb
@@ -33,11 +33,11 @@ describe Google::Cloud::Spanner::Database, :ddl, :mock_spanner do
 
     mock.verify
 
-    ddl.must_equal statements
+    _(ddl).must_equal statements
 
     # The results are cached, second call does not raise
     ddl2 = database.ddl
-    ddl2.must_equal ddl
+    _(ddl2).must_equal ddl
   end
 
   it "forces an API request" do
@@ -45,7 +45,7 @@ describe Google::Cloud::Spanner::Database, :ddl, :mock_spanner do
 
     # The results are cached, this does not make an API request
     cached_ddl = database.ddl
-    cached_ddl.must_equal statements
+    _(cached_ddl).must_equal statements
 
     update_res = Google::Spanner::Admin::Database::V1::GetDatabaseDdlResponse.new(
       statements: statements.reverse
@@ -58,6 +58,6 @@ describe Google::Cloud::Spanner::Database, :ddl, :mock_spanner do
 
     mock.verify
 
-    ddl.must_equal statements.reverse
+    _(ddl).must_equal statements.reverse
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/database/iam_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/iam_test.rb
@@ -54,14 +54,14 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Spanner::Policy
-    policy.etag.must_equal "\b\x01"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be_kind_of Array
-    policy.roles["roles/viewer"].count.must_equal 2
-    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    _(policy).must_be_kind_of Google::Cloud::Spanner::Policy
+    _(policy.etag).must_equal "\b\x01"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be_kind_of Array
+    _(policy.roles["roles/viewer"].count).must_equal 2
+    _(policy.roles["roles/viewer"].first).must_equal "user:viewer@example.com"
+    _(policy.roles["roles/viewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "sets the IAM Policy" do
@@ -87,15 +87,15 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Spanner::Policy
-    policy.etag.must_equal "\b\x10"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-    policy.roles["roles/owner"].last.must_equal  "user:newowner@example.com"
+    _(policy).must_be_kind_of Google::Cloud::Spanner::Policy
+    _(policy.etag).must_equal "\b\x10"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be :nil?
+    _(policy.roles["roles/owner"]).must_be_kind_of Array
+    _(policy.roles["roles/owner"].count).must_equal 2
+    _(policy.roles["roles/owner"].first).must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    _(policy.roles["roles/owner"].last).must_equal  "user:newowner@example.com"
   end
 
   it "sets the IAM Policy in a block" do
@@ -120,15 +120,15 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Spanner::Policy
-    policy.etag.must_equal "\b\x10"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-    policy.roles["roles/owner"].last.must_equal  "user:newowner@example.com"
+    _(policy).must_be_kind_of Google::Cloud::Spanner::Policy
+    _(policy.etag).must_equal "\b\x10"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be :nil?
+    _(policy.roles["roles/owner"]).must_be_kind_of Array
+    _(policy.roles["roles/owner"].count).must_equal 2
+    _(policy.roles["roles/owner"].first).must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    _(policy.roles["roles/owner"].last).must_equal  "user:newowner@example.com"
   end
 
   it "tests the available permissions" do
@@ -145,6 +145,6 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
 
     mock.verify
 
-    permissions.must_equal ["spanner.databases.get"]
+    _(permissions).must_equal ["spanner.databases.get"]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/database/update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/update_test.rb
@@ -44,8 +44,8 @@ describe Google::Cloud::Spanner::Database, :update, :mock_spanner do
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Spanner::Database::Job
-    job.wont_be :done?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Database::Job
+    _(job).wont_be :done?
   end
 
   it "updates with multiple statements" do
@@ -63,8 +63,8 @@ describe Google::Cloud::Spanner::Database, :update, :mock_spanner do
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Spanner::Database::Job
-    job.wont_be :done?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Database::Job
+    _(job).wont_be :done?
   end
 
   it "updates with operation_id" do
@@ -82,7 +82,7 @@ describe Google::Cloud::Spanner::Database, :update, :mock_spanner do
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Spanner::Database::Job
-    job.wont_be :done?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Database::Job
+    _(job).wont_be :done?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database_test.rb
@@ -34,28 +34,28 @@ describe Google::Cloud::Spanner::Instance, :mock_spanner do
   let(:database) { Google::Cloud::Spanner::Database.from_grpc database_grpc, spanner.service }
 
   it "knows the identifiers" do
-    database.must_be_kind_of Google::Cloud::Spanner::Database
-    database.project_id.must_equal project
-    database.instance_id.must_equal instance_id
-    database.database_id.must_equal database_id
+    _(database).must_be_kind_of Google::Cloud::Spanner::Database
+    _(database.project_id).must_equal project
+    _(database.instance_id).must_equal instance_id
+    _(database.database_id).must_equal database_id
 
-    database.state.must_equal :READY
-    database.must_be :ready?
-    database.wont_be :creating?
+    _(database.state).must_equal :READY
+    _(database).must_be :ready?
+    _(database).wont_be :creating?
 
     restore_info = database.restore_info
-    restore_info.must_be_kind_of Google::Cloud::Spanner::Database::RestoreInfo
-    restore_info.source_type.must_equal :BACKUP
-    restore_info.must_be :source_backup?
+    _(restore_info).must_be_kind_of Google::Cloud::Spanner::Database::RestoreInfo
+    _(restore_info.source_type).must_equal :BACKUP
+    _(restore_info).must_be :source_backup?
 
     backup_info = restore_info.backup_info
-    backup_info.must_be_kind_of Google::Cloud::Spanner::Database::BackupInfo
-    backup_info.project_id.must_equal project
-    backup_info.instance_id.must_equal instance_id
-    backup_info.backup_id.must_equal backup_id
-    backup_info.source_database_project_id.must_equal project
-    backup_info.source_database_instance_id.must_equal instance_id
-    backup_info.source_database_id.must_equal source_database_id
-    backup_info.create_time.must_be_kind_of Time
+    _(backup_info).must_be_kind_of Google::Cloud::Spanner::Database::BackupInfo
+    _(backup_info.project_id).must_equal project
+    _(backup_info.instance_id).must_equal instance_id
+    _(backup_info.backup_id).must_equal backup_id
+    _(backup_info.source_database_project_id).must_equal project
+    _(backup_info.source_database_instance_id).must_equal instance_id
+    _(backup_info.source_database_id).must_equal source_database_id
+    _(backup_info.create_time).must_be_kind_of Time
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/fields/deeply_nested_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/fields/deeply_nested_struct_test.rb
@@ -24,78 +24,78 @@ describe Google::Cloud::Spanner::Fields, :deeply_nested_struct do
                          birthday: Date.parse("1950-01-01"), avatar: StringIO.new("image"),
                          project_ids: [1, 2, 3]
 
-    data.must_be_kind_of Google::Cloud::Spanner::Data
+    _(data).must_be_kind_of Google::Cloud::Spanner::Data
 
-    data.fields.wont_be :nil?
-    data.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    data.fields.keys.count.must_equal 9
-    data.fields.to_h.must_equal({ id: :INT64, name: :STRING, active: :BOOL, age: :INT64,
+    _(data.fields).wont_be :nil?
+    _(data.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(data.fields.keys.count).must_equal 9
+    _(data.fields.to_h).must_equal({ id: :INT64, name: :STRING, active: :BOOL, age: :INT64,
                                  score: :FLOAT64, updated_at: :TIMESTAMP, birthday: :DATE,
                                  avatar: :BYTES, project_ids: [:INT64] })
 
-    data.fields.to_s.wont_be :empty?
-    data.fields.inspect.must_match /Google::Cloud::Spanner::Fields/
+    _(data.fields.to_s).wont_be :empty?
+    _(data.fields.inspect).must_match /Google::Cloud::Spanner::Fields/
 
-    data.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(data.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
     data_values = data.values
-    data_values[0].must_equal 1
-    data_values[1].must_equal "Charlie"
-    data_values[2].must_equal true
-    data_values[3].must_equal 29
-    data_values[4].must_equal 0.9
-    data_values[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    data_values[6].must_equal Date.parse("1950-01-01")
-    data_values[7].must_be_kind_of StringIO
-    data_values[7].read.must_equal "image"
-    data_values[8].must_equal [1, 2, 3]
+    _(data_values[0]).must_equal 1
+    _(data_values[1]).must_equal "Charlie"
+    _(data_values[2]).must_equal true
+    _(data_values[3]).must_equal 29
+    _(data_values[4]).must_equal 0.9
+    _(data_values[5]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(data_values[6]).must_equal Date.parse("1950-01-01")
+    _(data_values[7]).must_be_kind_of StringIO
+    _(data_values[7].read).must_equal "image"
+    _(data_values[8]).must_equal [1, 2, 3]
 
-    data[:id].must_equal 1
-    data[:name].must_equal "Charlie"
-    data[:active].must_equal true
-    data[:age].must_equal 29
-    data[:score].must_equal 0.9
-    data[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    data[:birthday].must_equal Date.parse("1950-01-01")
-    data[:avatar].must_be_kind_of StringIO
-    data[:avatar].read.must_equal "image"
-    data[:project_ids].must_equal [1, 2, 3]
+    _(data[:id]).must_equal 1
+    _(data[:name]).must_equal "Charlie"
+    _(data[:active]).must_equal true
+    _(data[:age]).must_equal 29
+    _(data[:score]).must_equal 0.9
+    _(data[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(data[:birthday]).must_equal Date.parse("1950-01-01")
+    _(data[:avatar]).must_be_kind_of StringIO
+    _(data[:avatar].read).must_equal "image"
+    _(data[:project_ids]).must_equal [1, 2, 3]
 
-    data[0].must_equal 1
-    data[1].must_equal "Charlie"
-    data[2].must_equal true
-    data[3].must_equal 29
-    data[4].must_equal 0.9
-    data[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    data[6].must_equal Date.parse("1950-01-01")
-    data[7].must_be_kind_of StringIO
-    data[7].read.must_equal "image"
-    data[8].must_equal [1, 2, 3]
+    _(data[0]).must_equal 1
+    _(data[1]).must_equal "Charlie"
+    _(data[2]).must_equal true
+    _(data[3]).must_equal 29
+    _(data[4]).must_equal 0.9
+    _(data[5]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(data[6]).must_equal Date.parse("1950-01-01")
+    _(data[7]).must_be_kind_of StringIO
+    _(data[7].read).must_equal "image"
+    _(data[8]).must_equal [1, 2, 3]
 
     data_hash = data.to_h
-    data_hash[:id].must_equal 1
-    data_hash[:name].must_equal "Charlie"
-    data_hash[:active].must_equal true
-    data_hash[:age].must_equal 29
-    data_hash[:score].must_equal 0.9
-    data_hash[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    data_hash[:birthday].must_equal Date.parse("1950-01-01")
-    data_hash[:avatar].must_be_kind_of StringIO
-    data_hash[:avatar].read.must_equal "image"
-    data_hash[:project_ids].must_equal [1, 2, 3]
+    _(data_hash[:id]).must_equal 1
+    _(data_hash[:name]).must_equal "Charlie"
+    _(data_hash[:active]).must_equal true
+    _(data_hash[:age]).must_equal 29
+    _(data_hash[:score]).must_equal 0.9
+    _(data_hash[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(data_hash[:birthday]).must_equal Date.parse("1950-01-01")
+    _(data_hash[:avatar]).must_be_kind_of StringIO
+    _(data_hash[:avatar].read).must_equal "image"
+    _(data_hash[:project_ids]).must_equal [1, 2, 3]
 
     data_array = data.to_a
-    data_array[0].must_equal 1
-    data_array[1].must_equal "Charlie"
-    data_array[2].must_equal true
-    data_array[3].must_equal 29
-    data_array[4].must_equal 0.9
-    data_array[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    data_array[6].must_equal Date.parse("1950-01-01")
-    data_array[7].must_be_kind_of StringIO
-    data_array[7].read.must_equal "image"
-    data_array[8].must_equal [1, 2, 3]
+    _(data_array[0]).must_equal 1
+    _(data_array[1]).must_equal "Charlie"
+    _(data_array[2]).must_equal true
+    _(data_array[3]).must_equal 29
+    _(data_array[4]).must_equal 0.9
+    _(data_array[5]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(data_array[6]).must_equal Date.parse("1950-01-01")
+    _(data_array[7]).must_be_kind_of StringIO
+    _(data_array[7].read).must_equal "image"
+    _(data_array[8]).must_equal [1, 2, 3]
 
-    data.to_s.wont_be :empty?
-    data.inspect.must_match /Google::Cloud::Spanner::Data/
+    _(data.to_s).wont_be :empty?
+    _(data.inspect).must_match /Google::Cloud::Spanner::Data/
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/fields/initializer_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/fields/initializer_test.rb
@@ -18,101 +18,101 @@ describe Google::Cloud::Spanner::Fields, :initializer do
   it "creates with an array of fields" do
     fields = Google::Cloud::Spanner::Fields.new [:INT64, :STRING, :BOOL]
 
-    fields.types.must_equal [:INT64, :STRING, :BOOL]
-    fields.keys.must_equal [0, 1, 2]
-    fields.pairs.must_equal [[0, :INT64], [1, :STRING], [2, :BOOL]]
-    fields.to_a.must_equal [:INT64, :STRING, :BOOL]
-    fields.to_h.must_equal({ 0=>:INT64, 1=>:STRING, 2=>:BOOL })
+    _(fields.types).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.keys).must_equal [0, 1, 2]
+    _(fields.pairs).must_equal [[0, :INT64], [1, :STRING], [2, :BOOL]]
+    _(fields.to_a).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.to_h).must_equal({ 0=>:INT64, 1=>:STRING, 2=>:BOOL })
   end
 
   it "creates with an array of type pairs" do
     fields = Google::Cloud::Spanner::Fields.new [[:id, :INT64], [:name, :STRING], [:active, :BOOL]]
 
-    fields.types.must_equal [:INT64, :STRING, :BOOL]
-    fields.keys.must_equal [:id, :name, :active]
-    fields.pairs.must_equal [[:id, :INT64], [:name, :STRING], [:active, :BOOL]]
-    fields.to_a.must_equal [:INT64, :STRING, :BOOL]
-    fields.to_h.must_equal({ id: :INT64, name: :STRING, active: :BOOL })
+    _(fields.types).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.keys).must_equal [:id, :name, :active]
+    _(fields.pairs).must_equal [[:id, :INT64], [:name, :STRING], [:active, :BOOL]]
+    _(fields.to_a).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.to_h).must_equal({ id: :INT64, name: :STRING, active: :BOOL })
   end
 
   it "creates with a mixed array of fields" do
     fields = Google::Cloud::Spanner::Fields.new [:INT64, [:name, :STRING], :BOOL]
 
-    fields.types.must_equal [:INT64, :STRING, :BOOL]
-    fields.keys.must_equal [0, :name, 2]
-    fields.pairs.must_equal [[0, :INT64], [:name, :STRING], [2, :BOOL]]
-    fields.to_a.must_equal [:INT64, :STRING, :BOOL]
-    fields.to_h.must_equal({ 0=>:INT64, name: :STRING, 2=>:BOOL })
+    _(fields.types).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.keys).must_equal [0, :name, 2]
+    _(fields.pairs).must_equal [[0, :INT64], [:name, :STRING], [2, :BOOL]]
+    _(fields.to_a).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.to_h).must_equal({ 0=>:INT64, name: :STRING, 2=>:BOOL })
   end
 
   it "creates with an unsorted mixed array of fields" do
     fields = Google::Cloud::Spanner::Fields.new [[:name, :STRING], :BOOL, [0, :INT64]]
 
-    fields.types.must_equal [:INT64, :STRING, :BOOL]
-    fields.keys.must_equal [0, :name, 2]
-    fields.pairs.must_equal [[0, :INT64], [:name, :STRING], [2, :BOOL]]
-    fields.to_a.must_equal [:INT64, :STRING, :BOOL]
-    fields.to_h.must_equal({ 0=>:INT64, name: :STRING, 2=>:BOOL })
+    _(fields.types).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.keys).must_equal [0, :name, 2]
+    _(fields.pairs).must_equal [[0, :INT64], [:name, :STRING], [2, :BOOL]]
+    _(fields.to_a).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.to_h).must_equal({ 0=>:INT64, name: :STRING, 2=>:BOOL })
   end
 
   it "creates with a positional hash of fields" do
     fields = Google::Cloud::Spanner::Fields.new 0=>:INT64, 1=>:STRING, 2=>:BOOL
 
-    fields.types.must_equal [:INT64, :STRING, :BOOL]
-    fields.keys.must_equal [0, 1, 2]
-    fields.pairs.must_equal [[0, :INT64], [1, :STRING], [2, :BOOL]]
-    fields.to_a.must_equal [:INT64, :STRING, :BOOL]
-    fields.to_h.must_equal({ 0=>:INT64, 1=>:STRING, 2=>:BOOL })
+    _(fields.types).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.keys).must_equal [0, 1, 2]
+    _(fields.pairs).must_equal [[0, :INT64], [1, :STRING], [2, :BOOL]]
+    _(fields.to_a).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.to_h).must_equal({ 0=>:INT64, 1=>:STRING, 2=>:BOOL })
   end
 
   it "creates with named hash of fields" do
     fields = Google::Cloud::Spanner::Fields.new id: :INT64, name: :STRING, active: :BOOL
 
-    fields.types.must_equal [:INT64, :STRING, :BOOL]
-    fields.keys.must_equal [:id, :name, :active]
-    fields.pairs.must_equal [[:id, :INT64], [:name, :STRING], [:active, :BOOL]]
-    fields.to_a.must_equal [:INT64, :STRING, :BOOL]
-    fields.to_h.must_equal({ id: :INT64, name: :STRING, active: :BOOL })
+    _(fields.types).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.keys).must_equal [:id, :name, :active]
+    _(fields.pairs).must_equal [[:id, :INT64], [:name, :STRING], [:active, :BOOL]]
+    _(fields.to_a).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.to_h).must_equal({ id: :INT64, name: :STRING, active: :BOOL })
   end
 
   it "creates with mixed hash of fields" do
     fields = Google::Cloud::Spanner::Fields.new 0=>:INT64, name: :STRING, 2=>:BOOL
 
-    fields.types.must_equal [:INT64, :STRING, :BOOL]
-    fields.keys.must_equal [0, :name, 2]
-    fields.pairs.must_equal [[0, :INT64], [:name, :STRING], [2, :BOOL]]
-    fields.to_a.must_equal [:INT64, :STRING, :BOOL]
-    fields.to_h.must_equal({ 0=>:INT64, name: :STRING, 2=>:BOOL })
+    _(fields.types).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.keys).must_equal [0, :name, 2]
+    _(fields.pairs).must_equal [[0, :INT64], [:name, :STRING], [2, :BOOL]]
+    _(fields.to_a).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.to_h).must_equal({ 0=>:INT64, name: :STRING, 2=>:BOOL })
   end
 
   it "creates with an unsorted mixed hash of fields" do
     fields = Google::Cloud::Spanner::Fields.new name: :STRING, 2=>:BOOL, 0=>:INT64
 
-    fields.types.must_equal [:INT64, :STRING, :BOOL]
-    fields.keys.must_equal [0, :name, 2]
-    fields.pairs.must_equal [[0, :INT64], [:name, :STRING], [2, :BOOL]]
-    fields.to_a.must_equal [:INT64, :STRING, :BOOL]
-    fields.to_h.must_equal({ 0=>:INT64, name: :STRING, 2=>:BOOL })
+    _(fields.types).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.keys).must_equal [0, :name, 2]
+    _(fields.pairs).must_equal [[0, :INT64], [:name, :STRING], [2, :BOOL]]
+    _(fields.to_a).must_equal [:INT64, :STRING, :BOOL]
+    _(fields.to_h).must_equal({ 0=>:INT64, name: :STRING, 2=>:BOOL })
   end
 
   it "raises when creating duplicate positions" do
     err = expect do
       fields = Google::Cloud::Spanner::Fields.new [[-1, :INT64], [:name, :STRING], [2, :BOOL]]
     end.must_raise ArgumentError
-    err.message.must_equal "cannot specify position less than 0"
+    _(err.message).must_equal "cannot specify position less than 0"
   end
 
   it "raises when creating duplicate positions" do
     err = expect do
       fields = Google::Cloud::Spanner::Fields.new [[0, :INT64], [:name, :STRING], [3, :BOOL]]
     end.must_raise ArgumentError
-    err.message.must_equal "cannot specify position more than field count"
+    _(err.message).must_equal "cannot specify position more than field count"
   end
 
   it "raises when creating duplicate positions" do
     err = expect do
       fields = Google::Cloud::Spanner::Fields.new [[0, :INT64], [:name, :STRING], [0, :BOOL]]
     end.must_raise ArgumentError
-    err.message.must_equal "cannot specify position more than once"
+    _(err.message).must_equal "cannot specify position more than once"
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/fields/struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/fields/struct_test.rb
@@ -124,141 +124,141 @@ describe Google::Cloud::Spanner::Fields, :struct do
   end
 
   def assert_unnamed_struct data
-    data.must_be_kind_of Google::Cloud::Spanner::Data
+    _(data).must_be_kind_of Google::Cloud::Spanner::Data
 
-    data.fields.wont_be :nil?
-    data.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    data.fields.keys.count.must_equal 9
-    data.fields.to_a.must_equal fields_unnamed_array
-    data.fields.to_h.must_equal fields_unnamed_hash
+    _(data.fields).wont_be :nil?
+    _(data.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(data.fields.keys.count).must_equal 9
+    _(data.fields.to_a).must_equal fields_unnamed_array
+    _(data.fields.to_h).must_equal fields_unnamed_hash
 
-    data.fields.to_s.wont_be :empty?
-    data.fields.inspect.must_match /Google::Cloud::Spanner::Fields/
+    _(data.fields.to_s).wont_be :empty?
+    _(data.fields.inspect).must_match /Google::Cloud::Spanner::Fields/
 
-    data.keys.must_equal [0, 1, 2, 3, 4, 5, 6, 7, 8]
+    _(data.keys).must_equal [0, 1, 2, 3, 4, 5, 6, 7, 8]
     data_values = data.values
-    data_values[0].must_equal 1
-    data_values[1].must_equal "Charlie"
-    data_values[2].must_equal true
-    data_values[3].must_equal 29
-    data_values[4].must_equal 0.9
-    data_values[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    data_values[6].must_equal Date.parse("1950-01-01")
-    data_values[7].must_be_kind_of StringIO
-    data_values[7].read.must_equal "image"
-    data_values[8].must_equal [1, 2, 3]
+    _(data_values[0]).must_equal 1
+    _(data_values[1]).must_equal "Charlie"
+    _(data_values[2]).must_equal true
+    _(data_values[3]).must_equal 29
+    _(data_values[4]).must_equal 0.9
+    _(data_values[5]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(data_values[6]).must_equal Date.parse("1950-01-01")
+    _(data_values[7]).must_be_kind_of StringIO
+    _(data_values[7].read).must_equal "image"
+    _(data_values[8]).must_equal [1, 2, 3]
 
-    data[0].must_equal 1
-    data[1].must_equal "Charlie"
-    data[2].must_equal true
-    data[3].must_equal 29
-    data[4].must_equal 0.9
-    data[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    data[6].must_equal Date.parse("1950-01-01")
-    data[7].must_be_kind_of StringIO
-    data[7].read.must_equal "image"
-    data[8].must_equal [1, 2, 3]
+    _(data[0]).must_equal 1
+    _(data[1]).must_equal "Charlie"
+    _(data[2]).must_equal true
+    _(data[3]).must_equal 29
+    _(data[4]).must_equal 0.9
+    _(data[5]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(data[6]).must_equal Date.parse("1950-01-01")
+    _(data[7]).must_be_kind_of StringIO
+    _(data[7].read).must_equal "image"
+    _(data[8]).must_equal [1, 2, 3]
 
     data_hash = data.to_h
-    data_hash[0].must_equal 1
-    data_hash[1].must_equal "Charlie"
-    data_hash[2].must_equal true
-    data_hash[3].must_equal 29
-    data_hash[4].must_equal 0.9
-    data_hash[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    data_hash[6].must_equal Date.parse("1950-01-01")
-    data_hash[7].must_be_kind_of StringIO
-    data_hash[7].read.must_equal "image"
-    data_hash[8].must_equal [1, 2, 3]
+    _(data_hash[0]).must_equal 1
+    _(data_hash[1]).must_equal "Charlie"
+    _(data_hash[2]).must_equal true
+    _(data_hash[3]).must_equal 29
+    _(data_hash[4]).must_equal 0.9
+    _(data_hash[5]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(data_hash[6]).must_equal Date.parse("1950-01-01")
+    _(data_hash[7]).must_be_kind_of StringIO
+    _(data_hash[7].read).must_equal "image"
+    _(data_hash[8]).must_equal [1, 2, 3]
 
     data_array = data.to_a
-    data_array[0].must_equal 1
-    data_array[1].must_equal "Charlie"
-    data_array[2].must_equal true
-    data_array[3].must_equal 29
-    data_array[4].must_equal 0.9
-    data_array[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    data_array[6].must_equal Date.parse("1950-01-01")
-    data_array[7].must_be_kind_of StringIO
-    data_array[7].read.must_equal "image"
-    data_array[8].must_equal [1, 2, 3]
+    _(data_array[0]).must_equal 1
+    _(data_array[1]).must_equal "Charlie"
+    _(data_array[2]).must_equal true
+    _(data_array[3]).must_equal 29
+    _(data_array[4]).must_equal 0.9
+    _(data_array[5]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(data_array[6]).must_equal Date.parse("1950-01-01")
+    _(data_array[7]).must_be_kind_of StringIO
+    _(data_array[7].read).must_equal "image"
+    _(data_array[8]).must_equal [1, 2, 3]
 
-    data.to_s.wont_be :empty?
-    data.inspect.must_match /Google::Cloud::Spanner::Data/
+    _(data.to_s).wont_be :empty?
+    _(data.inspect).must_match /Google::Cloud::Spanner::Data/
   end
 
   def assert_named_struct data
-    data.must_be_kind_of Google::Cloud::Spanner::Data
+    _(data).must_be_kind_of Google::Cloud::Spanner::Data
 
-    data.fields.wont_be :nil?
-    data.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    data.fields.keys.count.must_equal 9
-    data.fields.to_a.must_equal fields_unnamed_array
-    data.fields.to_h.must_equal fields_named_hash
+    _(data.fields).wont_be :nil?
+    _(data.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(data.fields.keys.count).must_equal 9
+    _(data.fields.to_a).must_equal fields_unnamed_array
+    _(data.fields.to_h).must_equal fields_named_hash
 
-    data.fields.to_s.wont_be :empty?
-    data.fields.inspect.must_match /Google::Cloud::Spanner::Fields/
+    _(data.fields.to_s).wont_be :empty?
+    _(data.fields.inspect).must_match /Google::Cloud::Spanner::Fields/
 
-    data.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(data.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
     data_values = data.values
-    data_values[0].must_equal 1
-    data_values[1].must_equal "Charlie"
-    data_values[2].must_equal true
-    data_values[3].must_equal 29
-    data_values[4].must_equal 0.9
-    data_values[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    data_values[6].must_equal Date.parse("1950-01-01")
-    data_values[7].must_be_kind_of StringIO
-    data_values[7].read.must_equal "image"
-    data_values[8].must_equal [1, 2, 3]
+    _(data_values[0]).must_equal 1
+    _(data_values[1]).must_equal "Charlie"
+    _(data_values[2]).must_equal true
+    _(data_values[3]).must_equal 29
+    _(data_values[4]).must_equal 0.9
+    _(data_values[5]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(data_values[6]).must_equal Date.parse("1950-01-01")
+    _(data_values[7]).must_be_kind_of StringIO
+    _(data_values[7].read).must_equal "image"
+    _(data_values[8]).must_equal [1, 2, 3]
 
-    data[:id].must_equal 1
-    data[:name].must_equal "Charlie"
-    data[:active].must_equal true
-    data[:age].must_equal 29
-    data[:score].must_equal 0.9
-    data[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    data[:birthday].must_equal Date.parse("1950-01-01")
-    data[:avatar].must_be_kind_of StringIO
-    data[:avatar].read.must_equal "image"
-    data[:project_ids].must_equal [1, 2, 3]
+    _(data[:id]).must_equal 1
+    _(data[:name]).must_equal "Charlie"
+    _(data[:active]).must_equal true
+    _(data[:age]).must_equal 29
+    _(data[:score]).must_equal 0.9
+    _(data[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(data[:birthday]).must_equal Date.parse("1950-01-01")
+    _(data[:avatar]).must_be_kind_of StringIO
+    _(data[:avatar].read).must_equal "image"
+    _(data[:project_ids]).must_equal [1, 2, 3]
 
-    data[0].must_equal 1
-    data[1].must_equal "Charlie"
-    data[2].must_equal true
-    data[3].must_equal 29
-    data[4].must_equal 0.9
-    data[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    data[6].must_equal Date.parse("1950-01-01")
-    data[7].must_be_kind_of StringIO
-    data[7].read.must_equal "image"
-    data[8].must_equal [1, 2, 3]
+    _(data[0]).must_equal 1
+    _(data[1]).must_equal "Charlie"
+    _(data[2]).must_equal true
+    _(data[3]).must_equal 29
+    _(data[4]).must_equal 0.9
+    _(data[5]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(data[6]).must_equal Date.parse("1950-01-01")
+    _(data[7]).must_be_kind_of StringIO
+    _(data[7].read).must_equal "image"
+    _(data[8]).must_equal [1, 2, 3]
 
     data_hash = data.to_h
-    data_hash[:id].must_equal 1
-    data_hash[:name].must_equal "Charlie"
-    data_hash[:active].must_equal true
-    data_hash[:age].must_equal 29
-    data_hash[:score].must_equal 0.9
-    data_hash[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    data_hash[:birthday].must_equal Date.parse("1950-01-01")
-    data_hash[:avatar].must_be_kind_of StringIO
-    data_hash[:avatar].read.must_equal "image"
-    data_hash[:project_ids].must_equal [1, 2, 3]
+    _(data_hash[:id]).must_equal 1
+    _(data_hash[:name]).must_equal "Charlie"
+    _(data_hash[:active]).must_equal true
+    _(data_hash[:age]).must_equal 29
+    _(data_hash[:score]).must_equal 0.9
+    _(data_hash[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(data_hash[:birthday]).must_equal Date.parse("1950-01-01")
+    _(data_hash[:avatar]).must_be_kind_of StringIO
+    _(data_hash[:avatar].read).must_equal "image"
+    _(data_hash[:project_ids]).must_equal [1, 2, 3]
 
     data_array = data.to_a
-    data_array[0].must_equal 1
-    data_array[1].must_equal "Charlie"
-    data_array[2].must_equal true
-    data_array[3].must_equal 29
-    data_array[4].must_equal 0.9
-    data_array[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    data_array[6].must_equal Date.parse("1950-01-01")
-    data_array[7].must_be_kind_of StringIO
-    data_array[7].read.must_equal "image"
-    data_array[8].must_equal [1, 2, 3]
+    _(data_array[0]).must_equal 1
+    _(data_array[1]).must_equal "Charlie"
+    _(data_array[2]).must_equal true
+    _(data_array[3]).must_equal 29
+    _(data_array[4]).must_equal 0.9
+    _(data_array[5]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(data_array[6]).must_equal Date.parse("1950-01-01")
+    _(data_array[7]).must_be_kind_of StringIO
+    _(data_array[7].read).must_equal "image"
+    _(data_array[8]).must_equal [1, 2, 3]
 
-    data.to_s.wont_be :empty?
-    data.inspect.must_match /Google::Cloud::Spanner::Data/
+    _(data.to_s).wont_be :empty?
+    _(data.inspect).must_match /Google::Cloud::Spanner::Data/
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/backup_operations_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/backup_operations_test.rb
@@ -76,19 +76,19 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
     instance.service.mocked_databases = mock
 
     jobs = instance.backup_operations
-    jobs.size.must_equal 3
+    _(jobs.size).must_equal 3
 
     jobs.each do |job|
-      job.must_be_kind_of Google::Cloud::Spanner::Backup::Job
-      job.wont_be :done?
-      job.wont_be :error?
-      job.error.must_be :nil?
-      job.backup.must_be :nil?
+      _(job).must_be_kind_of Google::Cloud::Spanner::Backup::Job
+      _(job).wont_be :done?
+      _(job).wont_be :error?
+      _(job.error).must_be :nil?
+      _(job.backup).must_be :nil?
       job.reload!
 
       backup = job.backup
-      backup.wont_be :nil?
-      backup.must_be_kind_of Google::Cloud::Spanner::Backup
+      _(backup).wont_be :nil?
+      _(backup).must_be_kind_of Google::Cloud::Spanner::Backup
     end
 
     mock.verify
@@ -106,19 +106,19 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
     instance.service.mocked_databases = mock
 
     jobs = instance.backup_operations page_size: 3
-    jobs.size.must_equal 3
+    _(jobs.size).must_equal 3
 
     jobs.each do |job|
-      job.must_be_kind_of Google::Cloud::Spanner::Backup::Job
-      job.wont_be :done?
-      job.wont_be :error?
-      job.error.must_be :nil?
-      job.backup.must_be :nil?
+      _(job).must_be_kind_of Google::Cloud::Spanner::Backup::Job
+      _(job).wont_be :done?
+      _(job).wont_be :error?
+      _(job.error).must_be :nil?
+      _(job.backup).must_be :nil?
       job.reload!
 
       backup = job.backup
-      backup.wont_be :nil?
-      backup.must_be_kind_of Google::Cloud::Spanner::Backup
+      _(backup).wont_be :nil?
+      _(backup).must_be_kind_of Google::Cloud::Spanner::Backup
     end
 
     mock.verify
@@ -135,10 +135,10 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
 
     jobs = instance.backup_operations
 
-    jobs.size.must_equal 3
-    jobs.next?.must_equal true
-    jobs.next.size.must_equal 2
-    jobs.next?.must_equal false
+    _(jobs.size).must_equal 3
+    _(jobs.next?).must_equal true
+    _(jobs.next.size).must_equal 2
+    _(jobs.next?).must_equal false
 
     mock.verify
   end
@@ -156,7 +156,7 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
 
     mock.verify
 
-    jobs.size.must_equal 5
+    _(jobs.size).must_equal 5
   end
 
   it "paginates backup operations with all and page size" do
@@ -172,7 +172,7 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
 
     mock.verify
 
-    jobs.size.must_equal 5
+    _(jobs.size).must_equal 5
   end
 
   it "iterates backup operations with all using Enumerator" do
@@ -188,7 +188,7 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
 
     mock.verify
 
-    jobs.size.must_equal 5
+    _(jobs.size).must_equal 5
   end
 
   it "paginates backup operations with filter" do
@@ -203,7 +203,7 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
 
     mock.verify
 
-    jobs.size.must_equal 3
+    _(jobs.size).must_equal 3
   end
 
   it "paginates backup operations with filter and page size" do
@@ -218,6 +218,6 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
 
     mock.verify
 
-    jobs.size.must_equal 3
+    _(jobs.size).must_equal 3
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/backup_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/backup_test.rb
@@ -34,16 +34,16 @@ describe Google::Cloud::Spanner::Instance, :backup, :mock_spanner do
 
     mock.verify
 
-    backup.project_id.must_equal project
-    backup.instance_id.must_equal instance_id
-    backup.database_id.must_equal database_id
-    backup.backup_id.must_equal backup_id
+    _(backup.project_id).must_equal project
+    _(backup.instance_id).must_equal instance_id
+    _(backup.database_id).must_equal database_id
+    _(backup.backup_id).must_equal backup_id
 
-    backup.path.must_equal backup_path(instance_id, backup_id)
+    _(backup.path).must_equal backup_path(instance_id, backup_id)
 
-    backup.state.must_equal :READY
-    backup.must_be :ready?
-    backup.wont_be :creating?
+    _(backup.state).must_equal :READY
+    _(backup).must_be :ready?
+    _(backup).wont_be :creating?
   end
 
   it "returns nil when getting a non-existent backup" do
@@ -58,6 +58,6 @@ describe Google::Cloud::Spanner::Instance, :backup, :mock_spanner do
     instance.service.mocked_databases = stub
 
     backup = instance.backup not_found_backup_id
-    backup.must_be :nil?
+    _(backup).must_be :nil?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/backups_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/backups_test.rb
@@ -46,7 +46,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
 
     mock.verify
 
-    backups.size.must_equal 3
+    _(backups.size).must_equal 3
   end
 
   it "paginates backups with page size" do
@@ -59,7 +59,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
 
     mock.verify
 
-    backups.size.must_equal 3
+    _(backups.size).must_equal 3
   end
 
   it "paginates backups with next? and next" do
@@ -72,10 +72,10 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
 
     mock.verify
 
-    list.size.must_equal 3
-    list.next?.must_equal true
-    list.next.size.must_equal 2
-    list.next?.must_equal false
+    _(list.size).must_equal 3
+    _(list.next?).must_equal true
+    _(list.next.size).must_equal 2
+    _(list.next?).must_equal false
   end
 
   it "paginates backups with next? and next and page size" do
@@ -88,10 +88,10 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
 
     mock.verify
 
-    list.size.must_equal 3
-    list.next?.must_equal true
-    list.next.size.must_equal 2
-    list.next?.must_equal false
+    _(list.size).must_equal 3
+    _(list.next?).must_equal true
+    _(list.next.size).must_equal 2
+    _(list.next?).must_equal false
   end
 
   it "paginates backups with all" do
@@ -104,7 +104,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
 
     mock.verify
 
-    backups.size.must_equal 5
+    _(backups.size).must_equal 5
   end
 
   it "paginates backups with all and page size" do
@@ -117,7 +117,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
 
     mock.verify
 
-    backups.size.must_equal 5
+    _(backups.size).must_equal 5
   end
 
   it "iterates backups with all using Enumerator" do
@@ -130,7 +130,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
 
     mock.verify
 
-    backups.size.must_equal 5
+    _(backups.size).must_equal 5
   end
 
   it "paginates backups with filter" do
@@ -143,7 +143,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
 
     mock.verify
 
-    backups.size.must_equal 3
+    _(backups.size).must_equal 3
   end
 
   it "paginates backups with filter and page size" do
@@ -156,6 +156,6 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
 
     mock.verify
 
-    backups.size.must_equal 3
+    _(backups.size).must_equal 3
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/config_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/config_test.rb
@@ -29,11 +29,11 @@ describe Google::Cloud::Spanner::Instance, :config, :mock_spanner do
 
     mock.verify
 
-    config.must_be_kind_of Google::Cloud::Spanner::Instance::Config
-    config.project_id.must_equal project
-    config.instance_config_id.must_equal instance_config_hash[:name].split("/").last
-    config.path.must_equal instance_config_hash[:name]
-    config.name.must_equal instance_config_hash[:display_name]
-    config.display_name.must_equal instance_config_hash[:display_name]
+    _(config).must_be_kind_of Google::Cloud::Spanner::Instance::Config
+    _(config.project_id).must_equal project
+    _(config.instance_config_id).must_equal instance_config_hash[:name].split("/").last
+    _(config.path).must_equal instance_config_hash[:name]
+    _(config.name).must_equal instance_config_hash[:display_name]
+    _(config.display_name).must_equal instance_config_hash[:display_name]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/create_database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/create_database_test.rb
@@ -66,17 +66,17 @@ describe Google::Cloud::Spanner::Instance, :create_database, :mock_spanner do
 
     job = instance.create_database database_id
 
-    job.must_be_kind_of Google::Cloud::Spanner::Database::Job
-    job.wont_be :done?
-    job.wont_be :error?
-    job.error.must_be :nil?
-    job.database.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Database::Job
+    _(job).wont_be :done?
+    _(job).wont_be :error?
+    _(job.error).must_be :nil?
+    _(job.database).must_be :nil?
 
     job.reload!
     database = job.database
 
-    database.wont_be :nil?
-    database.must_be_kind_of Google::Cloud::Spanner::Database
+    _(database).wont_be :nil?
+    _(database).must_be_kind_of Google::Cloud::Spanner::Database
 
     mock.verify
   end
@@ -102,7 +102,7 @@ describe Google::Cloud::Spanner::Instance, :create_database, :mock_spanner do
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Spanner::Database::Job
-    job.wont_be :done?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Database::Job
+    _(job).wont_be :done?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/database_operations_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/database_operations_test.rb
@@ -76,19 +76,19 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
     instance.service.mocked_databases = mock
 
     jobs = instance.database_operations
-    jobs.size.must_equal 3
+    _(jobs.size).must_equal 3
 
     jobs.each do |job|
-      job.must_be_kind_of Google::Cloud::Spanner::Database::Job
-      job.wont_be :done?
-      job.wont_be :error?
-      job.error.must_be :nil?
-      job.database.must_be :nil?
+      _(job).must_be_kind_of Google::Cloud::Spanner::Database::Job
+      _(job).wont_be :done?
+      _(job).wont_be :error?
+      _(job.error).must_be :nil?
+      _(job.database).must_be :nil?
       job.reload!
 
       database = job.database
-      database.wont_be :nil?
-      database.must_be_kind_of Google::Cloud::Spanner::Database
+      _(database).wont_be :nil?
+      _(database).must_be_kind_of Google::Cloud::Spanner::Database
     end
 
     mock.verify
@@ -106,19 +106,19 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
     instance.service.mocked_databases = mock
 
     jobs = instance.database_operations page_size: 3
-    jobs.size.must_equal 3
+    _(jobs.size).must_equal 3
 
     jobs.each do |job|
-      job.must_be_kind_of Google::Cloud::Spanner::Database::Job
-      job.wont_be :done?
-      job.wont_be :error?
-      job.error.must_be :nil?
-      job.database.must_be :nil?
+      _(job).must_be_kind_of Google::Cloud::Spanner::Database::Job
+      _(job).wont_be :done?
+      _(job).wont_be :error?
+      _(job.error).must_be :nil?
+      _(job.database).must_be :nil?
       job.reload!
 
       database = job.database
-      database.wont_be :nil?
-      database.must_be_kind_of Google::Cloud::Spanner::Database
+      _(database).wont_be :nil?
+      _(database).must_be_kind_of Google::Cloud::Spanner::Database
     end
 
     mock.verify
@@ -135,10 +135,10 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
 
     jobs = instance.database_operations
 
-    jobs.size.must_equal 3
-    jobs.next?.must_equal true
-    jobs.next.size.must_equal 2
-    jobs.next?.must_equal false
+    _(jobs.size).must_equal 3
+    _(jobs.next?).must_equal true
+    _(jobs.next.size).must_equal 2
+    _(jobs.next?).must_equal false
 
     mock.verify
   end
@@ -156,7 +156,7 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
 
     mock.verify
 
-    jobs.size.must_equal 5
+    _(jobs.size).must_equal 5
   end
 
   it "paginates database operations with all and page size" do
@@ -172,7 +172,7 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
 
     mock.verify
 
-    jobs.size.must_equal 5
+    _(jobs.size).must_equal 5
   end
 
   it "iterates database operations with all using Enumerator" do
@@ -188,7 +188,7 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
 
     mock.verify
 
-    jobs.size.must_equal 5
+    _(jobs.size).must_equal 5
   end
 
   it "paginates database operations with filter" do
@@ -203,7 +203,7 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
 
     mock.verify
 
-    jobs.size.must_equal 3
+    _(jobs.size).must_equal 3
   end
 
   it "paginates database operations with filter and page size" do
@@ -218,6 +218,6 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
 
     mock.verify
 
-    jobs.size.must_equal 3
+    _(jobs.size).must_equal 3
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/database_test.rb
@@ -31,15 +31,15 @@ describe Google::Cloud::Spanner::Instance, :database, :mock_spanner do
 
     mock.verify
 
-    database.project_id.must_equal project
-    database.instance_id.must_equal instance_id
-    database.database_id.must_equal database_id
+    _(database.project_id).must_equal project
+    _(database.instance_id).must_equal instance_id
+    _(database.database_id).must_equal database_id
 
-    database.path.must_equal database_path(instance_id, database_id)
+    _(database.path).must_equal database_path(instance_id, database_id)
 
-    database.state.must_equal :READY
-    database.must_be :ready?
-    database.wont_be :creating?
+    _(database.state).must_equal :READY
+    _(database).must_be :ready?
+    _(database).wont_be :creating?
   end
 
   it "returns nil when getting an non-existent database" do
@@ -54,6 +54,6 @@ describe Google::Cloud::Spanner::Instance, :database, :mock_spanner do
     instance.service.mocked_databases = stub
 
     database = instance.database not_found_database_id
-    database.must_be :nil?
+    _(database).must_be :nil?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/databases_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/databases_test.rb
@@ -48,7 +48,7 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
     mock.verify
 
-    databases.size.must_equal 3
+    _(databases.size).must_equal 3
   end
 
   it "paginates databases" do
@@ -62,13 +62,13 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
     mock.verify
 
-    first_databases.size.must_equal 3
+    _(first_databases.size).must_equal 3
     token = first_databases.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
 
-    second_databases.size.must_equal 2
-    second_databases.token.must_be :nil?
+    _(second_databases.size).must_equal 2
+    _(second_databases.token).must_be :nil?
   end
 
   it "paginates databases with max set" do
@@ -80,10 +80,10 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
     mock.verify
 
-    databases.size.must_equal 3
+    _(databases.size).must_equal 3
     token = databases.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
   end
 
   it "paginates databases with next? and next" do
@@ -97,11 +97,11 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
     mock.verify
 
-    first_databases.size.must_equal 3
-    first_databases.next?.must_equal true
+    _(first_databases.size).must_equal 3
+    _(first_databases.next?).must_equal true
 
-    second_databases.size.must_equal 2
-    second_databases.next?.must_equal false
+    _(second_databases.size).must_equal 2
+    _(second_databases.next?).must_equal false
   end
 
   it "paginates databases with next? and next and max set" do
@@ -115,11 +115,11 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
     mock.verify
 
-    first_databases.size.must_equal 3
-    first_databases.next?.must_equal true
+    _(first_databases.size).must_equal 3
+    _(first_databases.next?).must_equal true
 
-    second_databases.size.must_equal 2
-    second_databases.next?.must_equal false
+    _(second_databases.size).must_equal 2
+    _(second_databases.next?).must_equal false
   end
 
   it "paginates databases with all" do
@@ -132,7 +132,7 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
     mock.verify
 
-    databases.size.must_equal 5
+    _(databases.size).must_equal 5
   end
 
   it "paginates databases with all and max set" do
@@ -145,7 +145,7 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
     mock.verify
 
-    databases.size.must_equal 5
+    _(databases.size).must_equal 5
   end
 
   it "iterates databases with all using Enumerator" do
@@ -158,7 +158,7 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
     mock.verify
 
-    databases.size.must_equal 5
+    _(databases.size).must_equal 5
   end
 
   it "iterates databases with all and request_limit set" do
@@ -171,6 +171,6 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
     mock.verify
 
-    databases.size.must_equal 6
+    _(databases.size).must_equal 6
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/iam_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/iam_test.rb
@@ -53,14 +53,14 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Spanner::Policy
-    policy.etag.must_equal "\b\x01"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be_kind_of Array
-    policy.roles["roles/viewer"].count.must_equal 2
-    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    _(policy).must_be_kind_of Google::Cloud::Spanner::Policy
+    _(policy.etag).must_equal "\b\x01"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be_kind_of Array
+    _(policy.roles["roles/viewer"].count).must_equal 2
+    _(policy.roles["roles/viewer"].first).must_equal "user:viewer@example.com"
+    _(policy.roles["roles/viewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "sets the IAM Policy" do
@@ -86,15 +86,15 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Spanner::Policy
-    policy.etag.must_equal "\b\x10"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-    policy.roles["roles/owner"].last.must_equal  "user:newowner@example.com"
+    _(policy).must_be_kind_of Google::Cloud::Spanner::Policy
+    _(policy.etag).must_equal "\b\x10"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be :nil?
+    _(policy.roles["roles/owner"]).must_be_kind_of Array
+    _(policy.roles["roles/owner"].count).must_equal 2
+    _(policy.roles["roles/owner"].first).must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    _(policy.roles["roles/owner"].last).must_equal  "user:newowner@example.com"
   end
 
   it "sets the IAM Policy in a block" do
@@ -119,15 +119,15 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Spanner::Policy
-    policy.etag.must_equal "\b\x10"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-    policy.roles["roles/owner"].last.must_equal  "user:newowner@example.com"
+    _(policy).must_be_kind_of Google::Cloud::Spanner::Policy
+    _(policy.etag).must_equal "\b\x10"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be :nil?
+    _(policy.roles["roles/owner"]).must_be_kind_of Array
+    _(policy.roles["roles/owner"].count).must_equal 2
+    _(policy.roles["roles/owner"].first).must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    _(policy.roles["roles/owner"].last).must_equal  "user:newowner@example.com"
   end
 
   it "tests the available permissions" do
@@ -144,6 +144,6 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
 
     mock.verify
 
-    permissions.must_equal ["spanner.instances.get"]
+    _(permissions).must_equal ["spanner.instances.get"]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/save_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/save_test.rb
@@ -48,8 +48,8 @@ describe Google::Cloud::Spanner::Instance, :save, :mock_spanner do
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Spanner::Instance::Job
-    job.wont_be :done?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Instance::Job
+    _(job).wont_be :done?
   end
 
   it "updates and saves when changing the labels directly" do
@@ -72,7 +72,7 @@ describe Google::Cloud::Spanner::Instance, :save, :mock_spanner do
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Spanner::Instance::Job
-    job.wont_be :done?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Instance::Job
+    _(job).wont_be :done?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/instance_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance_test.rb
@@ -20,12 +20,12 @@ describe Google::Cloud::Spanner::Instance, :mock_spanner do
   let(:instance) { Google::Cloud::Spanner::Instance.from_grpc instance_grpc, spanner.service }
 
   it "knows the identifiers" do
-    instance.must_be_kind_of Google::Cloud::Spanner::Instance
-    instance.project_id.must_equal project
-    instance.instance_id.must_equal instance_id
+    _(instance).must_be_kind_of Google::Cloud::Spanner::Instance
+    _(instance.project_id).must_equal project
+    _(instance.instance_id).must_equal instance_id
 
-    instance.state.must_equal :READY
-    instance.must_be :ready?
-    instance.wont_be :creating?
+    _(instance.state).must_equal :READY
+    _(instance).must_be :ready?
+    _(instance).wont_be :creating?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/new_sessions_in_process_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/new_sessions_in_process_test.rb
@@ -46,42 +46,42 @@ describe Google::Cloud::Spanner::Pool, :new_sessions_in_process, :mock_spanner d
     end
     spanner.service.mocked_service = stub
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 1
-    pool.instance_variable_get(:@new_sessions_in_process).must_equal 0
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 1
+    _(pool.instance_variable_get(:@new_sessions_in_process)).must_equal 0
 
     s1 = pool.checkout_session # gets the one session from the queue
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 0
-    pool.instance_variable_get(:@new_sessions_in_process).must_equal 0
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 0
+    _(pool.instance_variable_get(:@new_sessions_in_process)).must_equal 0
 
     raised_error = assert_raises Google::Cloud::Error do
       pool.checkout_session
     end
-    raised_error.message.must_equal "11:sumthin happen"
+    _(raised_error.message).must_equal "11:sumthin happen"
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 0
-    pool.instance_variable_get(:@new_sessions_in_process).must_equal 0
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 0
+    _(pool.instance_variable_get(:@new_sessions_in_process)).must_equal 0
 
     10.times do
       raised_error = assert_raises Google::Cloud::Error do
         pool.checkout_session
       end
-      raised_error.message.must_equal "11:sumthin happen"
+      _(raised_error.message).must_equal "11:sumthin happen"
     end
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 0
-    pool.instance_variable_get(:@new_sessions_in_process).must_equal 0
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 0
+    _(pool.instance_variable_get(:@new_sessions_in_process)).must_equal 0
 
     pool.checkin_session s1
 
     shutdown_pool! pool
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 1
-    pool.instance_variable_get(:@new_sessions_in_process).must_equal 0
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 1
+    _(pool.instance_variable_get(:@new_sessions_in_process)).must_equal 0
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -48,9 +48,9 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
     shutdown_pool! pool
 
-    pool.all_sessions.size.must_equal 2
-    pool.session_queue.size.must_equal 1
-    pool.transaction_queue.size.must_equal 1
+    _(pool.all_sessions.size).must_equal 2
+    _(pool.session_queue.size).must_equal 1
+    _(pool.transaction_queue.size).must_equal 1
 
     mock.verify
   end
@@ -76,9 +76,9 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
     shutdown_pool! pool
 
-    pool.all_sessions.size.must_equal 2
-    pool.session_queue.size.must_equal 1
-    pool.transaction_queue.size.must_equal 1
+    _(pool.all_sessions.size).must_equal 2
+    _(pool.session_queue.size).must_equal 1
+    _(pool.transaction_queue.size).must_equal 1
 
     mock.verify
   end
@@ -104,9 +104,9 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
     shutdown_pool! pool
 
-    pool.all_sessions.size.must_equal 5
-    pool.session_queue.size.must_equal 2
-    pool.transaction_queue.size.must_equal 3
+    _(pool.all_sessions.size).must_equal 5
+    _(pool.session_queue.size).must_equal 2
+    _(pool.transaction_queue.size).must_equal 3
 
     mock.verify
   end
@@ -134,9 +134,9 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
     shutdown_pool! pool
 
-    pool.all_sessions.size.must_equal 8
-    pool.session_queue.size.must_equal 6
-    pool.transaction_queue.size.must_equal 2
+    _(pool.all_sessions.size).must_equal 8
+    _(pool.session_queue.size).must_equal 6
+    _(pool.transaction_queue.size).must_equal 2
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
@@ -38,20 +38,20 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
   end
 
   it "can checkout and checkin a session" do
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 1
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 1
 
     s = pool.checkout_session
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 0
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 0
 
     pool.checkin_session s
 
     shutdown_pool! pool
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 1
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 1
   end
 
   it "creates new sessions when needed" do
@@ -59,22 +59,22 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 1
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 1
 
     s1 = pool.checkout_session
     s2 = pool.checkout_session
 
-    pool.all_sessions.size.must_equal 2
-    pool.session_queue.size.must_equal 0
+    _(pool.all_sessions.size).must_equal 2
+    _(pool.session_queue.size).must_equal 0
 
     pool.checkin_session s1
     pool.checkin_session s2
 
     shutdown_pool! pool
 
-    pool.all_sessions.size.must_equal 2
-    pool.session_queue.size.must_equal 2
+    _(pool.all_sessions.size).must_equal 2
+    _(pool.session_queue.size).must_equal 2
 
     mock.verify
   end
@@ -86,8 +86,8 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 1
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 1
 
     s1 = pool.checkout_session
     s2 = pool.checkout_session
@@ -98,8 +98,8 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
       pool.checkout_session
     end
 
-    pool.all_sessions.size.must_equal 4
-    pool.session_queue.size.must_equal 0
+    _(pool.all_sessions.size).must_equal 4
+    _(pool.session_queue.size).must_equal 0
 
     pool.checkin_session s1
     pool.checkin_session s2
@@ -108,8 +108,8 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
 
     shutdown_pool! pool
 
-    pool.all_sessions.size.must_equal 4
-    pool.session_queue.size.must_equal 4
+    _(pool.all_sessions.size).must_equal 4
+    _(pool.session_queue.size).must_equal 4
 
     mock.verify
   end
@@ -120,7 +120,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     checkin_error = assert_raises ArgumentError do
       pool.checkin_session outside_session
     end
-    checkin_error.message.must_equal "Cannot checkin session"
+    _(checkin_error.message).must_equal "Cannot checkin session"
   end
 
   it "uses existing transaction when checking out and checking in a transaction" do
@@ -135,25 +135,25 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-02"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 0
-    pool.transaction_queue.size.must_equal 1
-    pool.transaction_queue.first.must_equal init_tx
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 0
+    _(pool.transaction_queue.size).must_equal 1
+    _(pool.transaction_queue.first).must_equal init_tx
 
     tx = pool.checkout_transaction
-    tx.must_equal init_tx
+    _(tx).must_equal init_tx
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 0
-    pool.transaction_queue.size.must_equal 0
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 0
+    _(pool.transaction_queue.size).must_equal 0
 
     pool.checkin_transaction tx
 
     shutdown_pool! pool
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 0
-    pool.transaction_queue.size.must_equal 1
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 0
+    _(pool.transaction_queue.size).must_equal 1
   end
 
   it "can create a transaction when checking out and checking in a transaction" do
@@ -164,23 +164,23 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-02"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 1
-    pool.transaction_queue.size.must_equal 0
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 1
+    _(pool.transaction_queue.size).must_equal 0
 
     tx = pool.checkout_transaction
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 0
-    pool.transaction_queue.size.must_equal 0
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 0
+    _(pool.transaction_queue.size).must_equal 0
 
     pool.checkin_transaction tx
 
     shutdown_pool! pool
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 0
-    pool.transaction_queue.size.must_equal 1
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 0
+    _(pool.transaction_queue.size).must_equal 1
   end
 
   it "creates new transaction when needed" do
@@ -191,25 +191,25 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 1
-    pool.transaction_queue.size.must_equal 0
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 1
+    _(pool.transaction_queue.size).must_equal 0
 
     tx1 = pool.checkout_transaction
     tx2 = pool.checkout_transaction
 
-    pool.all_sessions.size.must_equal 2
-    pool.session_queue.size.must_equal 0
-    pool.transaction_queue.size.must_equal 0
+    _(pool.all_sessions.size).must_equal 2
+    _(pool.session_queue.size).must_equal 0
+    _(pool.transaction_queue.size).must_equal 0
 
     pool.checkin_transaction tx1
     pool.checkin_transaction tx2
 
     shutdown_pool! pool
 
-    pool.all_sessions.size.must_equal 2
-    pool.session_queue.size.must_equal 0
-    pool.transaction_queue.size.must_equal 2
+    _(pool.all_sessions.size).must_equal 2
+    _(pool.session_queue.size).must_equal 0
+    _(pool.transaction_queue.size).must_equal 2
 
     mock.verify
   end
@@ -225,23 +225,23 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-02"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 1
-    pool.transaction_queue.size.must_equal 0
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 1
+    _(pool.transaction_queue.size).must_equal 0
 
     pool.with_transaction do |tx1|
       pool.with_transaction do |tx1|
-        pool.all_sessions.size.must_equal 2
-        pool.session_queue.size.must_equal 0
-        pool.transaction_queue.size.must_equal 0
+        _(pool.all_sessions.size).must_equal 2
+        _(pool.session_queue.size).must_equal 0
+        _(pool.transaction_queue.size).must_equal 0
       end
     end
 
     shutdown_pool! pool
 
-    pool.all_sessions.size.must_equal 2
-    pool.session_queue.size.must_equal 0
-    pool.transaction_queue.size.must_equal 2
+    _(pool.all_sessions.size).must_equal 2
+    _(pool.session_queue.size).must_equal 0
+    _(pool.transaction_queue.size).must_equal 2
 
     mock.verify
   end
@@ -258,9 +258,9 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-004-01"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
-    pool.all_sessions.size.must_equal 1
-    pool.session_queue.size.must_equal 1
-    pool.transaction_queue.size.must_equal 0
+    _(pool.all_sessions.size).must_equal 1
+    _(pool.session_queue.size).must_equal 1
+    _(pool.transaction_queue.size).must_equal 0
 
     tx1 = pool.checkout_transaction
     tx2 = pool.checkout_transaction
@@ -271,32 +271,32 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
       pool.checkout_transaction
     end
 
-    pool.all_sessions.size.must_equal 4
-    pool.session_queue.size.must_equal 0
-    pool.transaction_queue.size.must_equal 0
+    _(pool.all_sessions.size).must_equal 4
+    _(pool.session_queue.size).must_equal 0
+    _(pool.transaction_queue.size).must_equal 0
 
     pool.checkin_transaction tx1
     pool.checkin_transaction tx2
     pool.checkin_transaction tx3
     pool.checkin_transaction tx4
 
-    pool.all_sessions.size.must_equal 4
-    pool.session_queue.size.must_equal 0
-    pool.transaction_queue.size.must_equal 4
+    _(pool.all_sessions.size).must_equal 4
+    _(pool.session_queue.size).must_equal 0
+    _(pool.transaction_queue.size).must_equal 4
 
     s1 = pool.checkout_session
     s2 = pool.checkout_session
 
-    pool.all_sessions.size.must_equal 4
-    pool.session_queue.size.must_equal 0
-    pool.transaction_queue.size.must_equal 2
+    _(pool.all_sessions.size).must_equal 4
+    _(pool.session_queue.size).must_equal 0
+    _(pool.transaction_queue.size).must_equal 2
 
     pool.checkin_session s1
     pool.checkin_session s2
 
-    pool.all_sessions.size.must_equal 4
-    pool.session_queue.size.must_equal 2
-    pool.transaction_queue.size.must_equal 2
+    _(pool.all_sessions.size).must_equal 4
+    _(pool.session_queue.size).must_equal 2
+    _(pool.transaction_queue.size).must_equal 2
 
     shutdown_pool! pool
 
@@ -310,6 +310,6 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     checkin_error = assert_raises ArgumentError do
       pool.checkin_transaction outside_tx
     end
-    checkin_error.message.must_equal "Cannot checkin session"
+    _(checkin_error.message).must_equal "Cannot checkin session"
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/project/create_database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/create_database_test.rb
@@ -45,8 +45,8 @@ describe Google::Cloud::Spanner::Project, :create_database, :mock_spanner do
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Spanner::Database::Job
-    job.wont_be :done?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Database::Job
+    _(job).wont_be :done?
   end
 
   it "creates a database with additional statements" do
@@ -70,7 +70,7 @@ describe Google::Cloud::Spanner::Project, :create_database, :mock_spanner do
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Spanner::Database::Job
-    job.wont_be :done?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Database::Job
+    _(job).wont_be :done?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/project/create_instance_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/create_instance_test.rb
@@ -66,17 +66,17 @@ describe Google::Cloud::Spanner::Project, :create_instance, :mock_spanner do
 
     job = spanner.create_instance instance_id, config: config
 
-    job.must_be_kind_of Google::Cloud::Spanner::Instance::Job
-    job.wont_be :done?
-    job.wont_be :error?
-    job.error.must_be :nil?
-    job.instance.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Instance::Job
+    _(job).wont_be :done?
+    _(job).wont_be :error?
+    _(job.error).must_be :nil?
+    _(job.instance).must_be :nil?
 
     job.reload!
     instance = job.instance
 
-    instance.wont_be :nil?
-    instance.must_be_kind_of Google::Cloud::Spanner::Instance
+    _(instance).wont_be :nil?
+    _(instance).must_be_kind_of Google::Cloud::Spanner::Instance
 
     mock.verify
   end
@@ -101,7 +101,7 @@ describe Google::Cloud::Spanner::Project, :create_instance, :mock_spanner do
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Spanner::Instance::Job
-    job.wont_be :done?
+    _(job).must_be_kind_of Google::Cloud::Spanner::Instance::Job
+    _(job).wont_be :done?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/project/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/database_test.rb
@@ -29,15 +29,15 @@ describe Google::Cloud::Spanner::Project, :database, :mock_spanner do
 
     mock.verify
 
-    database.project_id.must_equal project
-    database.instance_id.must_equal instance_id
-    database.database_id.must_equal database_id
+    _(database.project_id).must_equal project
+    _(database.instance_id).must_equal instance_id
+    _(database.database_id).must_equal database_id
 
-    database.path.must_equal database_path(instance_id, database_id)
+    _(database.path).must_equal database_path(instance_id, database_id)
 
-    database.state.must_equal :READY
-    database.must_be :ready?
-    database.wont_be :creating?
+    _(database.state).must_equal :READY
+    _(database).must_be :ready?
+    _(database).wont_be :creating?
   end
 
   it "returns nil when getting an non-existent database" do
@@ -52,6 +52,6 @@ describe Google::Cloud::Spanner::Project, :database, :mock_spanner do
     spanner.service.mocked_databases = stub
 
     database = spanner.database instance_id, not_found_database_id
-    database.must_be :nil?
+    _(database).must_be :nil?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/project/databases_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/databases_test.rb
@@ -46,7 +46,7 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
     mock.verify
 
-    databases.size.must_equal 3
+    _(databases.size).must_equal 3
   end
 
   it "paginates databases" do
@@ -60,13 +60,13 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
     mock.verify
 
-    first_databases.size.must_equal 3
+    _(first_databases.size).must_equal 3
     token = first_databases.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
 
-    second_databases.size.must_equal 2
-    second_databases.token.must_be :nil?
+    _(second_databases.size).must_equal 2
+    _(second_databases.token).must_be :nil?
   end
 
   it "paginates databases with max set" do
@@ -78,10 +78,10 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
     mock.verify
 
-    databases.size.must_equal 3
+    _(databases.size).must_equal 3
     token = databases.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
   end
 
   it "paginates databases with next? and next" do
@@ -95,11 +95,11 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
     mock.verify
 
-    first_databases.size.must_equal 3
-    first_databases.next?.must_equal true
+    _(first_databases.size).must_equal 3
+    _(first_databases.next?).must_equal true
 
-    second_databases.size.must_equal 2
-    second_databases.next?.must_equal false
+    _(second_databases.size).must_equal 2
+    _(second_databases.next?).must_equal false
   end
 
   it "paginates databases with next? and next and max set" do
@@ -113,11 +113,11 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
     mock.verify
 
-    first_databases.size.must_equal 3
-    first_databases.next?.must_equal true
+    _(first_databases.size).must_equal 3
+    _(first_databases.next?).must_equal true
 
-    second_databases.size.must_equal 2
-    second_databases.next?.must_equal false
+    _(second_databases.size).must_equal 2
+    _(second_databases.next?).must_equal false
   end
 
   it "paginates databases with all" do
@@ -130,7 +130,7 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
     mock.verify
 
-    databases.size.must_equal 5
+    _(databases.size).must_equal 5
   end
 
   it "paginates databases with all and max set" do
@@ -143,7 +143,7 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
     mock.verify
 
-    databases.size.must_equal 5
+    _(databases.size).must_equal 5
   end
 
   it "iterates databases with all using Enumerator" do
@@ -156,7 +156,7 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
     mock.verify
 
-    databases.size.must_equal 5
+    _(databases.size).must_equal 5
   end
 
   it "iterates databases with all and request_limit set" do
@@ -169,6 +169,6 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
     mock.verify
 
-    databases.size.must_equal 6
+    _(databases.size).must_equal 6
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_config_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_config_test.rb
@@ -28,11 +28,11 @@ describe Google::Cloud::Spanner::Project, :instance_config, :mock_spanner do
 
     mock.verify
 
-    config.project_id.must_equal project
-    config.instance_config_id.must_equal instance_config_hash[:name].split("/").last
-    config.path.must_equal instance_config_hash[:name]
-    config.name.must_equal instance_config_hash[:display_name]
-    config.display_name.must_equal instance_config_hash[:display_name]
+    _(config.project_id).must_equal project
+    _(config.instance_config_id).must_equal instance_config_hash[:name].split("/").last
+    _(config.path).must_equal instance_config_hash[:name]
+    _(config.name).must_equal instance_config_hash[:display_name]
+    _(config.display_name).must_equal instance_config_hash[:display_name]
   end
 
   it "returns nil when getting an non-existent instance config" do
@@ -47,6 +47,6 @@ describe Google::Cloud::Spanner::Project, :instance_config, :mock_spanner do
     spanner.service.mocked_instances = stub
 
     config = spanner.instance_config not_found_config_name
-    config.must_be :nil?
+    _(config).must_be :nil?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_configs_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_configs_test.rb
@@ -45,7 +45,7 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
     mock.verify
 
-    configs.size.must_equal 3
+    _(configs.size).must_equal 3
   end
 
   it "paginates configs" do
@@ -59,13 +59,13 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
     mock.verify
 
-    first_configs.size.must_equal 3
+    _(first_configs.size).must_equal 3
     token = first_configs.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
 
-    second_configs.size.must_equal 2
-    second_configs.token.must_be :nil?
+    _(second_configs.size).must_equal 2
+    _(second_configs.token).must_be :nil?
   end
 
   it "paginates configs with max set" do
@@ -77,10 +77,10 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
     mock.verify
 
-    configs.size.must_equal 3
+    _(configs.size).must_equal 3
     token = configs.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
   end
 
   it "paginates configs with next? and next" do
@@ -94,11 +94,11 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
     mock.verify
 
-    first_configs.size.must_equal 3
-    first_configs.next?.must_equal true
+    _(first_configs.size).must_equal 3
+    _(first_configs.next?).must_equal true
 
-    second_configs.size.must_equal 2
-    second_configs.next?.must_equal false
+    _(second_configs.size).must_equal 2
+    _(second_configs.next?).must_equal false
   end
 
   it "paginates configs with next? and next and max set" do
@@ -112,11 +112,11 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
     mock.verify
 
-    first_configs.size.must_equal 3
-    first_configs.next?.must_equal true
+    _(first_configs.size).must_equal 3
+    _(first_configs.next?).must_equal true
 
-    second_configs.size.must_equal 2
-    second_configs.next?.must_equal false
+    _(second_configs.size).must_equal 2
+    _(second_configs.next?).must_equal false
   end
 
   it "paginates configs with all" do
@@ -129,7 +129,7 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
     mock.verify
 
-    configs.size.must_equal 5
+    _(configs.size).must_equal 5
   end
 
   it "paginates configs with all and max set" do
@@ -142,7 +142,7 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
     mock.verify
 
-    configs.size.must_equal 5
+    _(configs.size).must_equal 5
   end
 
   it "iterates configs with all using Enumerator" do
@@ -155,7 +155,7 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
     mock.verify
 
-    configs.size.must_equal 5
+    _(configs.size).must_equal 5
   end
 
   it "iterates configs with all and request_limit set" do
@@ -168,6 +168,6 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
     mock.verify
 
-    configs.size.must_equal 6
+    _(configs.size).must_equal 6
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_test.rb
@@ -27,11 +27,11 @@ describe Google::Cloud::Spanner::Project, :instance, :mock_spanner do
 
     mock.verify
 
-    instance.project_id.must_equal project
-    instance.instance_id.must_equal instance_id
-    instance.path.must_equal instance_path(instance_id)
-    instance.name.must_equal instance_id.split("-").map(&:capitalize).join(" ")
-    instance.display_name.must_equal instance_id.split("-").map(&:capitalize).join(" ")
+    _(instance.project_id).must_equal project
+    _(instance.instance_id).must_equal instance_id
+    _(instance.path).must_equal instance_path(instance_id)
+    _(instance.name).must_equal instance_id.split("-").map(&:capitalize).join(" ")
+    _(instance.display_name).must_equal instance_id.split("-").map(&:capitalize).join(" ")
   end
 
   it "returns nil when getting an non-existent instance" do
@@ -46,6 +46,6 @@ describe Google::Cloud::Spanner::Project, :instance, :mock_spanner do
     spanner.service.mocked_instances = stub
 
     instance = spanner.instance not_found_instance_id
-    instance.must_be :nil?
+    _(instance).must_be :nil?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instances_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instances_test.rb
@@ -45,7 +45,7 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
     mock.verify
 
-    instances.size.must_equal 3
+    _(instances.size).must_equal 3
   end
 
   it "paginates instances" do
@@ -59,13 +59,13 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
     mock.verify
 
-    first_instances.size.must_equal 3
+    _(first_instances.size).must_equal 3
     token = first_instances.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
 
-    second_instances.size.must_equal 2
-    second_instances.token.must_be :nil?
+    _(second_instances.size).must_equal 2
+    _(second_instances.token).must_be :nil?
   end
 
   it "paginates instances with max set" do
@@ -77,10 +77,10 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
     mock.verify
 
-    instances.size.must_equal 3
+    _(instances.size).must_equal 3
     token = instances.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
   end
 
   it "paginates instances with next? and next" do
@@ -94,11 +94,11 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
     mock.verify
 
-    first_instances.size.must_equal 3
-    first_instances.next?.must_equal true
+    _(first_instances.size).must_equal 3
+    _(first_instances.next?).must_equal true
 
-    second_instances.size.must_equal 2
-    second_instances.next?.must_equal false
+    _(second_instances.size).must_equal 2
+    _(second_instances.next?).must_equal false
   end
 
   it "paginates instances with next? and next and max set" do
@@ -112,11 +112,11 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
     mock.verify
 
-    first_instances.size.must_equal 3
-    first_instances.next?.must_equal true
+    _(first_instances.size).must_equal 3
+    _(first_instances.next?).must_equal true
 
-    second_instances.size.must_equal 2
-    second_instances.next?.must_equal false
+    _(second_instances.size).must_equal 2
+    _(second_instances.next?).must_equal false
   end
 
   it "paginates instances with all" do
@@ -129,7 +129,7 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
     mock.verify
 
-    instances.size.must_equal 5
+    _(instances.size).must_equal 5
   end
 
   it "paginates instances with all and max set" do
@@ -142,7 +142,7 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
     mock.verify
 
-    instances.size.must_equal 5
+    _(instances.size).must_equal 5
   end
 
   it "iterates instances with all using Enumerator" do
@@ -155,7 +155,7 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
     mock.verify
 
-    instances.size.must_equal 5
+    _(instances.size).must_equal 5
   end
 
   it "iterates instances with all and request_limit set" do
@@ -168,6 +168,6 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
     mock.verify
 
-    instances.size.must_equal 6
+    _(instances.size).must_equal 6
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/project_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project_test.rb
@@ -16,7 +16,7 @@ require "helper"
 
 describe Google::Cloud::Spanner::Project, :mock_spanner do
   it "knows the project identifier" do
-    spanner.must_be_kind_of Google::Cloud::Spanner::Project
-    spanner.project_id.must_equal project
+    _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+    _(spanner.project_id).must_equal project
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/range_test.rb
@@ -18,40 +18,40 @@ describe Google::Cloud::Spanner::Range do
   it "creates an inclusive range" do
     range = Google::Cloud::Spanner::Range.new 1, 100
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.wont_be :exclude_begin?
-    range.wont_be :exclude_end?
+    _(range).wont_be :exclude_begin?
+    _(range).wont_be :exclude_end?
   end
 
   it "creates an exclusive range" do
     range = Google::Cloud::Spanner::Range.new 1, 100, exclude_begin: true, exclude_end: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.must_be :exclude_begin?
-    range.must_be :exclude_end?
+    _(range).must_be :exclude_begin?
+    _(range).must_be :exclude_end?
   end
 
   it "creates a range that excludes beginning" do
     range = Google::Cloud::Spanner::Range.new 1, 100, exclude_begin: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.must_be :exclude_begin?
-    range.wont_be :exclude_end?
+    _(range).must_be :exclude_begin?
+    _(range).wont_be :exclude_end?
   end
 
   it "creates a range that excludes ending" do
     range = Google::Cloud::Spanner::Range.new 1, 100, exclude_end: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.wont_be :exclude_begin?
-    range.must_be :exclude_end?
+    _(range).wont_be :exclude_begin?
+    _(range).must_be :exclude_end?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/anonymous_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/anonymous_struct_test.rb
@@ -39,23 +39,23 @@ describe Google::Cloud::Spanner::Results, :anonymous_struct, :mock_spanner do
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 
   it "handles anonymous structs" do
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.must_equal [0]
-    results.fields.pairs.must_equal [[0, [Google::Cloud::Spanner::Fields.new([:INT64, :INT64])]]]
-    results.fields.to_a.must_equal [[Google::Cloud::Spanner::Fields.new([:INT64, :INT64])]]
-    results.fields.to_h.must_equal({ 0 => [Google::Cloud::Spanner::Fields.new([:INT64, :INT64])] })
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys).must_equal [0]
+    _(results.fields.pairs).must_equal [[0, [Google::Cloud::Spanner::Fields.new([:INT64, :INT64])]]]
+    _(results.fields.to_a).must_equal [[Google::Cloud::Spanner::Fields.new([:INT64, :INT64])]]
+    _(results.fields.to_h).must_equal({ 0 => [Google::Cloud::Spanner::Fields.new([:INT64, :INT64])] })
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [0]
-    row.values.must_equal [[Google::Cloud::Spanner::Fields.new([:INT64, :INT64]).new([1, 2])]]
-    row.pairs.must_equal [[0, [Google::Cloud::Spanner::Fields.new([:INT64, :INT64]).new([1, 2])]]]
-    row.to_a.must_equal [[{ 0 => 1, 1 => 2 }]]
-    row.to_h.must_equal({ 0 => [{ 0 => 1, 1 => 2 }] })
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [0]
+    _(row.values).must_equal [[Google::Cloud::Spanner::Fields.new([:INT64, :INT64]).new([1, 2])]]
+    _(row.pairs).must_equal [[0, [Google::Cloud::Spanner::Fields.new([:INT64, :INT64]).new([1, 2])]]]
+    _(row.to_a).must_equal [[{ 0 => 1, 1 => 2 }]]
+    _(row.to_h).must_equal({ 0 => [{ 0 => 1, 1 => 2 }] })
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/deeply_nested_list_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/deeply_nested_list_test.rb
@@ -178,23 +178,23 @@ describe Google::Cloud::Spanner::Results, :deeply_nested_list, :mock_spanner do
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 
   it "handles nested structs" do
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.must_equal [0]
-    results.fields.to_a.must_equal [[Google::Cloud::Spanner::Fields.new({ name: :STRING, numbers: [:INT64], strings: [:STRING] })]]
-    results.fields.to_h.must_equal({ 0 => [Google::Cloud::Spanner::Fields.new({ name: :STRING, numbers: [:INT64], strings: [:STRING] })] })
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys).must_equal [0]
+    _(results.fields.to_a).must_equal [[Google::Cloud::Spanner::Fields.new({ name: :STRING, numbers: [:INT64], strings: [:STRING] })]]
+    _(results.fields.to_h).must_equal({ 0 => [Google::Cloud::Spanner::Fields.new({ name: :STRING, numbers: [:INT64], strings: [:STRING] })] })
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [0]
-    row.to_a.must_equal [[{ name: "foo", numbers: [111, 222333], strings: ["foo", "barbaz"] },
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [0]
+    _(row.to_a).must_equal [[{ name: "foo", numbers: [111, 222333], strings: ["foo", "barbaz"] },
                           { name: "bar", numbers: [444555, 666], strings: ["foobar", "baz"] },
                           { name: "baz", numbers: [777888999], strings: ["foobarbaz"] }]]
-    row.to_h.must_equal({ 0 => [{ name: "foo", numbers: [111, 222333], strings: ["foo", "barbaz"] },
+    _(row.to_h).must_equal({ 0 => [{ name: "foo", numbers: [111, 222333], strings: ["foo", "barbaz"] },
                                 { name: "bar", numbers: [444555, 666], strings: ["foobar", "baz"] },
                                 { name: "baz", numbers: [777888999], strings: ["foobarbaz"] }] })
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_struct_test.rb
@@ -39,22 +39,22 @@ describe Google::Cloud::Spanner::Results, :duplicate_struct, :mock_spanner do
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 
   it "handles duplicate structs" do
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.must_equal [0]
-    results.fields.pairs.must_equal [[0, [Google::Cloud::Spanner::Fields.new([[:num, :INT64], [:num, :INT64]])]]]
-    results.fields.to_a.must_equal [[Google::Cloud::Spanner::Fields.new([[:num, :INT64], [:num, :INT64]])]]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys).must_equal [0]
+    _(results.fields.pairs).must_equal [[0, [Google::Cloud::Spanner::Fields.new([[:num, :INT64], [:num, :INT64]])]]]
+    _(results.fields.to_a).must_equal [[Google::Cloud::Spanner::Fields.new([[:num, :INT64], [:num, :INT64]])]]
     results.fields.to_h
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [0]
-    row.values.must_equal [[Google::Cloud::Spanner::Fields.new([[:num, :INT64], [:num, :INT64]]).new([1, 2])]]
-    row.pairs.must_equal [[0, [Google::Cloud::Spanner::Fields.new([[:num, :INT64], [:num, :INT64]]).new([1, 2])]]]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [0]
+    _(row.values).must_equal [[Google::Cloud::Spanner::Fields.new([[:num, :INT64], [:num, :INT64]]).new([1, 2])]]
+    _(row.pairs).must_equal [[0, [Google::Cloud::Spanner::Fields.new([[:num, :INT64], [:num, :INT64]]).new([1, 2])]]]
     assert_raises Google::Cloud::Spanner::DuplicateNameError do
       row.to_a
     end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_test.rb
@@ -50,23 +50,23 @@ describe Google::Cloud::Spanner::Results, :duplicate, :mock_spanner do
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 
   it "handles duplicate names" do
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
     fields = results.fields
-    fields.wont_be :nil?
-    fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    fields.types.must_equal [:INT64, :INT64, :STRING, :STRING]
-    fields.keys.must_equal [:num, :str, :num, :str]
-    fields.pairs.must_equal [[:num, :INT64], [:str, :INT64], [:num, :STRING], [:str, :STRING]]
-    fields.to_a.must_equal [:INT64, :INT64, :STRING, :STRING]
+    _(fields).wont_be :nil?
+    _(fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(fields.types).must_equal [:INT64, :INT64, :STRING, :STRING]
+    _(fields.keys).must_equal [:num, :str, :num, :str]
+    _(fields.pairs).must_equal [[:num, :INT64], [:str, :INT64], [:num, :STRING], [:str, :STRING]]
+    _(fields.to_a).must_equal [:INT64, :INT64, :STRING, :STRING]
     assert_raises Google::Cloud::Spanner::DuplicateNameError do
       fields.to_h
     end
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 2
-    rows.first.to_a.must_equal [1, 2, "hello", "world"]
-    rows.last.to_a.must_equal [3, 4, "hola", "mundo"]
+    _(rows.count).must_equal 2
+    _(rows.first.to_a).must_equal [1, 2, "hello", "world"]
+    _(rows.last.to_a).must_equal [3, 4, "hola", "mundo"]
     assert_raises Google::Cloud::Spanner::DuplicateNameError do
       rows.first.to_h
     end
@@ -75,7 +75,7 @@ describe Google::Cloud::Spanner::Results, :duplicate, :mock_spanner do
       rows.last.to_h
     end
     rows.last.to_h skip_dup_check: true # does not raise
-    rows.first.pairs.must_equal [[:num, 1], [:str, 2], [:num, "hello"], [:str, "world"]]
-    rows.last.pairs.must_equal [[:num, 3], [:str, 4], [:num, "hola"], [:str, "mundo"]]
+    _(rows.first.pairs).must_equal [[:num, 1], [:str, 2], [:num, "hello"], [:str, "world"]]
+    _(rows.last.pairs).must_equal [[:num, 3], [:str, 4], [:num, "hola"], [:str, "mundo"]]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/empty_field_names_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/empty_field_names_test.rb
@@ -50,24 +50,24 @@ describe Google::Cloud::Spanner::Results, :empty_field_names, :mock_spanner do
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 
   it "handles empty field names" do
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
     fields = results.fields
-    fields.wont_be :nil?
-    fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    fields.types.must_equal [:INT64, :INT64, :INT64, :INT64]
-    fields.keys.must_equal [0, 1, 2, 3]
-    fields.pairs.must_equal [[0, :INT64], [1, :INT64], [2, :INT64], [3, :INT64]]
-    fields.to_a.must_equal [:INT64, :INT64, :INT64, :INT64]
-    fields.to_h.must_equal({ 0=>:INT64, 1=>:INT64, 2=>:INT64, 3=>:INT64 })
+    _(fields).wont_be :nil?
+    _(fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(fields.types).must_equal [:INT64, :INT64, :INT64, :INT64]
+    _(fields.keys).must_equal [0, 1, 2, 3]
+    _(fields.pairs).must_equal [[0, :INT64], [1, :INT64], [2, :INT64], [3, :INT64]]
+    _(fields.to_a).must_equal [:INT64, :INT64, :INT64, :INT64]
+    _(fields.to_h).must_equal({ 0=>:INT64, 1=>:INT64, 2=>:INT64, 3=>:INT64 })
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 2
-    rows.first.to_a.must_equal [1, 2, 3, 4]
-    rows.last.to_a.must_equal [5, 6, 7, 8]
-    rows.first.to_h.must_equal({ 0=>1, 1=>2, 2=>3, 3=>4 })
-    rows.last.to_h.must_equal({ 0=>5, 1=>6, 2=>7, 3=>8 })
-    rows.first.pairs.must_equal [[0, 1], [1, 2], [2, 3], [3, 4]]
-    rows.last.pairs.must_equal [[0, 5], [1, 6], [2, 7], [3, 8]]
+    _(rows.count).must_equal 2
+    _(rows.first.to_a).must_equal [1, 2, 3, 4]
+    _(rows.last.to_a).must_equal [5, 6, 7, 8]
+    _(rows.first.to_h).must_equal({ 0=>1, 1=>2, 2=>3, 3=>4 })
+    _(rows.last.to_h).must_equal({ 0=>5, 1=>6, 2=>7, 3=>8 })
+    _(rows.first.pairs).must_equal [[0, 1], [1, 2], [2, 3], [3, 4]]
+    _(rows.last.pairs).must_equal [[0, 5], [1, 6], [2, 7], [3, 8]]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/empty_fields_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/empty_fields_test.rb
@@ -35,18 +35,18 @@ describe Google::Cloud::Spanner::Results, :empty_fields, :mock_spanner do
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 
   it "handles empty field names" do
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
     fields = results.fields
-    fields.wont_be :nil?
-    fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    fields.types.must_equal []
-    fields.keys.must_equal []
-    fields.pairs.must_equal []
-    fields.to_a.must_equal []
-    fields.to_h.must_equal({})
+    _(fields).wont_be :nil?
+    _(fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(fields.types).must_equal []
+    _(fields.keys).must_equal []
+    _(fields.pairs).must_equal []
+    _(fields.to_a).must_equal []
+    _(fields.to_h).must_equal({})
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 0
+    _(rows.count).must_equal 0
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/empty_rows_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/empty_rows_test.rb
@@ -40,18 +40,18 @@ describe Google::Cloud::Spanner::Results, :empty_rows, :mock_spanner do
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 
   it "handles empty field names" do
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
     fields = results.fields
-    fields.wont_be :nil?
-    fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    fields.types.must_equal [:INT64, :INT64, :INT64, :INT64]
-    fields.keys.must_equal [0, 1, 2, 3]
-    fields.pairs.must_equal [[0, :INT64], [1, :INT64], [2, :INT64], [3, :INT64]]
-    fields.to_a.must_equal [:INT64, :INT64, :INT64, :INT64]
-    fields.to_h.must_equal({ 0=>:INT64, 1=>:INT64, 2=>:INT64, 3=>:INT64 })
+    _(fields).wont_be :nil?
+    _(fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(fields.types).must_equal [:INT64, :INT64, :INT64, :INT64]
+    _(fields.keys).must_equal [0, 1, 2, 3]
+    _(fields.pairs).must_equal [[0, :INT64], [1, :INT64], [2, :INT64], [3, :INT64]]
+    _(fields.to_a).must_equal [:INT64, :INT64, :INT64, :INT64]
+    _(fields.to_h).must_equal({ 0=>:INT64, 1=>:INT64, 2=>:INT64, 3=>:INT64 })
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 0
+    _(rows.count).must_equal 0
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_single_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_single_test.rb
@@ -54,35 +54,35 @@ describe Google::Cloud::Spanner::Results, :from_enum, :single_response, :mock_sp
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 
   it "exists" do
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_test.rb
@@ -66,35 +66,35 @@ describe Google::Cloud::Spanner::Results, :from_enum, :mock_spanner do
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 
   it "exists" do
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/merge_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/merge_test.rb
@@ -27,18 +27,18 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:f1].must_equal :STRING
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:f1]).must_equal :STRING
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row[:f1].must_equal "abcdefghi"
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row[:f1]).must_equal "abcdefghi"
   end
 
   it "merges String Arrays" do
@@ -53,18 +53,18 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:f1].must_equal [:STRING]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:f1]).must_equal [:STRING]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row[:f1].must_equal ["abc", "def", "ghi", "jkl"]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row[:f1]).must_equal ["abc", "def", "ghi", "jkl"]
   end
 
   it "merges String Arrays With Nulls" do
@@ -79,18 +79,18 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:f1].must_equal [:STRING]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:f1]).must_equal [:STRING]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row[:f1].must_equal ["abc", "def", nil, "ghi", nil, "jkl"]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row[:f1]).must_equal ["abc", "def", nil, "ghi", nil, "jkl"]
   end
 
   it "merges String Arrays With Empty Strings" do
@@ -105,18 +105,18 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:f1].must_equal [:STRING]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:f1]).must_equal [:STRING]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row[:f1].must_equal ["abc", "def", "ghi", "jkl"]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row[:f1]).must_equal ["abc", "def", "ghi", "jkl"]
   end
 
   it "merges String Arrays With One Large String" do
@@ -131,18 +131,18 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:f1].must_equal [:STRING]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:f1]).must_equal [:STRING]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row[:f1].must_equal ["abcdefghi"]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row[:f1]).must_equal ["abcdefghi"]
   end
 
   it "merges INT64 Arrays" do
@@ -157,18 +157,18 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:f1].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:f1]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row[:f1].must_equal [1, 23, 4, nil, 5]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row[:f1]).must_equal [1, 23, 4, nil, 5]
   end
 
   it "merges FLOAT64 Arrays" do
@@ -183,18 +183,18 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:f1].must_equal [:FLOAT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:f1]).must_equal [:FLOAT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row[:f1].must_equal [1.0, 2.0, Float::INFINITY, -Float::INFINITY, Float::NAN, nil, 3.0]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row[:f1]).must_equal [1.0, 2.0, Float::INFINITY, -Float::INFINITY, Float::NAN, nil, 3.0]
   end
 
   it "merges Multiple Row Chunks/Non Chunks Interleaved" do
@@ -210,15 +210,15 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.new hash }.to_enum
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 1
-    results.fields[:f1].must_equal :STRING
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 1
+    _(results.fields[:f1]).must_equal :STRING
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 4
-    rows.map(&:to_h).must_equal [{ f1: "ab" }, { f1: "c" }, { f1: "d" }, { f1: "ef" }]
+    _(rows.count).must_equal 4
+    _(rows.map(&:to_h)).must_equal [{ f1: "ab" }, { f1: "c" }, { f1: "d" }, { f1: "ef" }]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/nested_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/nested_struct_test.rb
@@ -41,25 +41,25 @@ describe Google::Cloud::Spanner::Results, :nested_struct, :mock_spanner do
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 
   it "handles nested structs" do
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.must_equal [0]
-    results.fields.pairs.must_equal [[0, [Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 })]]]
-    results.fields.to_a.must_equal [[Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 })]]
-    results.fields.to_h.must_equal({ 0 => [Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 })] })
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys).must_equal [0]
+    _(results.fields.pairs).must_equal [[0, [Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 })]]]
+    _(results.fields.to_a).must_equal [[Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 })]]
+    _(results.fields.to_h).must_equal({ 0 => [Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 })] })
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [0]
-    row.values.must_equal [[Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 }).new(["a", 1]),
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [0]
+    _(row.values).must_equal [[Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 }).new(["a", 1]),
                             Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 }).new(["b", 2])]]
-    row.pairs.must_equal [[0, [Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 }).new(["a", 1]),
+    _(row.pairs).must_equal [[0, [Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 }).new(["a", 1]),
                                Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 }).new(["b", 2])]]]
-    row.to_a.must_equal [[{ C1: "a", C2: 1 }, { C1: "b", C2: 2 }]]
-    row.to_h.must_equal({ 0 => [{ C1: "a", C2: 1 }, { C1: "b", C2: 2 }] })
+    _(row.to_a).must_equal [[{ C1: "a", C2: 1 }, { C1: "b", C2: 2 }]]
+    _(row.to_h).must_equal({ 0 => [{ C1: "a", C2: 1 }, { C1: "b", C2: 2 }] })
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/row_count_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/row_count_test.rb
@@ -33,9 +33,9 @@ describe Google::Cloud::Spanner::Results, :row_count, :mock_spanner do
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
     results.rows.to_a # force all results to be processed
 
-    results.must_be :row_count_exact?
-    results.wont_be :row_count_lower_bound?
-    results.row_count.must_equal 1
+    _(results).must_be :row_count_exact?
+    _(results).wont_be :row_count_lower_bound?
+    _(results.row_count).must_equal 1
   end
 
   it "knows lower bound row count" do
@@ -56,9 +56,9 @@ describe Google::Cloud::Spanner::Results, :row_count, :mock_spanner do
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
     results.rows.to_a # force all results to be processed
 
-    results.must_be :row_count_lower_bound?
-    results.wont_be :row_count_exact?
-    results.row_count.must_equal 42
+    _(results).must_be :row_count_lower_bound?
+    _(results).wont_be :row_count_exact?
+    _(results.row_count).must_equal 42
   end
 
   it "does not present row_count if none is provided" do
@@ -76,8 +76,8 @@ describe Google::Cloud::Spanner::Results, :row_count, :mock_spanner do
     results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
     results.rows.to_a # force all results to be processed
 
-    results.wont_be :row_count_exact?
-    results.wont_be :row_count_lower_bound?
-    results.row_count.must_be :nil?
+    _(results).wont_be :row_count_exact?
+    _(results).wont_be :row_count_lower_bound?
+    _(results.row_count).must_be :nil?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/timestamp_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/timestamp_test.rb
@@ -40,8 +40,8 @@ describe Google::Cloud::Spanner::Results, :timestamp, :mock_spanner do
   let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 
   it "knows it has a timestamp" do
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.timestamp.must_equal time_obj
+    _(results.timestamp).must_equal time_obj
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/session/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/commit_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
       c.replace "users", [{ id: 4, name: "Henry",  active: true }]
       c.delete "users", [1, 2, 3, 4, 5]
     end
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     mock.verify
   end
@@ -94,7 +94,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     session.service.mocked_service = mock
 
     timestamp = session.update "users", [{ id: 1, name: "Charlie", active: false }]
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     mock.verify
   end
@@ -114,7 +114,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     session.service.mocked_service = mock
 
     timestamp = session.insert "users", [{ id: 2, name: "Harvey",  active: true }]
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     mock.verify
   end
@@ -134,7 +134,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     session.service.mocked_service = mock
 
     timestamp = session.upsert "users", [{ id: 3, name: "Marley",  active: false }]
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     mock.verify
   end
@@ -154,7 +154,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     session.service.mocked_service = mock
 
     timestamp = session.save "users", [{ id: 3, name: "Marley",  active: false }]
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     mock.verify
   end
@@ -174,7 +174,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     session.service.mocked_service = mock
 
     timestamp = session.replace "users", [{ id: 4, name: "Henry",  active: true }]
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     mock.verify
   end
@@ -197,7 +197,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     session.service.mocked_service = mock
 
     timestamp = session.delete "users", [1, 2, 3, 4, 5]
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     mock.verify
   end
@@ -218,7 +218,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     session.service.mocked_service = mock
 
     timestamp = session.delete "users", 1..100
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     mock.verify
   end
@@ -241,7 +241,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     session.service.mocked_service = mock
 
     timestamp = session.delete "users", 5
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     mock.verify
   end
@@ -260,7 +260,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     session.service.mocked_service = mock
 
     timestamp = session.delete "users"
-    timestamp.must_equal commit_time
+    _(timestamp).must_equal commit_time
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/session/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/execute_query_test.rb
@@ -277,35 +277,35 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
     # results.fields[:project_ids].must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
     # row[:project_ids].must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
@@ -62,7 +62,7 @@ describe Google::Cloud::Spanner::Session, :keepalive, :mock_spanner do
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
 
     result = session.keepalive!
-    result.must_equal false
+    _(result).must_equal false
     mock.verify
   end
 
@@ -76,7 +76,7 @@ describe Google::Cloud::Spanner::Session, :keepalive, :mock_spanner do
     mock.expect :create_session, session_grpc_labels, [database_path(instance_id, database_id), session: Google::Spanner::V1::Session.new(labels: labels), options: default_options]
 
     result = session_labels.keepalive!
-    result.must_equal false
+    _(result).must_equal false
     mock.verify
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
@@ -149,35 +149,35 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/session/reload_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/reload_test.rb
@@ -31,18 +31,18 @@ describe Google::Cloud::Spanner::Session, :reload, :mock_spanner do
     mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     session.service.mocked_service = mock
 
-    session.must_be_kind_of Google::Cloud::Spanner::Session
+    _(session).must_be_kind_of Google::Cloud::Spanner::Session
 
     session.reload!
 
     mock.verify
 
-    session.must_be_kind_of Google::Cloud::Spanner::Session
+    _(session).must_be_kind_of Google::Cloud::Spanner::Session
 
-    session.project_id.must_equal "test"
-    session.instance_id.must_equal "my-instance-id"
-    session.database_id.must_equal "my-database-id"
-    session.session_id.must_equal "session123"
+    _(session.project_id).must_equal "test"
+    _(session.instance_id).must_equal "my-instance-id"
+    _(session.database_id).must_equal "my-database-id"
+    _(session.session_id).must_equal "session123"
   end
 
   it "can recreate itself if error is raised on reload" do
@@ -53,18 +53,18 @@ describe Google::Cloud::Spanner::Session, :reload, :mock_spanner do
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     session.service.mocked_service = mock
 
-    session.must_be_kind_of Google::Cloud::Spanner::Session
+    _(session).must_be_kind_of Google::Cloud::Spanner::Session
 
     session.reload!
 
     mock.verify
 
-    session.must_be_kind_of Google::Cloud::Spanner::Session
+    _(session).must_be_kind_of Google::Cloud::Spanner::Session
 
-    session.project_id.must_equal "test"
-    session.instance_id.must_equal "my-instance-id"
-    session.database_id.must_equal "my-database-id"
-    session.session_id.must_equal "session123"
+    _(session.project_id).must_equal "test"
+    _(session.instance_id).must_equal "my-instance-id"
+    _(session.database_id).must_equal "my-database-id"
+    _(session.session_id).must_equal "session123"
   end
 
   it "can recreate itself with labels if error on reload" do
@@ -75,17 +75,17 @@ describe Google::Cloud::Spanner::Session, :reload, :mock_spanner do
     mock.expect :create_session, session_grpc_labels, [database_path(instance_id, database_id), session: Google::Spanner::V1::Session.new(labels: labels), options: default_options]
     session_labels.service.mocked_service = mock
 
-    session_labels.must_be_kind_of Google::Cloud::Spanner::Session
+    _(session_labels).must_be_kind_of Google::Cloud::Spanner::Session
 
     session_labels.reload!
 
     mock.verify
 
-    session_labels.must_be_kind_of Google::Cloud::Spanner::Session
+    _(session_labels).must_be_kind_of Google::Cloud::Spanner::Session
 
-    session_labels.project_id.must_equal "test"
-    session_labels.instance_id.must_equal "my-instance-id"
-    session_labels.database_id.must_equal "my-database-id"
-    session_labels.session_id.must_equal "session123"
+    _(session_labels.project_id).must_equal "test"
+    _(session_labels.instance_id).must_equal "my-instance-id"
+    _(session_labels.database_id).must_equal "my-database-id"
+    _(session_labels.session_id).must_equal "session123"
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_query_test.rb
@@ -262,35 +262,35 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/metadata_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/metadata_test.rb
@@ -27,14 +27,14 @@ describe Google::Cloud::Spanner::Snapshot, :metadata, :mock_spanner do
   let(:snapshot) { Google::Cloud::Spanner::Snapshot.from_grpc transaction_grpc, session }
 
   it "knows it has a transaction_id" do
-    snapshot.must_be_kind_of Google::Cloud::Spanner::Snapshot
+    _(snapshot).must_be_kind_of Google::Cloud::Spanner::Snapshot
 
-    snapshot.transaction_id.must_equal transaction_id
+    _(snapshot.transaction_id).must_equal transaction_id
   end
 
   it "knows it has a timestamp" do
-    snapshot.must_be_kind_of Google::Cloud::Spanner::Snapshot
+    _(snapshot).must_be_kind_of Google::Cloud::Spanner::Snapshot
 
-    snapshot.timestamp.must_equal time_obj
+    _(snapshot.timestamp).must_equal time_obj
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/range_test.rb
@@ -27,40 +27,40 @@ describe Google::Cloud::Spanner::Snapshot, :range, :mock_spanner do
   it "creates an inclusive range" do
     range = snapshot.range 1, 100
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.wont_be :exclude_begin?
-    range.wont_be :exclude_end?
+    _(range).wont_be :exclude_begin?
+    _(range).wont_be :exclude_end?
   end
 
   it "creates an exclusive range" do
     range = snapshot.range 1, 100, exclude_begin: true, exclude_end: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.must_be :exclude_begin?
-    range.must_be :exclude_end?
+    _(range).must_be :exclude_begin?
+    _(range).must_be :exclude_end?
   end
 
   it "creates a range that excludes beginning" do
     range = snapshot.range 1, 100, exclude_begin: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.must_be :exclude_begin?
-    range.wont_be :exclude_end?
+    _(range).must_be :exclude_begin?
+    _(range).wont_be :exclude_end?
   end
 
   it "creates a range that excludes ending" do
     range = snapshot.range 1, 100, exclude_end: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.wont_be :exclude_begin?
-    range.must_be :exclude_end?
+    _(range).wont_be :exclude_begin?
+    _(range).must_be :exclude_end?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
@@ -160,35 +160,35 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/status_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/status_test.rb
@@ -19,138 +19,138 @@ describe Google::Cloud::Spanner::Status do
 
   it "supports code 0" do
     status = from_grpc 0
-    status.code.must_equal 0
-    status.description.must_equal "OK"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 0
+    _(status.description).must_equal "OK"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 1" do
     status = from_grpc 1
-    status.code.must_equal 1
-    status.description.must_equal "CANCELLED"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 1
+    _(status.description).must_equal "CANCELLED"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 2" do
     status = from_grpc 2
-    status.code.must_equal 2
-    status.description.must_equal "UNKNOWN"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 2
+    _(status.description).must_equal "UNKNOWN"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 3" do
     status = from_grpc 3
-    status.code.must_equal 3
-    status.description.must_equal "INVALID_ARGUMENT"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 3
+    _(status.description).must_equal "INVALID_ARGUMENT"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 4" do
     status = from_grpc 4
-    status.code.must_equal 4
-    status.description.must_equal "DEADLINE_EXCEEDED"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 4
+    _(status.description).must_equal "DEADLINE_EXCEEDED"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 5" do
     status = from_grpc 5
-    status.code.must_equal 5
-    status.description.must_equal "NOT_FOUND"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 5
+    _(status.description).must_equal "NOT_FOUND"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 6" do
     status = from_grpc 6
-    status.code.must_equal 6
-    status.description.must_equal "ALREADY_EXISTS"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 6
+    _(status.description).must_equal "ALREADY_EXISTS"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 7" do
     status = from_grpc 7
-    status.code.must_equal 7
-    status.description.must_equal "PERMISSION_DENIED"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 7
+    _(status.description).must_equal "PERMISSION_DENIED"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 8" do
     status = from_grpc 8
-    status.code.must_equal 8
-    status.description.must_equal "RESOURCE_EXHAUSTED"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 8
+    _(status.description).must_equal "RESOURCE_EXHAUSTED"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 9" do
     status = from_grpc 9
-    status.code.must_equal 9
-    status.description.must_equal "FAILED_PRECONDITION"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 9
+    _(status.description).must_equal "FAILED_PRECONDITION"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 10" do
     status = from_grpc 10
-    status.code.must_equal 10
-    status.description.must_equal "ABORTED"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 10
+    _(status.description).must_equal "ABORTED"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 11" do
     status = from_grpc 11
-    status.code.must_equal 11
-    status.description.must_equal "OUT_OF_RANGE"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 11
+    _(status.description).must_equal "OUT_OF_RANGE"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 12" do
     status = from_grpc 12
-    status.code.must_equal 12
-    status.description.must_equal "UNIMPLEMENTED"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 12
+    _(status.description).must_equal "UNIMPLEMENTED"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 13" do
     status = from_grpc 13
-    status.code.must_equal 13
-    status.description.must_equal "INTERNAL"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 13
+    _(status.description).must_equal "INTERNAL"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 14" do
     status = from_grpc 14
-    status.code.must_equal 14
-    status.description.must_equal "UNAVAILABLE"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 14
+    _(status.description).must_equal "UNAVAILABLE"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 15" do
     status = from_grpc 15
-    status.code.must_equal 15
-    status.description.must_equal "DATA_LOSS"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 15
+    _(status.description).must_equal "DATA_LOSS"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   it "supports code 16" do
     status = from_grpc 16
-    status.code.must_equal 16
-    status.description.must_equal "UNAUTHENTICATED"
-    status.message.must_equal msg
-    status.details.must_equal []
+    _(status.code).must_equal 16
+    _(status.description).must_equal "UNAUTHENTICATED"
+    _(status.message).must_equal msg
+    _(status.details).must_equal []
   end
 
   def from_grpc code

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/batch_update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/batch_update_test.rb
@@ -40,8 +40,8 @@ describe Google::Cloud::Spanner::Transaction, :batch_update, :mock_spanner do
 
     mock.verify
 
-    row_counts.count.must_equal 1
-    row_counts.first.must_equal 1
+    _(row_counts.count).must_equal 1
+    _(row_counts.first).must_equal 1
   end
 
   it "can execute a DML query with multiple statements and param types" do
@@ -73,16 +73,16 @@ describe Google::Cloud::Spanner::Transaction, :batch_update, :mock_spanner do
 
     mock.verify
 
-    row_counts.count.must_equal 9
-    row_counts.first.must_equal 1
-    row_counts.last.must_equal 1
+    _(row_counts.count).must_equal 9
+    _(row_counts.first).must_equal 1
+    _(row_counts.last).must_equal 1
   end
 
   it "raises ArgumentError if no block is provided" do
     err = expect do
       transaction.batch_update
     end.must_raise ArgumentError
-    err.message.must_equal "block is required"
+    _(err.message).must_equal "block is required"
   end
 
   describe "when used with execute_update" do

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/commit_timestamp.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/commit_timestamp.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Spanner::Transaction, :commit_timestamp, :mock_spanner d
   it "creates a commit_timestamp column value" do
     column_value = transaction.commit_timestamp
 
-    column_value.must_be_kind_of Google::Cloud::Spanner::ColumnValue
-    column_value.type.must_equal :commit_timestamp
+    _(column_value).must_be_kind_of Google::Cloud::Spanner::ColumnValue
+    _(column_value.type).must_equal :commit_timestamp
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_query_test.rb
@@ -262,35 +262,35 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_update_test.rb
@@ -49,7 +49,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a DML query with bool param" do
@@ -61,7 +61,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a DML query with int param" do
@@ -73,7 +73,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a DML query with float param" do
@@ -85,7 +85,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a DML query with Time param" do
@@ -99,7 +99,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a DML query with Date param" do
@@ -113,7 +113,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a DML query with String param" do
@@ -125,7 +125,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a DML query with IO-ish param" do
@@ -139,7 +139,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a DML query with an Array param" do
@@ -151,7 +151,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a DML query with an empty Array param" do
@@ -163,7 +163,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a DML query with a simple Hash param" do
@@ -175,7 +175,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a DML query with a complex Hash param" do
@@ -187,7 +187,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "can execute a DML query with an empty Hash param" do
@@ -199,7 +199,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 
   it "raises InvalidArgumentError if the response does not contain stats" do
@@ -228,6 +228,6 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
 
     mock.verify
 
-    row_count.must_equal 1
+    _(row_count).must_equal 1
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/fields_for_test.rb
@@ -61,17 +61,17 @@ describe Google::Cloud::Spanner::Transaction, :fields_for, :mock_spanner do
   end
 
   def assert_fields fields
-    fields.wont_be :nil?
-    fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    fields.keys.count.must_equal 9
-    fields[:id].must_equal          :INT64
-    fields[:name].must_equal        :STRING
-    fields[:active].must_equal      :BOOL
-    fields[:age].must_equal         :INT64
-    fields[:score].must_equal       :FLOAT64
-    fields[:updated_at].must_equal  :TIMESTAMP
-    fields[:birthday].must_equal    :DATE
-    fields[:avatar].must_equal      :BYTES
-    fields[:project_ids].must_equal [:INT64]
+    _(fields).wont_be :nil?
+    _(fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(fields.keys.count).must_equal 9
+    _(fields[:id]).must_equal          :INT64
+    _(fields[:name]).must_equal        :STRING
+    _(fields[:active]).must_equal      :BOOL
+    _(fields[:age]).must_equal         :INT64
+    _(fields[:score]).must_equal       :FLOAT64
+    _(fields[:updated_at]).must_equal  :TIMESTAMP
+    _(fields[:birthday]).must_equal    :DATE
+    _(fields[:avatar]).must_equal      :BYTES
+    _(fields[:project_ids]).must_equal [:INT64]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/range_test.rb
@@ -27,40 +27,40 @@ describe Google::Cloud::Spanner::Transaction, :range, :mock_spanner do
   it "creates an inclusive range" do
     range = transaction.range 1, 100
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.wont_be :exclude_begin?
-    range.wont_be :exclude_end?
+    _(range).wont_be :exclude_begin?
+    _(range).wont_be :exclude_end?
   end
 
   it "creates an exclusive range" do
     range = transaction.range 1, 100, exclude_begin: true, exclude_end: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.must_be :exclude_begin?
-    range.must_be :exclude_end?
+    _(range).must_be :exclude_begin?
+    _(range).must_be :exclude_end?
   end
 
   it "creates a range that excludes beginning" do
     range = transaction.range 1, 100, exclude_begin: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.must_be :exclude_begin?
-    range.wont_be :exclude_end?
+    _(range).must_be :exclude_begin?
+    _(range).wont_be :exclude_end?
   end
 
   it "creates a range that excludes ending" do
     range = transaction.range 1, 100, exclude_end: true
 
-    range.begin.must_equal 1
-    range.end.must_equal 100
+    _(range.begin).must_equal 1
+    _(range.end).must_equal 100
 
-    range.wont_be :exclude_begin?
-    range.must_be :exclude_end?
+    _(range).wont_be :exclude_begin?
+    _(range).must_be :exclude_end?
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
@@ -160,35 +160,35 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
   end
 
   def assert_results results
-    results.must_be_kind_of Google::Cloud::Spanner::Results
+    _(results).must_be_kind_of Google::Cloud::Spanner::Results
 
-    results.fields.wont_be :nil?
-    results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    results.fields.keys.count.must_equal 9
-    results.fields[:id].must_equal          :INT64
-    results.fields[:name].must_equal        :STRING
-    results.fields[:active].must_equal      :BOOL
-    results.fields[:age].must_equal         :INT64
-    results.fields[:score].must_equal       :FLOAT64
-    results.fields[:updated_at].must_equal  :TIMESTAMP
-    results.fields[:birthday].must_equal    :DATE
-    results.fields[:avatar].must_equal      :BYTES
-    results.fields[:project_ids].must_equal [:INT64]
+    _(results.fields).wont_be :nil?
+    _(results.fields).must_be_kind_of Google::Cloud::Spanner::Fields
+    _(results.fields.keys.count).must_equal 9
+    _(results.fields[:id]).must_equal          :INT64
+    _(results.fields[:name]).must_equal        :STRING
+    _(results.fields[:active]).must_equal      :BOOL
+    _(results.fields[:age]).must_equal         :INT64
+    _(results.fields[:score]).must_equal       :FLOAT64
+    _(results.fields[:updated_at]).must_equal  :TIMESTAMP
+    _(results.fields[:birthday]).must_equal    :DATE
+    _(results.fields[:avatar]).must_equal      :BYTES
+    _(results.fields[:project_ids]).must_equal [:INT64]
 
     rows = results.rows.to_a # grab them all from the enumerator
-    rows.count.must_equal 1
+    _(rows.count).must_equal 1
     row = rows.first
-    row.must_be_kind_of Google::Cloud::Spanner::Data
-    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
-    row[:id].must_equal 1
-    row[:name].must_equal "Charlie"
-    row[:active].must_equal true
-    row[:age].must_equal 29
-    row[:score].must_equal 0.9
-    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
-    row[:birthday].must_equal Date.parse("1950-01-01")
-    row[:avatar].must_be_kind_of StringIO
-    row[:avatar].read.must_equal "image"
-    row[:project_ids].must_equal [1, 2, 3]
+    _(row).must_be_kind_of Google::Cloud::Spanner::Data
+    _(row.keys).must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    _(row[:id]).must_equal 1
+    _(row[:name]).must_equal "Charlie"
+    _(row[:active]).must_equal true
+    _(row[:age]).must_equal 29
+    _(row[:score]).must_equal 0.9
+    _(row[:updated_at]).must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    _(row[:birthday]).must_equal Date.parse("1950-01-01")
+    _(row[:avatar]).must_be_kind_of StringIO
+    _(row[:avatar].read).must_equal "image"
+    _(row[:project_ids]).must_equal [1, 2, 3]
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/transaction_id_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/transaction_id_test.rb
@@ -25,8 +25,8 @@ describe Google::Cloud::Spanner::Transaction, :transaction_id, :mock_spanner do
   let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
 
   it "knows it has a timestamp" do
-    transaction.must_be_kind_of Google::Cloud::Spanner::Transaction
+    _(transaction).must_be_kind_of Google::Cloud::Spanner::Transaction
 
-    transaction.transaction_id.must_equal transaction_id
+    _(transaction.transaction_id).must_equal transaction_id
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner_test.rb
@@ -19,76 +19,76 @@ describe Google::Cloud do
     it "calls out to Google::Cloud.spanner" do
       gcloud = Google::Cloud.new
       stubbed_spanner = ->(project, keyfile, scope: nil, timeout: nil, host: nil, client_config: nil, lib_name: nil, lib_version: nil) {
-        project.must_be :nil?
-        keyfile.must_be :nil?
-        scope.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
-        lib_name.must_be :nil?
-        lib_version.must_be :nil?
+        _(project).must_be :nil?
+        _(keyfile).must_be :nil?
+        _(scope).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
+        _(lib_name).must_be :nil?
+        _(lib_version).must_be :nil?
         "spanner-project-object-empty"
       }
       Google::Cloud.stub :spanner, stubbed_spanner do
         project = gcloud.spanner
-        project.must_equal "spanner-project-object-empty"
+        _(project).must_equal "spanner-project-object-empty"
       end
     end
 
     it "passes project and keyfile to Google::Cloud.spanner" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_spanner = ->(project, keyfile, scope: nil, timeout: nil, host: nil, client_config: nil, lib_name: nil, lib_version: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
-        lib_name.must_be :nil?
-        lib_version.must_be :nil?
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
+        _(lib_name).must_be :nil?
+        _(lib_version).must_be :nil?
         "spanner-project-object"
       }
       Google::Cloud.stub :spanner, stubbed_spanner do
         project = gcloud.spanner
-        project.must_equal "spanner-project-object"
+        _(project).must_equal "spanner-project-object"
       end
     end
 
     it "passes project and keyfile and options to Google::Cloud.spanner" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_spanner = ->(project, keyfile, scope: nil, timeout: nil, host: nil, client_config: nil, lib_name: nil, lib_version: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_equal "http://example.com/scope"
-        timeout.must_equal 60
-        host.must_be :nil?
-        client_config.must_equal({ "gax" => "options" })
-        lib_name.must_be :nil?
-        lib_version.must_be :nil?
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_equal "http://example.com/scope"
+        _(timeout).must_equal 60
+        _(host).must_be :nil?
+        _(client_config).must_equal({ "gax" => "options" })
+        _(lib_name).must_be :nil?
+        _(lib_version).must_be :nil?
         "spanner-project-object-scoped"
       }
       Google::Cloud.stub :spanner, stubbed_spanner do
         project = gcloud.spanner scope: "http://example.com/scope", timeout: 60, client_config: { "gax" => "options" }
-        project.must_equal "spanner-project-object-scoped"
+        _(project).must_equal "spanner-project-object-scoped"
       end
     end
 
     it "passes lib name and version to Google::Cloud.spanner" do
       gcloud = Google::Cloud.new
       stubbed_spanner = ->(project, keyfile, scope: nil, timeout: nil, host: nil, client_config: nil, lib_name: nil, lib_version: nil) {
-        project.must_be :nil?
-        keyfile.must_be :nil?
-        scope.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
-        lib_name.must_equal "spanner-ruby"
-        lib_version.must_equal "1.0.0"
+        _(project).must_be :nil?
+        _(keyfile).must_be :nil?
+        _(scope).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
+        _(lib_name).must_equal "spanner-ruby"
+        _(lib_version).must_equal "1.0.0"
         "spanner-project-object-with-lib-version-name"
       }
       Google::Cloud.stub :spanner, stubbed_spanner do
         project = gcloud.spanner lib_name: "spanner-ruby", lib_version: "1.0.0"
-        project.must_equal "spanner-project-object-with-lib-version-name"
+        _(project).must_equal "spanner-project-object-with-lib-version-name"
       end
     end
   end
@@ -110,9 +110,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Spanner::Credentials.stub :default, default_credentials do
             spanner = Google::Cloud.spanner
-            spanner.must_be_kind_of Google::Cloud::Spanner::Project
-            spanner.project.must_equal "project-id"
-            spanner.service.credentials.must_equal default_credentials
+            _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+            _(spanner.project).must_equal "project-id"
+            _(spanner.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -120,21 +120,21 @@ describe Google::Cloud do
 
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "spanner-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
 
-        project.must_equal "project-id"
-        credentials.must_equal "spanner-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
-        keyword_args.key?(:lib_name).must_equal true
-        keyword_args.key?(:lib_version).must_equal true
-        keyword_args[:lib_name].must_be :nil?
-        keyword_args[:lib_version].must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "spanner-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
+        _(keyword_args.key?(:lib_name)).must_equal true
+        _(keyword_args.key?(:lib_version)).must_equal true
+        _(keyword_args[:lib_name]).must_be :nil?
+        _(keyword_args[:lib_version]).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -145,9 +145,9 @@ describe Google::Cloud do
             Google::Cloud::Spanner::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Spanner::Service.stub :new, stubbed_service do
                 spanner = Google::Cloud.spanner "project-id", "path/to/keyfile.json"
-                spanner.must_be_kind_of Google::Cloud::Spanner::Project
-                spanner.project.must_equal "project-id"
-                spanner.service.must_be_kind_of OpenStruct
+                _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+                _(spanner.project).must_equal "project-id"
+                _(spanner.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -173,12 +173,12 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Spanner::Credentials.stub :default, default_credentials do
             spanner = Google::Cloud::Spanner.new
-            spanner.must_be_kind_of Google::Cloud::Spanner::Project
-            spanner.project.must_equal "project-id"
-            spanner.service.credentials.must_equal default_credentials
-            spanner.service.lib_name.must_be :nil?
-            spanner.service.lib_version.must_be :nil?
-            spanner.service.send(:lib_name_with_prefix).must_equal "gccl"
+            _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+            _(spanner.project).must_equal "project-id"
+            _(spanner.service.credentials).must_equal default_credentials
+            _(spanner.service.lib_name).must_be :nil?
+            _(spanner.service.lib_version).must_be :nil?
+            _(spanner.service.send(:lib_name_with_prefix)).must_equal "gccl"
           end
         end
       end
@@ -186,20 +186,20 @@ describe Google::Cloud do
 
     it "uses provided project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "spanner-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
-        project.must_equal "project-id"
-        credentials.must_equal "spanner-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
-        keyword_args.key?(:lib_name).must_equal true
-        keyword_args.key?(:lib_version).must_equal true
-        keyword_args[:lib_name].must_be :nil?
-        keyword_args[:lib_version].must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "spanner-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
+        _(keyword_args.key?(:lib_name)).must_equal true
+        _(keyword_args.key?(:lib_version)).must_equal true
+        _(keyword_args[:lib_name]).must_be :nil?
+        _(keyword_args[:lib_version]).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -210,9 +210,9 @@ describe Google::Cloud do
             Google::Cloud::Spanner::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Spanner::Service.stub :new, stubbed_service do
                 spanner = Google::Cloud::Spanner.new project_id: "project-id", credentials: "path/to/keyfile.json"
-                spanner.must_be_kind_of Google::Cloud::Spanner::Project
-                spanner.project.must_equal "project-id"
-                spanner.service.must_be_kind_of OpenStruct
+                _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+                _(spanner.project).must_equal "project-id"
+                _(spanner.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -223,15 +223,15 @@ describe Google::Cloud do
     it "uses provided endpoint" do
       endpoint = "spanner-endpoint2.example.com"
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
-        project.must_equal "project-id"
-        credentials.must_equal default_credentials
-        timeout.must_be :nil?
-        host.must_equal endpoint
-        client_config.must_be :nil?
-        keyword_args.key?(:lib_name).must_equal true
-        keyword_args.key?(:lib_version).must_equal true
-        keyword_args[:lib_name].must_be :nil?
-        keyword_args[:lib_version].must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(timeout).must_be :nil?
+        _(host).must_equal endpoint
+        _(client_config).must_be :nil?
+        _(keyword_args.key?(:lib_name)).must_equal true
+        _(keyword_args.key?(:lib_version)).must_equal true
+        _(keyword_args[:lib_name]).must_be :nil?
+        _(keyword_args[:lib_version]).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -239,29 +239,29 @@ describe Google::Cloud do
       ENV.stub :[], nil do
         Google::Cloud::Spanner::Service.stub :new, stubbed_service do
           spanner = Google::Cloud::Spanner.new project: "project-id", credentials: default_credentials, endpoint: endpoint
-          spanner.must_be_kind_of Google::Cloud::Spanner::Project
-          spanner.project.must_equal "project-id"
-          spanner.service.must_be_kind_of OpenStruct
+          _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+          _(spanner.project).must_equal "project-id"
+          _(spanner.service).must_be_kind_of OpenStruct
         end
       end
     end
 
     it "uses provided project and keyfile aliases" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "spanner-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
-        project.must_equal "project-id"
-        credentials.must_equal "spanner-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
-        keyword_args.key?(:lib_name).must_equal true
-        keyword_args.key?(:lib_version).must_equal true
-        keyword_args[:lib_name].must_be :nil?
-        keyword_args[:lib_version].must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "spanner-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
+        _(keyword_args.key?(:lib_name)).must_equal true
+        _(keyword_args.key?(:lib_version)).must_equal true
+        _(keyword_args[:lib_name]).must_be :nil?
+        _(keyword_args[:lib_version]).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -272,9 +272,9 @@ describe Google::Cloud do
             Google::Cloud::Spanner::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Spanner::Service.stub :new, stubbed_service do
                 spanner = Google::Cloud::Spanner.new project: "project-id", keyfile: "path/to/keyfile.json"
-                spanner.must_be_kind_of Google::Cloud::Spanner::Project
-                spanner.project.must_equal "project-id"
-                spanner.service.must_be_kind_of OpenStruct
+                _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+                _(spanner.project).must_equal "project-id"
+                _(spanner.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -284,21 +284,21 @@ describe Google::Cloud do
 
     it "gets project_id from credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         OpenStruct.new project_id: "project-id"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
-        project.must_equal "project-id"
-        credentials.must_be_kind_of OpenStruct
-        credentials.project_id.must_equal "project-id"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
-        keyword_args.key?(:lib_name).must_equal true
-        keyword_args.key?(:lib_version).must_equal true
-        keyword_args[:lib_name].must_be :nil?
-        keyword_args[:lib_version].must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_be_kind_of OpenStruct
+        _(credentials.project_id).must_equal "project-id"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
+        _(keyword_args.key?(:lib_name)).must_equal true
+        _(keyword_args.key?(:lib_version)).must_equal true
+        _(keyword_args[:lib_name]).must_be :nil?
+        _(keyword_args[:lib_version]).must_be :nil?
         OpenStruct.new project: project
       }
       empty_env = OpenStruct.new
@@ -311,9 +311,9 @@ describe Google::Cloud do
               Google::Cloud::Spanner::Credentials.stub :new, stubbed_credentials do
                 Google::Cloud::Spanner::Service.stub :new, stubbed_service do
                   spanner = Google::Cloud::Spanner.new credentials: "path/to/keyfile.json"
-                  spanner.must_be_kind_of Google::Cloud::Spanner::Project
-                  spanner.project.must_equal "project-id"
-                  spanner.service.must_be_kind_of OpenStruct
+                  _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+                  _(spanner.project).must_equal "project-id"
+                  _(spanner.service).must_be_kind_of OpenStruct
                 end
               end
             end
@@ -331,10 +331,10 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Spanner::Credentials.stub :default, default_credentials do
             spanner = Google::Cloud::Spanner.new
-            spanner.must_be_kind_of Google::Cloud::Spanner::Project
-            spanner.project.must_equal "project-id"
-            spanner.service.credentials.must_equal :this_channel_is_insecure
-            spanner.service.host.must_equal emulator_host
+            _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+            _(spanner.project).must_equal "project-id"
+            _(spanner.service.credentials).must_equal :this_channel_is_insecure
+            _(spanner.service.host).must_equal emulator_host
           end
         end
       end
@@ -347,7 +347,7 @@ describe Google::Cloud do
           credentials = OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {}))
           new_spanner = Google::Cloud::Spanner.new
           new_client = new_spanner.client "instance-id", "database-id", pool: { min: 0 }, query_options: expect_query_options
-          new_client.query_options.must_equal expect_query_options
+          _(new_client.query_options).must_equal expect_query_options
         end
       end
     end
@@ -362,7 +362,7 @@ describe Google::Cloud do
             credentials = OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {}))
             new_spanner = Google::Cloud::Spanner.new
             new_client = new_spanner.client "instance-id", "database-id", pool: { min: 0 }, query_options: { optimizer_version: "1", another_field: "test" }
-            new_client.query_options.must_equal expect_query_options
+            _(new_client.query_options).must_equal expect_query_options
           end
         end
       end
@@ -376,10 +376,10 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Spanner::Credentials.stub :default, default_credentials do
             spanner = Google::Cloud::Spanner.new emulator_host: emulator_host
-            spanner.must_be_kind_of Google::Cloud::Spanner::Project
-            spanner.project.must_equal "project-id"
-            spanner.service.credentials.must_equal :this_channel_is_insecure
-            spanner.service.host.must_equal emulator_host
+            _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+            _(spanner.project).must_equal "project-id"
+            _(spanner.service.credentials).must_equal :this_channel_is_insecure
+            _(spanner.service.host).must_equal emulator_host
           end
         end
       end
@@ -395,11 +395,11 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Spanner::Credentials.stub :default, default_credentials do
             spanner = Google::Cloud::Spanner.new lib_name: lib_name, lib_version: lib_version
-            spanner.must_be_kind_of Google::Cloud::Spanner::Project
-            spanner.project.must_equal "project-id"
-            spanner.service.lib_name.must_equal lib_name
-            spanner.service.lib_version.must_equal lib_version
-            spanner.service.send(:lib_name_with_prefix).must_equal "#{lib_name}/#{lib_version} gccl"
+            _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+            _(spanner.project).must_equal "project-id"
+            _(spanner.service.lib_name).must_equal lib_name
+            _(spanner.service.lib_version).must_equal lib_version
+            _(spanner.service.send(:lib_name_with_prefix)).must_equal "#{lib_name}/#{lib_version} gccl"
           end
         end
       end
@@ -415,7 +415,7 @@ describe Google::Cloud do
           Google::Cloud::Spanner::Credentials.stub :default, default_credentials do
             spanner = Google::Cloud::Spanner.new
             query_options = {optimizer_version: optimizer_version}
-            spanner.query_options.must_equal query_options
+            _(spanner.query_options).must_equal query_options
           end
         end
       end
@@ -430,11 +430,11 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Spanner::Credentials.stub :default, default_credentials do
             spanner = Google::Cloud::Spanner.new lib_name: lib_name
-            spanner.must_be_kind_of Google::Cloud::Spanner::Project
-            spanner.project.must_equal "project-id"
-            spanner.service.lib_name.must_equal lib_name
-            spanner.service.lib_version.must_be :nil?
-            spanner.service.send(:lib_name_with_prefix).must_equal "#{lib_name} gccl"
+            _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+            _(spanner.project).must_equal "project-id"
+            _(spanner.service.lib_name).must_equal lib_name
+            _(spanner.service.lib_version).must_be :nil?
+            _(spanner.service.send(:lib_name_with_prefix)).must_equal "#{lib_name} gccl"
           end
         end
       end
@@ -444,8 +444,8 @@ describe Google::Cloud do
   describe "Spanner.configure" do
     let(:default_credentials) do
       ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "spanner-credentials"
       }
     end
@@ -462,15 +462,15 @@ describe Google::Cloud do
 
     it "uses shared config for project and keyfile" do
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
-        project.must_equal "project-id"
-        credentials.must_equal "spanner-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
-        keyword_args.key?(:lib_name).must_equal true
-        keyword_args.key?(:lib_version).must_equal true
-        keyword_args[:lib_name].must_be :nil?
-        keyword_args[:lib_version].must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "spanner-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
+        _(keyword_args.key?(:lib_name)).must_equal true
+        _(keyword_args.key?(:lib_version)).must_equal true
+        _(keyword_args[:lib_name]).must_be :nil?
+        _(keyword_args[:lib_version]).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -487,9 +487,9 @@ describe Google::Cloud do
             Google::Cloud::Spanner::Credentials.stub :new, default_credentials do
               Google::Cloud::Spanner::Service.stub :new, stubbed_service do
                 spanner = Google::Cloud::Spanner.new
-                spanner.must_be_kind_of Google::Cloud::Spanner::Project
-                spanner.project.must_equal "project-id"
-                spanner.service.must_be_kind_of OpenStruct
+                _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+                _(spanner.project).must_equal "project-id"
+                _(spanner.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -499,15 +499,15 @@ describe Google::Cloud do
 
     it "uses shared config for project_id and credentials" do
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
-        project.must_equal "project-id"
-        credentials.must_equal "spanner-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
-        keyword_args.key?(:lib_name).must_equal true
-        keyword_args.key?(:lib_version).must_equal true
-        keyword_args[:lib_name].must_be :nil?
-        keyword_args[:lib_version].must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "spanner-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
+        _(keyword_args.key?(:lib_name)).must_equal true
+        _(keyword_args.key?(:lib_version)).must_equal true
+        _(keyword_args[:lib_name]).must_be :nil?
+        _(keyword_args[:lib_version]).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -524,9 +524,9 @@ describe Google::Cloud do
             Google::Cloud::Spanner::Credentials.stub :new, default_credentials do
               Google::Cloud::Spanner::Service.stub :new, stubbed_service do
                 spanner = Google::Cloud::Spanner.new
-                spanner.must_be_kind_of Google::Cloud::Spanner::Project
-                spanner.project.must_equal "project-id"
-                spanner.service.must_be_kind_of OpenStruct
+                _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+                _(spanner.project).must_equal "project-id"
+                _(spanner.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -536,15 +536,15 @@ describe Google::Cloud do
 
     it "uses spanner config for project and keyfile" do
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
-        project.must_equal "project-id"
-        credentials.must_equal "spanner-credentials"
-        timeout.must_equal 42
-        host.must_be :nil?
-        client_config.must_equal spanner_client_config
-        keyword_args.key?(:lib_name).must_equal true
-        keyword_args.key?(:lib_version).must_equal true
-        keyword_args[:lib_name].must_be :nil?
-        keyword_args[:lib_version].must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "spanner-credentials"
+        _(timeout).must_equal 42
+        _(host).must_be :nil?
+        _(client_config).must_equal spanner_client_config
+        _(keyword_args.key?(:lib_name)).must_equal true
+        _(keyword_args.key?(:lib_version)).must_equal true
+        _(keyword_args[:lib_name]).must_be :nil?
+        _(keyword_args[:lib_version]).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -563,9 +563,9 @@ describe Google::Cloud do
             Google::Cloud::Spanner::Credentials.stub :new, default_credentials do
               Google::Cloud::Spanner::Service.stub :new, stubbed_service do
                 spanner = Google::Cloud::Spanner.new
-                spanner.must_be_kind_of Google::Cloud::Spanner::Project
-                spanner.project.must_equal "project-id"
-                spanner.service.must_be_kind_of OpenStruct
+                _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+                _(spanner.project).must_equal "project-id"
+                _(spanner.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -575,15 +575,15 @@ describe Google::Cloud do
 
     it "uses spanner config for project_id and credentials" do
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
-        project.must_equal "project-id"
-        credentials.must_equal "spanner-credentials"
-        timeout.must_equal 42
-        host.must_be :nil?
-        client_config.must_equal spanner_client_config
-        keyword_args.key?(:lib_name).must_equal true
-        keyword_args.key?(:lib_version).must_equal true
-        keyword_args[:lib_name].must_be :nil?
-        keyword_args[:lib_version].must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "spanner-credentials"
+        _(timeout).must_equal 42
+        _(host).must_be :nil?
+        _(client_config).must_equal spanner_client_config
+        _(keyword_args.key?(:lib_name)).must_equal true
+        _(keyword_args.key?(:lib_version)).must_equal true
+        _(keyword_args[:lib_name]).must_be :nil?
+        _(keyword_args[:lib_version]).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -602,9 +602,9 @@ describe Google::Cloud do
             Google::Cloud::Spanner::Credentials.stub :new, default_credentials do
               Google::Cloud::Spanner::Service.stub :new, stubbed_service do
                 spanner = Google::Cloud::Spanner.new
-                spanner.must_be_kind_of Google::Cloud::Spanner::Project
-                spanner.project.must_equal "project-id"
-                spanner.service.must_be_kind_of OpenStruct
+                _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+                _(spanner.project).must_equal "project-id"
+                _(spanner.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -615,15 +615,15 @@ describe Google::Cloud do
     it "uses spanner config for endpoint" do
       endpoint = "spanner-endpoint2.example.com"
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
-        project.must_equal "project-id"
-        credentials.must_equal "spanner-credentials"
-        timeout.must_be :nil?
-        host.must_equal endpoint
-        client_config.must_be :nil?
-        keyword_args.key?(:lib_name).must_equal true
-        keyword_args.key?(:lib_version).must_equal true
-        keyword_args[:lib_name].must_be :nil?
-        keyword_args[:lib_version].must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "spanner-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_equal endpoint
+        _(client_config).must_be :nil?
+        _(keyword_args.key?(:lib_name)).must_equal true
+        _(keyword_args.key?(:lib_version)).must_equal true
+        _(keyword_args[:lib_name]).must_be :nil?
+        _(keyword_args[:lib_version]).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -641,9 +641,9 @@ describe Google::Cloud do
             Google::Cloud::Spanner::Credentials.stub :new, default_credentials do
               Google::Cloud::Spanner::Service.stub :new, stubbed_service do
                 spanner = Google::Cloud::Spanner.new
-                spanner.must_be_kind_of Google::Cloud::Spanner::Project
-                spanner.project.must_equal "project-id"
-                spanner.service.must_be_kind_of OpenStruct
+                _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+                _(spanner.project).must_equal "project-id"
+                _(spanner.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -662,10 +662,10 @@ describe Google::Cloud do
         end
 
         spanner = Google::Cloud::Spanner.new
-        spanner.must_be_kind_of Google::Cloud::Spanner::Project
-        spanner.project.must_equal "project-id"
-        spanner.service.credentials.must_equal :this_channel_is_insecure
-        spanner.service.host.must_equal "localhost:4567"
+        _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+        _(spanner.project).must_equal "project-id"
+        _(spanner.service.credentials).must_equal :this_channel_is_insecure
+        _(spanner.service.host).must_equal "localhost:4567"
       end
     end
 
@@ -674,17 +674,17 @@ describe Google::Cloud do
       custom_lib_version = "1.0.0"
 
       stubbed_credentials = ->(keyfile, scope: nil) {
-        scope.must_be :nil?
+        _(scope).must_be :nil?
         "spanner-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, client_config: nil, **keyword_args) {
-        project.must_equal "project-id"
-        credentials.must_equal "spanner-credentials"
-        timeout.must_be :nil?
-        host.must_be :nil?
-        client_config.must_be :nil?
-        keyword_args[:lib_name].must_equal custom_lib_name
-        keyword_args[:lib_version].must_equal custom_lib_version
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "spanner-credentials"
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
+        _(client_config).must_be :nil?
+        _(keyword_args[:lib_name]).must_equal custom_lib_name
+        _(keyword_args[:lib_version]).must_equal custom_lib_version
         OpenStruct.new project: project, lib_name: keyword_args[:lib_name], lib_version: keyword_args[:lib_version]
       }
 
@@ -703,11 +703,11 @@ describe Google::Cloud do
             Google::Cloud::Spanner::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Spanner::Service.stub :new, stubbed_service do
                 spanner = Google::Cloud::Spanner.new
-                spanner.must_be_kind_of Google::Cloud::Spanner::Project
-                spanner.project.must_equal "project-id"
-                spanner.service.must_be_kind_of OpenStruct
-                spanner.service.lib_name.must_equal custom_lib_name
-                spanner.service.lib_version.must_equal custom_lib_version
+                _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+                _(spanner.project).must_equal "project-id"
+                _(spanner.service).must_be_kind_of OpenStruct
+                _(spanner.service.lib_name).must_equal custom_lib_name
+                _(spanner.service.lib_version).must_equal custom_lib_version
               end
             end
           end
@@ -730,8 +730,8 @@ describe Google::Cloud do
           File.stub :read, found_credentials, ["path/to/keyfile.json"] do
             Google::Cloud::Spanner::Credentials.stub :new, default_credentials do
               spanner = Google::Cloud::Spanner.new
-              spanner.project.must_equal "project-id"
-              spanner.query_options.must_equal query_options
+              _(spanner.project).must_equal "project-id"
+              _(spanner.query_options).must_equal query_options
             end
           end
         end


### PR DESCRIPTION
Use `rubocop-minitest` gem and `bundle exec rubocop --only Minitest/GlobalExpectations -a` to autocorrect minitest warnings for Ruby 2.7.

refs: #4110
refs: #4116