### PR TITLE
Release google-cloud-bigquery-data_transfer-v1 0.1.0

### DIFF
--- a/google-cloud-bigquery-data_transfer-v1/CHANGELOG.md
+++ b/google-cloud-bigquery-data_transfer-v1/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-04-23
+
+Initial release.
+

--- a/google-cloud-bigquery-data_transfer-v1/lib/google/cloud/bigquery/data_transfer/v1/version.rb
+++ b/google-cloud-bigquery-data_transfer-v1/lib/google/cloud/bigquery/data_transfer/v1/version.rb
@@ -22,7 +22,7 @@ module Google
     module Bigquery
       module DataTransfer
         module V1
-          VERSION = "0.0.1"
+          VERSION = "0.1.0"
         end
       end
     end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-bigquery-data_transfer-v1/CHANGELOG.md b/google-cloud-bigquery-data_transfer-v1/CHANGELOG.md
index 04266ce0d..f88957a62 100644
--- a/google-cloud-bigquery-data_transfer-v1/CHANGELOG.md
+++ b/google-cloud-bigquery-data_transfer-v1/CHANGELOG.md
@@ -1,6 +1,2 @@
 # Release History
 
-### 0.1.0 / 2020-04-23
-
-Initial release.
-
diff --git a/google-cloud-bigquery-data_transfer-v1/lib/google/cloud/bigquery/data_transfer/v1/version.rb b/google-cloud-bigquery-data_transfer-v1/lib/google/cloud/bigquery/data_transfer/v1/version.rb
index 061076687..c594fa7e4 100644
--- a/google-cloud-bigquery-data_transfer-v1/lib/google/cloud/bigquery/data_transfer/v1/version.rb
+++ b/google-cloud-bigquery-data_transfer-v1/lib/google/cloud/bigquery/data_transfer/v1/version.rb
@@ -22,7 +22,7 @@ module Google
     module Bigquery
       module DataTransfer
         module V1
-          VERSION = "0.1.0"
+          VERSION = "0.0.1"
         end
       end
     end

```

</details>

This pull request was generated using releasetool.