### PR TITLE
chore: Activate AUTOSYNTH_MULTIPLE_COMMITS for several additional libraries

### DIFF
--- a/google-cloud-asset-v1/synth.py
+++ b/google-cloud-asset-v1/synth.py
@@ -19,6 +19,7 @@ import synthtool.gcp as gcp
 import synthtool.languages.ruby as ruby
 import logging
 
+AUTOSYNTH_MULTIPLE_COMMITS = True
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -19,6 +19,8 @@ import synthtool.gcp as gcp
 import synthtool.languages.ruby as ruby
 import logging
 
+AUTOSYNTH_MULTIPLE_COMMITS = True
+
 logging.basicConfig(level=logging.DEBUG)
 
 gapic = gcp.GAPICMicrogenerator()

--- a/google-cloud-container_analysis/synth.py
+++ b/google-cloud-container_analysis/synth.py
@@ -21,6 +21,8 @@ import logging
 import os
 import re
 
+AUTOSYNTH_MULTIPLE_COMMITS = True
+
 logging.basicConfig(level=logging.DEBUG)
 
 gapic = gcp.GAPICGenerator()

--- a/google-cloud-logging/synth.py
+++ b/google-cloud-logging/synth.py
@@ -19,6 +19,8 @@ import synthtool.gcp as gcp
 import logging
 import re
 
+AUTOSYNTH_MULTIPLE_COMMITS = True
+
 logging.basicConfig(level=logging.DEBUG)
 
 gapic = gcp.GAPICGenerator()

--- a/google-cloud-secret_manager-v1beta1/synth.py
+++ b/google-cloud-secret_manager-v1beta1/synth.py
@@ -19,6 +19,7 @@ import synthtool.gcp as gcp
 import synthtool.languages.ruby as ruby
 import logging
 
+AUTOSYNTH_MULTIPLE_COMMITS = True
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/google-cloud-secret_manager/synth.py
+++ b/google-cloud-secret_manager/synth.py
@@ -19,6 +19,8 @@ import synthtool.gcp as gcp
 import synthtool.languages.ruby as ruby
 import logging
 
+AUTOSYNTH_MULTIPLE_COMMITS = True
+
 logging.basicConfig(level=logging.DEBUG)
 
 gapic = gcp.GAPICMicrogenerator()

--- a/google-cloud-spanner/synth.py
+++ b/google-cloud-spanner/synth.py
@@ -19,6 +19,8 @@ import synthtool.gcp as gcp
 import logging
 import re
 
+AUTOSYNTH_MULTIPLE_COMMITS = True
+
 logging.basicConfig(level=logging.DEBUG)
 
 gapic = gcp.GAPICGenerator()


### PR DESCRIPTION
A total of 8 Ruby libraries are now on AUTOSYNTH_MULTIPLE_COMMITS, covering various cases:

* Microgenerator-generated libraries (secret_manager-v1, secret_manager-v1beta1, asset-v1)
* Microgenerator-generated wrappers (secret_manager, asset)
* Monolith-generated standalone libraries (container_analysis)
* Veneers supported by a single monolith-generated interface (logging)
* Veneers supported by multiple monolith-generated interfaces (spanner)
