### PR TITLE
Release google-cloud-web_risk-v1 0.1.0

### DIFF
--- a/google-cloud-web_risk-v1/CHANGELOG.md
+++ b/google-cloud-web_risk-v1/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-04-23
+
+Initial release.
+

--- a/google-cloud-web_risk-v1/lib/google/cloud/web_risk/v1/version.rb
+++ b/google-cloud-web_risk-v1/lib/google/cloud/web_risk/v1/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module WebRisk
       module V1
-        VERSION = "0.0.1"
+        VERSION = "0.1.0"
       end
     end
   end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-web_risk-v1/CHANGELOG.md b/google-cloud-web_risk-v1/CHANGELOG.md
index 04266ce0d..f88957a62 100644
--- a/google-cloud-web_risk-v1/CHANGELOG.md
+++ b/google-cloud-web_risk-v1/CHANGELOG.md
@@ -1,6 +1,2 @@
 # Release History
 
-### 0.1.0 / 2020-04-23
-
-Initial release.
-
diff --git a/google-cloud-web_risk-v1/lib/google/cloud/web_risk/v1/version.rb b/google-cloud-web_risk-v1/lib/google/cloud/web_risk/v1/version.rb
index 642c4745a..90ab6fc0b 100644
--- a/google-cloud-web_risk-v1/lib/google/cloud/web_risk/v1/version.rb
+++ b/google-cloud-web_risk-v1/lib/google/cloud/web_risk/v1/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module WebRisk
       module V1
-        VERSION = "0.1.0"
+        VERSION = "0.0.1"
       end
     end
   end

```

</details>

This pull request was generated using releasetool.